### PR TITLE
fix(integrations): add PKCE support for HubSpot OAuth

### DIFF
--- a/src/app/api/integrations/callback/[provider]/route.ts
+++ b/src/app/api/integrations/callback/[provider]/route.ts
@@ -13,6 +13,7 @@ import {
 } from "@/lib/integrations/catalog";
 import {
   buildOAuthRedirectUri,
+  decodeOAuthStateCookie,
   compactErrorMessage,
   exchangeOAuthCode,
   fetchOAuthAccountProfile,
@@ -122,6 +123,7 @@ export async function GET(
   const state = request.nextUrl.searchParams.get("state");
   const cookieName = getOAuthStateCookieName(definition.slug);
   const stateCookie = request.cookies.get(cookieName)?.value;
+  const statePayload = stateCookie ? decodeOAuthStateCookie(stateCookie) : null;
 
   if (oauthError) {
     const message = `OAuth denied: ${oauthError}`;
@@ -138,7 +140,7 @@ export async function GET(
     );
   }
 
-  if (!code || !state || !stateCookie) {
+  if (!code || !state || !statePayload) {
     await markConnectionError({
       userId: session.user.id,
       provider: definition.provider,
@@ -152,7 +154,8 @@ export async function GET(
     );
   }
 
-  const [expectedState, userIdFromCookie] = stateCookie.split(":");
+  const expectedState = statePayload.state;
+  const userIdFromCookie = statePayload.userId;
   if (
     !expectedState ||
     !userIdFromCookie ||
@@ -163,6 +166,19 @@ export async function GET(
       userId: session.user.id,
       provider: definition.provider,
       message: "OAuth state mismatch",
+    });
+    return redirectWithStateCookieCleared(
+      request,
+      "invalid_state",
+      cookieName,
+      definition.slug
+    );
+  }
+  if (definition.oauth.pkce && !statePayload.codeVerifier) {
+    await markConnectionError({
+      userId: session.user.id,
+      provider: definition.provider,
+      message: "OAuth PKCE verifier missing",
     });
     return redirectWithStateCookieCleared(
       request,
@@ -195,6 +211,7 @@ export async function GET(
       clientId: credentials.clientId,
       clientSecret: credentials.clientSecret,
       redirectUri,
+      codeVerifier: statePayload.codeVerifier ?? undefined,
     });
     const accountProfile = await fetchOAuthAccountProfile(
       definition,
@@ -266,4 +283,3 @@ export async function GET(
     );
   }
 }
-

--- a/src/app/api/integrations/connect/[provider]/route.ts
+++ b/src/app/api/integrations/connect/[provider]/route.ts
@@ -11,6 +11,8 @@ import {
 import {
   buildOAuthAuthorizationUrl,
   buildOAuthRedirectUri,
+  createOAuthPkcePair,
+  encodeOAuthStateCookie,
   getOAuthStateCookieName,
 } from "@/lib/integrations/oauth";
 import { enforcePermission } from "@/lib/permissions";
@@ -67,18 +69,25 @@ export async function GET(
   }
 
   const state = randomBytes(24).toString("hex");
+  const pkce = definition.oauth.pkce ? createOAuthPkcePair() : null;
   const redirectUri = buildOAuthRedirectUri(getBaseUrl(request), definition.slug);
   const authorizationUrl = buildOAuthAuthorizationUrl({
     definition,
     clientId: credentials.clientId,
     redirectUri,
     state,
+    codeChallenge: pkce?.codeChallenge,
+    codeChallengeMethod: pkce?.codeChallengeMethod,
   });
 
   const response = NextResponse.redirect(authorizationUrl);
   response.cookies.set({
     name: getOAuthStateCookieName(definition.slug),
-    value: `${state}:${session.user.id}`,
+    value: encodeOAuthStateCookie({
+      state,
+      userId: session.user.id,
+      codeVerifier: pkce?.codeVerifier,
+    }),
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax",

--- a/src/lib/integrations/catalog.ts
+++ b/src/lib/integrations/catalog.ts
@@ -13,6 +13,7 @@ interface OAuthSettings {
   tokenEndpoint: string;
   scopes: string[];
   scopeSeparator?: " " | ",";
+  pkce?: boolean;
   extraAuthParams?: Record<string, string>;
   clientIdEnv: string;
   clientSecretEnv: string;
@@ -88,6 +89,7 @@ const INTEGRATION_DEFINITIONS: readonly IntegrationDefinition[] = [
     oauth: {
       authorizationEndpoint: "https://app.hubspot.com/oauth/authorize",
       tokenEndpoint: "https://api.hubapi.com/oauth/v1/token",
+      pkce: true,
       // HubSpot expects only required scopes in `scope`; request feature scopes
       // via `optional_scope` to avoid install URL / app scope mismatch.
       scopes: ["oauth"],

--- a/src/lib/integrations/oauth.ts
+++ b/src/lib/integrations/oauth.ts
@@ -1,6 +1,8 @@
+import { createHash, randomBytes } from "crypto";
 import type { OAuthIntegrationDefinition, IntegrationSlug } from "@/lib/integrations/catalog";
 
 const OAUTH_STATE_COOKIE_PREFIX = "wgint_state";
+const PKCE_VERIFIER_BYTES = 32;
 
 interface OAuthTokenResponse {
   accessToken: string;
@@ -15,6 +17,12 @@ interface AccountProfile {
   providerAccountId: string;
   accountLabel: string | null;
   metadata?: Record<string, unknown>;
+}
+
+interface OAuthStateCookiePayload {
+  state: string;
+  userId: string;
+  codeVerifier: string | null;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -60,8 +68,17 @@ export function buildOAuthAuthorizationUrl(input: {
   clientId: string;
   redirectUri: string;
   state: string;
+  codeChallenge?: string;
+  codeChallengeMethod?: "S256";
 }): string {
-  const { definition, clientId, redirectUri, state } = input;
+  const {
+    definition,
+    clientId,
+    redirectUri,
+    state,
+    codeChallenge,
+    codeChallengeMethod,
+  } = input;
   const url = new URL(definition.oauth.authorizationEndpoint);
   url.searchParams.set("response_type", "code");
   url.searchParams.set("client_id", clientId);
@@ -71,6 +88,10 @@ export function buildOAuthAuthorizationUrl(input: {
     definition.oauth.scopes.join(definition.oauth.scopeSeparator ?? " ")
   );
   url.searchParams.set("state", state);
+  if (codeChallenge) {
+    url.searchParams.set("code_challenge", codeChallenge);
+    url.searchParams.set("code_challenge_method", codeChallengeMethod ?? "S256");
+  }
 
   for (const [key, value] of Object.entries(definition.oauth.extraAuthParams ?? {})) {
     url.searchParams.set(key, value);
@@ -85,8 +106,10 @@ export async function exchangeOAuthCode(input: {
   clientId: string;
   clientSecret: string;
   redirectUri: string;
+  codeVerifier?: string;
 }): Promise<OAuthTokenResponse> {
-  const { definition, code, clientId, clientSecret, redirectUri } = input;
+  const { definition, code, clientId, clientSecret, redirectUri, codeVerifier } =
+    input;
 
   const body = new URLSearchParams({
     grant_type: "authorization_code",
@@ -95,6 +118,9 @@ export async function exchangeOAuthCode(input: {
     client_secret: clientSecret,
     redirect_uri: redirectUri,
   });
+  if (codeVerifier) {
+    body.set("code_verifier", codeVerifier);
+  }
 
   const headers: Record<string, string> = {
     "Content-Type": "application/x-www-form-urlencoded",
@@ -154,6 +180,79 @@ export async function exchangeOAuthCode(input: {
     expiresAt,
     raw,
   };
+}
+
+export function createOAuthPkcePair(): {
+  codeVerifier: string;
+  codeChallenge: string;
+  codeChallengeMethod: "S256";
+} {
+  const codeVerifier = randomBytes(PKCE_VERIFIER_BYTES).toString("base64url");
+  const codeChallenge = createHash("sha256")
+    .update(codeVerifier)
+    .digest("base64url");
+  return {
+    codeVerifier,
+    codeChallenge,
+    codeChallengeMethod: "S256",
+  };
+}
+
+export function encodeOAuthStateCookie(payload: {
+  state: string;
+  userId: string;
+  codeVerifier?: string | null;
+}): string {
+  const normalized: OAuthStateCookiePayload = {
+    state: payload.state,
+    userId: payload.userId,
+    codeVerifier: payload.codeVerifier ?? null,
+  };
+  return Buffer.from(JSON.stringify(normalized), "utf8").toString("base64url");
+}
+
+export function decodeOAuthStateCookie(value: string): OAuthStateCookiePayload | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const decoded = Buffer.from(value, "base64url").toString("utf8");
+    const payload = JSON.parse(decoded) as Partial<OAuthStateCookiePayload>;
+    if (!payload || typeof payload !== "object") {
+      return null;
+    }
+    if (typeof payload.state !== "string" || payload.state.length === 0) {
+      return null;
+    }
+    if (typeof payload.userId !== "string" || payload.userId.length === 0) {
+      return null;
+    }
+    if (
+      payload.codeVerifier !== null &&
+      payload.codeVerifier !== undefined &&
+      (typeof payload.codeVerifier !== "string" || payload.codeVerifier.length === 0)
+    ) {
+      return null;
+    }
+    return {
+      state: payload.state,
+      userId: payload.userId,
+      codeVerifier: payload.codeVerifier ?? null,
+    };
+  } catch {
+    // Backward compatibility for legacy cookies that stored `state:userId`.
+    const separatorIndex = value.indexOf(":");
+    if (separatorIndex <= 0 || separatorIndex === value.length - 1) {
+      return null;
+    }
+
+    return {
+      state: value.slice(0, separatorIndex),
+      userId: value.slice(separatorIndex + 1),
+      codeVerifier: null,
+    };
+  }
 }
 
 async function fetchGoogleProfile(accessToken: string): Promise<AccountProfile> {


### PR DESCRIPTION
## Summary
- add PKCE support to OAuth helpers ( + )
- mark HubSpot integration as PKCE-enabled
- persist PKCE verifier in secure OAuth state cookie and validate it on callback

## Why
HubSpot now requires PKCE on this authorization flow and rejects auth requests without a code challenge.

## Test plan
- run HubSpot connect flow and confirm authorization no longer errors with missing code challenge
- verify callback token exchange succeeds with PKCE verifier
