### PR TITLE
fix: unblock production builds for deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "db:generate": "prisma generate --schema prisma/schema.prisma",
+    "prebuild": "npm run db:generate",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/src/components/analytics/finance-tab.tsx
+++ b/src/components/analytics/finance-tab.tsx
@@ -11,7 +11,7 @@ import {
   ArrowDownRight,
 } from "lucide-react";
 import { AnalyticsDashboardData } from "@/lib/analytics/types";
-import StatCard from "./stat-card";
+import { StatCard } from "./stat-card";
 import { RingStat } from "./bar-display";
 
 interface FinanceTabProps {
@@ -149,7 +149,7 @@ export function FinanceTab({ data }: FinanceTabProps) {
                 max={100}
                 label="Payment Success Rate"
                 color="hsl(var(--primary))"
-                size="md"
+                size={120}
               />
             </div>
 

--- a/src/components/analytics/marketing-tab-new.tsx
+++ b/src/components/analytics/marketing-tab-new.tsx
@@ -2,8 +2,8 @@
 
 import React, { useState } from 'react';
 import { AnalyticsDashboardData } from '@/lib/analytics/types';
-import StatCard from './stat-card';
-import BarDisplay from './bar-display';
+import { StatCard } from './stat-card';
+import { BarDisplay } from './bar-display';
 import {
   Globe,
   MousePointerClick,
@@ -128,8 +128,14 @@ export function MarketingTabNew({ data }: MarketingTabNewProps) {
         <StatCard
           label="Sessions (30d)"
           value={fmtNum(sessions30d)}
-          change={sessionsChange}
-          changeType={sessionsChange && sessionsChange > 0 ? 'increase' : 'decrease'}
+          change={sessionsChange == null ? undefined : fmtPct(sessionsChange)}
+          changeType={
+            sessionsChange == null
+              ? 'neutral'
+              : sessionsChange > 0
+                ? 'positive'
+                : 'negative'
+          }
           icon={TrendingUp}
         />
         <StatCard

--- a/src/components/analytics/overview-tab.tsx
+++ b/src/components/analytics/overview-tab.tsx
@@ -41,7 +41,7 @@ export function OverviewTab({ data }: { data: AnalyticsDashboardData | null }) {
 
   // Compute total ad spend across platforms
   const totalAdSpend =
-    (googleAds?.totalSpend || 0) + (metaAds?.totalSpend || 0);
+    (googleAds?.totalSpend30d || 0) + (metaAds?.totalSpend30d || 0);
   const hasAdData = !!(googleAds || metaAds);
 
   return (
@@ -89,8 +89,8 @@ export function OverviewTab({ data }: { data: AnalyticsDashboardData | null }) {
           label="Total Ad Spend (30d)"
           value={hasAdData ? fmt$(totalAdSpend) : "—"}
           subtitle={hasAdData ? [
-            googleAds ? `Google: ${fmt$(googleAds.totalSpend)}` : null,
-            metaAds ? `Meta: ${fmt$(metaAds.totalSpend)}` : null,
+            googleAds ? `Google: ${fmt$(googleAds.totalSpend30d)}` : null,
+            metaAds ? `Meta: ${fmt$(metaAds.totalSpend30d)}` : null,
           ].filter(Boolean).join(" · ") : undefined}
           icon={Megaphone}
         />

--- a/src/lib/analytics/fetchers-ads.ts
+++ b/src/lib/analytics/fetchers-ads.ts
@@ -7,6 +7,13 @@ import {
   AnalyticsTimestamp,
 } from "./types";
 
+type RedditCampaignReport = {
+  campaign_id: string;
+  spend: number;
+  impressions: number;
+  clicks: number;
+};
+
 function makeMeta(source: "live" | "cached" = "live"): AnalyticsTimestamp {
   const now = new Date();
   return {
@@ -532,19 +539,14 @@ export async function fetchRedditAdsData(
     }
 
     const reportsData = await reportsResponse.json() as {
-      data?: Array<{
-        campaign_id: string;
-        spend: number;
-        impressions: number;
-        clicks: number;
-      }>;
+      data?: RedditCampaignReport[];
     };
 
     let totalSpend = 0;
     let totalImpressions = 0;
     let totalClicks = 0;
     const campaigns: AdCampaign[] = [];
-    const campaignMap = new Map<string, typeof reportsData.data[0]>();
+    const campaignMap = new Map<string, RedditCampaignReport>();
 
     // Build campaign report map
     if (reportsData.data) {

--- a/src/lib/integrations/slack-unanswered-requests.ts
+++ b/src/lib/integrations/slack-unanswered-requests.ts
@@ -761,6 +761,8 @@ export async function runSlackUnansweredDetector(input: {
       if (!message.ts || !message.user || !message.text) continue;
       if (!messageLooksLikeRequest(message.text, patterns)) continue;
 
+      const requesterUserId = message.user;
+      const requestText = message.text;
       const rootTs = message.thread_ts ?? message.ts;
       const rootMs = tsToMs(rootTs);
       if (!Number.isFinite(rootMs)) continue;
@@ -785,7 +787,7 @@ export async function runSlackUnansweredDetector(input: {
       if (
         hasQualifyingReply({
           replies,
-          requesterUserId: message.user,
+          requesterUserId,
           rootTs,
         })
       ) {
@@ -816,7 +818,7 @@ export async function runSlackUnansweredDetector(input: {
       const dueDate = addMinutes(now, config.triageDueMinutes);
       const title = buildTaskTitle({
         channelName,
-        text: message.text,
+        text: requestText,
       });
 
       if (input.dryRun) {
@@ -845,7 +847,7 @@ export async function runSlackUnansweredDetector(input: {
                   metadata: {
                     channelId,
                     threadTs: rootTs,
-                    requesterUserId: message.user,
+                    requesterUserId,
                     slaMinutes: config.slaMinutes,
                   },
                 },
@@ -863,9 +865,9 @@ export async function runSlackUnansweredDetector(input: {
                     sourceUrl,
                     channelId,
                     channelName,
-                    requesterUserId: message.user,
+                    requesterUserId,
                     threadTs: rootTs,
-                    text: message.text,
+                    text: requestText,
                     slaMinutes: config.slaMinutes,
                     observedAt: now,
                   }),


### PR DESCRIPTION
## Summary
- fix analytics component imports to use named exports for `StatCard` and `BarDisplay`
- align analytics field usage with current type contracts (`totalSpend30d`)
- fix Slack unanswered-request task typing around requester text/user capture
- fix Reddit campaign report map typing in ads fetcher
- add build-time Prisma client generation (`db:generate` + `prebuild`)

## Validation
- `npm run build`
- validated prebuild generation by moving `src/generated/prisma` aside and rebuilding

## Why this unblocks deploys
Hosted builds now generate Prisma client before `next build`, and TypeScript compile blockers in analytics/integrations are resolved.
