### PR TITLE
fix: use optional_scope for HubSpot OAuth scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Integrations:
 
 - `HUBSPOT_CLIENT_ID`
 - `HUBSPOT_CLIENT_SECRET`
-- `HUBSPOT_SCOPES` (optional, comma or space-separated, defaults to `crm.objects.deals.read crm.objects.contacts.read`)
+- `HUBSPOT_SCOPES` (optional, comma or space-separated; requested as HubSpot `optional_scope`, defaults to `crm.objects.deals.read crm.objects.contacts.read`)
 - `SLACK_CLIENT_ID`
 - `SLACK_CLIENT_SECRET`
 - `CODA_API_TOKEN` (optional, enables one-click Coda connect without pasting token)

--- a/src/lib/integrations/catalog.ts
+++ b/src/lib/integrations/catalog.ts
@@ -40,6 +40,10 @@ function getScopesFromEnv(key: string, fallback: string[]): string[] {
   return scopes.length > 0 ? scopes : fallback;
 }
 
+function joinScopes(scopes: string[]): string {
+  return scopes.join(" ");
+}
+
 const INTEGRATION_DEFINITIONS: readonly IntegrationDefinition[] = [
   {
     slug: "google-workspace",
@@ -79,10 +83,17 @@ const INTEGRATION_DEFINITIONS: readonly IntegrationDefinition[] = [
     oauth: {
       authorizationEndpoint: "https://app.hubspot.com/oauth/authorize",
       tokenEndpoint: "https://api.hubapi.com/oauth/v1/token",
-      scopes: getScopesFromEnv("HUBSPOT_SCOPES", [
-        "crm.objects.deals.read",
-        "crm.objects.contacts.read",
-      ]),
+      // HubSpot expects only required scopes in `scope`; request feature scopes
+      // via `optional_scope` to avoid install URL / app scope mismatch.
+      scopes: ["oauth"],
+      extraAuthParams: {
+        optional_scope: joinScopes(
+          getScopesFromEnv("HUBSPOT_SCOPES", [
+            "crm.objects.deals.read",
+            "crm.objects.contacts.read",
+          ])
+        ),
+      },
       clientIdEnv: "HUBSPOT_CLIENT_ID",
       clientSecretEnv: "HUBSPOT_CLIENT_SECRET",
     },


### PR DESCRIPTION
## Summary
- Uses HubSpot's `optional_scope` parameter for feature scopes instead of `scope`
- Sets `scope` to `["oauth"]` (minimum required) to prevent "scopes requested don't match app scopes" error
- Updates README to document the `optional_scope` behavior

## Details
HubSpot OAuth requires that scopes passed in the `scope` parameter match exactly what the app has been granted. Feature scopes like `crm.objects.deals.read` should be passed via `optional_scope` instead — HubSpot will grant whichever of those the app has access to, without throwing an error.

The existing `extraAuthParams` infrastructure (added in PR #38) already supports this pattern cleanly.

## Test plan
- [x] 41/41 tests pass
- [x] TypeScript: 0 errors
- [x] ESLint: clean
- [ ] Manual: verify HubSpot OAuth connect flow works with optional_scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)