### PR TITLE
Add Reddit integration provider wiring

### DIFF
--- a/prisma/migrations/20260216004100_add_reddit_integration_provider/migration.sql
+++ b/prisma/migrations/20260216004100_add_reddit_integration_provider/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "IntegrationProvider" ADD VALUE IF NOT EXISTS 'REDDIT';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -433,6 +433,7 @@ enum IntegrationProvider {
   HUBSPOT
   SLACK
   CODA
+  REDDIT
 }
 
 enum IntegrationConnectionStatus {

--- a/src/lib/__tests__/integrations-catalog.test.ts
+++ b/src/lib/__tests__/integrations-catalog.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  getIntegrationBySlug,
+  isOAuthIntegration,
+  listIntegrationDefinitions,
+} from "@/lib/integrations/catalog";
+
+describe("integrations catalog", () => {
+  it("includes reddit as an oauth integration", () => {
+    const reddit = getIntegrationBySlug("reddit");
+
+    expect(reddit).not.toBeNull();
+    expect(reddit?.provider).toBe("REDDIT");
+    expect(reddit ? isOAuthIntegration(reddit) : false).toBe(true);
+    expect(reddit?.authType).toBe("oauth");
+  });
+
+  it("exposes reddit in definitions list", () => {
+    const slugs = listIntegrationDefinitions().map((definition) => definition.slug);
+    expect(slugs).toContain("reddit");
+  });
+});

--- a/src/lib/integrations/catalog.ts
+++ b/src/lib/integrations/catalog.ts
@@ -1,6 +1,11 @@
 import { IntegrationProvider } from "@/generated/prisma/client";
 
-export type IntegrationSlug = "google-workspace" | "hubspot" | "slack" | "coda";
+export type IntegrationSlug =
+  | "google-workspace"
+  | "hubspot"
+  | "slack"
+  | "coda"
+  | "reddit";
 export type IntegrationAuthType = "oauth" | "token";
 
 interface OAuthSettings {
@@ -123,6 +128,24 @@ const INTEGRATION_DEFINITIONS: readonly IntegrationDefinition[] = [
       "Attach docs and migrate legacy Coda workflows using a Coda API token.",
     capabilities: ["Docs", "Rows", "Coda migration"],
     authType: "token",
+  },
+  {
+    slug: "reddit",
+    provider: IntegrationProvider.REDDIT,
+    name: "Reddit",
+    description: "Capture Reddit threads and community signals in WIPGuard.",
+    capabilities: ["Thread capture", "Community monitoring"],
+    authType: "oauth",
+    oauth: {
+      authorizationEndpoint: "https://www.reddit.com/api/v1/authorize",
+      tokenEndpoint: "https://www.reddit.com/api/v1/access_token",
+      scopes: ["identity", "read", "history"],
+      extraAuthParams: {
+        duration: "permanent",
+      },
+      clientIdEnv: "REDDIT_CLIENT_ID",
+      clientSecretEnv: "REDDIT_CLIENT_SECRET",
+    },
   },
 ] as const;
 

--- a/src/lib/integrations/oauth.ts
+++ b/src/lib/integrations/oauth.ts
@@ -96,9 +96,19 @@ export async function exchangeOAuthCode(input: {
     redirect_uri: redirectUri,
   });
 
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+  };
+
+  if (definition.slug === "reddit") {
+    body.delete("client_id");
+    body.delete("client_secret");
+    headers.Authorization = `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`;
+  }
+
   const response = await fetch(definition.oauth.tokenEndpoint, {
     method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    headers,
     body,
     cache: "no-store",
   });
@@ -249,6 +259,48 @@ async function fetchSlackProfile(accessToken: string): Promise<AccountProfile> {
   };
 }
 
+async function fetchRedditProfile(accessToken: string): Promise<AccountProfile> {
+  const userAgent = process.env.REDDIT_USER_AGENT?.trim() || "WIPGuard/1.0";
+  const response = await fetch("https://oauth.reddit.com/api/v1/me", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "User-Agent": userAgent,
+    },
+    cache: "no-store",
+  });
+  const raw = (await response.json().catch(() => null)) as unknown;
+  if (!response.ok) {
+    throw new Error("Reddit account lookup failed");
+  }
+  const profile = asRecord(raw);
+  if (!profile) {
+    throw new Error("Reddit account response was invalid");
+  }
+
+  const providerAccountId = getString(profile, "id") || getString(profile, "name");
+  if (!providerAccountId) {
+    throw new Error("Reddit profile did not include an account identifier");
+  }
+
+  const subreddit = asRecord(profile.subreddit);
+
+  return {
+    providerAccountId,
+    accountLabel: getString(profile, "name"),
+    metadata: {
+      name: getString(profile, "name"),
+      subreddit: subreddit
+        ? {
+            displayName: getString(subreddit, "display_name"),
+            title: getString(subreddit, "title"),
+            subscribers: getNumber(subreddit, "subscribers"),
+            over18: subreddit.over_18 === true,
+          }
+        : null,
+    },
+  };
+}
+
 export async function fetchOAuthAccountProfile(
   definition: OAuthIntegrationDefinition,
   accessToken: string
@@ -261,6 +313,9 @@ export async function fetchOAuthAccountProfile(
   }
   if (definition.slug === "slack") {
     return fetchSlackProfile(accessToken);
+  }
+  if (definition.slug === "reddit") {
+    return fetchRedditProfile(accessToken);
   }
   throw new Error(`No OAuth account profile fetcher for ${definition.slug}`);
 }


### PR DESCRIPTION
## Summary
- add `REDDIT` as an integration provider in Prisma schema plus migration
- add Reddit OAuth integration definition to catalog so `/api/integrations/connect/reddit` and callback routing are recognized
- add Reddit-specific OAuth token exchange handling (Basic auth) and account profile lookup (`/api/v1/me`)
- add catalog tests confirming Reddit is present and treated as OAuth

## Validation
- `npm run db:generate`
- `npm test -- --run src/lib/__tests__/integrations-catalog.test.ts`
- `npx eslint src/lib/integrations/catalog.ts src/lib/integrations/oauth.ts src/lib/__tests__/integrations-catalog.test.ts`
