### PR TITLE
feat: allow Coda connect from server env token

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Integrations:
 - `HUBSPOT_SCOPES` (optional, comma or space-separated, defaults to `crm.objects.deals.read crm.objects.contacts.read`)
 - `SLACK_CLIENT_ID`
 - `SLACK_CLIENT_SECRET`
+- `CODA_API_TOKEN` (optional, enables one-click Coda connect without pasting token)
 - `INTEGRATION_TOKEN_SECRET` (recommended, encrypts stored integration tokens)
 
 ## OAuth callback URLs

--- a/src/app/api/integrations/coda/token/route.ts
+++ b/src/app/api/integrations/coda/token/route.ts
@@ -34,11 +34,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       return permission.deniedResponse;
     }
 
-    const body = (await request.json()) as ConnectCodaBody;
-    const token = body.token?.trim();
+    const body = (await request.json().catch(() => ({}))) as ConnectCodaBody;
+    const token = body.token?.trim() || process.env.CODA_API_TOKEN?.trim();
     if (!token) {
       return NextResponse.json(
-        { error: "Coda API token is required" },
+        { error: "Coda API token is required (or set CODA_API_TOKEN on the server)" },
         { status: 400 }
       );
     }
@@ -94,4 +94,3 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
 }
-

--- a/src/components/settings/integrations-tab.tsx
+++ b/src/components/settings/integrations-tab.tsx
@@ -108,18 +108,14 @@ export function IntegrationsTab() {
   };
 
   const connectCoda = async () => {
-    if (!codaToken.trim()) {
-      setError("Coda API token is required.");
-      return;
-    }
-
     setWorking("coda");
     setError(null);
     try {
+      const token = codaToken.trim();
       const response = await fetch("/api/integrations/coda/token", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token: codaToken.trim() }),
+        body: JSON.stringify(token ? { token } : {}),
       });
 
       if (!response.ok) {
@@ -268,7 +264,7 @@ export function IntegrationsTab() {
                         type="password"
                         value={codaToken}
                         onChange={(event) => setCodaToken(event.target.value)}
-                        placeholder="Paste Coda API token"
+                        placeholder="Paste Coda API token (optional if server token is set)"
                         className="w-full rounded-md border border-border bg-secondary px-3 py-2 text-sm text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none"
                       />
                     )}


### PR DESCRIPTION
## Summary
- Allow one-click Coda integration connect when `CODA_API_TOKEN` is set as a server environment variable
- Falls back to manual token input when env var is not set
- Updates placeholder text to indicate server token availability

Closes no issue — quality-of-life improvement for Coda integration setup.

## Changes
- **API route** (`src/app/api/integrations/coda/token/route.ts`): Falls back to `process.env.CODA_API_TOKEN` when no token in request body; gracefully handles empty/malformed JSON body
- **Frontend** (`src/components/settings/integrations-tab.tsx`): Removes client-side empty-token guard (server returns descriptive 400), sends empty body when no token typed
- **README**: Documents `CODA_API_TOKEN` env var

## Test plan
- [ ] Set `CODA_API_TOKEN` env var, click Connect with empty token field → should connect via server token
- [ ] Unset `CODA_API_TOKEN`, click Connect with empty token field → should show error message
- [ ] Paste token manually → should still work as before
- [ ] Existing 41/41 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)