### PR TITLE
fix(analytics): support GA4 OAuth2 refresh token

### DIFF
--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -60,11 +60,14 @@ export async function GET(request: Request) {
     fetchers.push({ key: "mercury", fn: () => fetchMercuryData(creds.mercuryKey!) });
   }
 
-  // Google Analytics (GA4) — needs all 3 service account fields
-  if (creds.gaPropertyId && creds.gaClientEmail && creds.gaPrivateKey) {
+  // Google Analytics (GA4) — service account OR OAuth2 refresh token
+  if (creds.gaPropertyId && (
+    (creds.gaClientEmail && creds.gaPrivateKey) ||
+    (creds.gaRefreshToken && creds.gaOAuthClientId && creds.gaOAuthClientSecret)
+  )) {
     fetchers.push({
       key: "googleAnalytics",
-      fn: () => fetchGAData(creds.gaPropertyId!, creds.gaClientEmail!, creds.gaPrivateKey!),
+      fn: () => fetchGAData(creds.gaPropertyId!, creds.gaClientEmail || "", creds.gaPrivateKey || ""),
     });
   }
 

--- a/src/lib/analytics/credentials.ts
+++ b/src/lib/analytics/credentials.ts
@@ -11,6 +11,10 @@ export interface AnalyticsCredentials {
   gaPropertyId: string | null;
   gaClientEmail: string | null;
   gaPrivateKey: string | null;
+  // Google Analytics (GA4) — OAuth2 alternative
+  gaRefreshToken: string | null;
+  gaOAuthClientId: string | null;
+  gaOAuthClientSecret: string | null;
   // Google Ads
   googleAdsDevToken: string | null;
   googleAdsCustomerId: string | null;
@@ -71,6 +75,11 @@ export async function getCredentials(userId?: string): Promise<AnalyticsCredenti
     gaPropertyId: process.env.GA_PROPERTY_ID?.trim() || null,
     gaClientEmail: process.env.GA_CLIENT_EMAIL?.trim() || null,
     gaPrivateKey: process.env.GA_PRIVATE_KEY?.replace(/\\n/g, "\n").trim() || null,
+
+    // Google Analytics (GA4) — OAuth2
+    gaRefreshToken: process.env.GA_REFRESH_TOKEN?.trim() || null,
+    gaOAuthClientId: process.env.GOOGLE_CLIENT_ID?.trim() || null,
+    gaOAuthClientSecret: process.env.GOOGLE_CLIENT_SECRET?.trim() || null,
 
     // Google Ads
     googleAdsDevToken: process.env.GOOGLE_ADS_DEVELOPER_TOKEN?.trim() || null,


### PR DESCRIPTION
## Summary
- Adds OAuth2 refresh token fields (`gaRefreshToken`, `gaOAuthClientId`, `gaOAuthClientSecret`) to the `AnalyticsCredentials` interface and `getCredentials()` helper
- Updates the GA4 guard in the analytics route to accept either service account credentials **or** OAuth2 refresh token credentials
- The underlying `fetchGAData` fetcher already supports OAuth2 internally — this fix unblocks it by letting the guard pass when `GA_REFRESH_TOKEN` + `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` are set

## Test plan
- [ ] Verify Railway env vars `GA_PROPERTY_ID`, `GA_REFRESH_TOKEN`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` are set
- [ ] Deploy and confirm `/api/analytics` returns `googleAnalytics` data instead of `null`
- [ ] Confirm existing service-account path still works if those env vars are set instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)