### PR TITLE
feat: Whip View for scope creep and WIP pressure [WGX-007]

### DIFF
--- a/src/app/(dashboard)/whip/page.tsx
+++ b/src/app/(dashboard)/whip/page.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useWhipData } from "@/components/whip/use-whip-data";
+import { WhipFilterBar } from "@/components/whip/whip-filter-bar";
+import { ScopeCreepSummary } from "@/components/whip/scope-creep-summary";
+import { ScopeTimeline } from "@/components/whip/scope-timeline";
+import { WipPressureHeatmap } from "@/components/whip/wip-pressure-heatmap";
+import { QuickActionsPanel } from "@/components/whip/quick-actions-panel";
+import { RetroExport } from "@/components/whip/retro-export";
+
+export default function WhipPage() {
+  const {
+    sprints,
+    sprintData,
+    riskReport,
+    tasks,
+    loading,
+    error,
+    filters,
+    setFilters,
+    updateTask,
+  } = useWhipData();
+
+  const activeSprint = sprints.find((s) => s.id === filters.sprintId);
+
+  return (
+    <div className="space-y-6 p-6">
+      {/* Header */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-foreground">
+            Whip View
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Scope creep visibility and WIP pressure for standup triage
+          </p>
+        </div>
+        {activeSprint && (
+          <div className="flex items-center gap-2">
+            <span className="h-2 w-2 rounded-full bg-emerald-500" />
+            <span className="text-sm font-medium text-foreground">
+              {activeSprint.name}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {new Date(activeSprint.startDate + "T00:00:00Z").toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" })}
+              {" -- "}
+              {new Date(activeSprint.endDate + "T00:00:00Z").toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" })}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="rounded-lg border border-wip-over-border bg-wip-over-bg px-4 py-3 text-sm text-wip-over-text">
+          {error}
+        </div>
+      )}
+
+      {/* Filters */}
+      <WhipFilterBar
+        sprints={sprints}
+        tasks={tasks}
+        filters={filters}
+        setFilters={setFilters}
+      />
+
+      {/* Loading skeleton */}
+      {loading && (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-20 animate-pulse rounded-lg border border-border bg-muted"
+              />
+            ))}
+          </div>
+          <div className="h-48 animate-pulse rounded-lg border border-border bg-muted" />
+          <div className="h-40 animate-pulse rounded-lg border border-border bg-muted" />
+        </div>
+      )}
+
+      {/* Main content (visible once loaded) */}
+      {!loading && (
+        <>
+          {/* Scope creep summary cards */}
+          <ScopeCreepSummary data={sprintData} />
+
+          {/* Two-column layout for timeline + heatmap on wider screens */}
+          <div className="grid gap-6 lg:grid-cols-2">
+            <ScopeTimeline data={sprintData} />
+            <WipPressureHeatmap riskReport={riskReport} />
+          </div>
+
+          {/* Quick actions for unplanned tasks */}
+          <QuickActionsPanel tasks={tasks} updateTask={updateTask} />
+
+          {/* Retrospective export */}
+          <RetroExport
+            sprintName={activeSprint?.name ?? null}
+            sprintData={sprintData}
+            riskReport={riskReport}
+            tasks={tasks}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Bot,
   BookOpen,
   Settings,
+  Gauge,
 } from "lucide-react";
 
 const PRIMARY_NAV_ITEMS = [
@@ -18,6 +19,7 @@ const PRIMARY_NAV_ITEMS = [
   { href: "/projects", label: "Projects", icon: FolderKanban },
   { href: "/tasks", label: "Tasks", icon: CheckSquare },
   { href: "/analytics", label: "Analytics", icon: BarChart3 },
+  { href: "/whip", label: "Whip View", icon: Gauge },
   { href: "/automations", label: "Automations", icon: Bot },
 ];
 

--- a/src/components/whip/quick-actions-panel.tsx
+++ b/src/components/whip/quick-actions-panel.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { WhipTask } from "./types";
+
+interface QuickActionsPanelProps {
+  tasks: WhipTask[];
+  updateTask: (taskId: string, patch: Record<string, unknown>) => Promise<boolean>;
+}
+
+type ActionType = "descope" | "defer";
+
+const PRIORITY_ORDER: Record<string, number> = { P0: 0, P1: 1, P2: 2, P3: 3 };
+
+function priorityBadgeClass(priority: string): string {
+  switch (priority) {
+    case "P0": return "bg-red-500/15 text-red-600 border-red-300/30";
+    case "P1": return "bg-orange-500/15 text-orange-600 border-orange-300/30";
+    case "P2": return "bg-blue-500/15 text-blue-600 border-blue-300/30";
+    case "P3": return "bg-neutral-500/10 text-neutral-500 border-neutral-300/30";
+    default: return "bg-neutral-500/10 text-neutral-500 border-neutral-300/30";
+  }
+}
+
+function statusDotColor(status: string): string {
+  switch (status) {
+    case "BACKLOG": return "bg-neutral-400";
+    case "QUEUED": return "bg-yellow-500";
+    case "WORKING_ON_TODAY": return "bg-blue-500";
+    case "ACTIVE": return "bg-emerald-500";
+    case "NOT_DONE": return "bg-red-500";
+    case "DONE": return "bg-emerald-400";
+    default: return "bg-neutral-400";
+  }
+}
+
+export function QuickActionsPanel({ tasks, updateTask }: QuickActionsPanelProps) {
+  const [actionInFlight, setActionInFlight] = useState<string | null>(null);
+  const [actionResult, setActionResult] = useState<Record<string, "success" | "error">>({});
+
+  // Show unplanned tasks that are NOT done -- prime candidates for de-scope/defer
+  const unplannedActive = tasks
+    .filter((t) => t.unplanned && t.status !== "DONE")
+    .sort((a, b) => {
+      const pa = PRIORITY_ORDER[a.priority] ?? 99;
+      const pb = PRIORITY_ORDER[b.priority] ?? 99;
+      return pb - pa; // lowest priority first (P3 first -- best descope candidates)
+    });
+
+  const handleAction = useCallback(
+    async (taskId: string, action: ActionType) => {
+      setActionInFlight(taskId);
+      setActionResult((prev) => {
+        const next = { ...prev };
+        delete next[taskId];
+        return next;
+      });
+
+      let patch: Record<string, unknown>;
+      if (action === "descope") {
+        // De-scope: remove from sprint, move to backlog
+        patch = { sprintId: null, status: "BACKLOG" };
+      } else {
+        // Defer: move to backlog but keep in sprint
+        patch = { status: "BACKLOG" };
+      }
+
+      const success = await updateTask(taskId, patch);
+      setActionResult((prev) => ({ ...prev, [taskId]: success ? "success" : "error" }));
+      setActionInFlight(null);
+    },
+    [updateTask]
+  );
+
+  if (unplannedActive.length === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-4">
+        <h3 className="text-sm font-semibold text-foreground">Quick Actions</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          No unplanned tasks to triage. Sprint scope is clean.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-foreground">
+          Triage Unplanned Tasks
+        </h3>
+        <span className="text-xs text-muted-foreground">
+          {unplannedActive.length} task{unplannedActive.length !== 1 ? "s" : ""} to review
+        </span>
+      </div>
+
+      <div className="max-h-72 space-y-1 overflow-y-auto">
+        {unplannedActive.map((task) => {
+          const isBusy = actionInFlight === task.id;
+          const result = actionResult[task.id];
+
+          return (
+            <div
+              key={task.id}
+              className="flex items-center gap-2 rounded-md border border-transparent px-2 py-1.5 transition-colors hover:border-border hover:bg-muted/50"
+            >
+              {/* Status dot */}
+              <span className={`h-2 w-2 shrink-0 rounded-full ${statusDotColor(task.status)}`} />
+
+              {/* Priority */}
+              <span
+                className={`shrink-0 rounded border px-1 py-0.5 text-[10px] font-semibold ${priorityBadgeClass(task.priority)}`}
+              >
+                {task.priority}
+              </span>
+
+              {/* Title */}
+              <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+                {task.title}
+              </span>
+
+              {/* Owner */}
+              {task.responsible.length > 0 && (
+                <span className="hidden shrink-0 text-xs text-muted-foreground sm:block">
+                  {task.responsible[0].name ?? task.responsible[0].email}
+                </span>
+              )}
+
+              {/* Reason badge */}
+              {task.unplannedReason && (
+                <span className="hidden shrink-0 rounded bg-tag-bg px-1.5 py-0.5 text-[10px] text-tag-text lg:block">
+                  {task.unplannedReason.replace(/_/g, " ").toLowerCase()}
+                </span>
+              )}
+
+              {/* Action result */}
+              {result === "success" && (
+                <span className="text-xs font-medium text-success">Done</span>
+              )}
+              {result === "error" && (
+                <span className="text-xs font-medium text-destructive">Failed</span>
+              )}
+
+              {/* Quick action buttons */}
+              {!result && (
+                <div className="flex shrink-0 items-center gap-1">
+                  <button
+                    type="button"
+                    disabled={isBusy}
+                    onClick={() => handleAction(task.id, "defer")}
+                    className="rounded px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground disabled:opacity-50"
+                    title="Defer to backlog (keep in sprint)"
+                  >
+                    {isBusy ? "..." : "Defer"}
+                  </button>
+                  <button
+                    type="button"
+                    disabled={isBusy}
+                    onClick={() => handleAction(task.id, "descope")}
+                    className="rounded px-2 py-1 text-xs font-medium text-wip-over-text transition-colors hover:bg-wip-over-bg disabled:opacity-50"
+                    title="De-scope from sprint entirely"
+                  >
+                    {isBusy ? "..." : "De-scope"}
+                  </button>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/whip/retro-export.tsx
+++ b/src/components/whip/retro-export.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { PlannedVsUnplannedResult, FlowRiskIntelligenceReport, WhipTask } from "./types";
+
+interface RetroExportProps {
+  sprintName: string | null;
+  sprintData: PlannedVsUnplannedResult | null;
+  riskReport: FlowRiskIntelligenceReport | null;
+  tasks: WhipTask[];
+}
+
+type ExportFormat = "markdown" | "json";
+
+function buildMarkdown(
+  sprintName: string,
+  sprintData: PlannedVsUnplannedResult,
+  riskReport: FlowRiskIntelligenceReport | null,
+  tasks: WhipTask[]
+): string {
+  const { summary } = sprintData;
+  const totalTasks = summary.totalPlanned + summary.totalUnplanned;
+  const creepPercent =
+    totalTasks > 0
+      ? Math.round((summary.totalUnplanned / totalTasks) * 100)
+      : 0;
+  const completionRate =
+    totalTasks > 0
+      ? Math.round(
+          ((summary.plannedDone + summary.unplannedDone) / totalTasks) * 100
+        )
+      : 0;
+
+  const lines: string[] = [
+    `# Sprint Retrospective: ${sprintName}`,
+    "",
+    `> Generated ${new Date().toLocaleDateString("en-US", { weekday: "long", year: "numeric", month: "long", day: "numeric" })}`,
+    "",
+    "## Scope Summary",
+    "",
+    `| Metric | Value |`,
+    `| --- | --- |`,
+    `| Planned tasks | ${summary.totalPlanned} (${summary.plannedDone} done) |`,
+    `| Unplanned tasks | ${summary.totalUnplanned} (${summary.unplannedDone} done) |`,
+    `| Scope creep ratio | ${creepPercent}% |`,
+    `| Sprint completion | ${completionRate}% |`,
+    "",
+  ];
+
+  // Unplanned task additions
+  const unplannedTasks = tasks.filter((t) => t.unplanned);
+  if (unplannedTasks.length > 0) {
+    lines.push("## Unplanned Tasks Added");
+    lines.push("");
+    for (const t of unplannedTasks) {
+      const reason = t.unplannedReason
+        ? ` _(${t.unplannedReason.replace(/_/g, " ").toLowerCase()})_`
+        : "";
+      const owner =
+        t.responsible.length > 0
+          ? ` -- ${t.responsible[0].name ?? t.responsible[0].email}`
+          : "";
+      lines.push(
+        `- **[${t.priority}]** ${t.title}${reason}${owner} (${t.status.replace(/_/g, " ").toLowerCase()})`
+      );
+    }
+    lines.push("");
+  }
+
+  // WIP pressure
+  if (riskReport && riskReport.wipPressure.people.length > 0) {
+    const people = riskReport.wipPressure.people;
+    const overloaded = people.filter((p) => p.overloaded);
+
+    lines.push("## WIP Pressure");
+    lines.push("");
+    lines.push("| Assignee | Active | Limit | Pressure | Status |");
+    lines.push("| --- | --- | --- | --- | --- |");
+    for (const p of people) {
+      const label = p.overloaded ? "OVERLOADED" : "OK";
+      lines.push(
+        `| ${p.name ?? p.email ?? "Unknown"} | ${p.activeTaskCount} | ${p.wipLimit} | ${Math.round(p.pressureScore)}% | ${label} |`
+      );
+    }
+    lines.push("");
+
+    if (overloaded.length > 0) {
+      lines.push(
+        `> **${overloaded.length}** team member${overloaded.length !== 1 ? "s" : ""} exceeded WIP limits during this sprint.`
+      );
+      lines.push("");
+    }
+  }
+
+  // Recommendations
+  if (riskReport && riskReport.recommendations.length > 0) {
+    lines.push("## Recommendations");
+    lines.push("");
+    for (const rec of riskReport.recommendations) {
+      lines.push(`- **${rec.severity.toUpperCase()}** -- ${rec.title}: ${rec.rationale}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function buildJson(
+  sprintName: string,
+  sprintData: PlannedVsUnplannedResult,
+  riskReport: FlowRiskIntelligenceReport | null,
+  tasks: WhipTask[]
+): string {
+  const { summary } = sprintData;
+  const totalTasks = summary.totalPlanned + summary.totalUnplanned;
+
+  const payload = {
+    sprint: sprintName,
+    generatedAt: new Date().toISOString(),
+    scope: {
+      totalPlanned: summary.totalPlanned,
+      plannedDone: summary.plannedDone,
+      totalUnplanned: summary.totalUnplanned,
+      unplannedDone: summary.unplannedDone,
+      creepPercent:
+        totalTasks > 0
+          ? Math.round((summary.totalUnplanned / totalTasks) * 100)
+          : 0,
+      completionPercent:
+        totalTasks > 0
+          ? Math.round(
+              ((summary.plannedDone + summary.unplannedDone) / totalTasks) * 100
+            )
+          : 0,
+    },
+    unplannedTasks: tasks
+      .filter((t) => t.unplanned)
+      .map((t) => ({
+        id: t.id,
+        title: t.title,
+        priority: t.priority,
+        status: t.status,
+        reason: t.unplannedReason,
+        owner:
+          t.responsible.length > 0
+            ? t.responsible[0].name ?? t.responsible[0].email
+            : null,
+      })),
+    wipPressure: riskReport
+      ? riskReport.wipPressure.people.map((p) => ({
+          name: p.name ?? p.email ?? "Unknown",
+          activeTaskCount: p.activeTaskCount,
+          wipLimit: p.wipLimit,
+          pressureScore: Math.round(p.pressureScore),
+          overloaded: p.overloaded,
+        }))
+      : [],
+    recommendations: riskReport
+      ? riskReport.recommendations.map((r) => ({
+          severity: r.severity,
+          title: r.title,
+          rationale: r.rationale,
+        }))
+      : [],
+  };
+
+  return JSON.stringify(payload, null, 2);
+}
+
+function downloadFile(content: string, filename: string, mimeType: string) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+function copyToClipboard(text: string): Promise<void> {
+  return navigator.clipboard.writeText(text);
+}
+
+export function RetroExport({
+  sprintName,
+  sprintData,
+  riskReport,
+  tasks,
+}: RetroExportProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleExport = useCallback(
+    (format: ExportFormat) => {
+      if (!sprintData || !sprintName) return;
+
+      if (format === "markdown") {
+        const md = buildMarkdown(sprintName, sprintData, riskReport, tasks);
+        const filename = `retro-${sprintName.replace(/\s+/g, "-").toLowerCase()}.md`;
+        downloadFile(md, filename, "text/markdown");
+      } else {
+        const json = buildJson(sprintName, sprintData, riskReport, tasks);
+        const filename = `retro-${sprintName.replace(/\s+/g, "-").toLowerCase()}.json`;
+        downloadFile(json, filename, "application/json");
+      }
+    },
+    [sprintName, sprintData, riskReport, tasks]
+  );
+
+  const handleCopyMarkdown = useCallback(async () => {
+    if (!sprintData || !sprintName) return;
+    const md = buildMarkdown(sprintName, sprintData, riskReport, tasks);
+    await copyToClipboard(md);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [sprintName, sprintData, riskReport, tasks]);
+
+  if (!sprintData) {
+    return (
+      <div className="h-24 animate-pulse rounded-lg border border-border bg-muted" />
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-foreground">
+          Sprint Retrospective Export
+        </h3>
+        <span className="text-xs text-muted-foreground">
+          {sprintName ?? "No sprint selected"}
+        </span>
+      </div>
+
+      <p className="mb-3 text-xs text-muted-foreground">
+        Generate a retrospective summary with scope creep data, WIP pressure
+        metrics, and recommendations.
+      </p>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => handleExport("markdown")}
+          disabled={!sprintData}
+          className="rounded-md border border-border bg-secondary px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:opacity-50"
+        >
+          Download Markdown
+        </button>
+        <button
+          type="button"
+          onClick={() => handleExport("json")}
+          disabled={!sprintData}
+          className="rounded-md border border-border bg-secondary px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:opacity-50"
+        >
+          Download JSON
+        </button>
+        <button
+          type="button"
+          onClick={handleCopyMarkdown}
+          disabled={!sprintData}
+          className="rounded-md border border-primary/30 bg-primary/5 px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/10 disabled:opacity-50"
+        >
+          {copied ? "Copied!" : "Copy to Clipboard"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/whip/scope-creep-summary.tsx
+++ b/src/components/whip/scope-creep-summary.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import type { PlannedVsUnplannedResult } from "./types";
+
+interface ScopeCreepSummaryProps {
+  data: PlannedVsUnplannedResult | null;
+}
+
+function StatCard({
+  label,
+  value,
+  subtext,
+  variant = "default",
+}: {
+  label: string;
+  value: string | number;
+  subtext?: string;
+  variant?: "default" | "warning" | "danger" | "success";
+}) {
+  const borderClass = {
+    default: "border-border",
+    warning: "border-wip-at-border",
+    danger: "border-wip-over-border",
+    success: "border-emerald-300",
+  }[variant];
+
+  const valueClass = {
+    default: "text-foreground",
+    warning: "text-wip-at-text",
+    danger: "text-wip-over-text",
+    success: "text-success",
+  }[variant];
+
+  return (
+    <div className={`rounded-lg border-2 ${borderClass} bg-card px-4 py-3`}>
+      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        {label}
+      </p>
+      <p className={`mt-1 text-2xl font-bold tabular-nums ${valueClass}`}>
+        {value}
+      </p>
+      {subtext && (
+        <p className="mt-0.5 text-xs text-muted-foreground">{subtext}</p>
+      )}
+    </div>
+  );
+}
+
+export function ScopeCreepSummary({ data }: ScopeCreepSummaryProps) {
+  if (!data) {
+    return (
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-20 animate-pulse rounded-lg border border-border bg-muted"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  const { summary } = data;
+  const totalTasks = summary.totalPlanned + summary.totalUnplanned;
+  const creepPercent = totalTasks > 0
+    ? Math.round((summary.totalUnplanned / totalTasks) * 100)
+    : 0;
+  const completionRate = totalTasks > 0
+    ? Math.round(((summary.plannedDone + summary.unplannedDone) / totalTasks) * 100)
+    : 0;
+
+  const creepVariant: "default" | "warning" | "danger" | "success" =
+    creepPercent > 30 ? "danger" : creepPercent > 15 ? "warning" : "default";
+
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <StatCard
+        label="Planned tasks"
+        value={summary.totalPlanned}
+        subtext={`${summary.plannedDone} done`}
+      />
+      <StatCard
+        label="Unplanned (scope creep)"
+        value={summary.totalUnplanned}
+        subtext={`${summary.unplannedDone} done`}
+        variant={creepVariant}
+      />
+      <StatCard
+        label="Creep ratio"
+        value={`${creepPercent}%`}
+        subtext={`${summary.totalUnplanned} of ${totalTasks} tasks`}
+        variant={creepVariant}
+      />
+      <StatCard
+        label="Sprint completion"
+        value={`${completionRate}%`}
+        subtext={`${summary.plannedDone + summary.unplannedDone} of ${totalTasks} done`}
+        variant={completionRate >= 80 ? "success" : "default"}
+      />
+    </div>
+  );
+}

--- a/src/components/whip/scope-timeline.tsx
+++ b/src/components/whip/scope-timeline.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useMemo } from "react";
+import type { DailyDelta, PlannedVsUnplannedResult } from "./types";
+
+interface ScopeTimelineProps {
+  data: PlannedVsUnplannedResult | null;
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00Z");
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+}
+
+function formatWeekday(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00Z");
+  return d.toLocaleDateString("en-US", { weekday: "short", timeZone: "UTC" });
+}
+
+/**
+ * Stacked bar chart showing planned vs unplanned tasks over time.
+ * Pure CSS -- no chart library needed for standup readability.
+ */
+export function ScopeTimeline({ data }: ScopeTimelineProps) {
+  const deltas = data?.dailyDeltas ?? [];
+
+  const maxTotal = useMemo(() => {
+    let max = 1;
+    for (const d of deltas) {
+      const total = d.planned.total + d.unplanned.total;
+      if (total > max) max = total;
+    }
+    return max;
+  }, [deltas]);
+
+  if (!data) {
+    return (
+      <div className="h-48 animate-pulse rounded-lg border border-border bg-muted" />
+    );
+  }
+
+  if (deltas.length === 0) {
+    return (
+      <div className="flex h-48 items-center justify-center rounded-lg border border-border bg-card text-sm text-muted-foreground">
+        No daily data available for this sprint.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <h3 className="mb-3 text-sm font-semibold text-foreground">
+        Planned vs Unplanned Timeline
+      </h3>
+
+      {/* Legend */}
+      <div className="mb-3 flex items-center gap-4 text-xs text-muted-foreground">
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-2.5 w-2.5 rounded-sm bg-blue-500" />
+          Planned
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-2.5 w-2.5 rounded-sm bg-primary" />
+          Unplanned
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-2.5 w-2.5 rounded-sm bg-emerald-500" />
+          Done
+        </span>
+      </div>
+
+      {/* Bar chart */}
+      <div className="flex items-end gap-1 overflow-x-auto pb-1" role="img" aria-label="Scope timeline chart">
+        {deltas.map((delta) => {
+          const planned = delta.planned.total;
+          const unplanned = delta.unplanned.total;
+          const total = planned + unplanned;
+          const done = delta.planned.done + delta.unplanned.done;
+          const barHeight = maxTotal > 0 ? (total / maxTotal) * 120 : 0;
+          const plannedHeight = total > 0 ? (planned / total) * barHeight : 0;
+          const unplannedHeight = total > 0 ? (unplanned / total) * barHeight : 0;
+          const hasAdditions = delta.additions.length > 0;
+
+          return (
+            <div
+              key={delta.date}
+              className="group relative flex min-w-[2.5rem] flex-1 flex-col items-center"
+            >
+              {/* Tooltip */}
+              <div className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 hidden w-48 -translate-x-1/2 rounded-md border border-border bg-popover p-2 text-xs shadow-lg group-hover:block">
+                <p className="font-semibold text-popover-foreground">{formatDate(delta.date)}</p>
+                <p className="text-muted-foreground">
+                  Planned: {planned} ({delta.planned.done} done)
+                </p>
+                <p className="text-muted-foreground">
+                  Unplanned: {unplanned} ({delta.unplanned.done} done)
+                </p>
+                {hasAdditions && (
+                  <div className="mt-1 border-t border-border pt-1">
+                    <p className="font-medium text-primary">
+                      +{delta.additions.length} added:
+                    </p>
+                    {delta.additions.slice(0, 3).map((a) => (
+                      <p key={a.taskId} className="truncate text-muted-foreground">
+                        {a.title}
+                      </p>
+                    ))}
+                    {delta.additions.length > 3 && (
+                      <p className="text-muted-foreground">
+                        +{delta.additions.length - 3} more
+                      </p>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {/* Bar */}
+              <div
+                className="flex w-full flex-col justify-end overflow-hidden rounded-t-sm"
+                style={{ height: `${Math.max(barHeight, 4)}px` }}
+              >
+                {unplannedHeight > 0 && (
+                  <div
+                    className="w-full bg-primary/80 transition-all duration-300"
+                    style={{ height: `${unplannedHeight}px` }}
+                  />
+                )}
+                {plannedHeight > 0 && (
+                  <div
+                    className="w-full bg-blue-500/80 transition-all duration-300"
+                    style={{ height: `${plannedHeight}px` }}
+                  />
+                )}
+              </div>
+
+              {/* Done indicator dot */}
+              {done > 0 && (
+                <div className="mt-0.5 h-1 w-1 rounded-full bg-emerald-500" />
+              )}
+
+              {/* Day-added indicator */}
+              {hasAdditions && (
+                <div className="mt-0.5 h-1 w-3 rounded-full bg-primary/60" />
+              )}
+
+              {/* Labels */}
+              <p className="mt-1 text-[10px] leading-none text-muted-foreground">
+                {formatWeekday(delta.date)}
+              </p>
+              <p className="text-[9px] leading-none text-muted-foreground/60">
+                {formatDate(delta.date)}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Unplanned additions list */}
+      {deltas.some((d) => d.additions.length > 0) && (
+        <div className="mt-4 border-t border-border pt-3">
+          <h4 className="mb-2 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+            Unplanned Additions
+          </h4>
+          <div className="max-h-40 space-y-1 overflow-y-auto">
+            {deltas
+              .flatMap((d) =>
+                d.additions.map((a) => ({
+                  ...a,
+                  date: d.date,
+                }))
+              )
+              .sort((a, b) => b.addedAt.localeCompare(a.addedAt))
+              .slice(0, 15)
+              .map((addition) => (
+                <div
+                  key={addition.taskId}
+                  className="flex items-center gap-2 rounded-md px-2 py-1 text-xs hover:bg-muted"
+                >
+                  <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
+                  <span className="min-w-[4rem] text-muted-foreground">
+                    {formatDate(addition.date)}
+                  </span>
+                  <span className="truncate font-medium text-foreground">
+                    {addition.title}
+                  </span>
+                  {addition.unplannedReason && (
+                    <span className="ml-auto shrink-0 rounded bg-tag-bg px-1.5 py-0.5 text-[10px] text-tag-text">
+                      {addition.unplannedReason.replace(/_/g, " ").toLowerCase()}
+                    </span>
+                  )}
+                </div>
+              ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/whip/types.ts
+++ b/src/components/whip/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared types for the Whip View (scope creep and WIP pressure dashboard).
+ */
+
+import type { PlannedVsUnplannedResult, DailyDelta } from "@/lib/sprint-ledger";
+import type {
+  PersonWipPressure,
+  FlowRiskRecommendation,
+  FixedDateRiskAlert,
+  FlowRiskIntelligenceReport,
+} from "@/lib/flow/risk-intelligence";
+
+/* ── Sprint selector ── */
+
+export interface SprintOption {
+  id: string;
+  name: string;
+  startDate: string;
+  endDate: string;
+  isActive: boolean;
+  _count?: { tasks: number };
+}
+
+/* ── Task (lightweight shape from /api/tasks) ── */
+
+export interface WhipTask {
+  id: string;
+  title: string;
+  status: string;
+  priority: string;
+  unplanned: boolean;
+  unplannedReason: string | null;
+  unplannedNote: string | null;
+  addedBy: string | null;
+  createdAt: string;
+  sprintId: string | null;
+  responsible: Array<{
+    id: string;
+    name: string | null;
+    email: string;
+  }>;
+}
+
+/* ── Filters ── */
+
+export interface WhipFilters {
+  sprintId: string | null;
+  priority: string | null;
+  ownerId: string | null;
+}
+
+/* ── Re-exports for convenience ── */
+
+export type {
+  PlannedVsUnplannedResult,
+  DailyDelta,
+  PersonWipPressure,
+  FlowRiskRecommendation,
+  FixedDateRiskAlert,
+  FlowRiskIntelligenceReport,
+};

--- a/src/components/whip/use-whip-data.ts
+++ b/src/components/whip/use-whip-data.ts
@@ -1,0 +1,166 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type {
+  SprintOption,
+  WhipTask,
+  WhipFilters,
+  PlannedVsUnplannedResult,
+  FlowRiskIntelligenceReport,
+} from "./types";
+
+interface WhipData {
+  sprints: SprintOption[];
+  sprintData: PlannedVsUnplannedResult | null;
+  riskReport: FlowRiskIntelligenceReport | null;
+  tasks: WhipTask[];
+  loading: boolean;
+  error: string | null;
+  filters: WhipFilters;
+  setFilters: (filters: Partial<WhipFilters>) => void;
+  refreshRisk: () => void;
+  updateTask: (taskId: string, patch: Record<string, unknown>) => Promise<boolean>;
+}
+
+export function useWhipData(): WhipData {
+  const [sprints, setSprints] = useState<SprintOption[]>([]);
+  const [sprintData, setSprintData] = useState<PlannedVsUnplannedResult | null>(null);
+  const [riskReport, setRiskReport] = useState<FlowRiskIntelligenceReport | null>(null);
+  const [tasks, setTasks] = useState<WhipTask[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filters, setFiltersState] = useState<WhipFilters>({
+    sprintId: null,
+    priority: null,
+    ownerId: null,
+  });
+
+  const setFilters = useCallback((partial: Partial<WhipFilters>) => {
+    setFiltersState((prev) => ({ ...prev, ...partial }));
+  }, []);
+
+  // Fetch sprints on mount
+  useEffect(() => {
+    async function fetchSprints() {
+      try {
+        const res = await fetch("/api/sprints");
+        if (!res.ok) throw new Error("Failed to fetch sprints");
+        const data = await res.json();
+        setSprints(data);
+        // Auto-select active sprint
+        const active = data.find((s: SprintOption) => s.isActive);
+        if (active) {
+          setFiltersState((prev) => ({ ...prev, sprintId: active.id }));
+        } else if (data.length > 0) {
+          setFiltersState((prev) => ({ ...prev, sprintId: data[0].id }));
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unknown error");
+      }
+    }
+    fetchSprints();
+  }, []);
+
+  // Fetch planned vs unplanned when sprint changes
+  useEffect(() => {
+    if (!filters.sprintId) return;
+    let cancelled = false;
+
+    async function fetchSprintData() {
+      try {
+        const res = await fetch(`/api/sprints/${filters.sprintId}/planned-vs-unplanned`);
+        if (!res.ok) throw new Error("Failed to fetch sprint data");
+        const data = await res.json();
+        if (!cancelled) setSprintData(data);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Unknown error");
+      }
+    }
+    fetchSprintData();
+
+    return () => { cancelled = true; };
+  }, [filters.sprintId]);
+
+  // Fetch tasks for the selected sprint
+  useEffect(() => {
+    if (!filters.sprintId) return;
+    let cancelled = false;
+
+    async function fetchTasks() {
+      try {
+        const params = new URLSearchParams({ sprint: filters.sprintId! });
+        if (filters.priority) params.set("priority", filters.priority);
+        if (filters.ownerId) params.set("assignee", filters.ownerId);
+
+        const res = await fetch(`/api/tasks?${params}`);
+        if (!res.ok) throw new Error("Failed to fetch tasks");
+        const data = await res.json();
+        if (!cancelled) setTasks(data);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Unknown error");
+      }
+    }
+    fetchTasks();
+
+    return () => { cancelled = true; };
+  }, [filters.sprintId, filters.priority, filters.ownerId]);
+
+  // Fetch risk intelligence
+  const fetchRisk = useCallback(async () => {
+    try {
+      const res = await fetch("/api/flow/risk");
+      if (!res.ok) throw new Error("Failed to fetch risk data");
+      const data = await res.json();
+      setRiskReport(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchRisk();
+  }, [fetchRisk]);
+
+  // Mark loading complete when all initial data arrives
+  useEffect(() => {
+    if (sprints.length > 0) {
+      setLoading(false);
+    }
+  }, [sprints]);
+
+  // Quick-action: update a task via PATCH
+  const updateTask = useCallback(async (taskId: string, patch: Record<string, unknown>): Promise<boolean> => {
+    try {
+      const res = await fetch(`/api/tasks/${taskId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      if (!res.ok) return false;
+      // Refresh tasks list
+      if (filters.sprintId) {
+        const params = new URLSearchParams({ sprint: filters.sprintId });
+        if (filters.priority) params.set("priority", filters.priority);
+        if (filters.ownerId) params.set("assignee", filters.ownerId);
+        const taskRes = await fetch(`/api/tasks?${params}`);
+        if (taskRes.ok) setTasks(await taskRes.json());
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }, [filters]);
+
+  return {
+    sprints,
+    sprintData,
+    riskReport,
+    tasks,
+    loading,
+    error,
+    filters,
+    setFilters,
+    refreshRisk: fetchRisk,
+    updateTask,
+  };
+}

--- a/src/components/whip/whip-filter-bar.tsx
+++ b/src/components/whip/whip-filter-bar.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useMemo } from "react";
+import type { SprintOption, WhipFilters, WhipTask } from "./types";
+
+interface WhipFilterBarProps {
+  sprints: SprintOption[];
+  tasks: WhipTask[];
+  filters: WhipFilters;
+  setFilters: (partial: Partial<WhipFilters>) => void;
+}
+
+export function WhipFilterBar({ sprints, tasks, filters, setFilters }: WhipFilterBarProps) {
+  const owners = useMemo(() => {
+    const map = new Map<string, { id: string; name: string }>();
+    for (const task of tasks) {
+      for (const r of task.responsible) {
+        if (!map.has(r.id)) {
+          map.set(r.id, { id: r.id, name: r.name ?? r.email });
+        }
+      }
+    }
+    return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }, [tasks]);
+
+  const selectClass =
+    "rounded-md border border-border bg-card px-3 py-1.5 text-sm text-foreground focus:border-ring focus:outline-none";
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      {/* Sprint selector */}
+      <label className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        Sprint
+        <select
+          value={filters.sprintId ?? ""}
+          onChange={(e) => setFilters({ sprintId: e.target.value || null })}
+          className={selectClass}
+        >
+          <option value="">All sprints</option>
+          {sprints.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+              {s.isActive ? " (active)" : ""}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {/* Priority filter */}
+      <label className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        Priority
+        <select
+          value={filters.priority ?? ""}
+          onChange={(e) => setFilters({ priority: e.target.value || null })}
+          className={selectClass}
+        >
+          <option value="">All</option>
+          <option value="P0">P0 - Critical</option>
+          <option value="P1">P1 - High</option>
+          <option value="P2">P2 - Medium</option>
+          <option value="P3">P3 - Low</option>
+        </select>
+      </label>
+
+      {/* Owner filter */}
+      <label className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        Owner
+        <select
+          value={filters.ownerId ?? ""}
+          onChange={(e) => setFilters({ ownerId: e.target.value || null })}
+          className={selectClass}
+        >
+          <option value="">All owners</option>
+          {owners.map((o) => (
+            <option key={o.id} value={o.id}>
+              {o.name}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/src/components/whip/wip-pressure-heatmap.tsx
+++ b/src/components/whip/wip-pressure-heatmap.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import type { FlowRiskIntelligenceReport, PersonWipPressure } from "./types";
+
+interface WipPressureHeatmapProps {
+  riskReport: FlowRiskIntelligenceReport | null;
+}
+
+function pressureColor(score: number): string {
+  if (score >= 150) return "bg-red-500/20 border-red-400/40 text-red-600";
+  if (score >= 100) return "bg-orange-500/15 border-orange-400/30 text-orange-600";
+  if (score >= 75) return "bg-amber-500/15 border-amber-400/30 text-amber-600";
+  if (score >= 50) return "bg-yellow-500/10 border-yellow-400/20 text-yellow-600";
+  return "bg-emerald-500/10 border-emerald-400/20 text-emerald-600";
+}
+
+function pressureLabel(score: number): string {
+  if (score >= 150) return "Critical";
+  if (score >= 100) return "Over limit";
+  if (score >= 75) return "Near limit";
+  if (score >= 50) return "Moderate";
+  return "Healthy";
+}
+
+function PressureCell({ person }: { person: PersonWipPressure }) {
+  const color = pressureColor(person.pressureScore);
+
+  return (
+    <div
+      className={`rounded-lg border-2 ${color} px-3 py-2.5 transition-all duration-200`}
+      title={`${person.name ?? "Unknown"}: ${person.activeTaskCount} active / ${person.wipLimit} limit`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="truncate text-sm font-medium">
+          {person.name ?? person.email ?? "Unassigned"}
+        </span>
+        {person.overloaded && (
+          <span className="shrink-0 text-xs font-bold">!!!</span>
+        )}
+      </div>
+      <div className="mt-1 flex items-baseline gap-1.5">
+        <span className="text-xl font-bold tabular-nums">
+          {person.activeTaskCount}
+        </span>
+        <span className="text-xs opacity-70">/ {person.wipLimit}</span>
+      </div>
+      <div className="mt-0.5 flex items-center justify-between">
+        <span className="text-[10px] font-medium uppercase tracking-wider opacity-80">
+          {pressureLabel(person.pressureScore)}
+        </span>
+        <span className="text-[10px] tabular-nums opacity-60">
+          {Math.round(person.pressureScore)}%
+        </span>
+      </div>
+
+      {/* Mini pressure bar */}
+      <div className="mt-1.5 h-1 w-full overflow-hidden rounded-full bg-black/5">
+        <div
+          className="h-full rounded-full bg-current opacity-60 transition-all duration-500"
+          style={{ width: `${Math.min(100, person.pressureScore)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function WipPressureHeatmap({ riskReport }: WipPressureHeatmapProps) {
+  if (!riskReport) {
+    return (
+      <div className="h-40 animate-pulse rounded-lg border border-border bg-muted" />
+    );
+  }
+
+  const people = riskReport.wipPressure.people;
+
+  if (people.length === 0) {
+    return (
+      <div className="flex h-40 items-center justify-center rounded-lg border border-border bg-card text-sm text-muted-foreground">
+        No active task assignments found.
+      </div>
+    );
+  }
+
+  // Summary stats
+  const overloaded = people.filter((p) => p.overloaded).length;
+  const avgPressure = Math.round(
+    people.reduce((sum, p) => sum + p.pressureScore, 0) / people.length
+  );
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-foreground">
+          WIP Pressure by Assignee
+        </h3>
+        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+          {overloaded > 0 && (
+            <span className="flex items-center gap-1 font-medium text-wip-over-text">
+              <span className="h-2 w-2 rounded-full bg-red-500" />
+              {overloaded} overloaded
+            </span>
+          )}
+          <span>Avg: {avgPressure}%</span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+        {people.map((person) => (
+          <PressureCell key={person.userId} person={person} />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds the **Whip View** dashboard page at `/whip` for standup-ready scope creep visibility and WIP pressure monitoring
- Implements planned vs unplanned timeline visualization, WIP pressure heatmap by assignee, quick triage actions (de-scope/defer), and sprint retrospective export (markdown/JSON)
- Adds sidebar navigation entry for Whip View

## What's Included

### New Components (`src/components/whip/`)
| Component | Purpose |
|-----------|---------|
| `types.ts` | Shared types, re-exports from sprint-ledger and risk-intelligence |
| `use-whip-data.ts` | Data fetching hook (sprints, planned-vs-unplanned, tasks, risk report) |
| `whip-filter-bar.tsx` | Sprint, priority, and owner filter dropdowns |
| `scope-creep-summary.tsx` | Four stat cards: planned, unplanned, creep ratio, completion % |
| `scope-timeline.tsx` | Pure CSS stacked bar chart (planned vs unplanned per day) |
| `wip-pressure-heatmap.tsx` | Grid of pressure cells per assignee with color-coded scoring |
| `quick-actions-panel.tsx` | Lists unplanned tasks with Defer/De-scope quick action buttons |
| `retro-export.tsx` | Sprint retrospective export (download markdown/JSON, copy to clipboard) |

### New Page
- `src/app/(dashboard)/whip/page.tsx` -- Assembles all components into the Whip View dashboard

### Modified
- `src/components/layout/sidebar.tsx` -- Added Whip View nav link with Gauge icon

## Key Design Decisions

- **Pure CSS bar charts** instead of a chart library -- keeps bundle lean and renders instantly for standup readability
- **De-scope** action removes task from sprint (`sprintId: null`) and moves to BACKLOG; **Defer** moves to BACKLOG but keeps sprint association
- **Pressure scoring**: Critical (>=150%), Over limit (>=100%), Near limit (>=75%), Moderate (>=50%), Healthy (<50%)
- All theme colors use Tailwind utility classes referencing CSS custom properties (no inline styles)

## Test Plan

- [ ] Navigate to `/whip` and verify the page renders with active sprint data
- [ ] Verify filter bar switches sprints, priorities, and owners correctly
- [ ] Confirm scope creep summary cards show correct planned/unplanned counts
- [ ] Verify timeline bar chart displays daily planned vs unplanned bars with hover tooltips
- [ ] Confirm WIP pressure heatmap shows assignee cells with correct color coding
- [ ] Test de-scope and defer quick actions update task status
- [ ] Test retrospective export downloads valid markdown and JSON files
- [ ] Verify clipboard copy works for markdown export
- [ ] Check sidebar shows Whip View link and highlights when active

Closes #7

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>