### PR TITLE
[WGX-008] Transactional outbox foundation with replay/metrics

### DIFF
--- a/prisma/migrations/20260215213000_outbox_event_bus/migration.sql
+++ b/prisma/migrations/20260215213000_outbox_event_bus/migration.sql
@@ -1,0 +1,36 @@
+-- CreateEnum
+CREATE TYPE "OutboxEventStatus" AS ENUM ('PENDING', 'DISPATCHED', 'FAILED', 'DEAD_LETTER');
+
+-- CreateTable
+CREATE TABLE "OutboxEvent" (
+    "id" TEXT NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "aggregateType" TEXT NOT NULL,
+    "aggregateId" TEXT NOT NULL,
+    "schemaVersion" INTEGER NOT NULL DEFAULT 1,
+    "payload" JSONB NOT NULL,
+    "idempotencyKey" TEXT NOT NULL,
+    "status" "OutboxEventStatus" NOT NULL DEFAULT 'PENDING',
+    "retryCount" INTEGER NOT NULL DEFAULT 0,
+    "nextAttemptAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastAttemptAt" TIMESTAMP(3),
+    "dispatchedAt" TIMESTAMP(3),
+    "failedAt" TIMESTAMP(3),
+    "error" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "OutboxEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OutboxEvent_idempotencyKey_key" ON "OutboxEvent"("idempotencyKey");
+
+-- CreateIndex
+CREATE INDEX "OutboxEvent_status_nextAttemptAt_idx" ON "OutboxEvent"("status", "nextAttemptAt");
+
+-- CreateIndex
+CREATE INDEX "OutboxEvent_aggregateType_aggregateId_createdAt_idx" ON "OutboxEvent"("aggregateType", "aggregateId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "OutboxEvent_eventType_createdAt_idx" ON "OutboxEvent"("eventType", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -463,3 +463,39 @@ model IntegrationConnection {
   @@unique([userId, provider])
   @@index([provider, status])
 }
+
+// ============================================================
+// OUTBOX / EVENT BUS
+// ============================================================
+
+enum OutboxEventStatus {
+  PENDING
+  DISPATCHED
+  FAILED
+  DEAD_LETTER
+}
+
+model OutboxEvent {
+  id            String           @id @default(cuid())
+  eventType     String
+  aggregateType String
+  aggregateId   String
+  schemaVersion Int              @default(1)
+  payload       Json
+
+  idempotencyKey String          @unique
+  status         OutboxEventStatus @default(PENDING)
+  retryCount     Int             @default(0)
+  nextAttemptAt  DateTime        @default(now())
+  lastAttemptAt  DateTime?
+  dispatchedAt   DateTime?
+  failedAt       DateTime?
+  error          String?         @db.Text
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([status, nextAttemptAt])
+  @@index([aggregateType, aggregateId, createdAt])
+  @@index([eventType, createdAt])
+}

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,0 +1,98 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { getOutboxOperationalMetrics, replayOutboxEvents } from "@/lib/outbox-worker";
+
+interface ReplayRequestBody {
+  action?: string;
+  eventIds?: string[];
+  statuses?: Array<"FAILED" | "DEAD_LETTER">;
+  limit?: number;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.length > 0);
+}
+
+export async function GET(): Promise<NextResponse> {
+  try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const metrics = await getOutboxOperationalMetrics(prisma);
+    return NextResponse.json({
+      generatedAt: new Date().toISOString(),
+      metrics,
+    });
+  } catch (error) {
+    console.error("GET /api/events error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch event bus metrics" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (session.user.role !== "admin") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const body = (await request.json().catch(() => ({}))) as ReplayRequestBody;
+    if (body.action !== "replay") {
+      return NextResponse.json(
+        { error: "Unsupported action. Use action='replay'." },
+        { status: 400 }
+      );
+    }
+
+    const eventIds = asStringArray(body.eventIds);
+    const statuses = asStringArray(body.statuses).filter(
+      (status): status is "FAILED" | "DEAD_LETTER" =>
+        status === "FAILED" || status === "DEAD_LETTER"
+    );
+
+    let limit: number | undefined;
+    if (typeof body.limit !== "undefined") {
+      if (!Number.isInteger(body.limit) || body.limit <= 0 || body.limit > 1000) {
+        return NextResponse.json(
+          { error: "limit must be an integer between 1 and 1000" },
+          { status: 400 }
+        );
+      }
+      limit = body.limit;
+    }
+
+    const replayed = await replayOutboxEvents(prisma, {
+      eventIds,
+      statuses,
+      limit,
+    });
+
+    return NextResponse.json({
+      action: "replay",
+      replayed,
+      eventIds: eventIds.length ? eventIds : null,
+      statuses: statuses.length ? statuses : ["FAILED", "DEAD_LETTER"],
+      limit: limit ?? 100,
+      replayedAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error("POST /api/events error:", error);
+    return NextResponse.json(
+      { error: "Failed to replay outbox events" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/__tests__/event-bus.test.ts
+++ b/src/lib/__tests__/event-bus.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildOutboxIdempotencyKey,
+  enqueueOutboxEvent,
+  publishDomainEvent,
+} from "@/lib/event-bus";
+import { prisma } from "@/lib/prisma";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    $transaction: vi.fn(),
+  },
+}));
+
+describe("event-bus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("builds canonical idempotency keys", () => {
+    const key = buildOutboxIdempotencyKey({
+      aggregateType: " Task ",
+      aggregateId: "ABC-123",
+      eventType: " Status.Changed ",
+      ruleVariant: " default ",
+    });
+
+    expect(key).toBe("task:abc-123:status.changed:default");
+  });
+
+  it("upserts outbox events by idempotency key", async () => {
+    const upsert = vi.fn().mockResolvedValue({ id: "evt_1" });
+    const db = {
+      outboxEvent: {
+        upsert,
+      },
+    } as unknown as Parameters<typeof enqueueOutboxEvent>[0];
+
+    await enqueueOutboxEvent(db, {
+      eventType: "task.status.changed",
+      aggregateType: "task",
+      aggregateId: "task_1",
+      payload: { to: "ACTIVE" },
+      idempotencyKey: "task:task_1:task.status.changed",
+    });
+
+    expect(upsert).toHaveBeenCalledWith({
+      where: { idempotencyKey: "task:task_1:task.status.changed" },
+      update: {},
+      create: {
+        eventType: "task.status.changed",
+        aggregateType: "task",
+        aggregateId: "task_1",
+        schemaVersion: 1,
+        payload: { to: "ACTIVE" },
+        idempotencyKey: "task:task_1:task.status.changed",
+        status: "PENDING",
+        retryCount: 0,
+        nextAttemptAt: expect.any(Date),
+      },
+    });
+  });
+
+  it("publishes inside a prisma transaction when no tx is provided", async () => {
+    const upsert = vi.fn().mockResolvedValue({ id: "evt_2" });
+    vi.mocked(prisma.$transaction).mockImplementation(async (callback) =>
+      callback({ outboxEvent: { upsert } } as never)
+    );
+
+    await publishDomainEvent({
+      eventType: "task.created",
+      aggregateType: "task",
+      aggregateId: "task_2",
+      payload: { title: "Test" },
+      idempotencyKey: "task:task_2:task.created",
+    });
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(upsert).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/__tests__/outbox-worker.test.ts
+++ b/src/lib/__tests__/outbox-worker.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  computeRetryDelayMs,
+  dispatchOutboxBatch,
+  getOutboxOperationalMetrics,
+  markOutboxEventFailure,
+  replayOutboxEvents,
+} from "@/lib/outbox-worker";
+
+describe("outbox-worker", () => {
+  it("computes exponential retry delay with deterministic jitter", () => {
+    const delay = computeRetryDelayMs(3, {
+      baseDelayMs: 1000,
+      maxDelayMs: 60000,
+      jitterRatio: 0.2,
+      random: () => 0.5,
+    });
+
+    expect(delay).toBe(4000);
+  });
+
+  it("marks events as dead-letter after max retries", async () => {
+    const update = vi.fn().mockResolvedValue({});
+    const db = {
+      outboxEvent: {
+        update,
+      },
+    } as never;
+
+    const status = await markOutboxEventFailure(
+      db,
+      { id: "evt_1", retryCount: 4 },
+      "dispatcher unavailable",
+      {
+        maxRetries: 5,
+        now: new Date("2026-02-15T00:00:00.000Z"),
+      }
+    );
+
+    expect(status).toBe("DEAD_LETTER");
+    expect(update).toHaveBeenCalledWith({
+      where: { id: "evt_1" },
+      data: {
+        status: "DEAD_LETTER",
+        retryCount: 5,
+        nextAttemptAt: new Date("2026-02-15T00:00:00.000Z"),
+        lastAttemptAt: new Date("2026-02-15T00:00:00.000Z"),
+        failedAt: new Date("2026-02-15T00:00:00.000Z"),
+        error: "dispatcher unavailable",
+        dispatchedAt: null,
+      },
+    });
+  });
+
+  it("dispatches retryable events and updates outcomes", async () => {
+    const update = vi.fn().mockResolvedValue({});
+    const findMany = vi.fn().mockResolvedValue([
+      {
+        id: "evt_ok",
+        status: "PENDING",
+        retryCount: 0,
+        nextAttemptAt: new Date("2026-02-15T00:00:00.000Z"),
+        createdAt: new Date("2026-02-15T00:00:00.000Z"),
+      },
+      {
+        id: "evt_fail",
+        status: "FAILED",
+        retryCount: 0,
+        nextAttemptAt: new Date("2026-02-15T00:00:00.000Z"),
+        createdAt: new Date("2026-02-15T00:00:00.000Z"),
+      },
+    ]);
+
+    const db = {
+      outboxEvent: {
+        findMany,
+        update,
+      },
+    } as never;
+
+    const dispatch = vi.fn().mockImplementation(async (event: { id: string }) => {
+      if (event.id === "evt_fail") {
+        throw new Error("boom");
+      }
+    });
+
+    const now = new Date("2026-02-15T00:00:00.000Z");
+
+    const result = await dispatchOutboxBatch(db, dispatch, {
+      now,
+      maxRetries: 3,
+      jitterRatio: 0,
+      random: () => 0.5,
+    });
+
+    expect(result).toEqual({
+      attempted: 2,
+      dispatched: 1,
+      failed: 1,
+      deadLetter: 0,
+    });
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(update).toHaveBeenCalledTimes(2);
+  });
+
+  it("replays failed/dead-letter events by status", async () => {
+    const findMany = vi.fn().mockResolvedValue([{ id: "evt_1" }, { id: "evt_2" }]);
+    const updateMany = vi.fn().mockResolvedValue({ count: 2 });
+
+    const db = {
+      outboxEvent: {
+        findMany,
+        updateMany,
+      },
+    } as never;
+
+    const replayed = await replayOutboxEvents(db, {
+      limit: 2,
+      now: new Date("2026-02-15T00:00:00.000Z"),
+    });
+
+    expect(replayed).toBe(2);
+    expect(findMany).toHaveBeenCalledWith({
+      where: { status: { in: ["FAILED", "DEAD_LETTER"] } },
+      orderBy: [{ failedAt: "desc" }, { createdAt: "desc" }],
+      take: 2,
+      select: { id: true },
+    });
+  });
+
+  it("returns operational metrics for dashboards", async () => {
+    const count = vi
+      .fn()
+      .mockResolvedValueOnce(3)
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(10);
+
+    const findFirst = vi.fn().mockResolvedValue({
+      id: "evt_oldest",
+      createdAt: new Date("2026-02-14T23:59:00.000Z"),
+    });
+
+    const findMany = vi
+      .fn()
+      .mockResolvedValueOnce([
+        { eventType: "task.created" },
+        { eventType: "task.created" },
+        { eventType: "task.updated" },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "dead_1",
+          eventType: "task.created",
+          aggregateType: "task",
+          aggregateId: "task_1",
+          retryCount: 5,
+          failedAt: new Date("2026-02-15T00:00:00.000Z"),
+          error: "timeout",
+        },
+      ]);
+
+    const db = {
+      outboxEvent: {
+        count,
+        findFirst,
+        findMany,
+      },
+    } as never;
+
+    const metrics = await getOutboxOperationalMetrics(
+      db,
+      new Date("2026-02-15T00:00:00.000Z")
+    );
+
+    expect(metrics.counts).toEqual({
+      pending: 3,
+      failed: 2,
+      deadLetter: 1,
+      dispatched: 10,
+      total: 16,
+    });
+    expect(metrics.lag.oldestRetryableEventId).toBe("evt_oldest");
+    expect(metrics.failuresByEventType).toEqual([
+      { eventType: "task.created", count: 2 },
+      { eventType: "task.updated", count: 1 },
+    ]);
+    expect(metrics.recentDeadLetters).toHaveLength(1);
+  });
+});

--- a/src/lib/event-bus.ts
+++ b/src/lib/event-bus.ts
@@ -1,0 +1,68 @@
+import type { OutboxEvent, Prisma } from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+
+export interface DomainEventInput {
+  eventType: string;
+  aggregateType: string;
+  aggregateId: string;
+  payload: Prisma.InputJsonValue;
+  idempotencyKey: string;
+  schemaVersion?: number;
+}
+
+type OutboxEventWriteClient = Pick<Prisma.TransactionClient, "outboxEvent">;
+
+function normalizeIdempotencyPart(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function buildOutboxIdempotencyKey(input: {
+  aggregateType: string;
+  aggregateId: string;
+  eventType: string;
+  ruleVariant?: string;
+}): string {
+  const parts = [
+    normalizeIdempotencyPart(input.aggregateType),
+    normalizeIdempotencyPart(input.aggregateId),
+    normalizeIdempotencyPart(input.eventType),
+  ];
+
+  if (input.ruleVariant) {
+    parts.push(normalizeIdempotencyPart(input.ruleVariant));
+  }
+
+  return parts.join(":");
+}
+
+export async function enqueueOutboxEvent(
+  db: OutboxEventWriteClient,
+  input: DomainEventInput
+): Promise<OutboxEvent> {
+  return db.outboxEvent.upsert({
+    where: { idempotencyKey: input.idempotencyKey },
+    update: {},
+    create: {
+      eventType: input.eventType,
+      aggregateType: input.aggregateType,
+      aggregateId: input.aggregateId,
+      schemaVersion: input.schemaVersion ?? 1,
+      payload: input.payload,
+      idempotencyKey: input.idempotencyKey,
+      status: "PENDING",
+      retryCount: 0,
+      nextAttemptAt: new Date(),
+    },
+  });
+}
+
+export async function publishDomainEvent(
+  input: DomainEventInput,
+  tx?: OutboxEventWriteClient
+): Promise<OutboxEvent> {
+  if (tx) {
+    return enqueueOutboxEvent(tx, input);
+  }
+
+  return prisma.$transaction((transaction) => enqueueOutboxEvent(transaction, input));
+}

--- a/src/lib/outbox-worker.ts
+++ b/src/lib/outbox-worker.ts
@@ -1,0 +1,324 @@
+import type {
+  OutboxEvent,
+  OutboxEventStatus,
+  Prisma,
+} from "@/generated/prisma/client";
+
+export const RETRYABLE_EVENT_STATUSES: OutboxEventStatus[] = [
+  "PENDING",
+  "FAILED",
+];
+
+export interface DispatchBatchOptions {
+  batchSize?: number;
+  maxRetries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  jitterRatio?: number;
+  now?: Date;
+  random?: () => number;
+}
+
+export interface ReplayOptions {
+  eventIds?: string[];
+  statuses?: Array<"FAILED" | "DEAD_LETTER">;
+  limit?: number;
+  now?: Date;
+}
+
+export interface OutboxOperationalMetrics {
+  counts: {
+    pending: number;
+    failed: number;
+    deadLetter: number;
+    dispatched: number;
+    total: number;
+  };
+  lag: {
+    oldestRetryableEventAgeSeconds: number | null;
+    oldestRetryableEventId: string | null;
+  };
+  failuresByEventType: Array<{ eventType: string; count: number }>;
+  recentDeadLetters: Array<{
+    id: string;
+    eventType: string;
+    aggregateType: string;
+    aggregateId: string;
+    retryCount: number;
+    failedAt: string | null;
+    error: string | null;
+  }>;
+}
+
+type OutboxDelegate = Prisma.TransactionClient["outboxEvent"];
+
+type OutboxClient = {
+  outboxEvent: OutboxDelegate;
+};
+
+export type OutboxDispatcher = (event: OutboxEvent) => Promise<void>;
+
+const DEFAULT_BATCH_SIZE = 50;
+const DEFAULT_MAX_RETRIES = 5;
+const DEFAULT_BASE_DELAY_MS = 1000;
+const DEFAULT_MAX_DELAY_MS = 300000;
+const DEFAULT_JITTER_RATIO = 0.2;
+
+function computeJitterMultiplier(jitterRatio: number, random: () => number): number {
+  const centered = random() * 2 - 1;
+  return 1 + centered * jitterRatio;
+}
+
+export function computeRetryDelayMs(
+  retryCount: number,
+  options?: {
+    baseDelayMs?: number;
+    maxDelayMs?: number;
+    jitterRatio?: number;
+    random?: () => number;
+  }
+): number {
+  const baseDelayMs = options?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  const maxDelayMs = options?.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+  const jitterRatio = options?.jitterRatio ?? DEFAULT_JITTER_RATIO;
+  const random = options?.random ?? Math.random;
+
+  const exponentialDelay = Math.min(baseDelayMs * 2 ** Math.max(retryCount - 1, 0), maxDelayMs);
+  const jitteredDelay = Math.round(exponentialDelay * computeJitterMultiplier(jitterRatio, random));
+  return Math.max(0, Math.min(jitteredDelay, maxDelayMs));
+}
+
+export async function fetchRetryableOutboxEvents(
+  db: OutboxClient,
+  options?: Pick<DispatchBatchOptions, "batchSize" | "now">
+): Promise<OutboxEvent[]> {
+  const now = options?.now ?? new Date();
+  const batchSize = options?.batchSize ?? DEFAULT_BATCH_SIZE;
+
+  return db.outboxEvent.findMany({
+    where: {
+      status: { in: [...RETRYABLE_EVENT_STATUSES] },
+      nextAttemptAt: { lte: now },
+    },
+    orderBy: [{ nextAttemptAt: "asc" }, { createdAt: "asc" }, { id: "asc" }],
+    take: batchSize,
+  });
+}
+
+export async function markOutboxEventDispatched(
+  db: OutboxClient,
+  eventId: string,
+  now = new Date()
+): Promise<void> {
+  await db.outboxEvent.update({
+    where: { id: eventId },
+    data: {
+      status: "DISPATCHED",
+      dispatchedAt: now,
+      failedAt: null,
+      error: null,
+      lastAttemptAt: now,
+    },
+  });
+}
+
+export async function markOutboxEventFailure(
+  db: OutboxClient,
+  event: Pick<OutboxEvent, "id" | "retryCount">,
+  errorMessage: string,
+  options?: Pick<DispatchBatchOptions, "maxRetries" | "baseDelayMs" | "maxDelayMs" | "jitterRatio" | "now" | "random">
+): Promise<"FAILED" | "DEAD_LETTER"> {
+  const now = options?.now ?? new Date();
+  const maxRetries = options?.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const nextRetryCount = event.retryCount + 1;
+  const exhausted = nextRetryCount >= maxRetries;
+  const status = exhausted ? "DEAD_LETTER" : "FAILED";
+  const nextAttemptAt = exhausted
+    ? now
+    : new Date(
+        now.getTime() +
+          computeRetryDelayMs(nextRetryCount, {
+            baseDelayMs: options?.baseDelayMs,
+            maxDelayMs: options?.maxDelayMs,
+            jitterRatio: options?.jitterRatio,
+            random: options?.random,
+          })
+      );
+
+  await db.outboxEvent.update({
+    where: { id: event.id },
+    data: {
+      status,
+      retryCount: nextRetryCount,
+      nextAttemptAt,
+      lastAttemptAt: now,
+      failedAt: now,
+      error: errorMessage,
+      dispatchedAt: null,
+    },
+  });
+
+  return status;
+}
+
+export async function dispatchOutboxBatch(
+  db: OutboxClient,
+  dispatch: OutboxDispatcher,
+  options?: DispatchBatchOptions
+): Promise<{ attempted: number; dispatched: number; failed: number; deadLetter: number }> {
+  const events = await fetchRetryableOutboxEvents(db, {
+    batchSize: options?.batchSize,
+    now: options?.now,
+  });
+
+  let dispatched = 0;
+  let failed = 0;
+  let deadLetter = 0;
+
+  for (const event of events) {
+    try {
+      await dispatch(event);
+      await markOutboxEventDispatched(db, event.id, options?.now ?? new Date());
+      dispatched += 1;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const status = await markOutboxEventFailure(db, event, message, options);
+      if (status === "DEAD_LETTER") {
+        deadLetter += 1;
+      } else {
+        failed += 1;
+      }
+    }
+  }
+
+  return {
+    attempted: events.length,
+    dispatched,
+    failed,
+    deadLetter,
+  };
+}
+
+export async function replayOutboxEvents(
+  db: OutboxClient,
+  options?: ReplayOptions
+): Promise<number> {
+  const statuses: OutboxEventStatus[] = options?.statuses?.length
+    ? options.statuses
+    : ["FAILED", "DEAD_LETTER"];
+  const now = options?.now ?? new Date();
+
+  let eventIds = options?.eventIds?.filter(Boolean) ?? [];
+
+  if (!eventIds.length) {
+    const limit = options?.limit ?? 100;
+    const replayableEvents = await db.outboxEvent.findMany({
+      where: { status: { in: statuses } },
+      orderBy: [{ failedAt: "desc" }, { createdAt: "desc" }],
+      take: limit,
+      select: { id: true },
+    });
+    eventIds = replayableEvents.map((event) => event.id);
+  }
+
+  if (!eventIds.length) {
+    return 0;
+  }
+
+  const result = await db.outboxEvent.updateMany({
+    where: {
+      id: { in: eventIds },
+      status: { in: statuses },
+    },
+    data: {
+      status: "PENDING",
+      retryCount: 0,
+      nextAttemptAt: now,
+      failedAt: null,
+      error: null,
+      lastAttemptAt: null,
+    },
+  });
+
+  return result.count;
+}
+
+async function countByStatus(db: OutboxClient, status: OutboxEvent["status"]): Promise<number> {
+  return db.outboxEvent.count({ where: { status } });
+}
+
+export async function getOutboxOperationalMetrics(
+  db: OutboxClient,
+  now = new Date()
+): Promise<OutboxOperationalMetrics> {
+  const [pending, failed, deadLetter, dispatched] = await Promise.all([
+    countByStatus(db, "PENDING"),
+    countByStatus(db, "FAILED"),
+    countByStatus(db, "DEAD_LETTER"),
+    countByStatus(db, "DISPATCHED"),
+  ]);
+
+  const oldestRetryableEvent = await db.outboxEvent.findFirst({
+    where: { status: { in: [...RETRYABLE_EVENT_STATUSES] } },
+    orderBy: { createdAt: "asc" },
+    select: { id: true, createdAt: true },
+  });
+
+  const failedAndDeadLetterEvents = await db.outboxEvent.findMany({
+    where: { status: { in: ["FAILED", "DEAD_LETTER"] } },
+    select: { eventType: true },
+    take: 1000,
+  });
+
+  const failuresByEventType = Array.from(
+    failedAndDeadLetterEvents.reduce((map, event) => {
+      const current = map.get(event.eventType) ?? 0;
+      map.set(event.eventType, current + 1);
+      return map;
+    }, new Map<string, number>())
+  )
+    .map(([eventType, count]) => ({ eventType, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10);
+
+  const recentDeadLetters = await db.outboxEvent.findMany({
+    where: { status: "DEAD_LETTER" },
+    orderBy: [{ failedAt: "desc" }, { createdAt: "desc" }],
+    take: 20,
+    select: {
+      id: true,
+      eventType: true,
+      aggregateType: true,
+      aggregateId: true,
+      retryCount: true,
+      failedAt: true,
+      error: true,
+    },
+  });
+
+  return {
+    counts: {
+      pending,
+      failed,
+      deadLetter,
+      dispatched,
+      total: pending + failed + deadLetter + dispatched,
+    },
+    lag: {
+      oldestRetryableEventAgeSeconds: oldestRetryableEvent
+        ? Math.max(0, Math.floor((now.getTime() - oldestRetryableEvent.createdAt.getTime()) / 1000))
+        : null,
+      oldestRetryableEventId: oldestRetryableEvent?.id ?? null,
+    },
+    failuresByEventType,
+    recentDeadLetters: recentDeadLetters.map((event) => ({
+      id: event.id,
+      eventType: event.eventType,
+      aggregateType: event.aggregateType,
+      aggregateId: event.aggregateId,
+      retryCount: event.retryCount,
+      failedAt: event.failedAt?.toISOString() ?? null,
+      error: event.error,
+    })),
+  };
+}


### PR DESCRIPTION
## Summary
- add `OutboxEvent` + `OutboxEventStatus` to Prisma schema and migration for transactional outbox persistence
- add `src/lib/event-bus.ts` for idempotent outbox enqueue and canonical idempotency key generation
- add `src/lib/outbox-worker.ts` for retry/backoff+jitter dispatch lifecycle, dead-letter transitions, replay support, and operational metrics
- add `GET /api/events` for operational lag/failure dashboards
- add `POST /api/events` replay tooling (admin-only)
- add unit tests for outbox enqueue/idempotency and worker retry/replay/metrics behavior

## Validation
- `npm test`
- `npx tsc --noEmit`
- `npx eslint src/lib/event-bus.ts src/lib/outbox-worker.ts src/app/api/events/route.ts src/lib/__tests__/event-bus.test.ts src/lib/__tests__/outbox-worker.test.ts`

Closes #8
