### PR TITLE
[WGX-014] Flow analytics engine (CFD, throughput, cycle/lead)

### DIFF
--- a/docs/metrics/flow-analytics-definitions.md
+++ b/docs/metrics/flow-analytics-definitions.md
@@ -1,0 +1,39 @@
+# Flow Analytics Definitions
+
+This document defines the metrics served by `/api/flow/metrics`.
+
+## Query Parameters
+- `from`: optional ISO timestamp or `YYYY-MM-DD` (default: now - 30 days)
+- `to`: optional ISO timestamp or `YYYY-MM-DD` (default: now)
+- `interval`: optional `day` or `week` (default: `day`)
+
+Responses include fixed bucket boundaries (`bucketStart`, `bucketEnd`) so both dashboard
+visualizations and export consumers can reproduce the same aggregations.
+
+## Cumulative Flow Diagram (CFD)
+- Source: `Task.createdAt`, `StatusHistory.changedAt`, `StatusHistory.toStatus`
+- Definition: Count of tasks in each workflow status at the end of each interval bucket.
+- Use: Visualize WIP distribution and queue buildup over time.
+
+## Throughput
+- Source: `StatusHistory.toStatus = DONE`
+- Definition: Number of tasks that transitioned to DONE in each interval bucket.
+- Use: Measure delivery output and completion velocity.
+
+## Lead Time
+- Source: `Task.createdAt` -> first `DONE` transition (`StatusHistory`) or `Task.completedOn` fallback.
+- Definition: Duration in days from task creation to completion.
+- Use: End-to-end flow efficiency measurement.
+
+## Cycle Time
+- Source: first `ACTIVE` / `WORKING_ON_TODAY` transition -> first `DONE` transition.
+- Definition: Duration in days spent in active execution before completion.
+- Use: Execution efficiency after work starts.
+
+## Data Quality Validation
+- Checks for:
+  - missing status history
+  - status transitions before task creation
+  - from-status chain mismatches
+  - DONE tasks missing completion transition/timestamp
+- Output includes issue counts and sampled task IDs for traceability.

--- a/src/app/api/flow/metrics/route.ts
+++ b/src/app/api/flow/metrics/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { computeFlowAnalytics, type FlowInterval } from "@/lib/flow/analytics";
+
+export const dynamic = "force-dynamic";
+
+const MAX_RANGE_DAYS = 365;
+const ISO_DATE_ONLY_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+class BadRequestError extends Error {}
+
+function parseDateParam(
+  value: string | null,
+  fallback: Date,
+  boundary: "start" | "end"
+): Date {
+  if (!value) return fallback;
+
+  if (ISO_DATE_ONLY_REGEX.test(value)) {
+    const suffix = boundary === "start" ? "T00:00:00.000Z" : "T23:59:59.999Z";
+    return new Date(`${value}${suffix}`);
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new BadRequestError(`Invalid date: ${value}`);
+  }
+  return parsed;
+}
+
+function parseInterval(value: string | null): FlowInterval {
+  if (!value) return "day";
+  if (value === "week") return "week";
+  if (value === "day") return "day";
+  throw new BadRequestError("interval must be one of: day, week");
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const now = new Date();
+    const defaultFrom = new Date(now);
+    defaultFrom.setUTCDate(defaultFrom.getUTCDate() - 30);
+
+    const from = parseDateParam(request.nextUrl.searchParams.get("from"), defaultFrom, "start");
+    const to = parseDateParam(request.nextUrl.searchParams.get("to"), now, "end");
+    const interval = parseInterval(request.nextUrl.searchParams.get("interval"));
+
+    if (from > to) {
+      return NextResponse.json(
+        { error: "from must be before to" },
+        { status: 400 }
+      );
+    }
+
+    const rangeDays = Math.ceil((to.getTime() - from.getTime()) / (1000 * 60 * 60 * 24));
+    if (rangeDays > MAX_RANGE_DAYS) {
+      return NextResponse.json(
+        { error: `Date range too large. Maximum ${MAX_RANGE_DAYS} days.` },
+        { status: 400 }
+      );
+    }
+
+    const result = await computeFlowAnalytics({
+      from,
+      to,
+      interval,
+    });
+
+    return NextResponse.json(result);
+  } catch (error) {
+    if (error instanceof BadRequestError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    const message = error instanceof Error ? error.message : "Failed to compute flow metrics";
+    console.error("GET /api/flow/metrics error:", error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/lib/__tests__/flow-analytics.test.ts
+++ b/src/lib/__tests__/flow-analytics.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import type { TaskStatus } from "@/generated/prisma/client";
+import { __private__ } from "@/lib/flow/analytics";
+
+describe("flow analytics helpers", () => {
+  it("computes percentiles and mean for duration stats", () => {
+    const stats = __private__.durationStats([1, 2, 3, 4, 5]);
+
+    expect(stats.sampleSize).toBe(5);
+    expect(stats.mean).toBe(3);
+    expect(stats.p50).toBe(3);
+    expect(stats.p75).toBe(4);
+    expect(stats.p90).toBe(4.6);
+  });
+
+  it("builds throughput buckets from DONE transitions", () => {
+    const transitions = [
+      {
+        id: "a",
+        taskId: "t1",
+        fromStatus: "ACTIVE" as TaskStatus,
+        toStatus: "DONE" as TaskStatus,
+        changedAt: new Date("2026-02-10T12:00:00.000Z"),
+      },
+      {
+        id: "b",
+        taskId: "t2",
+        fromStatus: "ACTIVE" as TaskStatus,
+        toStatus: "DONE" as TaskStatus,
+        changedAt: new Date("2026-02-10T18:00:00.000Z"),
+      },
+      {
+        id: "c",
+        taskId: "t3",
+        fromStatus: "ACTIVE" as TaskStatus,
+        toStatus: "NOT_DONE" as TaskStatus,
+        changedAt: new Date("2026-02-11T18:00:00.000Z"),
+      },
+      {
+        id: "d",
+        taskId: "t4",
+        fromStatus: "ACTIVE" as TaskStatus,
+        toStatus: "DONE" as TaskStatus,
+        changedAt: new Date("2026-02-12T00:00:00.000Z"),
+      },
+    ];
+
+    const buckets = __private__.buildThroughputSeries({
+      transitions,
+      from: new Date("2026-02-10T00:00:00.000Z"),
+      to: new Date("2026-02-11T23:59:59.000Z"),
+      interval: "day",
+    });
+
+    expect(buckets).toHaveLength(2);
+    expect(buckets[0].completed).toBe(2);
+    expect(buckets[1].completed).toBe(0);
+  });
+
+  it("uses first transition fromStatus as initial CFD state", () => {
+    const cfd = __private__.buildCfdSeries({
+      tasks: [
+        {
+          id: "task-1",
+          status: "DONE" as TaskStatus,
+          createdAt: new Date("2026-02-10T00:00:00.000Z"),
+          completedOn: null,
+        },
+      ],
+      transitionsByTask: new Map([
+        [
+          "task-1",
+          [
+            {
+              id: "tr-1",
+              taskId: "task-1",
+              fromStatus: "BACKLOG" as TaskStatus,
+              toStatus: "ACTIVE" as TaskStatus,
+              changedAt: new Date("2026-02-11T12:00:00.000Z"),
+            },
+          ],
+        ],
+      ]),
+      from: new Date("2026-02-10T00:00:00.000Z"),
+      to: new Date("2026-02-11T23:59:59.000Z"),
+      interval: "day",
+    });
+
+    expect(cfd[0].counts.BACKLOG).toBe(1);
+    expect(cfd[0].counts.ACTIVE).toBe(0);
+    expect(cfd[1].counts.ACTIVE).toBe(1);
+  });
+
+  it("flags data quality issues and counts valid tasks by unique task id", () => {
+    const report = __private__.evaluateDataQuality({
+      tasks: [
+        {
+          id: "task-1",
+          status: "DONE" as TaskStatus,
+          createdAt: new Date("2026-02-10T00:00:00.000Z"),
+          completedOn: null,
+        },
+        {
+          id: "task-2",
+          status: "ACTIVE" as TaskStatus,
+          createdAt: new Date("2026-02-10T00:00:00.000Z"),
+          completedOn: null,
+        },
+        {
+          id: "task-3",
+          status: "ACTIVE" as TaskStatus,
+          createdAt: new Date("2026-02-10T00:00:00.000Z"),
+          completedOn: null,
+        },
+      ],
+      transitionsByTask: new Map([
+        [
+          "task-2",
+          [
+            {
+              id: "tr-1",
+              taskId: "task-2",
+              fromStatus: "BACKLOG" as TaskStatus,
+              toStatus: "ACTIVE" as TaskStatus,
+              changedAt: new Date("2026-02-09T00:00:00.000Z"),
+            },
+          ],
+        ],
+        [
+          "task-3",
+          [
+            {
+              id: "tr-2",
+              taskId: "task-3",
+              fromStatus: "BACKLOG" as TaskStatus,
+              toStatus: "ACTIVE" as TaskStatus,
+              changedAt: new Date("2026-02-10T12:00:00.000Z"),
+            },
+          ],
+        ],
+      ]),
+    });
+
+    expect(report.checkedTaskCount).toBe(3);
+    expect(report.issueCount).toBe(3);
+    expect(report.validTaskCount).toBe(1);
+
+    const missingHistory = report.issues.find((issue) => issue.issue === "missing_status_history");
+    const missingDoneTransition = report.issues.find(
+      (issue) => issue.issue === "done_without_done_transition"
+    );
+    const invalidTransitionOrder = report.issues.find(
+      (issue) => issue.issue === "transition_before_task_created"
+    );
+
+    expect(missingHistory?.count).toBe(1);
+    expect(missingDoneTransition?.count).toBe(1);
+    expect(invalidTransitionOrder?.count).toBe(1);
+    expect(report.issues.some((issue) => issue.issue === "missing_status_history")).toBe(true);
+    expect(
+      report.issues.some((issue) => issue.issue === "transition_before_task_created")
+    ).toBe(true);
+  });
+});

--- a/src/lib/flow/analytics.ts
+++ b/src/lib/flow/analytics.ts
@@ -1,0 +1,556 @@
+import type { TaskStatus } from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+
+export type FlowInterval = "day" | "week";
+
+const ACTIVE_STATUSES = new Set<TaskStatus>(["WORKING_ON_TODAY", "ACTIVE"]);
+
+interface FlowTaskRecord {
+  id: string;
+  status: TaskStatus;
+  createdAt: Date;
+  completedOn: Date | null;
+}
+
+interface FlowTransitionRecord {
+  id: string;
+  taskId: string;
+  fromStatus: TaskStatus | null;
+  toStatus: TaskStatus;
+  changedAt: Date;
+}
+
+export interface FlowBucketStatusCounts {
+  bucketStart: string;
+  bucketEnd: string;
+  counts: Record<TaskStatus, number>;
+}
+
+export interface FlowThroughputBucket {
+  bucketStart: string;
+  bucketEnd: string;
+  completed: number;
+}
+
+export interface FlowDurationStats {
+  sampleSize: number;
+  unit: "days";
+  mean: number | null;
+  p50: number | null;
+  p75: number | null;
+  p90: number | null;
+}
+
+export interface FlowDataQualityIssue {
+  issue: string;
+  count: number;
+  sampleTaskIds: string[];
+}
+
+export interface FlowDataQualityReport {
+  checkedTaskCount: number;
+  validTaskCount: number;
+  issueCount: number;
+  issues: FlowDataQualityIssue[];
+}
+
+export interface FlowAnalyticsResult {
+  from: string;
+  to: string;
+  interval: FlowInterval;
+  generatedAt: string;
+  metricsDefinition: {
+    cfd: string;
+    throughput: string;
+    leadTime: string;
+    cycleTime: string;
+    dataQuality: string;
+  };
+  cfd: FlowBucketStatusCounts[];
+  throughput: FlowThroughputBucket[];
+  leadTime: FlowDurationStats;
+  cycleTime: FlowDurationStats;
+  dataQuality: FlowDataQualityReport;
+  traceability: {
+    source: "Task.createdAt + StatusHistory.changedAt + Task.completedOn";
+    taskSampleIds: string[];
+    transitionSampleIds: string[];
+    totalTasks: number;
+    totalTransitions: number;
+  };
+}
+
+interface DurationSample {
+  taskId: string;
+  leadDays: number | null;
+  cycleDays: number | null;
+}
+
+function startOfUtcDay(input: Date): Date {
+  const date = new Date(input);
+  date.setUTCHours(0, 0, 0, 0);
+  return date;
+}
+
+function endOfUtcDay(input: Date): Date {
+  const date = startOfUtcDay(input);
+  date.setUTCDate(date.getUTCDate() + 1);
+  return date;
+}
+
+function startOfUtcWeek(input: Date): Date {
+  const date = startOfUtcDay(input);
+  const day = date.getUTCDay();
+  const daysFromMonday = (day + 6) % 7;
+  date.setUTCDate(date.getUTCDate() - daysFromMonday);
+  return date;
+}
+
+function addInterval(date: Date, interval: FlowInterval): Date {
+  const next = new Date(date);
+  if (interval === "week") {
+    next.setUTCDate(next.getUTCDate() + 7);
+  } else {
+    next.setUTCDate(next.getUTCDate() + 1);
+  }
+  return next;
+}
+
+function floorToInterval(date: Date, interval: FlowInterval): Date {
+  return interval === "week" ? startOfUtcWeek(date) : startOfUtcDay(date);
+}
+
+function toBucketIso(date: Date): string {
+  return date.toISOString().split("T")[0];
+}
+
+function initStatusCounts(): Record<TaskStatus, number> {
+  return {
+    BACKLOG: 0,
+    QUEUED: 0,
+    WORKING_ON_TODAY: 0,
+    ACTIVE: 0,
+    NOT_DONE: 0,
+    DONE: 0,
+  };
+}
+
+function percentile(sortedValues: number[], percentilePoint: number): number | null {
+  if (sortedValues.length === 0) return null;
+  if (sortedValues.length === 1) return sortedValues[0];
+
+  const index = (percentilePoint / 100) * (sortedValues.length - 1);
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) return sortedValues[lower];
+
+  const weight = index - lower;
+  return sortedValues[lower] * (1 - weight) + sortedValues[upper] * weight;
+}
+
+function round2(value: number | null): number | null {
+  if (value === null) return null;
+  return Math.round(value * 100) / 100;
+}
+
+function durationStats(samples: number[]): FlowDurationStats {
+  if (samples.length === 0) {
+    return {
+      sampleSize: 0,
+      unit: "days",
+      mean: null,
+      p50: null,
+      p75: null,
+      p90: null,
+    };
+  }
+
+  const sorted = [...samples].sort((a, b) => a - b);
+  const mean = sorted.reduce((sum, value) => sum + value, 0) / sorted.length;
+
+  return {
+    sampleSize: sorted.length,
+    unit: "days",
+    mean: round2(mean),
+    p50: round2(percentile(sorted, 50)),
+    p75: round2(percentile(sorted, 75)),
+    p90: round2(percentile(sorted, 90)),
+  };
+}
+
+function inferInitialStatus(task: FlowTaskRecord, transitions: FlowTransitionRecord[]): TaskStatus {
+  const firstTransition = transitions[0];
+  if (firstTransition) {
+    return firstTransition.fromStatus ?? firstTransition.toStatus;
+  }
+
+  return task.status;
+}
+
+function buildTimelineBuckets(from: Date, to: Date, interval: FlowInterval): Date[] {
+  const start = floorToInterval(from, interval);
+  const end = endOfUtcDay(to);
+  const buckets: Date[] = [];
+
+  for (let cursor = new Date(start); cursor < end; cursor = addInterval(cursor, interval)) {
+    buckets.push(new Date(cursor));
+  }
+
+  return buckets;
+}
+
+function buildCfdSeries(input: {
+  tasks: FlowTaskRecord[];
+  transitionsByTask: Map<string, FlowTransitionRecord[]>;
+  from: Date;
+  to: Date;
+  interval: FlowInterval;
+}): FlowBucketStatusCounts[] {
+  const buckets = buildTimelineBuckets(input.from, input.to, input.interval);
+
+  const events: Array<{ at: Date; taskId: string; status: TaskStatus }> = [];
+
+  for (const task of input.tasks) {
+    const transitions = input.transitionsByTask.get(task.id) ?? [];
+    const initialStatus = inferInitialStatus(task, transitions);
+    events.push({ at: task.createdAt, taskId: task.id, status: initialStatus });
+
+    for (const transition of transitions) {
+      events.push({
+        at: transition.changedAt,
+        taskId: task.id,
+        status: transition.toStatus,
+      });
+    }
+  }
+
+  events.sort((a, b) => a.at.getTime() - b.at.getTime());
+
+  const statusByTask = new Map<string, TaskStatus>();
+  let eventCursor = 0;
+
+  const output: FlowBucketStatusCounts[] = [];
+
+  for (const bucketStart of buckets) {
+    const bucketEnd = addInterval(bucketStart, input.interval);
+
+    while (eventCursor < events.length && events[eventCursor].at < bucketEnd) {
+      const event = events[eventCursor];
+      statusByTask.set(event.taskId, event.status);
+      eventCursor += 1;
+    }
+
+    const counts = initStatusCounts();
+    for (const status of statusByTask.values()) {
+      counts[status] += 1;
+    }
+
+    output.push({
+      bucketStart: toBucketIso(bucketStart),
+      bucketEnd: toBucketIso(bucketEnd),
+      counts,
+    });
+  }
+
+  return output;
+}
+
+function buildThroughputSeries(input: {
+  transitions: FlowTransitionRecord[];
+  from: Date;
+  to: Date;
+  interval: FlowInterval;
+}): FlowThroughputBucket[] {
+  const buckets = buildTimelineBuckets(input.from, input.to, input.interval);
+  const throughputByBucket = new Map<string, number>();
+  const rangeEndExclusive = endOfUtcDay(input.to);
+
+  for (const transition of input.transitions) {
+    if (transition.toStatus !== "DONE") continue;
+    if (transition.changedAt < input.from || transition.changedAt >= rangeEndExclusive) {
+      continue;
+    }
+
+    const bucketStart = floorToInterval(transition.changedAt, input.interval);
+    const key = toBucketIso(bucketStart);
+    throughputByBucket.set(key, (throughputByBucket.get(key) ?? 0) + 1);
+  }
+
+  return buckets.map((bucketStart) => {
+    const key = toBucketIso(bucketStart);
+    return {
+      bucketStart: key,
+      bucketEnd: toBucketIso(addInterval(bucketStart, input.interval)),
+      completed: throughputByBucket.get(key) ?? 0,
+    };
+  });
+}
+
+function computeDurationSamples(input: {
+  tasks: FlowTaskRecord[];
+  transitionsByTask: Map<string, FlowTransitionRecord[]>;
+  from: Date;
+  to: Date;
+}): DurationSample[] {
+  const samples: DurationSample[] = [];
+  const rangeEndExclusive = endOfUtcDay(input.to);
+
+  for (const task of input.tasks) {
+    const transitions = input.transitionsByTask.get(task.id) ?? [];
+
+    const doneTransition = transitions.find((transition) => transition.toStatus === "DONE");
+    const doneAt = doneTransition?.changedAt ?? task.completedOn;
+    if (!doneAt) continue;
+    if (doneAt < input.from || doneAt >= rangeEndExclusive) {
+      continue;
+    }
+
+    const activeTransition = transitions.find((transition) =>
+      ACTIVE_STATUSES.has(transition.toStatus)
+    );
+
+    const leadDays = (doneAt.getTime() - task.createdAt.getTime()) / (1000 * 60 * 60 * 24);
+    const cycleDays = activeTransition
+      ? (doneAt.getTime() - activeTransition.changedAt.getTime()) / (1000 * 60 * 60 * 24)
+      : null;
+
+    samples.push({
+      taskId: task.id,
+      leadDays: leadDays >= 0 ? leadDays : null,
+      cycleDays: cycleDays !== null && cycleDays >= 0 ? cycleDays : null,
+    });
+  }
+
+  return samples;
+}
+
+function evaluateDataQuality(input: {
+  tasks: FlowTaskRecord[];
+  transitionsByTask: Map<string, FlowTransitionRecord[]>;
+}): FlowDataQualityReport {
+  type IssueKey =
+    | "missing_status_history"
+    | "transition_before_task_created"
+    | "from_status_mismatch"
+    | "done_without_done_transition";
+
+  const issueCounts: Record<IssueKey, number> = {
+    missing_status_history: 0,
+    transition_before_task_created: 0,
+    from_status_mismatch: 0,
+    done_without_done_transition: 0,
+  };
+  const issueSamples: Record<IssueKey, string[]> = {
+    missing_status_history: [],
+    transition_before_task_created: [],
+    from_status_mismatch: [],
+    done_without_done_transition: [],
+  };
+
+  const invalidTaskIds = new Set<string>();
+
+  const registerIssue = (issue: IssueKey, taskId: string): void => {
+    issueCounts[issue] += 1;
+    invalidTaskIds.add(taskId);
+    if (issueSamples[issue].length < 20 && !issueSamples[issue].includes(taskId)) {
+      issueSamples[issue].push(taskId);
+    }
+  };
+
+  for (const task of input.tasks) {
+    const transitions = input.transitionsByTask.get(task.id) ?? [];
+    if (transitions.length === 0) {
+      registerIssue("missing_status_history", task.id);
+    }
+
+    let previousStatus: TaskStatus | null = null;
+    let hasDoneTransition = false;
+
+    for (const transition of transitions) {
+      if (transition.changedAt < task.createdAt) {
+        registerIssue("transition_before_task_created", task.id);
+        break;
+      }
+
+      if (
+        previousStatus !== null &&
+        transition.fromStatus !== null &&
+        transition.fromStatus !== previousStatus
+      ) {
+        registerIssue("from_status_mismatch", task.id);
+        break;
+      }
+
+      previousStatus = transition.toStatus;
+      if (transition.toStatus === "DONE") {
+        hasDoneTransition = true;
+      }
+    }
+
+    if (task.status === "DONE" && !hasDoneTransition && !task.completedOn) {
+      registerIssue("done_without_done_transition", task.id);
+    }
+  }
+
+  const issues: FlowDataQualityIssue[] = Object.entries(issueSamples)
+    .map(([issue, sampleTaskIds]) => ({
+      issue,
+      count: issueCounts[issue as IssueKey],
+      sampleTaskIds,
+    }))
+    .filter((issue) => issue.count > 0);
+
+  const issueCount = issues.reduce((sum, issue) => sum + issue.count, 0);
+  const validTaskCount = Math.max(0, input.tasks.length - invalidTaskIds.size);
+
+  return {
+    checkedTaskCount: input.tasks.length,
+    validTaskCount,
+    issueCount,
+    issues,
+  };
+}
+
+async function fetchFlowDataset(input: { from: Date; to: Date }): Promise<{
+  tasks: FlowTaskRecord[];
+  transitions: FlowTransitionRecord[];
+  transitionsByTask: Map<string, FlowTransitionRecord[]>;
+}> {
+  const rangeEndExclusive = endOfUtcDay(input.to);
+  const tasks = await prisma.task.findMany({
+    where: {
+      createdAt: { lt: rangeEndExclusive },
+      OR: [{ completedOn: null }, { completedOn: { gte: input.from } }],
+    },
+    select: {
+      id: true,
+      status: true,
+      createdAt: true,
+      completedOn: true,
+    },
+  });
+
+  if (tasks.length === 0) {
+    return {
+      tasks: [],
+      transitions: [],
+      transitionsByTask: new Map(),
+    };
+  }
+
+  const transitions = await prisma.statusHistory.findMany({
+    where: {
+      taskId: {
+        in: tasks.map((task) => task.id),
+      },
+      changedAt: {
+        lt: rangeEndExclusive,
+      },
+    },
+    select: {
+      id: true,
+      taskId: true,
+      fromStatus: true,
+      toStatus: true,
+      changedAt: true,
+    },
+    orderBy: [{ changedAt: "asc" }, { id: "asc" }],
+  });
+
+  const transitionsByTask = new Map<string, FlowTransitionRecord[]>();
+  for (const transition of transitions) {
+    const existing = transitionsByTask.get(transition.taskId) ?? [];
+    existing.push(transition);
+    transitionsByTask.set(transition.taskId, existing);
+  }
+
+  return {
+    tasks,
+    transitions,
+    transitionsByTask,
+  };
+}
+
+export async function computeFlowAnalytics(input: {
+  from: Date;
+  to: Date;
+  interval: FlowInterval;
+}): Promise<FlowAnalyticsResult> {
+  const dataset = await fetchFlowDataset({ from: input.from, to: input.to });
+
+  const cfd = buildCfdSeries({
+    tasks: dataset.tasks,
+    transitionsByTask: dataset.transitionsByTask,
+    from: input.from,
+    to: input.to,
+    interval: input.interval,
+  });
+
+  const throughput = buildThroughputSeries({
+    transitions: dataset.transitions,
+    from: input.from,
+    to: input.to,
+    interval: input.interval,
+  });
+
+  const durationSamples = computeDurationSamples({
+    tasks: dataset.tasks,
+    transitionsByTask: dataset.transitionsByTask,
+    from: input.from,
+    to: input.to,
+  });
+
+  const leadTime = durationStats(
+    durationSamples
+      .map((sample) => sample.leadDays)
+      .filter((value): value is number => value !== null)
+  );
+  const cycleTime = durationStats(
+    durationSamples
+      .map((sample) => sample.cycleDays)
+      .filter((value): value is number => value !== null)
+  );
+
+  const dataQuality = evaluateDataQuality({
+    tasks: dataset.tasks,
+    transitionsByTask: dataset.transitionsByTask,
+  });
+
+  return {
+    from: input.from.toISOString(),
+    to: input.to.toISOString(),
+    interval: input.interval,
+    generatedAt: new Date().toISOString(),
+    metricsDefinition: {
+      cfd: "Cumulative Flow Diagram counts tasks by status at the end of each interval bucket.",
+      throughput:
+        "Throughput counts DONE transitions per interval bucket from status history events.",
+      leadTime:
+        "Lead time measures days from task.createdAt to first DONE transition (or completedOn fallback).",
+      cycleTime:
+        "Cycle time measures days from first ACTIVE/WORKING_ON_TODAY transition to first DONE transition.",
+      dataQuality:
+        "Validation scans for missing histories, timestamp anomalies, and transition-chain inconsistencies.",
+    },
+    cfd,
+    throughput,
+    leadTime,
+    cycleTime,
+    dataQuality,
+    traceability: {
+      source: "Task.createdAt + StatusHistory.changedAt + Task.completedOn",
+      taskSampleIds: dataset.tasks.slice(0, 20).map((task) => task.id),
+      transitionSampleIds: dataset.transitions.slice(0, 40).map((transition) => transition.id),
+      totalTasks: dataset.tasks.length,
+      totalTransitions: dataset.transitions.length,
+    },
+  };
+}
+
+export const __private__ = {
+  percentile,
+  durationStats,
+  buildCfdSeries,
+  buildThroughputSeries,
+  evaluateDataQuality,
+};


### PR DESCRIPTION
## Summary
- add a reusable flow analytics engine that computes CFD, throughput, lead time, cycle time, and data-quality diagnostics from task/status history events
- add authenticated `/api/flow/metrics` endpoint with `from`, `to`, and `interval` query parameters plus request validation
- document metric definitions and add helper-level tests for percentile math, throughput bucketing, initial-status inference, and data-quality accounting

## Validation
- `npm test -- --run src/lib/__tests__/flow-analytics.test.ts`
- `npx eslint src/lib/flow/analytics.ts src/lib/__tests__/flow-analytics.test.ts src/app/api/flow/metrics/route.ts`

Closes #14
