### PR TITLE
feat(#4): enforce optimistic concurrency and deterministic task ordering

### DIFF
--- a/src/app/api/tasks/[id]/advance/route.ts
+++ b/src/app/api/tasks/[id]/advance/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { TaskStatus } from "@/generated/prisma/client";
 import { enforcePolicy, getUserRole, recordPolicyOverride } from "@/lib/policy-check";
+import { compactColumns, getNextColumnOrder } from "@/lib/task-order";
 
 const STATUS_FLOW: Partial<Record<TaskStatus, TaskStatus>> = {
   BACKLOG: "QUEUED",
@@ -39,6 +40,40 @@ export async function POST(
       return NextResponse.json({ error: "Task not found" }, { status: 404 });
     }
 
+    const body = await request.json().catch(() => ({}));
+    const expectedUpdatedAt = (body as Record<string, unknown>).expectedUpdatedAt as
+      | string
+      | undefined;
+    if (expectedUpdatedAt) {
+      const expectedTs = Date.parse(expectedUpdatedAt);
+      if (Number.isNaN(expectedTs)) {
+        return NextResponse.json(
+          { error: "Invalid expectedUpdatedAt" },
+          { status: 400 }
+        );
+      }
+      if (existing.updatedAt.getTime() !== expectedTs) {
+        return NextResponse.json(
+          {
+            error: "Conflict",
+            conflict: {
+              reason: "STALE_VERSION",
+              message:
+                "Task changed before this advance was applied. Refresh and retry.",
+              current: {
+                id: existing.id,
+                status: existing.status,
+                columnOrder: existing.columnOrder,
+                updatedAt: existing.updatedAt.toISOString(),
+              },
+              expectedUpdatedAt,
+            },
+          },
+          { status: 409 }
+        );
+      }
+    }
+
     const nextStatus: TaskStatus | undefined = STATUS_FLOW[existing.status];
     if (!nextStatus) {
       return NextResponse.json(
@@ -65,7 +100,6 @@ export async function POST(
 
     // If override is required, the client must supply a reason
     if (policyResult.requiresOverride) {
-      const body = await request.json().catch(() => ({}));
       const overrideReason = (body as Record<string, unknown>).overrideReason as string | undefined;
       if (!overrideReason) {
         return NextResponse.json(
@@ -91,11 +125,13 @@ export async function POST(
     }
 
     const movingToDone = nextStatus === "DONE";
+    const nextColumnOrder = await getNextColumnOrder(prisma, nextStatus, id);
 
     const task = await prisma.task.update({
       where: { id },
       data: {
         status: nextStatus,
+        columnOrder: nextColumnOrder,
         completedOn: movingToDone ? new Date() : undefined,
       },
       include: {
@@ -155,6 +191,8 @@ export async function POST(
         },
       });
     }
+
+    await compactColumns(prisma, [existing.status, nextStatus]);
 
     return NextResponse.json({
       task,

--- a/src/app/api/tasks/[id]/retreat/route.ts
+++ b/src/app/api/tasks/[id]/retreat/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { TaskStatus } from "@/generated/prisma/client";
 import { enforcePolicy, getUserRole, recordPolicyOverride } from "@/lib/policy-check";
+import { compactColumns, getNextColumnOrder } from "@/lib/task-order";
 
 const STATUS_BACK: Partial<Record<TaskStatus, TaskStatus>> = {
   QUEUED: "BACKLOG",
@@ -32,6 +33,40 @@ export async function POST(
       return NextResponse.json({ error: "Task not found" }, { status: 404 });
     }
 
+    const body = await request.json().catch(() => ({}));
+    const expectedUpdatedAt = (body as Record<string, unknown>).expectedUpdatedAt as
+      | string
+      | undefined;
+    if (expectedUpdatedAt) {
+      const expectedTs = Date.parse(expectedUpdatedAt);
+      if (Number.isNaN(expectedTs)) {
+        return NextResponse.json(
+          { error: "Invalid expectedUpdatedAt" },
+          { status: 400 }
+        );
+      }
+      if (existing.updatedAt.getTime() !== expectedTs) {
+        return NextResponse.json(
+          {
+            error: "Conflict",
+            conflict: {
+              reason: "STALE_VERSION",
+              message:
+                "Task changed before this retreat was applied. Refresh and retry.",
+              current: {
+                id: existing.id,
+                status: existing.status,
+                columnOrder: existing.columnOrder,
+                updatedAt: existing.updatedAt.toISOString(),
+              },
+              expectedUpdatedAt,
+            },
+          },
+          { status: 409 }
+        );
+      }
+    }
+
     const prevStatus: TaskStatus | undefined = STATUS_BACK[existing.status];
     if (!prevStatus) {
       return NextResponse.json(
@@ -55,7 +90,6 @@ export async function POST(
     }
 
     if (policyResult.requiresOverride) {
-      const body = await request.json().catch(() => ({}));
       const overrideReason = (body as Record<string, unknown>).overrideReason as string | undefined;
       if (!overrideReason) {
         return NextResponse.json(
@@ -80,10 +114,13 @@ export async function POST(
       });
     }
 
+    const previousColumnOrder = await getNextColumnOrder(prisma, prevStatus, id);
+
     const task = await prisma.task.update({
       where: { id },
       data: {
         status: prevStatus,
+        columnOrder: previousColumnOrder,
         completedOn: existing.status === "DONE" ? null : undefined,
       },
       include: {
@@ -113,6 +150,8 @@ export async function POST(
         changedBy: session.user.id,
       },
     });
+
+    await compactColumns(prisma, [existing.status, prevStatus]);
 
     return NextResponse.json({
       task,

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { emitBoardEvent } from "@/lib/socket-emit";
 import { enforcePolicy, getUserRole, recordPolicyOverride } from "@/lib/policy-check";
+import { compactColumns, getNextColumnOrder } from "@/lib/task-order";
 import type { TaskStatus } from "@/generated/prisma/client";
 
 const TASK_INCLUDE = {
@@ -83,6 +84,37 @@ export async function PATCH(
       return NextResponse.json({ error: "Task not found" }, { status: 404 });
     }
 
+    const expectedUpdatedAt = body.expectedUpdatedAt as string | undefined;
+    if (expectedUpdatedAt) {
+      const expectedTs = Date.parse(expectedUpdatedAt);
+      if (Number.isNaN(expectedTs)) {
+        return NextResponse.json(
+          { error: "Invalid expectedUpdatedAt" },
+          { status: 400 }
+        );
+      }
+      if (existing.updatedAt.getTime() !== expectedTs) {
+        return NextResponse.json(
+          {
+            error: "Conflict",
+            conflict: {
+              reason: "STALE_VERSION",
+              message:
+                "Task changed before this update was applied. Refresh and retry.",
+              current: {
+                id: existing.id,
+                status: existing.status,
+                columnOrder: existing.columnOrder,
+                updatedAt: existing.updatedAt.toISOString(),
+              },
+              expectedUpdatedAt,
+            },
+          },
+          { status: 409 }
+        );
+      }
+    }
+
     const {
       responsibleIds,
       accountableIds,
@@ -140,6 +172,7 @@ export async function PATCH(
     const data: Record<string, unknown> = { ...directFields };
     // Remove overrideReason from data so it doesn't get passed to Prisma
     delete data.overrideReason;
+    delete data.expectedUpdatedAt;
 
     if (startDate !== undefined) {
       data.startDate = startDate ? new Date(startDate) : null;
@@ -149,6 +182,16 @@ export async function PATCH(
     }
     if (movingToDone) {
       data.completedOn = new Date();
+    }
+    if (statusChanged) {
+      data.columnOrder = await getNextColumnOrder(
+        prisma,
+        directFields.status as TaskStatus,
+        id
+      );
+      if (existing.status === "DONE" && directFields.status !== "DONE") {
+        data.completedOn = null;
+      }
     }
 
     if (responsibleIds) {
@@ -222,6 +265,10 @@ export async function PATCH(
           },
         },
       });
+    }
+
+    if (statusChanged) {
+      await compactColumns(prisma, [existing.status, task.status]);
     }
 
     emitBoardEvent("task:updated", task);

--- a/src/app/api/tasks/reorder/route.ts
+++ b/src/app/api/tasks/reorder/route.ts
@@ -8,8 +8,35 @@ import type { TaskStatus } from "@/generated/prisma/client";
 
 interface ReorderItem {
   taskId: string;
-  status: string;
+  status: TaskStatus;
   columnOrder: number;
+  expectedUpdatedAt?: string;
+}
+
+const VALID_STATUSES: ReadonlySet<TaskStatus> = new Set([
+  "BACKLOG",
+  "QUEUED",
+  "WORKING_ON_TODAY",
+  "ACTIVE",
+  "NOT_DONE",
+  "DONE",
+]);
+
+interface ConflictEntry {
+  taskId: string;
+  expectedUpdatedAt: string;
+  currentUpdatedAt: string;
+  currentStatus: TaskStatus;
+  currentColumnOrder: number;
+}
+
+function parseIsoTimestamp(value: string): number | null {
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
 }
 
 export async function PATCH(request: NextRequest): Promise<NextResponse> {
@@ -20,126 +47,226 @@ export async function PATCH(request: NextRequest): Promise<NextResponse> {
     }
 
     const body = await request.json();
-    const items: ReorderItem[] = body.items ?? body;
+    const itemsRaw = body.items ?? body;
     const overrideReason = body.overrideReason as string | undefined;
+    const requestId =
+      typeof body.requestId === "string" && body.requestId.trim().length > 0
+        ? body.requestId.trim()
+        : undefined;
 
-    if (!Array.isArray(items) || items.length === 0) {
+    if (!Array.isArray(itemsRaw) || itemsRaw.length === 0) {
       return NextResponse.json(
         { error: "Request body must include an array of reorder items" },
         { status: 400 }
       );
     }
 
+    const items: ReorderItem[] = [];
+    const seenTaskIds = new Set<string>();
+    for (const raw of itemsRaw) {
+      const taskId = raw?.taskId as string | undefined;
+      const status = raw?.status as TaskStatus | undefined;
+      const columnOrder = raw?.columnOrder as number | undefined;
+      const expectedUpdatedAt = raw?.expectedUpdatedAt as string | undefined;
+
+      if (!taskId || typeof taskId !== "string") {
+        return NextResponse.json(
+          { error: "Each reorder item must include taskId" },
+          { status: 400 }
+        );
+      }
+      if (seenTaskIds.has(taskId)) {
+        return NextResponse.json(
+          { error: `Duplicate taskId in reorder payload: ${taskId}` },
+          { status: 400 }
+        );
+      }
+      seenTaskIds.add(taskId);
+
+      if (!status || !VALID_STATUSES.has(status)) {
+        return NextResponse.json(
+          { error: `Invalid task status for ${taskId}` },
+          { status: 400 }
+        );
+      }
+      if (
+        typeof columnOrder !== "number" ||
+        !Number.isFinite(columnOrder) ||
+        columnOrder < 0
+      ) {
+        return NextResponse.json(
+          { error: `Invalid columnOrder for ${taskId}` },
+          { status: 400 }
+        );
+      }
+      if (
+        expectedUpdatedAt !== undefined &&
+        (typeof expectedUpdatedAt !== "string" ||
+          parseIsoTimestamp(expectedUpdatedAt) === null)
+      ) {
+        return NextResponse.json(
+          { error: `Invalid expectedUpdatedAt for ${taskId}` },
+          { status: 400 }
+        );
+      }
+
+      items.push({ taskId, status, columnOrder, expectedUpdatedAt });
+    }
+
     const taskIds = items.map((item) => item.taskId);
     const existingTasks = await prisma.task.findMany({
       where: { id: { in: taskIds } },
-      select: { id: true, status: true },
+      select: {
+        id: true,
+        title: true,
+        status: true,
+        columnOrder: true,
+        updatedAt: true,
+      },
     });
 
-    const existingByIdMap = new Map<string, string>(
-      existingTasks.map((t: { id: string; status: string }) => [t.id, t.status])
+    if (existingTasks.length !== taskIds.length) {
+      const foundIds = new Set(existingTasks.map((task) => task.id));
+      const missing = taskIds.filter((id) => !foundIds.has(id));
+      return NextResponse.json(
+        { error: `Task(s) not found: ${missing.join(", ")}` },
+        { status: 404 }
+      );
+    }
+
+    const existingById = new Map(
+      existingTasks.map((task) => [task.id, task])
     );
 
-    // Identify which items involve a status change
-    const statusChanges: { taskId: string; from: string; to: string }[] = [];
+    // Optimistic locking checks.
+    const conflicts: ConflictEntry[] = [];
     for (const item of items) {
-      const previousStatus = existingByIdMap.get(item.taskId);
-      if (previousStatus !== undefined && previousStatus !== item.status) {
-        statusChanges.push({
+      if (!item.expectedUpdatedAt) continue;
+      const expectedTs = parseIsoTimestamp(item.expectedUpdatedAt);
+      const current = existingById.get(item.taskId);
+      if (!current || expectedTs === null) continue;
+      if (current.updatedAt.getTime() !== expectedTs) {
+        conflicts.push({
           taskId: item.taskId,
-          from: previousStatus,
-          to: item.status,
+          expectedUpdatedAt: item.expectedUpdatedAt,
+          currentUpdatedAt: current.updatedAt.toISOString(),
+          currentStatus: current.status,
+          currentColumnOrder: current.columnOrder,
         });
       }
     }
 
-    // ── WIP policy enforcement for each column gaining tasks ──
+    if (conflicts.length > 0) {
+      return NextResponse.json(
+        {
+          error: "Conflict",
+          conflict: {
+            reason: "STALE_VERSION",
+            message:
+              "One or more tasks changed before this reorder was applied. Refresh and retry.",
+            items: conflicts,
+          },
+        },
+        { status: 409 }
+      );
+    }
+
+    const statusChanges = items
+      .map((item) => {
+        const existing = existingById.get(item.taskId);
+        if (!existing || existing.status === item.status) {
+          return null;
+        }
+        return {
+          taskId: item.taskId,
+          from: existing.status,
+          to: item.status,
+        };
+      })
+      .filter((change): change is NonNullable<typeof change> => Boolean(change));
+
+    // WIP policy enforcement for columns gaining tasks.
     if (statusChanges.length > 0) {
       const [policies, userRole] = await Promise.all([
         loadPolicies(),
         getUserRole(session.user.id),
       ]);
 
-      // Calculate net additions per target column
-      const columnDeltas = new Map<string, string[]>();
+      const columnDeltas = new Map<TaskStatus, string[]>();
       for (const change of statusChanges) {
-        const list = columnDeltas.get(change.to) ?? [];
-        list.push(change.taskId);
-        columnDeltas.set(change.to, list);
+        const taskList = columnDeltas.get(change.to) ?? [];
+        taskList.push(change.taskId);
+        columnDeltas.set(change.to, taskList);
       }
 
-      // Get current counts per affected column, excluding the tasks being moved
-      const movingTaskIds = new Set(statusChanges.map((c) => c.taskId));
+      const movingTaskIds = new Set(statusChanges.map((change) => change.taskId));
       const affectedColumns = [...columnDeltas.keys()];
+      const columnCounts = new Map<TaskStatus, number>();
 
-      const columnCounts = new Map<string, number>();
       for (const col of affectedColumns) {
         const count = await prisma.task.count({
           where: {
-            status: col as TaskStatus,
+            status: col,
             id: { notIn: [...movingTaskIds] },
           },
         });
         columnCounts.set(col, count);
       }
 
-      // Check policy for each column gaining tasks
       const violations: Array<{
-        column: string;
-        policyResult: ReturnType<typeof checkWipPolicy>;
+        column: TaskStatus;
         taskIds: string[];
+        policy: ReturnType<typeof checkWipPolicy>;
       }> = [];
 
-      for (const [column, taskIdsMoving] of columnDeltas) {
+      for (const [column, movedTaskIds] of columnDeltas) {
         const baseCount = columnCounts.get(column) ?? 0;
-        const projectedCount = baseCount + taskIdsMoving.length;
-
-        const policyResult = checkWipPolicy({
-          targetColumn: column as TaskStatus,
+        const projectedCount = baseCount + movedTaskIds.length;
+        const policy = checkWipPolicy({
+          targetColumn: column,
           currentColumnTaskCount: projectedCount,
           userRole,
           policies,
         });
 
-        if (!policyResult.allowed || policyResult.requiresOverride) {
-          violations.push({ column, policyResult, taskIds: taskIdsMoving });
+        if (!policy.allowed || policy.requiresOverride) {
+          violations.push({ column, taskIds: movedTaskIds, policy });
         }
       }
 
-      // If any column is blocked and user can't override, reject the whole batch
-      const blocked = violations.filter((v) => !v.policyResult.allowed);
+      const blocked = violations.filter((violation) => !violation.policy.allowed);
       if (blocked.length > 0) {
         return NextResponse.json(
           {
             error: "WIP limit exceeded",
-            violations: blocked.map((v) => ({
-              column: v.column,
-              policy: v.policyResult,
+            violations: blocked.map((violation) => ({
+              column: violation.column,
+              policy: violation.policy,
             })),
           },
           { status: 409 }
         );
       }
 
-      // If override required, demand reason
-      const overrideNeeded = violations.filter((v) => v.policyResult.requiresOverride);
-      if (overrideNeeded.length > 0) {
+      const needsOverride = violations.filter(
+        (violation) => violation.policy.requiresOverride
+      );
+      if (needsOverride.length > 0) {
         if (!overrideReason) {
           return NextResponse.json(
             {
               error: "Override reason required",
-              violations: overrideNeeded.map((v) => ({
-                column: v.column,
-                policy: v.policyResult,
+              violations: needsOverride.map((violation) => ({
+                column: violation.column,
+                policy: violation.policy,
               })),
             },
             { status: 409 }
           );
         }
 
-        // Record overrides for each affected task
-        for (const v of overrideNeeded) {
-          for (const taskId of v.taskIds) {
+        for (const violation of needsOverride) {
+          for (const taskId of violation.taskIds) {
             await recordPolicyOverride({
               taskId,
               action: "reorder",
@@ -147,49 +274,125 @@ export async function PATCH(request: NextRequest): Promise<NextResponse> {
               actorId: session.user.id,
               actorName: session.user.name ?? undefined,
               actorRole: userRole,
-              column: v.column,
-              wipCount: v.policyResult.currentCount,
-              wipLimit: v.policyResult.wipLimit,
+              column: violation.column,
+              wipCount: violation.policy.currentCount,
+              wipLimit: violation.policy.wipLimit,
             });
           }
         }
       }
     }
 
-    // ── Perform the reorder transaction ──
-    await prisma.$transaction(
-      items.map((item) => {
-        const previousStatus = existingByIdMap.get(item.taskId);
-        const statusChanged =
-          previousStatus !== undefined && previousStatus !== item.status;
+    // Build deterministic final ordering per affected column.
+    const affectedColumns = new Set<TaskStatus>();
+    for (const item of items) {
+      affectedColumns.add(item.status);
+      const existing = existingById.get(item.taskId);
+      if (existing) {
+        affectedColumns.add(existing.status);
+      }
+    }
 
-        return prisma.task.update({
-          where: { id: item.taskId },
-          data: {
-            status: item.status as never,
-            columnOrder: item.columnOrder,
-            completedOn:
-              statusChanged && item.status === "DONE" ? new Date() : undefined,
-          },
-        });
-      })
-    );
+    const columnTasks = await prisma.task.findMany({
+      where: { status: { in: [...affectedColumns] } },
+      select: {
+        id: true,
+        status: true,
+        columnOrder: true,
+        updatedAt: true,
+      },
+      orderBy: [{ status: "asc" }, { columnOrder: "asc" }, { updatedAt: "asc" }, { id: "asc" }],
+    });
+
+    const movingIds = new Set(items.map((item) => item.taskId));
+    const baselineByColumn = new Map<TaskStatus, string[]>();
+
+    for (const task of columnTasks) {
+      if (movingIds.has(task.id)) continue;
+      const list = baselineByColumn.get(task.status) ?? [];
+      list.push(task.id);
+      baselineByColumn.set(task.status, list);
+    }
+
+    for (const status of affectedColumns) {
+      if (!baselineByColumn.has(status)) {
+        baselineByColumn.set(status, []);
+      }
+    }
+
+    const insertionsByColumn = new Map<TaskStatus, ReorderItem[]>();
+    for (const item of items) {
+      const list = insertionsByColumn.get(item.status) ?? [];
+      list.push(item);
+      insertionsByColumn.set(item.status, list);
+    }
+
+    const finalByColumn = new Map<TaskStatus, string[]>();
+    for (const status of affectedColumns) {
+      const ordered = [...(baselineByColumn.get(status) ?? [])];
+      const insertions = [...(insertionsByColumn.get(status) ?? [])].sort(
+        (a, b) =>
+          a.columnOrder - b.columnOrder || a.taskId.localeCompare(b.taskId)
+      );
+
+      for (const insertion of insertions) {
+        const idx = clamp(insertion.columnOrder, 0, ordered.length);
+        ordered.splice(idx, 0, insertion.taskId);
+      }
+
+      finalByColumn.set(status, ordered);
+    }
+
+    const now = new Date();
+    const updates: Array<ReturnType<typeof prisma.task.update>> = [];
+
+    for (const [status, orderedIds] of finalByColumn) {
+      for (let index = 0; index < orderedIds.length; index += 1) {
+        const taskId = orderedIds[index];
+        const existing = existingById.get(taskId);
+        const statusChanged = existing && existing.status !== status;
+        const orderChanged = existing && existing.columnOrder !== index;
+
+        if (!statusChanged && !orderChanged) {
+          continue;
+        }
+
+        updates.push(
+          prisma.task.update({
+            where: { id: taskId },
+            data: {
+              status,
+              columnOrder: index,
+              completedOn: statusChanged
+                ? status === "DONE"
+                  ? now
+                  : existing?.status === "DONE"
+                    ? null
+                    : undefined
+                : undefined,
+            },
+          })
+        );
+      }
+    }
+
+    await prisma.$transaction(updates);
 
     if (statusChanges.length > 0) {
       await prisma.statusHistory.createMany({
         data: statusChanges.map((change) => ({
           taskId: change.taskId,
-          fromStatus: change.from as never,
-          toStatus: change.to as never,
+          fromStatus: change.from,
+          toStatus: change.to,
           changedBy: session.user.id,
         })),
       });
     }
 
-    const doneChanges = statusChanges.filter((c) => c.to === "DONE");
+    const doneChanges = statusChanges.filter((change) => change.to === "DONE");
     if (doneChanges.length > 0) {
       const doneTasks = await prisma.task.findMany({
-        where: { id: { in: doneChanges.map((c) => c.taskId) } },
+        where: { id: { in: doneChanges.map((change) => change.taskId) } },
         include: {
           project: true,
           sprint: true,
@@ -209,10 +412,14 @@ export async function PATCH(request: NextRequest): Promise<NextResponse> {
             priority: task.priority,
             status: task.status,
             responsible:
-              task.responsible.map((u: { name: string | null }) => u.name).join(", ") || null,
+              task.responsible
+                .map((user: { name: string | null }) => user.name)
+                .join(", ") || null,
             accountable:
-              task.accountable.map((u: { name: string | null }) => u.name).join(", ") || null,
-            completedOn: task.completedOn ?? new Date(),
+              task.accountable
+                .map((user: { name: string | null }) => user.name)
+                .join(", ") || null,
+            completedOn: task.completedOn ?? now,
             metadata: {
               taskId: task.id,
               projectId: task.projectId,
@@ -231,9 +438,26 @@ export async function PATCH(request: NextRequest): Promise<NextResponse> {
       }
     }
 
-    emitBoardEvent("task:reordered", { items });
+    const eventId = requestId ? `task:reordered:${requestId}` : undefined;
+    emitBoardEvent(
+      "task:reordered",
+      {
+        items: items.map((item) => ({
+          taskId: item.taskId,
+          status: item.status,
+          columnOrder: item.columnOrder,
+        })),
+        statusChanges,
+      },
+      eventId
+    );
 
-    return NextResponse.json({ success: true, updated: items.length });
+    return NextResponse.json({
+      success: true,
+      updated: updates.length,
+      statusChanges: statusChanges.length,
+      eventId: eventId ?? null,
+    });
   } catch (error) {
     console.error("PATCH /api/tasks/reorder error:", error);
     return NextResponse.json(

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { emitBoardEvent } from "@/lib/socket-emit";
+import { getNextColumnOrder } from "@/lib/task-order";
 
 const TASK_INCLUDE = {
   project: true,
@@ -96,6 +97,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       );
     }
 
+    const nextColumnOrder = await getNextColumnOrder(prisma, status);
+
     const task = await prisma.task.create({
       data: {
         title,
@@ -111,6 +114,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         sprintId,
         unplanned: unplanned ?? false,
         slackThread,
+        columnOrder: nextColumnOrder,
         responsible: {
           connect: responsibleIds.map((id: string) => ({ id })),
         },

--- a/src/components/board/kanban-board.tsx
+++ b/src/components/board/kanban-board.tsx
@@ -151,19 +151,38 @@ export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) 
 
       // Persist
       try {
-        await fetch("/api/tasks/reorder", {
+        const movedTask = columns
+          .find((column) => column.id === fromColumn)
+          ?.tasks.find((task) => task.id === draggableId);
+
+        const requestId = `${draggableId}:${Date.now()}`;
+        const response = await fetch("/api/tasks/reorder", {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
+            requestId,
             items: [
               {
                 taskId: draggableId,
                 status: toColumn,
                 columnOrder: destination.index,
+                expectedUpdatedAt: movedTask?.updatedAt,
               },
             ],
           }),
         });
+
+        if (!response.ok) {
+          if (response.status === 409) {
+            const conflict = await response.json().catch(() => null);
+            const message =
+              conflict?.conflict?.message ||
+              conflict?.error ||
+              "This task changed before your move was applied. Refreshing board.";
+            window.alert(message);
+          }
+          throw new Error("Failed to reorder task");
+        }
       } catch {
         // Revert on failure
         fetchBoard();

--- a/src/components/board/kanban-column.tsx
+++ b/src/components/board/kanban-column.tsx
@@ -96,15 +96,39 @@ export function KanbanColumn({
                 index={index}
                 onClick={() => onTaskClick(task)}
                 onAdvance={async () => {
-                  await fetch(`/api/tasks/${task.id}/advance`, {
+                  const response = await fetch(`/api/tasks/${task.id}/advance`, {
                     method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                      expectedUpdatedAt: task.updatedAt,
+                    }),
                   });
+                  if (!response.ok && response.status === 409) {
+                    const conflict = await response.json().catch(() => null);
+                    window.alert(
+                      conflict?.conflict?.message ||
+                        conflict?.error ||
+                        "Task changed before advance was applied. Refreshing board."
+                    );
+                  }
                   onRefresh();
                 }}
                 onRetreat={async () => {
-                  await fetch(`/api/tasks/${task.id}/retreat`, {
+                  const response = await fetch(`/api/tasks/${task.id}/retreat`, {
                     method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                      expectedUpdatedAt: task.updatedAt,
+                    }),
                   });
+                  if (!response.ok && response.status === 409) {
+                    const conflict = await response.json().catch(() => null);
+                    window.alert(
+                      conflict?.conflict?.message ||
+                        conflict?.error ||
+                        "Task changed before retreat was applied. Refreshing board."
+                    );
+                  }
                   onRefresh();
                 }}
               />

--- a/src/components/layout/socket-provider.tsx
+++ b/src/components/layout/socket-provider.tsx
@@ -1,10 +1,33 @@
 "use client";
 
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 import { useSocket } from "@/hooks/use-socket";
 import { useBoardStore } from "@/store/board-store";
 import type { TaskWithRelations, BoardColumn } from "@/types";
 import { COLUMN_ORDER, COLUMN_LABELS } from "@/types";
+
+interface EventEnvelope<T = unknown> {
+  eventId: string;
+  emittedAt: string;
+  payload: T;
+}
+
+function parseEventPayload<T>(raw: unknown): {
+  eventId: string | null;
+  payload: T;
+} {
+  if (
+    raw &&
+    typeof raw === "object" &&
+    "eventId" in raw &&
+    "payload" in raw &&
+    typeof (raw as { eventId?: unknown }).eventId === "string"
+  ) {
+    const envelope = raw as EventEnvelope<T>;
+    return { eventId: envelope.eventId, payload: envelope.payload };
+  }
+  return { eventId: null, payload: raw as T };
+}
 
 /**
  * SocketProvider — listens for real-time board events and updates the
@@ -15,11 +38,24 @@ import { COLUMN_ORDER, COLUMN_LABELS } from "@/types";
 export function SocketProvider({ children }: { children: ReactNode }) {
   const { on } = useSocket();
   const { setColumns } = useBoardStore();
+  const seenEventIds = useRef<Set<string>>(new Set());
+
+  const markSeen = (eventId: string | null): boolean => {
+    if (!eventId) return false;
+    if (seenEventIds.current.has(eventId)) return true;
+    seenEventIds.current.add(eventId);
+    if (seenEventIds.current.size > 500) {
+      const oldest = seenEventIds.current.values().next().value;
+      if (oldest) seenEventIds.current.delete(oldest);
+    }
+    return false;
+  };
 
   useEffect(() => {
     // ── task:created – add the new task into the right column ──
-    const offCreated = on("task:created", (payload: unknown) => {
-      const task = payload as TaskWithRelations;
+    const offCreated = on("task:created", (raw: unknown) => {
+      const { eventId, payload: task } = parseEventPayload<TaskWithRelations>(raw);
+      if (markSeen(eventId)) return;
       setColumns(
         useBoardStore.getState().columns.map((col) => {
           if (col.id === task.status) {
@@ -31,8 +67,9 @@ export function SocketProvider({ children }: { children: ReactNode }) {
     });
 
     // ── task:updated – replace the task in place (may change column) ──
-    const offUpdated = on("task:updated", (payload: unknown) => {
-      const task = payload as TaskWithRelations;
+    const offUpdated = on("task:updated", (raw: unknown) => {
+      const { eventId, payload: task } = parseEventPayload<TaskWithRelations>(raw);
+      if (markSeen(eventId)) return;
       const state = useBoardStore.getState();
 
       // Remove from old column, add to new one
@@ -54,7 +91,9 @@ export function SocketProvider({ children }: { children: ReactNode }) {
     });
 
     // ── task:deleted – remove from whichever column it was in ──
-    const offDeleted = on("task:deleted", (payload: unknown) => {
+    const offDeleted = on("task:deleted", (raw: unknown) => {
+      const { eventId, payload } = parseEventPayload<{ taskId: string }>(raw);
+      if (markSeen(eventId)) return;
       const { taskId } = payload as { taskId: string };
       setColumns(
         useBoardStore.getState().columns.map((col) => ({
@@ -65,13 +104,17 @@ export function SocketProvider({ children }: { children: ReactNode }) {
     });
 
     // ── task:reordered – full refresh (cheapest correct approach) ──
-    const offReordered = on("task:reordered", () => {
+    const offReordered = on("task:reordered", (raw: unknown) => {
+      const { eventId } = parseEventPayload(raw);
+      if (markSeen(eventId)) return;
       // Trigger a lightweight board refresh by re-fetching tasks
       refreshBoard();
     });
 
     // ── board:refresh – explicit full refresh signal ──
-    const offRefresh = on("board:refresh", () => {
+    const offRefresh = on("board:refresh", (raw: unknown) => {
+      const { eventId } = parseEventPayload(raw);
+      if (markSeen(eventId)) return;
       refreshBoard();
     });
 

--- a/src/components/tasks/task-modal.tsx
+++ b/src/components/tasks/task-modal.tsx
@@ -271,11 +271,12 @@ export function TaskModal({ task, onClose }: TaskModalProps) {
       const method = isNew ? "POST" : "PATCH";
 
       const { responsibleId, accountableId, ...rest } = form;
-      await fetch(url, {
+      const response = await fetch(url, {
         method,
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           ...rest,
+          expectedUpdatedAt: detail?.updatedAt || task?.updatedAt,
           responsibleIds: responsibleId ? [responsibleId] : [],
           accountableIds: accountableId ? [accountableId] : [],
           projectId: form.projectId || null,
@@ -286,6 +287,18 @@ export function TaskModal({ task, onClose }: TaskModalProps) {
           slackThread: form.slackThread || null,
         }),
       });
+
+      if (!response.ok) {
+        if (response.status === 409) {
+          const conflict = await response.json().catch(() => null);
+          window.alert(
+            conflict?.conflict?.message ||
+              conflict?.error ||
+              "Task changed before save was applied. Refresh and retry."
+          );
+        }
+        return;
+      }
 
       onClose();
     } catch (err) {
@@ -305,7 +318,21 @@ export function TaskModal({ task, onClose }: TaskModalProps) {
 
   const handleAdvance = async () => {
     if (!task) return;
-    await fetch(`/api/tasks/${task.id}/advance`, { method: "POST" });
+    const response = await fetch(`/api/tasks/${task.id}/advance`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        expectedUpdatedAt: detail?.updatedAt || task.updatedAt,
+      }),
+    });
+    if (!response.ok && response.status === 409) {
+      const conflict = await response.json().catch(() => null);
+      window.alert(
+        conflict?.conflict?.message ||
+          conflict?.error ||
+          "Task changed before advance was applied. Refresh and retry."
+      );
+    }
     onClose();
   };
 

--- a/src/lib/__tests__/task-order.test.ts
+++ b/src/lib/__tests__/task-order.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  compactColumnOrders,
+  compactColumns,
+  getNextColumnOrder,
+} from "@/lib/task-order";
+
+describe("task-order helpers", () => {
+  it("returns next column order using task count", async () => {
+    const count = vi.fn().mockResolvedValue(4);
+    const db = {
+      task: {
+        count,
+      },
+    } as unknown as Parameters<typeof getNextColumnOrder>[0];
+
+    const next = await getNextColumnOrder(db, "ACTIVE");
+
+    expect(next).toBe(4);
+    expect(count).toHaveBeenCalledWith({
+      where: { status: "ACTIVE", id: undefined },
+    });
+  });
+
+  it("compacts sparse/duplicate order values deterministically", async () => {
+    const update = vi.fn().mockResolvedValue({});
+    const findMany = vi.fn().mockResolvedValue([
+      { id: "a", columnOrder: 0 },
+      { id: "b", columnOrder: 2 },
+      { id: "c", columnOrder: 2 },
+      { id: "d", columnOrder: 7 },
+    ]);
+    const db = {
+      task: {
+        findMany,
+        update,
+      },
+    } as unknown as Parameters<typeof compactColumnOrders>[0];
+
+    const updates = await compactColumnOrders(db, "QUEUED");
+
+    expect(updates).toBe(2);
+    expect(findMany).toHaveBeenCalledWith({
+      where: { status: "QUEUED" },
+      select: { id: true, columnOrder: true },
+      orderBy: [{ columnOrder: "asc" }, { updatedAt: "asc" }, { id: "asc" }],
+    });
+    expect(update).toHaveBeenNthCalledWith(1, {
+      where: { id: "b" },
+      data: { columnOrder: 1 },
+    });
+    expect(update).toHaveBeenNthCalledWith(2, {
+      where: { id: "d" },
+      data: { columnOrder: 3 },
+    });
+  });
+
+  it("runs compaction once per unique status", async () => {
+    const updatesByStatus = new Map([
+      ["BACKLOG", 1],
+      ["DONE", 2],
+    ]);
+    const findMany = vi.fn().mockImplementation(({ where }) => {
+      const status = where.status as string;
+      const count = updatesByStatus.get(status) ?? 0;
+      return Promise.resolve(
+        Array.from({ length: count }, (_, idx) => ({
+          id: `${status}-${idx}`,
+          columnOrder: idx + 1,
+        }))
+      );
+    });
+    const update = vi.fn().mockResolvedValue({});
+    const db = {
+      task: {
+        findMany,
+        update,
+      },
+    } as unknown as Parameters<typeof compactColumns>[0];
+
+    const total = await compactColumns(db, ["BACKLOG", "DONE", "BACKLOG"]);
+
+    expect(total).toBe(3);
+    expect(findMany).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/socket-emit.ts
+++ b/src/lib/socket-emit.ts
@@ -1,4 +1,5 @@
 import { getIO } from "./socket-server";
+import { randomUUID } from "node:crypto";
 
 export type SocketEvent =
   | "task:created"
@@ -7,13 +8,28 @@ export type SocketEvent =
   | "task:reordered"
   | "board:refresh";
 
+export interface SocketEnvelope<T = unknown> {
+  eventId: string;
+  emittedAt: string;
+  payload: T;
+}
+
 /**
  * Emit a real-time event to all connected board clients.
  * Safe to call even if Socket.IO hasn't been initialised yet —
  * it silently no-ops so API routes still work for REST-only clients.
  */
-export function emitBoardEvent(event: SocketEvent, payload?: unknown): void {
+export function emitBoardEvent(
+  event: SocketEvent,
+  payload?: unknown,
+  eventId?: string
+): void {
   const io = getIO();
   if (!io) return;
-  io.to("board").emit(event, payload);
+  const envelope: SocketEnvelope = {
+    eventId: eventId ?? `${event}:${randomUUID()}`,
+    emittedAt: new Date().toISOString(),
+    payload,
+  };
+  io.to("board").emit(event, envelope);
 }

--- a/src/lib/task-order.ts
+++ b/src/lib/task-order.ts
@@ -1,0 +1,72 @@
+import type { TaskStatus } from "@/generated/prisma/client";
+
+type SortOrder = "asc" | "desc";
+
+interface TaskOrderClient {
+  task: {
+    count(args: {
+      where: { status: TaskStatus; id?: { not?: string } };
+    }): Promise<number>;
+    findMany(args: {
+      where: { status: TaskStatus };
+      select: { id: true; columnOrder: true };
+      orderBy: Array<
+        { columnOrder: SortOrder } | { updatedAt: SortOrder } | { id: SortOrder }
+      >;
+    }): Promise<Array<{ id: string; columnOrder: number }>>;
+    update(args: {
+      where: { id: string };
+      data: { columnOrder: number };
+    }): Promise<unknown>;
+  };
+}
+
+export async function getNextColumnOrder(
+  db: TaskOrderClient,
+  status: TaskStatus,
+  excludeTaskId?: string
+): Promise<number> {
+  const count = await db.task.count({
+    where: {
+      status,
+      id: excludeTaskId ? { not: excludeTaskId } : undefined,
+    },
+  });
+  return count;
+}
+
+export async function compactColumnOrders(
+  db: TaskOrderClient,
+  status: TaskStatus
+): Promise<number> {
+  const tasks = await db.task.findMany({
+    where: { status },
+    select: { id: true, columnOrder: true },
+    orderBy: [{ columnOrder: "asc" }, { updatedAt: "asc" }, { id: "asc" }],
+  });
+
+  let updates = 0;
+  for (let idx = 0; idx < tasks.length; idx += 1) {
+    const task = tasks[idx];
+    if (task.columnOrder !== idx) {
+      await db.task.update({
+        where: { id: task.id },
+        data: { columnOrder: idx },
+      });
+      updates += 1;
+    }
+  }
+
+  return updates;
+}
+
+export async function compactColumns(
+  db: TaskOrderClient,
+  statuses: Iterable<TaskStatus>
+): Promise<number> {
+  let totalUpdates = 0;
+  for (const status of new Set(statuses)) {
+    totalUpdates += await compactColumnOrders(db, status);
+  }
+  return totalUpdates;
+}


### PR DESCRIPTION
## Summary
- add optimistic concurrency checks using `expectedUpdatedAt` across reorder, patch, advance, and retreat task APIs
- implement deterministic column order normalization and compaction helpers for consistent ordering under concurrent updates
- add socket event envelopes with event IDs and client-side dedupe handling for idempotent real-time updates
- wire board/task modal clients to send optimistic timestamps and surface conflict messaging
- add unit tests for task order helper behavior

## Validation
- `npm test`
- `npm run build`

Closes #27
Closes #28
Closes #29
Closes #30
Closes #31