### PR TITLE
feat(ops): add observability SLO dashboard and incident runbooks

### DIFF
--- a/docs/runbooks/queue-backup.md
+++ b/docs/runbooks/queue-backup.md
@@ -1,0 +1,28 @@
+# Runbook: Queue Backup
+
+## Trigger
+- Outbox lag SLO breach (`outbox_delivery_lag`) or failure budget breach.
+- Oldest retryable event age > 300s, or failed+dead-letter exceeds threshold.
+
+## Immediate Triage (0-5 minutes)
+1. Open Operations tab and record current queue lag + failed/dead-letter counts.
+2. Call `/api/events` to inspect event-bus metrics payload.
+3. Identify top failing event types under `failuresByEventType`.
+
+## Investigation (5-15 minutes)
+1. Inspect logs for `outbox.event.dispatch_failed` and correlate event IDs.
+2. Validate downstream dependencies for top failing event types.
+3. Check if retryable backlog is growing faster than dispatch throughput.
+
+## Mitigation
+1. Replay failed/dead-letter events via `/api/events` with `action: replay`.
+2. Temporarily reduce new sync load (disable noisy rules) while backlog drains.
+3. Fix root-cause dispatch errors, then re-enable normal traffic.
+
+## Verification
+1. Oldest retryable lag returns under 300s.
+2. Failed/dead-letter counts trend down for 5+ minutes.
+3. No repeated failures for the same idempotency keys.
+
+## Escalation
+- Escalate to engineering lead if backlog cannot be reduced within 20 minutes.

--- a/docs/runbooks/sync-lag.md
+++ b/docs/runbooks/sync-lag.md
@@ -1,0 +1,28 @@
+# Runbook: Integration Sync Lag
+
+## Trigger
+- Integration freshness SLO breach (`integration_sync_freshness`) or connection health breach.
+- One or more providers show `ERROR` or stale sync > 30 minutes.
+
+## Immediate Triage (0-5 minutes)
+1. Open the Operations tab in Settings and capture affected providers.
+2. Check `/api/ops/observability` and verify stale rule + stale connection counts.
+3. Confirm token state in Integrations settings and note `lastError` messages.
+
+## Investigation (5-15 minutes)
+1. Query integration rules for the affected provider and identify stale `lastRunAt`.
+2. Inspect recent dead-letter events matching `integration.<provider>`.
+3. Validate provider credentials and OAuth refresh behavior.
+
+## Mitigation
+1. Re-authenticate affected integrations if token errors persist.
+2. Replay failed/dead-letter outbox events via `/api/events` with `action: replay`.
+3. Run provider sync endpoint in dry-run mode, then execute live sync.
+
+## Verification
+1. Confirm stale rule count drops to 0.
+2. Confirm stale connection count drops to 0.
+3. Confirm no new integration dead letters in the last 5 minutes.
+
+## Escalation
+- Escalate to backend owner if stale rules persist beyond 30 minutes after replay.

--- a/docs/runbooks/websocket-degradation.md
+++ b/docs/runbooks/websocket-degradation.md
@@ -1,0 +1,28 @@
+# Runbook: WebSocket Degradation
+
+## Trigger
+- Realtime delivery proxy SLO breach (`websocket_delivery_proxy`).
+- Board updates are delayed/missing while queue lag or failure rates increase.
+
+## Immediate Triage (0-5 minutes)
+1. Confirm user-facing symptoms: stale board cards, delayed status updates.
+2. Check Operations tab for proxy SLO status and outbox lag trend.
+3. Check server logs for websocket transport/connectivity warnings.
+
+## Investigation (5-15 minutes)
+1. Validate socket server health and active transport fallback behavior.
+2. Inspect outbox failures that represent update fanout events.
+3. Verify client reconnect behavior and polling fallback health.
+
+## Mitigation
+1. Clear queue pressure first (use Queue Backup runbook if lagged).
+2. Restart realtime service components if socket subsystem is stuck.
+3. Temporarily rely on polling fallback and reduce update burst traffic.
+
+## Verification
+1. Realtime proxy SLO returns to healthy.
+2. New task status transitions appear in clients within expected latency.
+3. No recurring websocket-related errors for 10 minutes.
+
+## Escalation
+- Escalate to platform owner if realtime remains degraded after queue recovery.

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -10,6 +10,7 @@ import { PrioritiesTab } from "@/components/settings/priorities-tab";
 import { TeamTab } from "@/components/settings/team-tab";
 import { DepartmentsTab } from "@/components/settings/departments-tab";
 import { IntegrationsTab } from "@/components/settings/integrations-tab";
+import { OperationsTab } from "@/components/settings/operations-tab";
 
 const TABS = [
   { id: "board", label: "Board & WIP Limits" },
@@ -19,6 +20,7 @@ const TABS = [
   { id: "priorities", label: "Company Priorities" },
   { id: "team", label: "Team" },
   { id: "integrations", label: "Integrations" },
+  { id: "operations", label: "Operations" },
 ] as const;
 
 type TabId = (typeof TABS)[number]["id"];
@@ -79,6 +81,7 @@ export default function SettingsPage() {
         {activeTab === "priorities" && <PrioritiesTab />}
         {activeTab === "team" && <TeamTab />}
         {activeTab === "integrations" && <IntegrationsTab />}
+        {activeTab === "operations" && <OperationsTab />}
       </div>
     </div>
   );

--- a/src/app/api/ops/observability/route.ts
+++ b/src/app/api/ops/observability/route.ts
@@ -1,0 +1,103 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { getOutboxOperationalMetrics } from "@/lib/outbox-worker";
+import { evaluateObservabilitySlos } from "@/lib/observability/slo";
+
+const RUNBOOKS = [
+  {
+    id: "sync-lag",
+    title: "Integration Sync Lag",
+    description:
+      "Use when provider syncs fall behind freshness SLOs or integration status enters ERROR.",
+    path: "docs/runbooks/sync-lag.md",
+  },
+  {
+    id: "queue-backup",
+    title: "Queue Backup",
+    description:
+      "Use when outbox lag grows, retries increase, or dead-letter events exceed budget.",
+    path: "docs/runbooks/queue-backup.md",
+  },
+  {
+    id: "websocket-degradation",
+    title: "WebSocket Degradation",
+    description:
+      "Use when realtime board updates are delayed or not delivered to connected clients.",
+    path: "docs/runbooks/websocket-degradation.md",
+  },
+] as const;
+
+export async function GET(): Promise<NextResponse> {
+  try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const [outboxMetrics, connections, rules] = await Promise.all([
+      getOutboxOperationalMetrics(prisma),
+      prisma.integrationConnection.findMany({
+        select: {
+          provider: true,
+          status: true,
+          lastSyncedAt: true,
+          lastError: true,
+        },
+      }),
+      prisma.integrationRule.findMany({
+        where: {
+          enabled: true,
+        },
+        select: {
+          provider: true,
+          enabled: true,
+          lastRunAt: true,
+          lastError: true,
+        },
+      }),
+    ]);
+
+    const generatedAt = new Date();
+    const report = evaluateObservabilitySlos({
+      outboxMetrics,
+      connections: connections.map((connection) => ({
+        provider: connection.provider,
+        status: connection.status,
+        lastSyncedAt: connection.lastSyncedAt?.toISOString() ?? null,
+        lastError: connection.lastError,
+      })),
+      rules: rules.map((rule) => ({
+        provider: rule.provider,
+        enabled: rule.enabled,
+        lastRunAt: rule.lastRunAt?.toISOString() ?? null,
+        lastError: rule.lastError,
+      })),
+      now: generatedAt,
+    });
+
+    const suggestedRunbookIds = Array.from(
+      new Set(
+        report.slos
+          .filter((slo) => slo.breached)
+          .flatMap((slo) => slo.runbookIds)
+      )
+    );
+
+    return NextResponse.json({
+      generatedAt: generatedAt.toISOString(),
+      report,
+      outboxMetrics,
+      runbooks: RUNBOOKS,
+      suggestedRunbookIds,
+    });
+  } catch (error) {
+    console.error("GET /api/ops/observability error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch observability report" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/settings/operations-tab.tsx
+++ b/src/components/settings/operations-tab.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { AlertTriangle, CheckCircle2, RefreshCw, Siren, Wrench } from "lucide-react";
+
+type OverallStatus = "healthy" | "degraded" | "critical";
+type SloSeverity = "warning" | "critical" | null;
+
+interface ObservabilityResponse {
+  generatedAt: string;
+  report: {
+    overallStatus: OverallStatus;
+    breachCount: number;
+    criticalBreachCount: number;
+    slos: Array<{
+      key: string;
+      label: string;
+      objective: string;
+      thresholdLabel: string;
+      value: string;
+      breached: boolean;
+      severity: SloSeverity;
+      runbookIds: string[];
+    }>;
+    integrationHealth: {
+      totalConnections: number;
+      connectedConnections: number;
+      errorConnections: number;
+      staleConnections: number;
+      enabledRules: number;
+      staleRules: number;
+      providers: Array<{
+        provider: string;
+        connected: number;
+        errored: number;
+        staleConnections: number;
+        enabledRules: number;
+        staleRules: number;
+      }>;
+    };
+  };
+  outboxMetrics: {
+    counts: {
+      pending: number;
+      failed: number;
+      deadLetter: number;
+      dispatched: number;
+      total: number;
+    };
+    lag: {
+      oldestRetryableEventAgeSeconds: number | null;
+    };
+    failuresByEventType: Array<{ eventType: string; count: number }>;
+    recentDeadLetters: Array<{
+      id: string;
+      eventType: string;
+      aggregateType: string;
+      aggregateId: string;
+      retryCount: number;
+      failedAt: string | null;
+      error: string | null;
+    }>;
+  };
+  runbooks: Array<{
+    id: string;
+    title: string;
+    description: string;
+    path: string;
+  }>;
+  suggestedRunbookIds: string[];
+}
+
+function formatTimestamp(value: string): string {
+  return new Date(value).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function statusBadge(status: OverallStatus): { label: string; classes: string } {
+  if (status === "healthy") {
+    return {
+      label: "Healthy",
+      classes: "bg-[var(--success)]/10 text-[var(--success)]",
+    };
+  }
+  if (status === "degraded") {
+    return {
+      label: "Degraded",
+      classes: "bg-[var(--warning)]/10 text-[var(--warning)]",
+    };
+  }
+  return {
+    label: "Critical",
+    classes: "bg-[var(--danger)]/10 text-[var(--danger)]",
+  };
+}
+
+export function OperationsTab() {
+  const [data, setData] = useState<ObservabilityResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (isRefresh = false) => {
+    if (isRefresh) setRefreshing(true);
+    else setLoading(true);
+
+    try {
+      const response = await fetch("/api/ops/observability", { cache: "no-store" });
+      if (!response.ok) {
+        throw new Error("Failed to fetch observability report");
+      }
+
+      const payload = (await response.json()) as ObservabilityResponse;
+      setData(payload);
+      setError(null);
+    } catch {
+      setError("Could not load observability report.");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load(false);
+  }, [load]);
+
+  const suggestedRunbooks = useMemo(() => {
+    if (!data) return [];
+
+    const set = new Set(data.suggestedRunbookIds);
+    return data.runbooks.filter((runbook) => set.has(runbook.id));
+  }, [data]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="max-w-4xl space-y-4">
+        {error && (
+          <div className="flex items-center gap-2 rounded-lg border border-[var(--danger)]/40 bg-[var(--danger)]/10 px-3 py-2 text-sm text-foreground">
+            <AlertTriangle className="h-4 w-4 text-[var(--danger)]" />
+            {error}
+          </div>
+        )}
+        <button
+          onClick={() => load(true)}
+          className="btn-ghost-muted rounded-lg border border-border px-3 py-2 text-sm"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const badge = statusBadge(data.report.overallStatus);
+
+  return (
+    <div className="max-w-5xl space-y-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold text-foreground">Operations</h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Live SLOs, queue pressure, and integration health for on-call triage.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${badge.classes}`}>
+            {badge.label}
+          </span>
+          <button
+            onClick={() => load(true)}
+            disabled={refreshing}
+            className="btn-ghost-muted inline-flex items-center gap-1 rounded-lg border border-border px-3 py-1.5 text-xs disabled:opacity-60"
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? "animate-spin" : ""}`} />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <div className="rounded-lg border border-border bg-card p-3">
+          <p className="text-xs text-muted-foreground">SLO Breaches</p>
+          <p className="mt-1 text-xl font-semibold text-foreground">{data.report.breachCount}</p>
+        </div>
+        <div className="rounded-lg border border-border bg-card p-3">
+          <p className="text-xs text-muted-foreground">Critical Breaches</p>
+          <p className="mt-1 text-xl font-semibold text-foreground">{data.report.criticalBreachCount}</p>
+        </div>
+        <div className="rounded-lg border border-border bg-card p-3">
+          <p className="text-xs text-muted-foreground">Queue Lag</p>
+          <p className="mt-1 text-xl font-semibold text-foreground">
+            {data.outboxMetrics.lag.oldestRetryableEventAgeSeconds ?? 0}s
+          </p>
+        </div>
+        <div className="rounded-lg border border-border bg-card p-3">
+          <p className="text-xs text-muted-foreground">Integration Errors</p>
+          <p className="mt-1 text-xl font-semibold text-foreground">
+            {data.report.integrationHealth.errorConnections}
+          </p>
+        </div>
+      </div>
+
+      <section className="rounded-lg border border-border bg-card p-4">
+        <h3 className="text-sm font-semibold text-foreground">Service-level Objectives</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Generated at {formatTimestamp(data.generatedAt)}.
+        </p>
+
+        <div className="mt-3 space-y-2">
+          {data.report.slos.map((slo) => {
+            const icon = slo.breached ? Siren : CheckCircle2;
+            const Icon = icon;
+            const indicatorClasses =
+              slo.breached && slo.severity === "critical"
+                ? "text-[var(--danger)]"
+                : slo.breached
+                  ? "text-[var(--warning)]"
+                  : "text-[var(--success)]";
+
+            return (
+              <div
+                key={slo.key}
+                className="rounded-md border border-border bg-secondary/30 px-3 py-2"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex items-start gap-2">
+                    <Icon className={`mt-0.5 h-4 w-4 ${indicatorClasses}`} />
+                    <div>
+                      <p className="text-sm font-medium text-foreground">{slo.label}</p>
+                      <p className="text-xs text-muted-foreground">{slo.objective}</p>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-sm font-semibold text-foreground">{slo.value}</p>
+                    <p className="text-xs text-muted-foreground">Target: {slo.thresholdLabel}</p>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-border bg-card p-4">
+        <h3 className="text-sm font-semibold text-foreground">Integration Health</h3>
+        <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-2">
+          {data.report.integrationHealth.providers.map((provider) => (
+            <div
+              key={provider.provider}
+              className="rounded-md border border-border bg-secondary/30 px-3 py-2"
+            >
+              <p className="text-sm font-medium text-foreground">{provider.provider}</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Connected {provider.connected} • Error {provider.errored} • Stale sync {provider.staleConnections}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Enabled rules {provider.enabledRules} • Stale rules {provider.staleRules}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-border bg-card p-4">
+        <h3 className="text-sm font-semibold text-foreground">Runbooks</h3>
+        {suggestedRunbooks.length > 0 && (
+          <div className="mt-2 rounded-md border border-[var(--warning)]/40 bg-[var(--warning)]/10 px-3 py-2 text-xs text-foreground">
+            Suggested now: {suggestedRunbooks.map((runbook) => runbook.title).join(", ")}
+          </div>
+        )}
+        <div className="mt-3 space-y-2">
+          {data.runbooks.map((runbook) => (
+            <div
+              key={runbook.id}
+              className="rounded-md border border-border bg-secondary/30 px-3 py-2"
+            >
+              <div className="flex items-start gap-2">
+                <Wrench className="mt-0.5 h-4 w-4 text-primary" />
+                <div>
+                  <p className="text-sm font-medium text-foreground">{runbook.title}</p>
+                  <p className="text-xs text-muted-foreground">{runbook.description}</p>
+                  <p className="mt-1 text-xs font-mono text-muted-foreground">{runbook.path}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {data.outboxMetrics.recentDeadLetters.length > 0 && (
+        <section className="rounded-lg border border-border bg-card p-4">
+          <h3 className="text-sm font-semibold text-foreground">Recent Dead Letters</h3>
+          <div className="mt-2 space-y-2">
+            {data.outboxMetrics.recentDeadLetters.slice(0, 8).map((event) => (
+              <div
+                key={event.id}
+                className="rounded-md border border-[var(--danger)]/30 bg-[var(--danger)]/10 px-3 py-2"
+              >
+                <p className="text-xs font-medium text-foreground">{event.eventType}</p>
+                <p className="text-xs text-muted-foreground">
+                  {event.aggregateType}:{event.aggregateId} • retries {event.retryCount}
+                </p>
+                {event.error && (
+                  <p className="mt-1 text-xs text-[var(--danger)]">{event.error}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {error && (
+        <div className="rounded-lg border border-[var(--warning)]/40 bg-[var(--warning)]/10 px-3 py-2 text-xs text-foreground">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/__tests__/observability-slo.test.ts
+++ b/src/lib/__tests__/observability-slo.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { OutboxOperationalMetrics } from "@/lib/outbox-worker";
+import { evaluateObservabilitySlos } from "@/lib/observability/slo";
+
+function baseOutboxMetrics(): OutboxOperationalMetrics {
+  return {
+    counts: {
+      pending: 0,
+      failed: 0,
+      deadLetter: 0,
+      dispatched: 10,
+      total: 10,
+    },
+    lag: {
+      oldestRetryableEventAgeSeconds: 0,
+      oldestRetryableEventId: null,
+    },
+    failuresByEventType: [],
+    recentDeadLetters: [],
+  };
+}
+
+describe("evaluateObservabilitySlos", () => {
+  it("returns healthy when lag and integration freshness are within thresholds", () => {
+    const now = new Date("2026-02-16T15:00:00.000Z");
+
+    const report = evaluateObservabilitySlos({
+      now,
+      outboxMetrics: baseOutboxMetrics(),
+      connections: [
+        {
+          provider: "GOOGLE_WORKSPACE",
+          status: "CONNECTED",
+          lastSyncedAt: "2026-02-16T14:50:00.000Z",
+          lastError: null,
+        },
+      ],
+      rules: [
+        {
+          provider: "GOOGLE_WORKSPACE",
+          enabled: true,
+          lastRunAt: "2026-02-16T14:45:00.000Z",
+          lastError: null,
+        },
+      ],
+    });
+
+    expect(report.overallStatus).toBe("healthy");
+    expect(report.breachCount).toBe(0);
+  });
+
+  it("flags critical when queue lag and integration errors breach thresholds", () => {
+    const now = new Date("2026-02-16T15:00:00.000Z");
+
+    const outbox = baseOutboxMetrics();
+    outbox.lag.oldestRetryableEventAgeSeconds = 901;
+    outbox.counts.failed = 21;
+
+    const report = evaluateObservabilitySlos({
+      now,
+      outboxMetrics: outbox,
+      connections: [
+        {
+          provider: "SLACK",
+          status: "ERROR",
+          lastSyncedAt: "2026-02-16T13:00:00.000Z",
+          lastError: "token expired",
+        },
+      ],
+      rules: [
+        {
+          provider: "SLACK",
+          enabled: true,
+          lastRunAt: "2026-02-16T13:00:00.000Z",
+          lastError: "sync failed",
+        },
+      ],
+    });
+
+    expect(report.overallStatus).toBe("critical");
+    expect(report.breachCount).toBeGreaterThanOrEqual(2);
+    expect(report.integrationHealth.errorConnections).toBe(1);
+    expect(report.integrationHealth.staleRules).toBe(1);
+  });
+});

--- a/src/lib/event-bus.ts
+++ b/src/lib/event-bus.ts
@@ -39,7 +39,7 @@ export async function enqueueOutboxEvent(
   db: OutboxEventWriteClient,
   input: DomainEventInput
 ): Promise<OutboxEvent> {
-  return db.outboxEvent.upsert({
+  const event = await db.outboxEvent.upsert({
     where: { idempotencyKey: input.idempotencyKey },
     update: {},
     create: {
@@ -54,6 +54,17 @@ export async function enqueueOutboxEvent(
       nextAttemptAt: new Date(),
     },
   });
+
+  console.info("outbox.event.enqueued", {
+    eventId: event.id,
+    eventType: event.eventType,
+    aggregateType: event.aggregateType,
+    aggregateId: event.aggregateId,
+    idempotencyKey: event.idempotencyKey,
+    status: event.status,
+  });
+
+  return event;
 }
 
 export async function publishDomainEvent(

--- a/src/lib/observability/slo.ts
+++ b/src/lib/observability/slo.ts
@@ -1,0 +1,244 @@
+import type { OutboxOperationalMetrics } from "@/lib/outbox-worker";
+
+export type SloSeverity = "warning" | "critical";
+
+export interface ObservabilityConnectionSample {
+  provider: string;
+  status: "CONNECTED" | "DISCONNECTED" | "ERROR";
+  lastSyncedAt: string | null;
+  lastError: string | null;
+}
+
+export interface ObservabilityRuleSample {
+  provider: string;
+  enabled: boolean;
+  lastRunAt: string | null;
+  lastError: string | null;
+}
+
+export interface ObservabilitySlo {
+  key: string;
+  label: string;
+  objective: string;
+  thresholdLabel: string;
+  value: string;
+  breached: boolean;
+  severity: SloSeverity | null;
+  runbookIds: string[];
+}
+
+export interface ProviderHealthSummary {
+  provider: string;
+  connected: number;
+  errored: number;
+  staleConnections: number;
+  enabledRules: number;
+  staleRules: number;
+}
+
+export interface IntegrationHealthSummary {
+  totalConnections: number;
+  connectedConnections: number;
+  errorConnections: number;
+  staleConnections: number;
+  enabledRules: number;
+  staleRules: number;
+  providers: ProviderHealthSummary[];
+}
+
+export interface ObservabilitySloReport {
+  overallStatus: "healthy" | "degraded" | "critical";
+  breachCount: number;
+  criticalBreachCount: number;
+  slos: ObservabilitySlo[];
+  integrationHealth: IntegrationHealthSummary;
+}
+
+interface EvaluateSloInput {
+  outboxMetrics: OutboxOperationalMetrics;
+  connections: ObservabilityConnectionSample[];
+  rules: ObservabilityRuleSample[];
+  now?: Date;
+}
+
+const OUTBOX_LAG_THRESHOLD_SECONDS = 5 * 60;
+const FAILED_EVENT_THRESHOLD = 20;
+const INTEGRATION_FRESHNESS_THRESHOLD_MINUTES = 30;
+
+function ageMinutes(now: Date, isoDate: string | null): number | null {
+  if (!isoDate) return null;
+  const parsed = new Date(isoDate);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return Math.max(0, Math.floor((now.getTime() - parsed.getTime()) / 60000));
+}
+
+function formatValue(value: number | null, suffix: string): string {
+  if (value === null) return "n/a";
+  return `${value}${suffix}`;
+}
+
+function summarizeIntegrationHealth(input: {
+  now: Date;
+  connections: ObservabilityConnectionSample[];
+  rules: ObservabilityRuleSample[];
+}): IntegrationHealthSummary {
+  const providerMap = new Map<string, ProviderHealthSummary>();
+
+  for (const connection of input.connections) {
+    const current = providerMap.get(connection.provider) ?? {
+      provider: connection.provider,
+      connected: 0,
+      errored: 0,
+      staleConnections: 0,
+      enabledRules: 0,
+      staleRules: 0,
+    };
+
+    if (connection.status === "CONNECTED") {
+      current.connected += 1;
+      const minutes = ageMinutes(input.now, connection.lastSyncedAt);
+      if (minutes === null || minutes > INTEGRATION_FRESHNESS_THRESHOLD_MINUTES) {
+        current.staleConnections += 1;
+      }
+    }
+
+    if (connection.status === "ERROR") {
+      current.errored += 1;
+    }
+
+    providerMap.set(connection.provider, current);
+  }
+
+  for (const rule of input.rules) {
+    const current = providerMap.get(rule.provider) ?? {
+      provider: rule.provider,
+      connected: 0,
+      errored: 0,
+      staleConnections: 0,
+      enabledRules: 0,
+      staleRules: 0,
+    };
+
+    if (rule.enabled) {
+      current.enabledRules += 1;
+      const minutes = ageMinutes(input.now, rule.lastRunAt);
+      if (minutes === null || minutes > INTEGRATION_FRESHNESS_THRESHOLD_MINUTES) {
+        current.staleRules += 1;
+      }
+    }
+
+    providerMap.set(rule.provider, current);
+  }
+
+  const providers = Array.from(providerMap.values()).sort((a, b) =>
+    a.provider.localeCompare(b.provider)
+  );
+
+  return {
+    totalConnections: input.connections.length,
+    connectedConnections: input.connections.filter((item) => item.status === "CONNECTED").length,
+    errorConnections: input.connections.filter((item) => item.status === "ERROR").length,
+    staleConnections: providers.reduce((sum, provider) => sum + provider.staleConnections, 0),
+    enabledRules: providers.reduce((sum, provider) => sum + provider.enabledRules, 0),
+    staleRules: providers.reduce((sum, provider) => sum + provider.staleRules, 0),
+    providers,
+  };
+}
+
+export function evaluateObservabilitySlos(input: EvaluateSloInput): ObservabilitySloReport {
+  const now = input.now ?? new Date();
+
+  const integrationHealth = summarizeIntegrationHealth({
+    now,
+    connections: input.connections,
+    rules: input.rules,
+  });
+
+  const outboxLagSeconds = input.outboxMetrics.lag.oldestRetryableEventAgeSeconds;
+  const failedOrDeadLetter =
+    input.outboxMetrics.counts.failed + input.outboxMetrics.counts.deadLetter;
+
+  const slos: ObservabilitySlo[] = [
+    {
+      key: "outbox_delivery_lag",
+      label: "Outbox Delivery Lag",
+      objective: "Retryable events are dispatched within 5 minutes.",
+      thresholdLabel: `<= ${OUTBOX_LAG_THRESHOLD_SECONDS}s`,
+      value: formatValue(outboxLagSeconds, "s"),
+      breached:
+        outboxLagSeconds !== null && outboxLagSeconds > OUTBOX_LAG_THRESHOLD_SECONDS,
+      severity:
+        outboxLagSeconds !== null && outboxLagSeconds > OUTBOX_LAG_THRESHOLD_SECONDS
+          ? "critical"
+          : null,
+      runbookIds: ["queue-backup"],
+    },
+    {
+      key: "outbox_failure_budget",
+      label: "Outbox Failure Budget",
+      objective: "Failed + dead-letter events remain below the warning threshold.",
+      thresholdLabel: `< ${FAILED_EVENT_THRESHOLD}`,
+      value: String(failedOrDeadLetter),
+      breached: failedOrDeadLetter >= FAILED_EVENT_THRESHOLD,
+      severity: failedOrDeadLetter >= FAILED_EVENT_THRESHOLD ? "warning" : null,
+      runbookIds: ["queue-backup"],
+    },
+    {
+      key: "integration_sync_freshness",
+      label: "Integration Sync Freshness",
+      objective: "Enabled integration rules run at least every 30 minutes.",
+      thresholdLabel: `${INTEGRATION_FRESHNESS_THRESHOLD_MINUTES}m`,
+      value: `${integrationHealth.staleRules} stale rule(s)`,
+      breached: integrationHealth.staleRules > 0,
+      severity: integrationHealth.staleRules > 0 ? "warning" : null,
+      runbookIds: ["sync-lag"],
+    },
+    {
+      key: "integration_connection_health",
+      label: "Integration Connection Health",
+      objective: "Connected integrations stay healthy and recently synced.",
+      thresholdLabel: "0 errors, 0 stale connections",
+      value: `${integrationHealth.errorConnections} error, ${integrationHealth.staleConnections} stale`,
+      breached:
+        integrationHealth.errorConnections > 0 || integrationHealth.staleConnections > 0,
+      severity:
+        integrationHealth.errorConnections > 0 || integrationHealth.staleConnections > 0
+          ? "critical"
+          : null,
+      runbookIds: ["sync-lag"],
+    },
+    {
+      key: "websocket_delivery_proxy",
+      label: "Realtime Delivery Proxy",
+      objective:
+        "Realtime event channel remains healthy (proxied by outbox lag and event failures).",
+      thresholdLabel: `lag <= ${OUTBOX_LAG_THRESHOLD_SECONDS}s and failed/dead-letter < ${FAILED_EVENT_THRESHOLD}`,
+      value: `${formatValue(outboxLagSeconds, "s")} lag / ${failedOrDeadLetter} failed+dead-letter`,
+      breached:
+        (outboxLagSeconds !== null && outboxLagSeconds > OUTBOX_LAG_THRESHOLD_SECONDS) ||
+        failedOrDeadLetter >= FAILED_EVENT_THRESHOLD,
+      severity:
+        (outboxLagSeconds !== null && outboxLagSeconds > OUTBOX_LAG_THRESHOLD_SECONDS) ||
+        failedOrDeadLetter >= FAILED_EVENT_THRESHOLD
+          ? "critical"
+          : null,
+      runbookIds: ["websocket-degradation", "queue-backup"],
+    },
+  ];
+
+  const breachCount = slos.filter((item) => item.breached).length;
+  const criticalBreachCount = slos.filter(
+    (item) => item.breached && item.severity === "critical"
+  ).length;
+
+  const overallStatus =
+    criticalBreachCount > 0 ? "critical" : breachCount > 0 ? "degraded" : "healthy";
+
+  return {
+    overallStatus,
+    breachCount,
+    criticalBreachCount,
+    slos,
+    integrationHealth,
+  };
+}

--- a/src/lib/outbox-worker.ts
+++ b/src/lib/outbox-worker.ts
@@ -176,13 +176,40 @@ export async function dispatchOutboxBatch(
   let deadLetter = 0;
 
   for (const event of events) {
+    const startedAt = Date.now();
+    console.info("outbox.event.dispatch_started", {
+      eventId: event.id,
+      eventType: event.eventType,
+      aggregateType: event.aggregateType,
+      aggregateId: event.aggregateId,
+      retryCount: event.retryCount,
+      status: event.status,
+    });
+
     try {
       await dispatch(event);
       await markOutboxEventDispatched(db, event.id, options?.now ?? new Date());
       dispatched += 1;
+      console.info("outbox.event.dispatch_succeeded", {
+        eventId: event.id,
+        eventType: event.eventType,
+        aggregateType: event.aggregateType,
+        aggregateId: event.aggregateId,
+        dispatchDurationMs: Date.now() - startedAt,
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const status = await markOutboxEventFailure(db, event, message, options);
+      console.error("outbox.event.dispatch_failed", {
+        eventId: event.id,
+        eventType: event.eventType,
+        aggregateType: event.aggregateType,
+        aggregateId: event.aggregateId,
+        retryCount: event.retryCount + 1,
+        nextStatus: status,
+        error: message,
+        dispatchDurationMs: Date.now() - startedAt,
+      });
       if (status === "DEAD_LETTER") {
         deadLetter += 1;
       } else {


### PR DESCRIPTION
## Summary
- add observability SLO evaluation library and authenticated API endpoint at `/api/ops/observability`
- add an Operations tab in Settings with live SLO status, integration health, dead-letter visibility, and runbook suggestions
- add incident runbooks for sync lag, queue backup, and websocket degradation
- add structured outbox event logging for enqueue/dispatch success/failure

## Testing
- npm test -- --run src/lib/__tests__/observability-slo.test.ts src/lib/__tests__/outbox-worker.test.ts
- npx eslint src/lib/observability/slo.ts src/app/api/ops/observability/route.ts src/components/settings/operations-tab.tsx src/lib/event-bus.ts src/lib/outbox-worker.ts 'src/app/(dashboard)/settings/page.tsx' src/lib/__tests__/observability-slo.test.ts
- npx tsc --noEmit

Closes #16
