### PR TITLE
fix(build): restore Railway deploy compilation

### DIFF
--- a/src/components/analytics/marketing-tab-new.tsx
+++ b/src/components/analytics/marketing-tab-new.tsx
@@ -570,10 +570,10 @@ export function MarketingTabNew({ data }: MarketingTabNewProps) {
         {data.semrush ? (
           <div className="space-y-4">
             <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-              <StatCard title="Authority Score" value={String(data.semrush.authorityScore)} icon={Award} />
-              <StatCard title="Backlinks" value={fmtNum(data.semrush.backlinks)} icon={Link2} />
-              <StatCard title="Organic Keywords" value={fmtNum(data.semrush.organicKeywords)} icon={Search} />
-              <StatCard title="Organic Traffic" value={fmtNum(data.semrush.organicTraffic)} icon={TrendingUp} />
+              <StatCard label="Authority Score" value={String(data.semrush.authorityScore)} icon={Award} />
+              <StatCard label="Backlinks" value={fmtNum(data.semrush.backlinks)} icon={Link2} />
+              <StatCard label="Organic Keywords" value={fmtNum(data.semrush.organicKeywords)} icon={Search} />
+              <StatCard label="Organic Traffic" value={fmtNum(data.semrush.organicTraffic)} icon={TrendingUp} />
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
               <div className="bg-card border border-border rounded-lg p-4">

--- a/src/lib/analytics/credentials.ts
+++ b/src/lib/analytics/credentials.ts
@@ -97,9 +97,6 @@ export async function getCredentials(userId?: string): Promise<AnalyticsCredenti
     webflowApiToken: process.env.WEBFLOW_API_TOKEN?.trim() || null,
     webflowSiteId: process.env.WEBFLOW_SITE_ID?.trim() || "67b7700312bb763ca2083376",
 
-    // SEMrush
-  semrushApiToken: string | null;
-
   // Coda
     codaApiToken: process.env.CODA_API_TOKEN?.trim() || null,
     codaDocId: process.env.CODA_DOC_ID?.trim() || "dPjhbdhLZh9",


### PR DESCRIPTION
## Summary
- remove stray TypeScript declaration accidentally left inside analytics credential return object
- fix SEMrush stat cards to use the `StatCard` API (`label` prop)
- restores successful `next build` for production deploys

## Verification
- npm run build

Fixes the Railway production build failure introduced on main.
