### PR TITLE
feat(#17): enforce role matrix, secure invite tokens, and security audit trail

### DIFF
--- a/prisma/migrations/20260213173500_auth_hardening_audit/migration.sql
+++ b/prisma/migrations/20260213173500_auth_hardening_audit/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable
+CREATE TABLE "SecurityAuditEvent" (
+    "id" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "outcome" TEXT NOT NULL,
+    "actorId" TEXT,
+    "actorRole" TEXT,
+    "targetType" TEXT,
+    "targetId" TEXT,
+    "details" JSONB,
+    "ipAddress" TEXT,
+    "userAgent" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SecurityAuditEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SecurityAuditEvent_category_createdAt_idx" ON "SecurityAuditEvent"("category", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "SecurityAuditEvent_action_createdAt_idx" ON "SecurityAuditEvent"("action", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "SecurityAuditEvent_actorId_createdAt_idx" ON "SecurityAuditEvent"("actorId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "SecurityAuditEvent" ADD CONSTRAINT "SecurityAuditEvent_actorId_fkey" FOREIGN KEY ("actorId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model User {
 
   accounts Account[]
   sessions Session[]
+  securityAuditEvents SecurityAuditEvent[]
 
   responsibleTasks  Task[]    @relation("TaskResponsible")
   accountableTasks  Task[]    @relation("TaskAccountable")
@@ -323,4 +324,32 @@ model PolicyOverride {
   wipLimit  Int
 
   createdAt DateTime @default(now())
+}
+
+// ============================================================
+// SECURITY AUDIT
+// ============================================================
+
+model SecurityAuditEvent {
+  id        String  @id @default(cuid())
+  action    String
+  category  String
+  outcome   String
+
+  actorId   String?
+  actor     User?   @relation(fields: [actorId], references: [id], onDelete: SetNull)
+  actorRole String?
+
+  targetType String?
+  targetId   String?
+
+  details   Json?
+  ipAddress String?
+  userAgent String?
+
+  createdAt DateTime @default(now())
+
+  @@index([category, createdAt])
+  @@index([action, createdAt])
+  @@index([actorId, createdAt])
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -14,6 +14,7 @@ export default function LoginPage() {
   const [devUsers, setDevUsers] = useState<DevUser[]>([]);
   const [selectedEmail, setSelectedEmail] = useState("");
   const [loading, setLoading] = useState(false);
+  const [inviteMessage, setInviteMessage] = useState<string | null>(null);
   const isDev = process.env.NODE_ENV !== "production";
 
   useEffect(() => {
@@ -27,6 +28,34 @@ export default function LoginPage() {
         .catch(() => {});
     }
   }, [isDev]);
+
+  useEffect(() => {
+    const inviteToken = new URLSearchParams(window.location.search).get(
+      "inviteToken"
+    );
+    if (!inviteToken) return;
+
+    fetch(`/api/team/invite?token=${encodeURIComponent(inviteToken)}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data?.valid && data?.invite?.email) {
+          const expiresAt = data.invite.expiresAt
+            ? new Date(data.invite.expiresAt).toLocaleString()
+            : null;
+          setInviteMessage(
+            expiresAt
+              ? `Invite accepted for ${data.invite.email}. Link expires ${expiresAt}.`
+              : `Invite accepted for ${data.invite.email}.`
+          );
+          setSelectedEmail(data.invite.email);
+          return;
+        }
+        setInviteMessage(data?.error || "Invite link is invalid or expired.");
+      })
+      .catch(() => {
+        setInviteMessage("Invite link is invalid or expired.");
+      });
+  }, []);
 
   const handleDevLogin = async () => {
     if (!selectedEmail) return;
@@ -47,6 +76,12 @@ export default function LoginPage() {
             Kanban task management with WIP limits
           </p>
         </div>
+
+        {inviteMessage && (
+          <div className="rounded-lg border border-amber-700/40 bg-amber-950/30 px-3 py-2 text-xs text-amber-200">
+            {inviteMessage}
+          </div>
+        )}
 
         {/* Google OAuth */}
         <button

--- a/src/app/api/board-settings/route.ts
+++ b/src/app/api/board-settings/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { enforcePermission } from "@/lib/permissions";
+import { recordSecurityAuditEvent } from "@/lib/security-audit";
 
 export async function GET(): Promise<NextResponse> {
   try {
@@ -37,6 +39,16 @@ export async function PUT(request: NextRequest): Promise<NextResponse> {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "board.write",
+      request,
+      targetType: "board_settings",
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
+    }
+
     const body: BoardSettingInput[] = await request.json();
 
     if (!Array.isArray(body) || body.length === 0) {
@@ -64,6 +76,18 @@ export async function PUT(request: NextRequest): Promise<NextResponse> {
         }),
       ),
     );
+
+    await recordSecurityAuditEvent({
+      action: "board.settings.update",
+      category: "board",
+      outcome: "ALLOWED",
+      actorId: session.user.id,
+      actorRole: permission.role,
+      request,
+      details: {
+        updatedColumns: settings.map((setting) => setting.columnName),
+      },
+    });
 
     return NextResponse.json(settings);
   } catch (error) {

--- a/src/app/api/policy/override/route.ts
+++ b/src/app/api/policy/override/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { getUserRole, enforcePolicy, recordPolicyOverride } from "@/lib/policy-check";
+import { enforcePermission } from "@/lib/permissions";
+import { recordSecurityAuditEvent } from "@/lib/security-audit";
 import type { TaskStatus } from "@/generated/prisma/client";
 
 interface OverrideInput {
@@ -20,6 +22,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const session = await auth();
     if (!session?.user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "policy.override",
+      request,
+      targetType: "policy_override",
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
     }
 
     const body: OverrideInput = await request.json();
@@ -59,6 +71,21 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       column: task.status,
       wipCount: policyResult.currentCount,
       wipLimit: policyResult.wipLimit,
+    });
+
+    await recordSecurityAuditEvent({
+      action: "policy.override",
+      category: "policy",
+      outcome: "ALLOWED",
+      actorId: session.user.id,
+      actorRole: permission.role,
+      targetType: "task",
+      targetId: body.taskId,
+      request,
+      details: {
+        column: task.status,
+        action: body.action,
+      },
     });
 
     return NextResponse.json(override, { status: 201 });

--- a/src/app/api/policy/route.ts
+++ b/src/app/api/policy/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@/lib/auth";
-import { getUserRole } from "@/lib/policy-check";
+import { enforcePermission } from "@/lib/permissions";
+import { recordSecurityAuditEvent } from "@/lib/security-audit";
 import type { EnforcementMode } from "@/generated/prisma/enums";
 
 /**
@@ -46,12 +47,14 @@ export async function PUT(request: NextRequest): Promise<NextResponse> {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const userRole = await getUserRole(session.user.id);
-    if (userRole !== "admin") {
-      return NextResponse.json(
-        { error: "Forbidden: admin role required" },
-        { status: 403 }
-      );
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "policy.write",
+      request,
+      targetType: "wip_policy",
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
     }
 
     const body = await request.json();
@@ -99,6 +102,18 @@ export async function PUT(request: NextRequest): Promise<NextResponse> {
         })
       )
     );
+
+    await recordSecurityAuditEvent({
+      action: "policy.update",
+      category: "policy",
+      outcome: "ALLOWED",
+      actorId: session.user.id,
+      actorRole: permission.role,
+      request,
+      details: {
+        updatedColumns: policies.map((policy) => policy.columnName),
+      },
+    });
 
     return NextResponse.json(policies);
   } catch (error) {

--- a/src/app/api/priorities/[id]/route.ts
+++ b/src/app/api/priorities/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { enforcePermission } from "@/lib/permissions";
 
 const USER_SELECT = {
   id: true,
@@ -18,8 +19,18 @@ export async function PATCH(
     if (!session?.user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
-
     const { id } = await params;
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "priority.write",
+      request,
+      targetType: "priority",
+      targetId: id,
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
+    }
     const body = await request.json();
     const {
       name,

--- a/src/app/api/priorities/route.ts
+++ b/src/app/api/priorities/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { enforcePermission } from "@/lib/permissions";
 
 const USER_SELECT = {
   id: true,
@@ -42,6 +43,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const session = await auth();
     if (!session?.user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "priority.write",
+      request,
+      targetType: "priority",
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
     }
 
     const body = await request.json();

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { enforcePermission } from "@/lib/permissions";
 
 export async function GET(): Promise<NextResponse> {
   try {
@@ -40,6 +41,17 @@ export async function PATCH(request: NextRequest): Promise<NextResponse> {
     const session = await auth();
     if (!session?.user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "profile.write",
+      request,
+      targetType: "profile",
+      targetId: session.user.id,
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
     }
 
     const body = await request.json();

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { enforcePermission } from "@/lib/permissions";
 
 const USER_SELECT = {
   id: true,
@@ -18,8 +19,19 @@ export async function PATCH(
     if (!session?.user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
-
     const { id } = await params;
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "project.write",
+      request,
+      targetType: "project",
+      targetId: id,
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
+    }
+
     const body = await request.json();
     const {
       name,

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { enforcePermission } from "@/lib/permissions";
 
 const USER_SELECT = {
   id: true,
@@ -44,6 +45,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const session = await auth();
     if (!session?.user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "project.write",
+      request,
+      targetType: "project",
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
     }
 
     const body = await request.json();

--- a/src/app/api/security/audit/route.ts
+++ b/src/app/api/security/audit/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { enforcePermission } from "@/lib/permissions";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "policy.write",
+      request,
+      targetType: "security_audit",
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
+    }
+
+    const { searchParams } = request.nextUrl;
+    const category = searchParams.get("category") || undefined;
+    const action = searchParams.get("action") || undefined;
+    const outcome = searchParams.get("outcome") || undefined;
+    const actorId = searchParams.get("actorId") || undefined;
+    const limit = Math.max(
+      1,
+      Math.min(200, Number.parseInt(searchParams.get("limit") ?? "50", 10) || 50)
+    );
+
+    const events = await prisma.securityAuditEvent.findMany({
+      where: {
+        ...(category ? { category } : {}),
+        ...(action ? { action } : {}),
+        ...(outcome ? { outcome } : {}),
+        ...(actorId ? { actorId } : {}),
+      },
+      include: {
+        actor: {
+          select: { id: true, name: true, email: true, role: true },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+    });
+
+    return NextResponse.json({
+      events,
+      count: events.length,
+    });
+  } catch (error) {
+    console.error("GET /api/security/audit error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch security audit events" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/sprints/[id]/route.ts
+++ b/src/app/api/sprints/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { enforcePermission } from "@/lib/permissions";
 
 export async function PATCH(
   request: NextRequest,
@@ -11,8 +12,19 @@ export async function PATCH(
     if (!session?.user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
-
     const { id } = await params;
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "sprint.write",
+      request,
+      targetType: "sprint",
+      targetId: id,
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
+    }
+
     const body = await request.json();
     const { name, startDate, endDate, isActive } = body;
 

--- a/src/app/api/sprints/route.ts
+++ b/src/app/api/sprints/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { enforcePermission } from "@/lib/permissions";
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
@@ -38,6 +39,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const session = await auth();
     if (!session?.user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "sprint.write",
+      request,
+      targetType: "sprint",
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
     }
 
     const body = await request.json();

--- a/src/app/api/tasks/[id]/advance/route.ts
+++ b/src/app/api/tasks/[id]/advance/route.ts
@@ -4,6 +4,7 @@ import { auth } from "@/lib/auth";
 import { TaskStatus } from "@/generated/prisma/client";
 import { enforcePolicy, getUserRole, recordPolicyOverride } from "@/lib/policy-check";
 import { compactColumns, getNextColumnOrder } from "@/lib/task-order";
+import { enforcePermission } from "@/lib/permissions";
 
 const STATUS_FLOW: Partial<Record<TaskStatus, TaskStatus>> = {
   BACKLOG: "QUEUED",
@@ -25,6 +26,17 @@ export async function POST(
     }
 
     const { id } = await params;
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "task.transition",
+      request,
+      targetType: "task",
+      targetId: id,
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
+    }
 
     const existing = await prisma.task.findUnique({
       where: { id },

--- a/src/app/api/tasks/[id]/retreat/route.ts
+++ b/src/app/api/tasks/[id]/retreat/route.ts
@@ -4,6 +4,7 @@ import { auth } from "@/lib/auth";
 import { TaskStatus } from "@/generated/prisma/client";
 import { enforcePolicy, getUserRole, recordPolicyOverride } from "@/lib/policy-check";
 import { compactColumns, getNextColumnOrder } from "@/lib/task-order";
+import { enforcePermission } from "@/lib/permissions";
 
 const STATUS_BACK: Partial<Record<TaskStatus, TaskStatus>> = {
   QUEUED: "BACKLOG",
@@ -26,6 +27,17 @@ export async function POST(
     }
 
     const { id } = await params;
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "task.transition",
+      request,
+      targetType: "task",
+      targetId: id,
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
+    }
 
     const existing = await prisma.task.findUnique({ where: { id } });
 

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -4,6 +4,7 @@ import { auth } from "@/lib/auth";
 import { emitBoardEvent } from "@/lib/socket-emit";
 import { enforcePolicy, getUserRole, recordPolicyOverride } from "@/lib/policy-check";
 import { compactColumns, getNextColumnOrder } from "@/lib/task-order";
+import { enforcePermission } from "@/lib/permissions";
 import type { TaskStatus } from "@/generated/prisma/client";
 
 const TASK_INCLUDE = {
@@ -68,6 +69,18 @@ export async function PATCH(
     }
 
     const { id } = await params;
+
+    const writePermission = await enforcePermission({
+      userId: session.user.id,
+      action: "task.write",
+      request,
+      targetType: "task",
+      targetId: id,
+    });
+    if (writePermission.deniedResponse) {
+      return writePermission.deniedResponse;
+    }
+
     const body = await request.json();
 
     const existing = await prisma.task.findUnique({
@@ -129,6 +142,19 @@ export async function PATCH(
     const statusChanged =
       directFields.status && directFields.status !== existing.status;
     const movingToDone = statusChanged && directFields.status === "DONE";
+
+    if (statusChanged) {
+      const transitionPermission = await enforcePermission({
+        userId: session.user.id,
+        action: "task.transition",
+        request,
+        targetType: "task",
+        targetId: id,
+      });
+      if (transitionPermission.deniedResponse) {
+        return transitionPermission.deniedResponse;
+      }
+    }
 
     // ── WIP policy enforcement on status change ──
     if (statusChanged) {
@@ -284,7 +310,7 @@ export async function PATCH(
 }
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: RouteParams
 ): Promise<NextResponse> {
   try {
@@ -294,6 +320,17 @@ export async function DELETE(
     }
 
     const { id } = await params;
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "task.write",
+      request,
+      targetType: "task",
+      targetId: id,
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
+    }
 
     const existing = await prisma.task.findUnique({ where: { id } });
     if (!existing) {

--- a/src/app/api/tasks/reorder/route.ts
+++ b/src/app/api/tasks/reorder/route.ts
@@ -4,6 +4,7 @@ import { auth } from "@/lib/auth";
 import { emitBoardEvent } from "@/lib/socket-emit";
 import { loadPolicies, getUserRole, recordPolicyOverride } from "@/lib/policy-check";
 import { checkWipPolicy } from "@/lib/policy-engine";
+import { enforcePermission } from "@/lib/permissions";
 import type { TaskStatus } from "@/generated/prisma/client";
 
 interface ReorderItem {
@@ -44,6 +45,16 @@ export async function PATCH(request: NextRequest): Promise<NextResponse> {
     const session = await auth();
     if (!session?.user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "task.transition",
+      request,
+      targetType: "task_reorder",
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
     }
 
     const body = await request.json();

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { emitBoardEvent } from "@/lib/socket-emit";
 import { getNextColumnOrder } from "@/lib/task-order";
+import { enforcePermission } from "@/lib/permissions";
 
 const TASK_INCLUDE = {
   project: true,
@@ -67,6 +68,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const session = await auth();
     if (!session?.user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "task.write",
+      request,
+      targetType: "task",
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
     }
 
     const body = await request.json();

--- a/src/app/api/team/invite/route.ts
+++ b/src/app/api/team/invite/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
+import { enforcePermission } from "@/lib/permissions";
+import { createInviteToken, verifyInviteToken } from "@/lib/invite-token";
+import { recordSecurityAuditEvent } from "@/lib/security-audit";
 
 /**
  * POST /api/team/invite
@@ -15,6 +18,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "team.invite",
+      request,
+      targetType: "team_invite",
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
+    }
+
     const { email } = await request.json();
 
     if (!email || typeof email !== "string" || !email.includes("@")) {
@@ -24,20 +37,81 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       );
     }
 
-    // Build the invite URL (Phase 1: login page with hint)
+    const normalizedEmail = email.trim().toLowerCase();
+    const ttlSeconds = Number.parseInt(
+      process.env.INVITE_TOKEN_TTL_SECONDS ?? "",
+      10
+    );
+    const { token, expiresAt } = createInviteToken({
+      email: normalizedEmail,
+      inviterId: session.user.id,
+      ttlSeconds: Number.isFinite(ttlSeconds) && ttlSeconds > 0 ? ttlSeconds : undefined,
+    });
+
+    // Build a signed, expiring invite URL
     const baseUrl = process.env.NEXTAUTH_URL || "http://localhost:3000";
-    const inviteUrl = `${baseUrl}/login?invited=true&email=${encodeURIComponent(email)}`;
+    const inviteUrl = `${baseUrl}/login?inviteToken=${encodeURIComponent(token)}`;
+
+    await recordSecurityAuditEvent({
+      action: "team.invite.create",
+      category: "team",
+      outcome: "ALLOWED",
+      actorId: session.user.id,
+      actorRole: permission.role,
+      targetType: "invite",
+      targetId: normalizedEmail,
+      request,
+      details: {
+        expiresAt,
+      },
+    });
 
     return NextResponse.json({
       success: true,
       inviteUrl,
-      message: `Invite link generated for ${email}. In Phase 2 an email will be sent automatically.`,
+      invitee: normalizedEmail,
+      expiresAt,
+      message: `Invite link generated for ${normalizedEmail}. In Phase 2 an email will be sent automatically.`,
     });
   } catch (error) {
     console.error("POST /api/team/invite error:", error);
     return NextResponse.json(
       { error: "Failed to create invite" },
       { status: 500 },
+    );
+  }
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const token = request.nextUrl.searchParams.get("token");
+    if (!token) {
+      return NextResponse.json(
+        { error: "Invite token is required" },
+        { status: 400 }
+      );
+    }
+
+    const verification = verifyInviteToken(token);
+    if (!verification.valid || !verification.claims) {
+      return NextResponse.json(
+        {
+          valid: false,
+          error: verification.error || "Invalid invite token",
+        },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json({
+      valid: true,
+      invite: verification.claims,
+    });
+  } catch (error) {
+    console.error("GET /api/team/invite error:", error);
+    return NextResponse.json(
+      { error: "Failed to verify invite token" },
+      { status: 500 }
     );
   }
 }

--- a/src/app/api/team/route.ts
+++ b/src/app/api/team/route.ts
@@ -1,6 +1,8 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { enforcePermission, normalizeRole } from "@/lib/permissions";
+import { recordSecurityAuditEvent } from "@/lib/security-audit";
 
 export async function GET(): Promise<NextResponse> {
   try {
@@ -27,6 +29,69 @@ export async function GET(): Promise<NextResponse> {
     return NextResponse.json(
       { error: "Failed to fetch team members" },
       { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "team.role.write",
+      request,
+      targetType: "user_role",
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
+    }
+
+    const body = (await request.json()) as { userId?: string; role?: string };
+    if (!body.userId || !body.role) {
+      return NextResponse.json(
+        { error: "userId and role are required" },
+        { status: 400 }
+      );
+    }
+
+    const role = normalizeRole(body.role);
+
+    const updatedUser = await prisma.user.update({
+      where: { id: body.userId },
+      data: { role },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        image: true,
+        role: true,
+        createdAt: true,
+      },
+    });
+
+    await recordSecurityAuditEvent({
+      action: "team.role.update",
+      category: "authorization",
+      outcome: "ALLOWED",
+      actorId: session.user.id,
+      actorRole: permission.role,
+      targetType: "user",
+      targetId: updatedUser.id,
+      details: {
+        newRole: role,
+      },
+    });
+
+    return NextResponse.json(updatedUser);
+  } catch (error) {
+    console.error("Failed to update team member role:", error);
+    return NextResponse.json(
+      { error: "Failed to update team member role" },
+      { status: 500 }
     );
   }
 }

--- a/src/components/settings/team-tab.tsx
+++ b/src/components/settings/team-tab.tsx
@@ -33,12 +33,14 @@ export function TeamTab() {
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteLink, setInviteLink] = useState<string | null>(null);
   const [inviting, setInviting] = useState(false);
+  const [inviteError, setInviteError] = useState<string | null>(null);
   const [inviteCopied, setInviteCopied] = useState(false);
 
   // Profile form
   const [profileName, setProfileName] = useState("");
   const [savingProfile, setSavingProfile] = useState(false);
   const [profileSaved, setProfileSaved] = useState(false);
+  const canInvite = session?.user?.role === "admin";
 
   const fetchMembers = useCallback(async () => {
     try {
@@ -80,6 +82,7 @@ export function TeamTab() {
     if (!inviteEmail.trim()) return;
     setInviting(true);
     setInviteLink(null);
+    setInviteError(null);
     try {
       const res = await fetch("/api/team/invite", {
         method: "POST",
@@ -90,9 +93,12 @@ export function TeamTab() {
         const data = await res.json();
         setInviteLink(data.inviteUrl);
         setInviteEmail("");
+      } else {
+        const data = await res.json().catch(() => null);
+        setInviteError(data?.error || "Could not create invite link.");
       }
     } catch {
-      // silently handle
+      setInviteError("Could not create invite link.");
     } finally {
       setInviting(false);
     }
@@ -242,29 +248,37 @@ export function TeamTab() {
         </div>
 
         {/* ── Email invite form ── */}
-        <div className="rounded-lg border border-zinc-800 bg-zinc-900/30 p-4 space-y-3">
+        <div className="space-y-3 rounded-lg border border-zinc-800 bg-zinc-900/30 p-4">
           <div className="flex items-center gap-2 text-xs font-medium text-zinc-400">
             <UserPlus className="h-4 w-4" />
             Invite by Email
           </div>
-          <div className="flex gap-2">
-            <input
-              type="email"
-              value={inviteEmail}
-              onChange={(e) => setInviteEmail(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && handleInvite()}
-              placeholder="teammate@company.com"
-              className="flex-1 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-200 placeholder-zinc-600 focus:border-amber-600 focus:outline-none"
-            />
-            <button
-              onClick={handleInvite}
-              disabled={inviting || !inviteEmail.trim()}
-              className="flex items-center gap-1.5 rounded-md bg-amber-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <Send className="h-3.5 w-3.5" />
-              {inviting ? "Sending…" : "Invite"}
-            </button>
-          </div>
+          {canInvite ? (
+            <div className="flex gap-2">
+              <input
+                type="email"
+                value={inviteEmail}
+                onChange={(e) => setInviteEmail(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleInvite()}
+                placeholder="teammate@company.com"
+                className="flex-1 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-200 placeholder-zinc-600 focus:border-amber-600 focus:outline-none"
+              />
+              <button
+                onClick={handleInvite}
+                disabled={inviting || !inviteEmail.trim()}
+                className="flex items-center gap-1.5 rounded-md bg-amber-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <Send className="h-3.5 w-3.5" />
+                {inviting ? "Sending…" : "Invite"}
+              </button>
+            </div>
+          ) : (
+            <p className="rounded-md border border-zinc-700 bg-zinc-900/50 px-3 py-2 text-xs text-zinc-500">
+              Only admins can generate invite links.
+            </p>
+          )}
+
+          {inviteError && <p className="text-xs text-red-400">{inviteError}</p>}
 
           {inviteLink && (
             <div className="flex items-center gap-2 rounded-md border border-zinc-700 bg-zinc-800/50 px-3 py-2">

--- a/src/lib/__tests__/invite-token.test.ts
+++ b/src/lib/__tests__/invite-token.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createInviteToken, verifyInviteToken } from "@/lib/invite-token";
+
+describe("invite-token", () => {
+  beforeEach(() => {
+    process.env.NEXTAUTH_SECRET = "test-secret";
+    delete process.env.INVITE_TOKEN_SECRET;
+  });
+
+  it("creates and verifies a signed token", () => {
+    const { token } = createInviteToken({
+      email: "new.user@example.com",
+      inviterId: "user_123",
+      ttlSeconds: 3600,
+    });
+
+    const verification = verifyInviteToken(token);
+
+    expect(verification.valid).toBe(true);
+    expect(verification.claims?.email).toBe("new.user@example.com");
+    expect(verification.claims?.inviterId).toBe("user_123");
+    expect(typeof verification.claims?.expiresAt).toBe("string");
+  });
+
+  it("rejects expired tokens", () => {
+    const { token } = createInviteToken({
+      email: "new.user@example.com",
+      inviterId: "user_123",
+      ttlSeconds: 0,
+    });
+
+    const verification = verifyInviteToken(token);
+
+    expect(verification.valid).toBe(false);
+    expect(verification.error).toContain("expired");
+  });
+
+  it("rejects tampered token signatures", () => {
+    const { token } = createInviteToken({
+      email: "new.user@example.com",
+      inviterId: "user_123",
+      ttlSeconds: 3600,
+    });
+    const [payload] = token.split(".");
+    const tampered = `${payload}.tampered`;
+
+    const verification = verifyInviteToken(tampered);
+
+    expect(verification.valid).toBe(false);
+    expect(verification.error).toContain("signature");
+  });
+});

--- a/src/lib/__tests__/permissions.test.ts
+++ b/src/lib/__tests__/permissions.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { can, normalizeRole } from "@/lib/permissions";
+
+describe("permissions", () => {
+  it("normalizes unknown roles to member", () => {
+    expect(normalizeRole("ADMIN")).toBe("admin");
+    expect(normalizeRole("observer")).toBe("observer");
+    expect(normalizeRole("something-else")).toBe("member");
+    expect(normalizeRole(undefined)).toBe("member");
+  });
+
+  it("allows admin privileged actions", () => {
+    expect(can("admin", "policy.write")).toBe(true);
+    expect(can("admin", "team.role.write")).toBe(true);
+    expect(can("admin", "team.invite")).toBe(true);
+  });
+
+  it("blocks observer task transitions and policy mutations", () => {
+    expect(can("observer", "task.transition")).toBe(false);
+    expect(can("observer", "task.write")).toBe(false);
+    expect(can("observer", "policy.write")).toBe(false);
+  });
+
+  it("allows members to mutate delivery flow but not privileged controls", () => {
+    expect(can("member", "task.transition")).toBe(true);
+    expect(can("member", "project.write")).toBe(true);
+    expect(can("member", "policy.write")).toBe(false);
+    expect(can("member", "team.role.write")).toBe(false);
+    expect(can("member", "team.invite")).toBe(false);
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,6 +4,8 @@ import GoogleProvider from "next-auth/providers/google";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { prisma } from "./prisma";
+import { normalizeRole } from "@/lib/permissions";
+import { recordSecurityAuditEvent } from "@/lib/security-audit";
 
 const providers: NextAuthOptions["providers"] = [];
 
@@ -41,17 +43,79 @@ export const authOptions: NextAuthOptions = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   adapter: PrismaAdapter(prisma as any) as any,
   providers,
-  session: { strategy: "jwt" },
+  session: {
+    strategy: "jwt",
+    maxAge: 60 * 60 * 8,
+    updateAge: 60 * 60,
+  },
+  jwt: {
+    maxAge: 60 * 60 * 8,
+  },
   callbacks: {
-    async jwt({ token, user }) {
+    async signIn({ user, account }) {
+      // Hygiene check: reject sign-ins that arrive with already expired OAuth tokens.
+      if (
+        account?.provider &&
+        account.provider !== "credentials" &&
+        typeof account.expires_at === "number" &&
+        account.expires_at <= Math.floor(Date.now() / 1000)
+      ) {
+        await recordSecurityAuditEvent({
+          action: "auth.signin",
+          category: "auth",
+          outcome: "DENIED",
+          actorId: user.id,
+          details: {
+            reason: "OAUTH_ACCESS_TOKEN_ALREADY_EXPIRED",
+            provider: account.provider,
+            expiresAt: account.expires_at,
+          },
+        });
+        return false;
+      }
+      return true;
+    },
+    async jwt({ token, user, account }) {
       if (user) {
         token.id = user.id;
       }
+
+      if (token.id) {
+        const dbUser = await prisma.user.findUnique({
+          where: { id: token.id as string },
+          select: { role: true },
+        });
+        token.role = normalizeRole(dbUser?.role);
+      }
+
+      if (
+        account?.provider &&
+        account.provider !== "credentials" &&
+        typeof account.expires_at === "number"
+      ) {
+        token.oauthExpiresAt = account.expires_at;
+      }
+
+      if (
+        typeof token.oauthExpiresAt === "number" &&
+        token.oauthExpiresAt <= Math.floor(Date.now() / 1000)
+      ) {
+        token.error = "OAUTH_TOKEN_EXPIRED";
+      } else {
+        delete token.error;
+      }
+
       return token;
     },
     async session({ session, token }) {
       if (session.user && token.id) {
         (session.user as { id?: string }).id = token.id as string;
+        (session.user as { role?: string }).role =
+          (token.role as string | undefined) ?? "member";
+      }
+
+      if (token.error) {
+        (session as { error?: string }).error = token.error as string;
       }
       return session;
     },

--- a/src/lib/invite-token.ts
+++ b/src/lib/invite-token.ts
@@ -1,0 +1,115 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+interface InviteTokenPayload {
+  email: string;
+  inviterId: string;
+  iat: number;
+  exp: number;
+}
+
+interface InviteTokenClaims {
+  email: string;
+  inviterId: string;
+  issuedAt: string;
+  expiresAt: string;
+}
+
+function encodeBase64Url(input: string): string {
+  return Buffer.from(input, "utf8").toString("base64url");
+}
+
+function decodeBase64Url(input: string): string {
+  return Buffer.from(input, "base64url").toString("utf8");
+}
+
+function getInviteSigningSecret(): string {
+  const secret =
+    process.env.INVITE_TOKEN_SECRET || process.env.NEXTAUTH_SECRET || "";
+  if (!secret) {
+    throw new Error("INVITE_TOKEN_SECRET (or NEXTAUTH_SECRET) is required");
+  }
+  return secret;
+}
+
+function signPayload(encodedPayload: string, secret: string): string {
+  return createHmac("sha256", secret).update(encodedPayload).digest("base64url");
+}
+
+export function createInviteToken(params: {
+  email: string;
+  inviterId: string;
+  ttlSeconds?: number;
+}): { token: string; expiresAt: string } {
+  const ttlSeconds = params.ttlSeconds ?? 60 * 60 * 72;
+  const nowSeconds = Math.floor(Date.now() / 1000);
+
+  const payload: InviteTokenPayload = {
+    email: params.email,
+    inviterId: params.inviterId,
+    iat: nowSeconds,
+    exp: nowSeconds + ttlSeconds,
+  };
+
+  const encodedPayload = encodeBase64Url(JSON.stringify(payload));
+  const signature = signPayload(encodedPayload, getInviteSigningSecret());
+  return {
+    token: `${encodedPayload}.${signature}`,
+    expiresAt: new Date(payload.exp * 1000).toISOString(),
+  };
+}
+
+export function verifyInviteToken(token: string): {
+  valid: boolean;
+  claims?: InviteTokenClaims;
+  error?: string;
+} {
+  if (!token || typeof token !== "string") {
+    return { valid: false, error: "Missing invite token" };
+  }
+
+  const [encodedPayload, providedSignature] = token.split(".");
+  if (!encodedPayload || !providedSignature) {
+    return { valid: false, error: "Malformed invite token" };
+  }
+
+  let expectedSignature: string;
+  try {
+    expectedSignature = signPayload(encodedPayload, getInviteSigningSecret());
+  } catch {
+    return { valid: false, error: "Invite token signing secret is not configured" };
+  }
+  const expectedBuffer = Buffer.from(expectedSignature);
+  const providedBuffer = Buffer.from(providedSignature);
+  if (
+    expectedBuffer.length !== providedBuffer.length ||
+    !timingSafeEqual(expectedBuffer, providedBuffer)
+  ) {
+    return { valid: false, error: "Invalid invite token signature" };
+  }
+
+  let payload: InviteTokenPayload;
+  try {
+    payload = JSON.parse(decodeBase64Url(encodedPayload)) as InviteTokenPayload;
+  } catch {
+    return { valid: false, error: "Invalid invite token payload" };
+  }
+
+  if (!payload.email || !payload.inviterId || !payload.exp || !payload.iat) {
+    return { valid: false, error: "Invite token payload incomplete" };
+  }
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (payload.exp <= nowSeconds) {
+    return { valid: false, error: "Invite token has expired" };
+  }
+
+  return {
+    valid: true,
+    claims: {
+      email: payload.email,
+      inviterId: payload.inviterId,
+      issuedAt: new Date(payload.iat * 1000).toISOString(),
+      expiresAt: new Date(payload.exp * 1000).toISOString(),
+    },
+  };
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,0 +1,112 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { recordSecurityAuditEvent } from "@/lib/security-audit";
+
+export type AppRole = "admin" | "member" | "observer";
+
+export type PermissionAction =
+  | "board.write"
+  | "task.write"
+  | "task.transition"
+  | "project.write"
+  | "sprint.write"
+  | "priority.write"
+  | "policy.write"
+  | "policy.override"
+  | "team.invite"
+  | "team.role.write"
+  | "profile.write";
+
+const PERMISSION_MATRIX: Readonly<Record<AppRole, readonly PermissionAction[]>> =
+  {
+    admin: [
+      "board.write",
+      "task.write",
+      "task.transition",
+      "project.write",
+      "sprint.write",
+      "priority.write",
+      "policy.write",
+      "policy.override",
+      "team.invite",
+      "team.role.write",
+      "profile.write",
+    ],
+    member: [
+      "board.write",
+      "task.write",
+      "task.transition",
+      "project.write",
+      "sprint.write",
+      "priority.write",
+      "policy.override",
+      "profile.write",
+    ],
+    observer: ["profile.write"],
+  };
+
+export function normalizeRole(role: string | null | undefined): AppRole {
+  const normalized = (role ?? "member").trim().toLowerCase();
+  if (normalized === "admin") return "admin";
+  if (normalized === "observer") return "observer";
+  return "member";
+}
+
+export async function getAppRole(userId: string): Promise<AppRole> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { role: true },
+  });
+  return normalizeRole(user?.role);
+}
+
+export function can(role: AppRole, action: PermissionAction): boolean {
+  return PERMISSION_MATRIX[role].includes(action);
+}
+
+interface EnforcePermissionInput {
+  userId: string;
+  action: PermissionAction;
+  request: NextRequest;
+  targetType?: string;
+  targetId?: string;
+}
+
+interface PermissionResult {
+  role: AppRole;
+  deniedResponse?: NextResponse;
+}
+
+export async function enforcePermission(
+  input: EnforcePermissionInput
+): Promise<PermissionResult> {
+  const role = await getAppRole(input.userId);
+  if (can(role, input.action)) {
+    return { role };
+  }
+
+  await recordSecurityAuditEvent({
+    action: input.action,
+    category: "authorization",
+    outcome: "DENIED",
+    actorId: input.userId,
+    actorRole: role,
+    targetType: input.targetType ?? null,
+    targetId: input.targetId ?? null,
+    request: input.request,
+    details: {
+      reason: "ROLE_FORBIDDEN",
+      requiredAction: input.action,
+      role,
+    },
+  });
+
+  return {
+    role,
+    deniedResponse: NextResponse.json(
+      { error: "Forbidden: insufficient permissions" },
+      { status: 403 }
+    ),
+  };
+}

--- a/src/lib/security-audit.ts
+++ b/src/lib/security-audit.ts
@@ -1,0 +1,54 @@
+import type { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import type { Prisma } from "@/generated/prisma/client";
+
+export type SecurityAuditOutcome = "ALLOWED" | "DENIED" | "ERROR";
+
+interface SecurityAuditEventInput {
+  action: string;
+  category: string;
+  outcome: SecurityAuditOutcome;
+  actorId?: string | null;
+  actorRole?: string | null;
+  targetType?: string | null;
+  targetId?: string | null;
+  details?: unknown;
+  request?: NextRequest | null;
+}
+
+function extractIpAddress(request?: NextRequest | null): string | null {
+  if (!request) return null;
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) {
+    const first = forwarded.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  const realIp = request.headers.get("x-real-ip");
+  return realIp?.trim() || null;
+}
+
+export async function recordSecurityAuditEvent(
+  input: SecurityAuditEventInput
+): Promise<void> {
+  try {
+    await prisma.securityAuditEvent.create({
+      data: {
+        action: input.action,
+        category: input.category,
+        outcome: input.outcome,
+        actorId: input.actorId ?? null,
+        actorRole: input.actorRole ?? null,
+        targetType: input.targetType ?? null,
+        targetId: input.targetId ?? null,
+        details:
+          input.details === undefined
+            ? undefined
+            : (input.details as Prisma.InputJsonValue),
+        ipAddress: extractIpAddress(input.request),
+        userAgent: input.request?.headers.get("user-agent") ?? null,
+      },
+    });
+  } catch (error) {
+    console.error("Failed to record security audit event:", error);
+  }
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -4,15 +4,20 @@ declare module "next-auth" {
   interface Session {
     user: {
       id: string;
+      role?: string;
       name?: string | null;
       email?: string | null;
       image?: string | null;
     };
+    error?: string;
   }
 }
 
 declare module "next-auth/jwt" {
   interface JWT {
     id?: string;
+    role?: string;
+    oauthExpiresAt?: number;
+    error?: string;
   }
 }


### PR DESCRIPTION
## Summary
- add a role-based permission matrix (`admin`, `member`, `observer`) with explicit mutation allow-list and default-deny behavior
- enforce authorization checks across all mutating API endpoints (tasks, board settings, projects, sprints, priorities, policy, team invite/role, profile)
- harden invite flow with signed, expiring invite tokens and verification endpoint
- add a persistent security audit event model + migration and a secured `/api/security/audit` endpoint
- add audit logging for privileged operations (policy updates, invite creation, role changes) and denied authorization attempts
- tighten session and OAuth hygiene in NextAuth callbacks/session config
- add unit tests for invite token signing/verification and permission matrix behavior

## Validation
- `npm run lint`
- `npm test`
- `npm run build`

Closes #17