### PR TITLE
feat(#13): add dense card presets and keyboard triage navigation

### DIFF
--- a/src/components/board/kanban-board.tsx
+++ b/src/components/board/kanban-board.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type KeyboardEvent } from "react";
 import {
   DragDropContext,
   type DropResult,
@@ -11,14 +11,24 @@ import { TaskModal } from "../tasks/task-modal";
 import { BoardFilters } from "./board-filters";
 import type { TaskStatus, TaskWithRelations, BoardColumn } from "@/types";
 import { COLUMN_ORDER, COLUMN_LABELS } from "@/types";
-import { Plus } from "lucide-react";
+import { Eye, EyeOff, Keyboard, Plus } from "lucide-react";
+import { useSession } from "next-auth/react";
 
 interface KanbanBoardProps {
   filterByUser?: string;
   filterByStatus?: TaskStatus[];
 }
 
+type DisplayPreset = "standard" | "dense" | "triage";
+
+const PRESET_DEFAULTS: Record<DisplayPreset, { showMetadata: boolean }> = {
+  standard: { showMetadata: true },
+  dense: { showMetadata: false },
+  triage: { showMetadata: false },
+};
+
 export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) {
+  const { data: session } = useSession();
   const {
     columns,
     setColumns,
@@ -39,6 +49,9 @@ export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) 
   } = useBoardStore();
 
   const [loading, setLoading] = useState(true);
+  const [displayPreset, setDisplayPreset] = useState<DisplayPreset>("standard");
+  const [showMetadata, setShowMetadata] = useState(true);
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
 
   const fetchBoard = useCallback(async () => {
     try {
@@ -121,6 +134,101 @@ export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) 
     fetchBoard();
   }, [fetchBoard]);
 
+  const userPresetKey = session?.user?.id
+    ? `board-display-preset:${session.user.id}`
+    : null;
+
+  useEffect(() => {
+    if (!userPresetKey) return;
+    try {
+      const raw = localStorage.getItem(userPresetKey);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as {
+        preset?: DisplayPreset;
+        showMetadata?: boolean;
+      };
+      if (
+        parsed.preset === "standard" ||
+        parsed.preset === "dense" ||
+        parsed.preset === "triage"
+      ) {
+        setDisplayPreset(parsed.preset);
+      }
+      if (typeof parsed.showMetadata === "boolean") {
+        setShowMetadata(parsed.showMetadata);
+      }
+    } catch {
+      // ignore broken local preference payloads
+    }
+  }, [userPresetKey]);
+
+  useEffect(() => {
+    if (!userPresetKey) return;
+    localStorage.setItem(
+      userPresetKey,
+      JSON.stringify({ preset: displayPreset, showMetadata })
+    );
+  }, [displayPreset, showMetadata, userPresetKey]);
+
+  const visibleTasks = useMemo(
+    () => columns.flatMap((column) => column.tasks.map((task) => ({ task, column }))),
+    [columns]
+  );
+
+  useEffect(() => {
+    if (visibleTasks.length === 0) {
+      setSelectedTaskId(null);
+      return;
+    }
+    if (!selectedTaskId || !visibleTasks.some((entry) => entry.task.id === selectedTaskId)) {
+      setSelectedTaskId(visibleTasks[0]?.task.id ?? null);
+    }
+  }, [selectedTaskId, visibleTasks]);
+
+  const applyPreset = useCallback((preset: DisplayPreset) => {
+    setDisplayPreset(preset);
+    setShowMetadata(PRESET_DEFAULTS[preset].showMetadata);
+  }, []);
+
+  const handleBoardKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      const target = event.target as HTMLElement;
+      const tag = target.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      if (visibleTasks.length === 0) return;
+
+      const currentIndex = selectedTaskId
+        ? visibleTasks.findIndex((entry) => entry.task.id === selectedTaskId)
+        : -1;
+      const safeIndex = currentIndex >= 0 ? currentIndex : 0;
+
+      if (event.key === "j" || event.key === "ArrowDown") {
+        event.preventDefault();
+        const nextIndex = Math.min(safeIndex + 1, visibleTasks.length - 1);
+        setSelectedTaskId(visibleTasks[nextIndex]?.task.id ?? null);
+        return;
+      }
+
+      if (event.key === "k" || event.key === "ArrowUp") {
+        event.preventDefault();
+        const previousIndex = Math.max(safeIndex - 1, 0);
+        setSelectedTaskId(visibleTasks[previousIndex]?.task.id ?? null);
+        return;
+      }
+
+      if (event.key === "Enter") {
+        event.preventDefault();
+        const selected =
+          visibleTasks[safeIndex]?.task ??
+          visibleTasks.find((entry) => entry.task.id === selectedTaskId)?.task;
+        if (selected) {
+          openTaskModal(selected);
+        }
+      }
+    },
+    [openTaskModal, selectedTaskId, visibleTasks]
+  );
+
   const handleDragEnd = useCallback(
     async (result: DropResult) => {
       const { source, destination, draggableId } = result;
@@ -198,34 +306,53 @@ export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) 
   if (loading) {
     return (
       <div className="flex h-full items-center justify-center">
-        <div
-          className="h-8 w-8 animate-spin rounded-full border-2"
-          style={{
-            borderColor: "var(--border)",
-            borderTopColor: "var(--primary)",
-          }}
-        />
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-border border-t-primary" />
       </div>
     );
   }
 
   return (
-    <div className="flex h-full flex-col">
-      <div className="flex items-center justify-between px-6 py-3">
-        <BoardFilters />
+    <div className="flex h-full flex-col" onKeyDown={handleBoardKeyDown} tabIndex={0}>
+      <div className="flex flex-wrap items-center justify-between gap-3 px-6 py-3">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <BoardFilters />
+          <div className="flex items-center gap-2">
+            <select
+              value={displayPreset}
+              onChange={(e) => applyPreset(e.target.value as DisplayPreset)}
+              className="rounded-md border border-border bg-card px-2 py-1 text-xs text-foreground"
+              title="Display preset"
+            >
+              <option value="standard">Standard</option>
+              <option value="dense">Dense</option>
+              <option value="triage">Triage</option>
+            </select>
+            <button
+              onClick={() => setShowMetadata((current) => !current)}
+              className="flex items-center gap-1 rounded-md border border-border bg-card px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+              title="Toggle metadata disclosure"
+            >
+              {showMetadata ? (
+                <>
+                  <EyeOff className="h-3.5 w-3.5" />
+                  Hide Details
+                </>
+              ) : (
+                <>
+                  <Eye className="h-3.5 w-3.5" />
+                  Show Details
+                </>
+              )}
+            </button>
+            <span className="hidden items-center gap-1 text-[11px] text-muted-foreground sm:flex">
+              <Keyboard className="h-3 w-3" />
+              J/K + Enter
+            </span>
+          </div>
+        </div>
         <button
           onClick={handleCreateTask}
-          className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium"
-          style={{
-            background: "var(--primary)",
-            color: "var(--primary-foreground)",
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.background = "var(--primary-hover)";
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.background = "var(--primary)";
-          }}
+          className="btn-primary-theme flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium"
         >
           <Plus className="h-4 w-4" />
           New Task
@@ -242,6 +369,10 @@ export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) 
                 wipLimit={wipLimits[column.id]}
                 onTaskClick={(task) => openTaskModal(task)}
                 onRefresh={fetchBoard}
+                displayPreset={displayPreset}
+                showMetadata={showMetadata}
+                selectedTaskId={selectedTaskId}
+                onSelectTask={setSelectedTaskId}
               />
             ))}
           </div>

--- a/src/components/board/kanban-column.tsx
+++ b/src/components/board/kanban-column.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Droppable } from "@hello-pangea/dnd";
+import { clsx } from "clsx";
 import { TaskCard } from "./task-card";
 import type { BoardColumn, TaskWithRelations } from "@/types";
 
@@ -9,6 +10,10 @@ interface KanbanColumnProps {
   wipLimit: number;
   onTaskClick: (task: TaskWithRelations) => void;
   onRefresh: () => void;
+  displayPreset: "standard" | "dense" | "triage";
+  showMetadata: boolean;
+  selectedTaskId: string | null;
+  onSelectTask: (taskId: string) => void;
 }
 
 export function KanbanColumn({
@@ -16,60 +21,54 @@ export function KanbanColumn({
   wipLimit,
   onTaskClick,
   onRefresh,
+  displayPreset,
+  showMetadata,
+  selectedTaskId,
+  onSelectTask,
 }: KanbanColumnProps) {
   const isOverLimit = wipLimit > 0 && column.tasks.length > wipLimit;
   const isAtLimit = wipLimit > 0 && column.tasks.length === wipLimit;
+  const isCompact = displayPreset !== "standard";
 
   return (
     <div
-      className="flex h-full w-72 min-w-[18rem] flex-col rounded-lg"
-      style={{ background: "var(--column-bg)" }}
+      className={clsx(
+        "flex h-full flex-col rounded-lg bg-column-bg",
+        isCompact ? "w-64 min-w-[16rem]" : "w-72 min-w-[18rem]"
+      )}
     >
       {/* Column header */}
       <div
-        className="flex items-center justify-between rounded-t-lg border-b px-3 py-2.5"
-        style={{
-          borderColor: isOverLimit
-            ? "var(--wip-over-border)"
+        className={clsx(
+          "flex items-center justify-between rounded-t-lg border-b px-3 py-2.5",
+          isOverLimit
+            ? "border-wip-over-border bg-wip-over-bg"
             : isAtLimit
-              ? "var(--wip-at-border)"
-              : "var(--column-border)",
-          background: isOverLimit
-            ? "var(--wip-over-bg)"
-            : isAtLimit
-              ? "var(--wip-at-bg)"
-              : "var(--column-header)",
-        }}
+              ? "border-wip-at-border bg-wip-at-bg"
+              : "border-column-border bg-column-header"
+        )}
       >
         <div className="flex items-center gap-2">
-          <h3
-            className="text-sm font-semibold"
-            style={{ color: "var(--foreground)" }}
-          >
+          <h3 className="text-sm font-semibold text-foreground">
             {column.label}
           </h3>
           <span
-            className="rounded-full px-1.5 py-0.5 text-xs font-medium"
-            style={{
-              background: isOverLimit
-                ? "var(--wip-over-border)"
-                : "var(--tag-bg)",
-              color: isOverLimit
-                ? "var(--wip-over-text)"
-                : "var(--muted-foreground)",
-            }}
+            className={clsx(
+              "rounded-full px-1.5 py-0.5 text-xs font-medium",
+              isOverLimit
+                ? "bg-wip-over-border text-wip-over-text"
+                : "bg-tag-bg text-muted-foreground"
+            )}
           >
             {column.tasks.length}
           </span>
         </div>
         {wipLimit > 0 && (
           <span
-            className="text-xs font-medium"
-            style={{
-              color: isOverLimit
-                ? "var(--wip-over-text)"
-                : "var(--muted-foreground)",
-            }}
+            className={clsx(
+              "text-xs font-medium",
+              isOverLimit ? "text-wip-over-text" : "text-muted-foreground"
+            )}
           >
             WIP: {wipLimit}
           </span>
@@ -82,7 +81,10 @@ export function KanbanColumn({
           <div
             ref={provided.innerRef}
             {...provided.droppableProps}
-            className="flex-1 space-y-2 overflow-y-auto p-2 transition-colors"
+            className={clsx(
+              "flex-1 overflow-y-auto transition-colors",
+              isCompact ? "space-y-1 p-1.5" : "space-y-2 p-2"
+            )}
             style={{
               background: snapshot.isDraggingOver
                 ? "var(--drop-highlight)"
@@ -95,6 +97,10 @@ export function KanbanColumn({
                 task={task}
                 index={index}
                 onClick={() => onTaskClick(task)}
+                onSelect={() => onSelectTask(task.id)}
+                selected={selectedTaskId === task.id}
+                displayPreset={displayPreset}
+                showMetadata={showMetadata}
                 onAdvance={async () => {
                   const response = await fetch(`/api/tasks/${task.id}/advance`, {
                     method: "POST",
@@ -136,10 +142,7 @@ export function KanbanColumn({
             {provided.placeholder}
 
             {column.tasks.length === 0 && !snapshot.isDraggingOver && (
-              <div
-                className="flex h-24 items-center justify-center text-xs"
-                style={{ color: "var(--muted-foreground)" }}
-              >
+              <div className="flex h-24 items-center justify-center text-xs text-muted-foreground">
                 No tasks
               </div>
             )}

--- a/src/components/board/task-card.tsx
+++ b/src/components/board/task-card.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useState } from "react";
 import { Draggable } from "@hello-pangea/dnd";
+import { clsx } from "clsx";
 import {
   ChevronRight,
   ChevronLeft,
@@ -8,6 +10,7 @@ import {
   MessageSquare,
   Link2,
   Gauge,
+  MoreHorizontal,
 } from "lucide-react";
 import type { TaskWithRelations } from "@/types";
 import {
@@ -24,6 +27,10 @@ interface TaskCardProps {
   onClick: () => void;
   onAdvance: () => void;
   onRetreat?: () => void;
+  displayPreset: "standard" | "dense" | "triage";
+  showMetadata: boolean;
+  selected: boolean;
+  onSelect: () => void;
 }
 
 export function TaskCard({
@@ -32,10 +39,17 @@ export function TaskCard({
   onClick,
   onAdvance,
   onRetreat,
+  displayPreset,
+  showMetadata,
+  selected,
+  onSelect,
 }: TaskCardProps) {
   const colIdx = COLUMN_ORDER.indexOf(task.status);
   const canRetreat = colIdx > 0;
   const canAdvance = task.status !== "DONE";
+  const isCompact = displayPreset !== "standard";
+  const [expanded, setExpanded] = useState(false);
+  const revealMetadata = showMetadata || expanded || displayPreset === "standard";
 
   return (
     <Draggable draggableId={task.id} index={index}>
@@ -44,8 +58,39 @@ export function TaskCard({
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
-          onClick={onClick}
-          className="group cursor-pointer rounded-md border p-3 transition-all"
+          tabIndex={0}
+          onClick={() => {
+            onSelect();
+            onClick();
+          }}
+          onFocus={onSelect}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              onSelect();
+              onClick();
+              return;
+            }
+            if (e.key === "ArrowRight" && canAdvance) {
+              e.preventDefault();
+              onAdvance();
+              return;
+            }
+            if (e.key === "ArrowLeft" && canRetreat) {
+              e.preventDefault();
+              onRetreat?.();
+              return;
+            }
+            if (e.key.toLowerCase() === "m") {
+              e.preventDefault();
+              setExpanded((current) => !current);
+            }
+          }}
+          className={clsx(
+            "group cursor-pointer rounded-md border transition-all outline-none",
+            isCompact ? "p-2" : "p-3",
+            selected && "ring-1 ring-primary/70"
+          )}
           style={{
             ...DIFFICULTY_STYLES[task.degreeOfDifficulty],
             borderColor: snapshot.isDragging
@@ -57,6 +102,7 @@ export function TaskCard({
             ...provided.draggableProps.style,
           }}
           onMouseEnter={(e) => {
+            onSelect();
             if (!snapshot.isDragging) {
               e.currentTarget.style.borderColor = "var(--card-hover-border)";
             }
@@ -75,78 +121,76 @@ export function TaskCard({
               title={task.status.replace(/_/g, " ")}
             />
             <h4
-              className="flex-1 text-sm font-medium leading-snug"
-              style={{ color: "var(--foreground)" }}
+              className={clsx(
+                "flex-1 font-medium leading-snug text-foreground",
+                isCompact ? "text-[13px]" : "text-sm"
+              )}
             >
               {task.title}
             </h4>
+            {displayPreset !== "standard" && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setExpanded((current) => !current);
+                }}
+                className="rounded p-0.5 text-muted-foreground hover:bg-tag-bg hover:text-foreground"
+                title={
+                  revealMetadata ? "Hide card metadata (M)" : "Show card metadata (M)"
+                }
+              >
+                <MoreHorizontal className="h-3.5 w-3.5" />
+              </button>
+            )}
           </div>
 
           {/* Tags row: project + difficulty + unplanned */}
-          <div className="mt-2 flex flex-wrap items-center gap-1.5">
-            {task.project && (
+          {revealMetadata && (
+            <div className="mt-2 flex flex-wrap items-center gap-1.5">
+              {task.project && (
+                <span className="rounded bg-tag-bg px-1.5 py-0.5 text-[10px] font-medium text-tag-text">
+                  {task.project.name}
+                </span>
+              )}
               <span
                 className="rounded px-1.5 py-0.5 text-[10px] font-medium"
-                style={{
-                  background: "var(--tag-bg)",
-                  color: "var(--tag-text)",
-                }}
+                style={DIFFICULTY_TAG_STYLES[task.degreeOfDifficulty]}
+                title={`Difficulty: ${DIFFICULTY_LABELS[task.degreeOfDifficulty]}`}
               >
-                {task.project.name}
+                <Gauge className="mr-0.5 inline h-2.5 w-2.5" />
+                {DIFFICULTY_LABELS[task.degreeOfDifficulty]}
               </span>
-            )}
-            <span
-              className="rounded px-1.5 py-0.5 text-[10px] font-medium"
-              style={DIFFICULTY_TAG_STYLES[task.degreeOfDifficulty]}
-              title={`Difficulty: ${DIFFICULTY_LABELS[task.degreeOfDifficulty]}`}
-            >
-              <Gauge className="mr-0.5 inline h-2.5 w-2.5" />
-              {DIFFICULTY_LABELS[task.degreeOfDifficulty]}
-            </span>
-            {task.unplanned && (
-              <span title="Unplanned" className="flex items-center">
-                <AlertTriangle
-                  className="h-3 w-3"
-                  style={{ color: "var(--primary)" }}
-                />
-              </span>
-            )}
-            {task.slackThread && (
-              <span title="Has Slack thread" className="flex items-center">
-                <MessageSquare
-                  className="h-3 w-3"
-                  style={{ color: "var(--muted-foreground)" }}
-                />
-              </span>
-            )}
-            {task.dependsOn && task.dependsOn.length > 0 && (
-              <span
-                title={`Depends on ${task.dependsOn.length} task(s)`}
-                className="flex items-center"
-              >
-                <Link2
-                  className="h-3 w-3"
-                  style={{ color: "var(--muted-foreground)" }}
-                />
-              </span>
-            )}
-          </div>
+              {task.unplanned && (
+                <span title="Unplanned" className="flex items-center">
+                  <AlertTriangle className="h-3 w-3 text-primary" />
+                </span>
+              )}
+              {task.slackThread && (
+                <span title="Has Slack thread" className="flex items-center">
+                  <MessageSquare className="h-3 w-3 text-muted-foreground" />
+                </span>
+              )}
+              {task.dependsOn && task.dependsOn.length > 0 && (
+                <span
+                  title={`Depends on ${task.dependsOn.length} task(s)`}
+                  className="flex items-center"
+                >
+                  <Link2 className="h-3 w-3 text-muted-foreground" />
+                </span>
+              )}
+            </div>
+          )}
 
           {/* Bottom row: avatars + action buttons */}
-          <div className="mt-2 flex items-center justify-between">
+          <div className={clsx("flex items-center justify-between", revealMetadata ? "mt-2" : "mt-1.5")}>
             {/* Assignee avatars */}
             <div className="flex items-center gap-1.5">
               {task.responsible && task.responsible.length > 0 && (
                 <div className="flex -space-x-1">
-                  {task.responsible.slice(0, 3).map((user) => (
+                  {task.responsible.slice(0, isCompact ? 2 : 3).map((user) => (
                     <div
                       key={user.id}
-                      className="flex h-5 w-5 items-center justify-center rounded-full border text-[9px] font-medium"
-                      style={{
-                        borderColor: "var(--avatar-border)",
-                        background: "var(--avatar-bg)",
-                        color: "var(--avatar-text)",
-                      }}
+                      className="flex h-5 w-5 items-center justify-center rounded-full border border-avatar-border bg-avatar-bg text-[9px] font-medium text-avatar-text"
                       title={user.name || user.email}
                     >
                       {(user.name || user.email)[0].toUpperCase()}
@@ -165,16 +209,7 @@ export function TaskCard({
                     e.stopPropagation();
                     onRetreat?.();
                   }}
-                  className="rounded p-0.5 opacity-0 transition-opacity group-hover:opacity-100"
-                  style={{ color: "var(--muted-foreground)" }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.background = "var(--sidebar-hover)";
-                    e.currentTarget.style.color = "var(--info)";
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.background = "";
-                    e.currentTarget.style.color = "var(--muted-foreground)";
-                  }}
+                  className="action-btn-retreat rounded p-0.5 opacity-0 group-hover:opacity-100"
                   title="Move back"
                 >
                   <ChevronLeft className="h-4 w-4" />
@@ -187,16 +222,7 @@ export function TaskCard({
                     e.stopPropagation();
                     onAdvance();
                   }}
-                  className="rounded p-0.5 opacity-0 transition-opacity group-hover:opacity-100"
-                  style={{ color: "var(--muted-foreground)" }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.background = "var(--sidebar-hover)";
-                    e.currentTarget.style.color = "var(--primary)";
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.background = "";
-                    e.currentTarget.style.color = "var(--muted-foreground)";
-                  }}
+                  className="action-btn-advance rounded p-0.5 opacity-0 group-hover:opacity-100"
                   title="Advance status"
                 >
                   <ChevronRight className="h-4 w-4" />
@@ -206,11 +232,8 @@ export function TaskCard({
           </div>
 
           {/* Due date */}
-          {task.dueDate && (
-            <div
-              className="mt-1.5 text-[10px]"
-              style={{ color: "var(--muted-foreground)" }}
-            >
+          {task.dueDate && revealMetadata && (
+            <div className="mt-1.5 text-[10px] text-muted-foreground">
               Due {new Date(task.dueDate).toLocaleDateString()}
             </div>
           )}


### PR DESCRIPTION
## Summary
- add three board display presets (`standard`, `dense`, `triage`) with per-user persistence
- add on-demand metadata disclosure toggle plus per-card expansion controls
- add keyboard triage flow (`j`/`k`/arrow keys + `Enter`) with visible selection state
- tune compact layout spacing/column width for high-volume board scanning

## Validation
- `npm run lint`
- `npm test`
- `npm run build`

Closes #13