### PR TITLE
feat(slack): Slack integration for flow events and task capture (WGX-010)

### DIFF
--- a/.ralph-team/agents/backend.md
+++ b/.ralph-team/agents/backend.md
@@ -26,9 +26,27 @@ patterns, gotchas, and conventions.
 - **Error responses**: `{ error: "message" }` with appropriate HTTP status codes
 - **Include patterns**: Define `const TASK_INCLUDE = { ... } as const` at top of route file for reuse
 
+## Slack Integration Patterns (Issue #10)
+
+- **Notification throttling**: In-memory per-channel sliding window with `shouldThrottle()` (pure, does not mutate) + `recordSend()` (mutates state). `ThrottleConfig` has `windowMs`, `maxBurst`, `bypassTypes`, `minIntervalMs`. Blocked notifications bypass throttle.
+- **Dedupe keys**: Format `slack:<domain>:<channel>:<id>:<type>:<qualifier>` — ensures idempotency. Notification keys include threadTs; task creation keys include trigger type+value.
+- **Source traceability**: Every Slack-created task stores a `SlackSourceTraceability` struct in `task.metadata.integration.sourceTraceability` with provider, channelId, threadTs, triggerType, slackUserId, sourceUrl, capturedAt.
+- **Channel routing**: First-match-wins with specificity sorting (more match criteria = higher priority). Policies use AND logic. Falls back to `defaultChannelId`, then to user DM. Config stored in `IntegrationRule` with key `slack_channel_routing`. In-memory cache with 30s TTL.
+- **RACI -> Notification mapping**: Responsible=assignment+status+blocked, Accountable=status+blocked, Consulted=mention, Informed=status_change. Self-notifications skipped (actor != recipient).
+- **Slack Event API handler**: HMAC signature verification with `v0:${timestamp}:${body}` base string and 5-min replay window. Handles `url_verification` challenge, `reaction_added` -> task creation, `/wipguard` slash commands.
+- **Dead letter pattern**: Failed Slack operations create `OutboxEvent` with `status: "DEAD_LETTER"` for later inspection/retry.
+- **Retry pattern**: `withRetries()` with exponential backoff via `computeRetryDelayMs()` from outbox-worker.
+
+## Test Count
+
+- Total test files: 4 new (slack-notifications, slack-task-creation, slack-channel-routing, slack-raci-bridge)
+- Total test cases: 74 new across those 4 files
+- All tests are pure function tests — no DB mocking needed
+
 ## Stack-Specific Notes
 
 - **Prisma client**: Generated to `src/generated/prisma`, uses `@prisma/adapter-pg` with PrismaPg adapter
 - **Prisma singleton**: Lazy proxy in `src/lib/prisma.ts` — avoid creating new PrismaClient instances
 - **vitest config**: `@/` alias mapped via `resolve.alias` in `vitest.config.ts`
 - **Package scripts**: `npm test` runs `vitest run`, `npm run test:watch` for dev mode
+- **Prisma in worktrees**: Need to run `npx prisma generate` in worktrees before tests will pass (the generated client is gitignored)

--- a/src/app/api/integrations/slack/channel-routing/route.ts
+++ b/src/app/api/integrations/slack/channel-routing/route.ts
@@ -1,0 +1,135 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { IntegrationProvider } from "@/generated/prisma/client";
+import { auth } from "@/lib/auth";
+import { enforcePermission } from "@/lib/permissions";
+import {
+  getOrCreateChannelRoutingRule,
+  serializeChannelRoutingRule,
+  updateChannelRoutingConfig,
+  addChannelRoutingPolicy,
+  removeChannelRoutingPolicy,
+  type ChannelRoutingConfig,
+  type ChannelRoutingPolicy,
+} from "@/lib/integrations/slack-channel-routing";
+
+interface ChannelRoutingRequestBody {
+  action?: "configure" | "add_policy" | "remove_policy";
+  config?: Partial<ChannelRoutingConfig>;
+  policy?: ChannelRoutingPolicy;
+  policyIndex?: number;
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "profile.write",
+      request,
+      targetType: "integration",
+      targetId: IntegrationProvider.SLACK,
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
+    }
+
+    const rule = await getOrCreateChannelRoutingRule(session.user.id);
+    return NextResponse.json({
+      rule: serializeChannelRoutingRule(rule),
+    });
+  } catch (error) {
+    console.error("GET /api/integrations/slack/channel-routing error:", error);
+    return NextResponse.json(
+      { error: "Failed to load channel routing config" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = (await request.json().catch(() => ({}))) as ChannelRoutingRequestBody;
+    const action = body.action ?? "configure";
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "profile.write",
+      request,
+      targetType: "integration",
+      targetId: IntegrationProvider.SLACK,
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
+    }
+
+    if (action === "add_policy") {
+      if (!body.policy || !body.policy.channelId || !body.policy.match) {
+        return NextResponse.json(
+          { error: "policy with channelId and match criteria is required" },
+          { status: 400 }
+        );
+      }
+
+      const rule = await addChannelRoutingPolicy(session.user.id, body.policy);
+      return NextResponse.json({
+        ok: true,
+        action: "add_policy",
+        rule,
+      });
+    }
+
+    if (action === "remove_policy") {
+      if (typeof body.policyIndex !== "number") {
+        return NextResponse.json(
+          { error: "policyIndex is required for remove_policy action" },
+          { status: 400 }
+        );
+      }
+
+      try {
+        const rule = await removeChannelRoutingPolicy(session.user.id, body.policyIndex);
+        return NextResponse.json({
+          ok: true,
+          action: "remove_policy",
+          rule,
+        });
+      } catch (error) {
+        if (error instanceof Error && error.message.includes("out of range")) {
+          return NextResponse.json({ error: error.message }, { status: 400 });
+        }
+        throw error;
+      }
+    }
+
+    // Default: configure
+    if (!body.config) {
+      return NextResponse.json(
+        { error: "config is required for configure action" },
+        { status: 400 }
+      );
+    }
+
+    const rule = await updateChannelRoutingConfig(session.user.id, body.config);
+    return NextResponse.json({
+      ok: true,
+      action: "configure",
+      rule,
+    });
+  } catch (error) {
+    console.error("POST /api/integrations/slack/channel-routing error:", error);
+    const message =
+      error instanceof Error ? error.message : "Failed to update channel routing config";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/integrations/slack/events/route.ts
+++ b/src/app/api/integrations/slack/events/route.ts
@@ -1,0 +1,199 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { createHmac } from "crypto";
+import {
+  createTaskFromSlack,
+  type SlackTaskTrigger,
+} from "@/lib/integrations/slack-task-creation";
+import { prisma } from "@/lib/prisma";
+import { IntegrationConnectionStatus, IntegrationProvider } from "@/generated/prisma/client";
+
+// ---------------------------------------------------------------------------
+// Slack Event API verification
+// ---------------------------------------------------------------------------
+
+function verifySlackSignature(
+  body: string,
+  timestamp: string,
+  signature: string
+): boolean {
+  const signingSecret = process.env.SLACK_SIGNING_SECRET;
+  if (!signingSecret) {
+    console.warn("SLACK_SIGNING_SECRET not configured; skipping signature verification");
+    return true;
+  }
+
+  // Prevent replay attacks (5 min window)
+  const requestTimestamp = parseInt(timestamp, 10);
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - requestTimestamp) > 300) {
+    return false;
+  }
+
+  const sigBasestring = `v0:${timestamp}:${body}`;
+  const computedSignature = `v0=${createHmac("sha256", signingSecret)
+    .update(sigBasestring, "utf8")
+    .digest("hex")}`;
+
+  return computedSignature === signature;
+}
+
+// ---------------------------------------------------------------------------
+// Event type parsing
+// ---------------------------------------------------------------------------
+
+interface SlackEventPayload {
+  type: string;
+  token?: string;
+  challenge?: string;
+  team_id?: string;
+  event?: {
+    type: string;
+    user?: string;
+    reaction?: string;
+    item?: {
+      type: string;
+      channel: string;
+      ts: string;
+    };
+    channel?: string;
+    ts?: string;
+    thread_ts?: string;
+    text?: string;
+    trigger_id?: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Resolve WIPGuard user from Slack team + user ID
+// ---------------------------------------------------------------------------
+
+async function resolveWipguardUser(
+  slackTeamId: string | undefined,
+  slackUserId: string | undefined
+): Promise<string | null> {
+  if (!slackUserId) return null;
+
+  // Find the IntegrationConnection that matches this Slack user
+  const connection = await prisma.integrationConnection.findFirst({
+    where: {
+      provider: IntegrationProvider.SLACK,
+      status: IntegrationConnectionStatus.CONNECTED,
+      providerAccountId: slackUserId,
+    },
+    select: { userId: true },
+  });
+
+  return connection?.userId ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Route handler
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const rawBody = await request.text();
+    const timestamp = request.headers.get("x-slack-request-timestamp") ?? "";
+    const signature = request.headers.get("x-slack-signature") ?? "";
+
+    // Verify Slack signature
+    if (!verifySlackSignature(rawBody, timestamp, signature)) {
+      return NextResponse.json({ error: "Invalid signature" }, { status: 403 });
+    }
+
+    const payload = JSON.parse(rawBody) as SlackEventPayload;
+
+    // Handle Slack URL verification challenge
+    if (payload.type === "url_verification" && payload.challenge) {
+      return NextResponse.json({ challenge: payload.challenge });
+    }
+
+    if (payload.type !== "event_callback" || !payload.event) {
+      return NextResponse.json({ ok: true });
+    }
+
+    const event = payload.event;
+
+    // Handle reaction_added events -> task creation
+    if (event.type === "reaction_added" && event.item?.type === "message") {
+      const userId = await resolveWipguardUser(payload.team_id, event.user);
+      if (!userId) {
+        console.info("integration.slack.events.no_user_match", {
+          slackUserId: event.user,
+          teamId: payload.team_id,
+        });
+        return NextResponse.json({ ok: true });
+      }
+
+      try {
+        const result = await createTaskFromSlack({
+          userId,
+          payload: {
+            triggerType: "reaction" as SlackTaskTrigger,
+            channelId: event.item.channel,
+            threadTs: event.item.ts,
+            reaction: event.reaction,
+            slackUserId: event.user,
+          },
+        });
+
+        console.info("integration.slack.events.reaction_task_created", {
+          taskId: result.taskId,
+          deduped: result.deduped,
+          reaction: event.reaction,
+        });
+      } catch (error) {
+        console.error("integration.slack.events.reaction_task_failed", {
+          error: error instanceof Error ? error.message : String(error),
+          reaction: event.reaction,
+          channel: event.item.channel,
+        });
+      }
+
+      return NextResponse.json({ ok: true });
+    }
+
+    // Handle message shortcut events -> task creation
+    if (event.type === "message" && event.text?.startsWith("/wipguard")) {
+      const userId = await resolveWipguardUser(payload.team_id, event.user);
+      if (!userId) {
+        return NextResponse.json({ ok: true });
+      }
+
+      try {
+        const result = await createTaskFromSlack({
+          userId,
+          payload: {
+            triggerType: "slash_command" as SlackTaskTrigger,
+            channelId: event.channel ?? "",
+            threadTs: event.thread_ts ?? event.ts ?? "",
+            text: event.text,
+            slackUserId: event.user,
+          },
+        });
+
+        console.info("integration.slack.events.command_task_created", {
+          taskId: result.taskId,
+          deduped: result.deduped,
+        });
+      } catch (error) {
+        console.error("integration.slack.events.command_task_failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
+      return NextResponse.json({ ok: true });
+    }
+
+    // Acknowledge other events without action
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("POST /api/integrations/slack/events error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/integrations/slack/notifications/route.ts
+++ b/src/app/api/integrations/slack/notifications/route.ts
@@ -1,0 +1,109 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { IntegrationProvider } from "@/generated/prisma/client";
+import { auth } from "@/lib/auth";
+import { enforcePermission } from "@/lib/permissions";
+import {
+  sendSlackNotification,
+  sendBatchSlackNotifications,
+  type SlackNotificationPayload,
+  type ThrottleConfig,
+} from "@/lib/integrations/slack-notifications";
+
+interface NotificationRequestBody {
+  action?: "send" | "batch";
+  payload?: SlackNotificationPayload;
+  payloads?: SlackNotificationPayload[];
+  throttleConfig?: Partial<ThrottleConfig>;
+  dryRun?: boolean;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = (await request.json().catch(() => ({}))) as NotificationRequestBody;
+    const action = body.action ?? "send";
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "task.write",
+      request,
+      targetType: "integration",
+      targetId: IntegrationProvider.SLACK,
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
+    }
+
+    if (action === "batch") {
+      if (!body.payloads || body.payloads.length === 0) {
+        return NextResponse.json(
+          { error: "payloads array is required for batch action" },
+          { status: 400 }
+        );
+      }
+
+      if (body.payloads.length > 20) {
+        return NextResponse.json(
+          { error: "Maximum 20 notifications per batch" },
+          { status: 400 }
+        );
+      }
+
+      const results = await sendBatchSlackNotifications({
+        userId: session.user.id,
+        payloads: body.payloads,
+        dryRun: body.dryRun,
+      });
+
+      return NextResponse.json({
+        ok: true,
+        action: "batch",
+        results,
+        summary: {
+          total: results.length,
+          sent: results.filter((r) => r.sent).length,
+          throttled: results.filter((r) => r.throttled).length,
+          failed: results.filter((r) => !r.sent && !r.throttled).length,
+        },
+      });
+    }
+
+    // Single notification
+    if (!body.payload) {
+      return NextResponse.json(
+        { error: "payload is required" },
+        { status: 400 }
+      );
+    }
+
+    if (!body.payload.channelId || !body.payload.taskId || !body.payload.type) {
+      return NextResponse.json(
+        { error: "payload must include channelId, taskId, and type" },
+        { status: 400 }
+      );
+    }
+
+    const result = await sendSlackNotification({
+      userId: session.user.id,
+      payload: body.payload,
+      dryRun: body.dryRun,
+    });
+
+    return NextResponse.json({
+      ok: true,
+      action: "send",
+      result,
+    });
+  } catch (error) {
+    console.error("POST /api/integrations/slack/notifications error:", error);
+    const message =
+      error instanceof Error ? error.message : "Failed to send Slack notification";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/integrations/slack/task-create/route.ts
+++ b/src/app/api/integrations/slack/task-create/route.ts
@@ -1,0 +1,79 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { IntegrationProvider } from "@/generated/prisma/client";
+import { auth } from "@/lib/auth";
+import { enforcePermission } from "@/lib/permissions";
+import {
+  createTaskFromSlack,
+  type SlackTaskCreationInput,
+} from "@/lib/integrations/slack-task-creation";
+
+interface TaskCreateRequestBody {
+  /** The Slack event / shortcut payload */
+  payload: SlackTaskCreationInput;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = (await request.json().catch(() => ({}))) as TaskCreateRequestBody;
+
+    if (!body.payload) {
+      return NextResponse.json(
+        { error: "payload is required" },
+        { status: 400 }
+      );
+    }
+
+    if (!body.payload.channelId || !body.payload.threadTs || !body.payload.triggerType) {
+      return NextResponse.json(
+        { error: "payload must include channelId, threadTs, and triggerType" },
+        { status: 400 }
+      );
+    }
+
+    const validTriggers = ["reaction", "shortcut", "slash_command", "webhook"];
+    if (!validTriggers.includes(body.payload.triggerType)) {
+      return NextResponse.json(
+        { error: `triggerType must be one of: ${validTriggers.join(", ")}` },
+        { status: 400 }
+      );
+    }
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "task.write",
+      request,
+      targetType: "integration",
+      targetId: IntegrationProvider.SLACK,
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
+    }
+
+    const result = await createTaskFromSlack({
+      userId: session.user.id,
+      payload: body.payload,
+    });
+
+    const status = result.deduped ? 200 : 201;
+
+    return NextResponse.json(
+      {
+        ok: true,
+        result,
+      },
+      { status }
+    );
+  } catch (error) {
+    console.error("POST /api/integrations/slack/task-create error:", error);
+    const message =
+      error instanceof Error ? error.message : "Failed to create task from Slack";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/lib/__tests__/slack-channel-routing.test.ts
+++ b/src/lib/__tests__/slack-channel-routing.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  policyMatches,
+  resolveChannelForNotification,
+  normalizeChannelRoutingConfig,
+  defaultChannelRoutingConfig,
+  clearChannelRoutingCache,
+  type ChannelRoutingPolicy,
+  type ChannelRoutingConfig,
+  type ChannelRoutingContext,
+} from "@/lib/integrations/slack-channel-routing";
+
+describe("slack-channel-routing helpers", () => {
+  beforeEach(() => {
+    clearChannelRoutingCache();
+  });
+
+  // -----------------------------------------------------------------------
+  // defaultChannelRoutingConfig
+  // -----------------------------------------------------------------------
+
+  describe("defaultChannelRoutingConfig", () => {
+    it("returns expected defaults", () => {
+      expect(defaultChannelRoutingConfig()).toEqual({
+        policies: [],
+        defaultChannelId: null,
+        fallbackToDm: true,
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // normalizeChannelRoutingConfig
+  // -----------------------------------------------------------------------
+
+  describe("normalizeChannelRoutingConfig", () => {
+    it("returns defaults for null input", () => {
+      expect(normalizeChannelRoutingConfig(null)).toEqual(
+        defaultChannelRoutingConfig()
+      );
+    });
+
+    it("returns defaults for empty object", () => {
+      expect(normalizeChannelRoutingConfig({})).toEqual(
+        defaultChannelRoutingConfig()
+      );
+    });
+
+    it("normalizes valid config", () => {
+      const raw = {
+        policies: [
+          {
+            label: "P0 urgent",
+            match: { priority: "P0" },
+            channelId: "C_URGENT",
+            enabled: true,
+          },
+        ],
+        defaultChannelId: "C_DEFAULT",
+        fallbackToDm: false,
+      };
+
+      const config = normalizeChannelRoutingConfig(raw);
+      expect(config.policies).toHaveLength(1);
+      expect(config.policies[0].label).toBe("P0 urgent");
+      expect(config.policies[0].channelId).toBe("C_URGENT");
+      expect(config.defaultChannelId).toBe("C_DEFAULT");
+      expect(config.fallbackToDm).toBe(false);
+    });
+
+    it("strips policies without channelId", () => {
+      const raw = {
+        policies: [
+          { label: "No channel", match: { priority: "P0" } },
+          { label: "Has channel", match: { priority: "P1" }, channelId: "C_P1" },
+        ],
+      };
+
+      const config = normalizeChannelRoutingConfig(raw);
+      expect(config.policies).toHaveLength(1);
+      expect(config.policies[0].label).toBe("Has channel");
+    });
+
+    it("strips policies without match criteria", () => {
+      const raw = {
+        policies: [
+          { label: "No match", channelId: "C_ORPHAN", match: {} },
+          { label: "Has match", channelId: "C_OK", match: { projectId: "proj-1" } },
+        ],
+      };
+
+      const config = normalizeChannelRoutingConfig(raw);
+      expect(config.policies).toHaveLength(1);
+      expect(config.policies[0].label).toBe("Has match");
+    });
+
+    it("defaults label to 'Unnamed policy' when missing", () => {
+      const raw = {
+        policies: [
+          { match: { priority: "P0" }, channelId: "C_P0" },
+        ],
+      };
+
+      const config = normalizeChannelRoutingConfig(raw);
+      expect(config.policies[0].label).toBe("Unnamed policy");
+    });
+
+    it("defaults enabled to true when missing", () => {
+      const raw = {
+        policies: [
+          { label: "Test", match: { priority: "P0" }, channelId: "C_P0" },
+        ],
+      };
+
+      const config = normalizeChannelRoutingConfig(raw);
+      expect(config.policies[0].enabled).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // policyMatches
+  // -----------------------------------------------------------------------
+
+  describe("policyMatches", () => {
+    it("matches when all specified criteria match", () => {
+      const policy: ChannelRoutingPolicy = {
+        label: "Test",
+        match: { projectId: "proj-1", priority: "P0" },
+        channelId: "C123",
+        enabled: true,
+      };
+      const context: ChannelRoutingContext = {
+        projectId: "proj-1",
+        priority: "P0",
+      };
+
+      expect(policyMatches(policy, context)).toBe(true);
+    });
+
+    it("does not match when disabled", () => {
+      const policy: ChannelRoutingPolicy = {
+        label: "Disabled",
+        match: { priority: "P0" },
+        channelId: "C123",
+        enabled: false,
+      };
+
+      expect(policyMatches(policy, { priority: "P0" })).toBe(false);
+    });
+
+    it("does not match when projectId differs", () => {
+      const policy: ChannelRoutingPolicy = {
+        label: "Project match",
+        match: { projectId: "proj-1" },
+        channelId: "C123",
+        enabled: true,
+      };
+
+      expect(policyMatches(policy, { projectId: "proj-2" })).toBe(false);
+    });
+
+    it("does not match when priority differs", () => {
+      const policy: ChannelRoutingPolicy = {
+        label: "Priority match",
+        match: { priority: "P0" },
+        channelId: "C123",
+        enabled: true,
+      };
+
+      expect(policyMatches(policy, { priority: "P1" })).toBe(false);
+    });
+
+    it("does not match when notificationType differs", () => {
+      const policy: ChannelRoutingPolicy = {
+        label: "Type match",
+        match: { notificationType: "blocked" },
+        channelId: "C123",
+        enabled: true,
+      };
+
+      expect(policyMatches(policy, { notificationType: "status_change" })).toBe(false);
+    });
+
+    it("matches when policy has one criterion and context has extras", () => {
+      const policy: ChannelRoutingPolicy = {
+        label: "Priority only",
+        match: { priority: "P0" },
+        channelId: "C123",
+        enabled: true,
+      };
+
+      // Context has more info than the policy requires -- that's fine
+      expect(
+        policyMatches(policy, {
+          priority: "P0",
+          projectId: "proj-1",
+          notificationType: "blocked",
+        })
+      ).toBe(true);
+    });
+
+    it("uses AND logic for multiple criteria", () => {
+      const policy: ChannelRoutingPolicy = {
+        label: "Project + Priority",
+        match: { projectId: "proj-1", priority: "P0" },
+        channelId: "C123",
+        enabled: true,
+      };
+
+      // Only one criterion matches -- should fail
+      expect(policyMatches(policy, { projectId: "proj-1", priority: "P1" })).toBe(false);
+      expect(policyMatches(policy, { projectId: "proj-2", priority: "P0" })).toBe(false);
+
+      // Both match -- should pass
+      expect(policyMatches(policy, { projectId: "proj-1", priority: "P0" })).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // resolveChannelForNotification
+  // -----------------------------------------------------------------------
+
+  describe("resolveChannelForNotification", () => {
+    it("returns null when no config provided", () => {
+      expect(resolveChannelForNotification({}, null)).toBeNull();
+    });
+
+    it("returns default channel when no policies match", () => {
+      const config: ChannelRoutingConfig = {
+        policies: [
+          {
+            label: "P0 only",
+            match: { priority: "P0" },
+            channelId: "C_URGENT",
+            enabled: true,
+          },
+        ],
+        defaultChannelId: "C_DEFAULT",
+        fallbackToDm: true,
+      };
+
+      const result = resolveChannelForNotification({ priority: "P3" }, config);
+      expect(result).toEqual({
+        channelId: "C_DEFAULT",
+        matchedPolicy: "default",
+      });
+    });
+
+    it("returns null when no policies match and no default", () => {
+      const config: ChannelRoutingConfig = {
+        policies: [],
+        defaultChannelId: null,
+        fallbackToDm: true,
+      };
+
+      expect(resolveChannelForNotification({ priority: "P0" }, config)).toBeNull();
+    });
+
+    it("returns first matching policy", () => {
+      const config: ChannelRoutingConfig = {
+        policies: [
+          {
+            label: "P0 urgent",
+            match: { priority: "P0" },
+            channelId: "C_URGENT",
+            enabled: true,
+          },
+          {
+            label: "P1 important",
+            match: { priority: "P1" },
+            channelId: "C_IMPORTANT",
+            enabled: true,
+          },
+        ],
+        defaultChannelId: "C_DEFAULT",
+        fallbackToDm: true,
+      };
+
+      const result = resolveChannelForNotification({ priority: "P1" }, config);
+      expect(result?.channelId).toBe("C_IMPORTANT");
+      expect(result?.matchedPolicy).toBe("P1 important");
+    });
+
+    it("prefers more specific policies (higher specificity)", () => {
+      const config: ChannelRoutingConfig = {
+        policies: [
+          {
+            label: "Just priority",
+            match: { priority: "P0" },
+            channelId: "C_PRIORITY_ONLY",
+            enabled: true,
+          },
+          {
+            label: "Project + priority",
+            match: { projectId: "proj-1", priority: "P0" },
+            channelId: "C_SPECIFIC",
+            enabled: true,
+          },
+        ],
+        defaultChannelId: null,
+        fallbackToDm: true,
+      };
+
+      const result = resolveChannelForNotification(
+        { projectId: "proj-1", priority: "P0" },
+        config
+      );
+      // The more specific policy (2 criteria) should win even though
+      // the less specific one (1 criterion) also matches
+      expect(result?.channelId).toBe("C_SPECIFIC");
+      expect(result?.matchedPolicy).toBe("Project + priority");
+    });
+
+    it("skips disabled policies", () => {
+      const config: ChannelRoutingConfig = {
+        policies: [
+          {
+            label: "Disabled P0",
+            match: { priority: "P0" },
+            channelId: "C_DISABLED",
+            enabled: false,
+          },
+        ],
+        defaultChannelId: "C_FALLBACK",
+        fallbackToDm: true,
+      };
+
+      const result = resolveChannelForNotification({ priority: "P0" }, config);
+      expect(result?.channelId).toBe("C_FALLBACK");
+      expect(result?.matchedPolicy).toBe("default");
+    });
+
+    it("includes threadTs from matching policy", () => {
+      const config: ChannelRoutingConfig = {
+        policies: [
+          {
+            label: "Threaded",
+            match: { priority: "P0" },
+            channelId: "C_URGENT",
+            threadTs: "1739470000.000000",
+            enabled: true,
+          },
+        ],
+        defaultChannelId: null,
+        fallbackToDm: true,
+      };
+
+      const result = resolveChannelForNotification({ priority: "P0" }, config);
+      expect(result?.threadTs).toBe("1739470000.000000");
+    });
+  });
+});

--- a/src/lib/__tests__/slack-notifications.test.ts
+++ b/src/lib/__tests__/slack-notifications.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  shouldThrottle,
+  recordSend,
+  resetThrottleState,
+  getThrottleEntry,
+  renderNotificationMessage,
+  buildNotificationDedupeKey,
+  defaultThrottleConfig,
+  type SlackNotificationPayload,
+  type ThrottleConfig,
+} from "@/lib/integrations/slack-notifications";
+
+describe("slack-notifications helpers", () => {
+  beforeEach(() => {
+    resetThrottleState();
+  });
+
+  // -----------------------------------------------------------------------
+  // defaultThrottleConfig
+  // -----------------------------------------------------------------------
+
+  describe("defaultThrottleConfig", () => {
+    it("returns expected defaults", () => {
+      expect(defaultThrottleConfig()).toEqual({
+        windowMs: 60_000,
+        maxBurst: 5,
+        bypassTypes: ["blocked"],
+        minIntervalMs: 2_000,
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // shouldThrottle
+  // -----------------------------------------------------------------------
+
+  describe("shouldThrottle", () => {
+    const config: ThrottleConfig = {
+      windowMs: 60_000,
+      maxBurst: 3,
+      bypassTypes: ["blocked"],
+      minIntervalMs: 1_000,
+    };
+
+    it("returns false when no prior sends exist", () => {
+      const result = shouldThrottle("C123", "status_change", config);
+      expect(result.throttled).toBe(false);
+    });
+
+    it("bypasses throttle for blocked notifications", () => {
+      // Fill up the burst limit first
+      const now = 1_000_000;
+      for (let i = 0; i < 5; i++) {
+        recordSend("C123", now + i * 100, config.windowMs);
+      }
+
+      const result = shouldThrottle("C123", "blocked", config, now + 600);
+      expect(result.throttled).toBe(false);
+    });
+
+    it("throttles when min interval not met", () => {
+      const now = 1_000_000;
+      recordSend("C123", now, config.windowMs);
+
+      // 500ms later -- below the 1000ms minIntervalMs
+      const result = shouldThrottle("C123", "status_change", config, now + 500);
+      expect(result.throttled).toBe(true);
+      expect(result.reason).toContain("min_interval");
+    });
+
+    it("does not throttle after min interval has passed", () => {
+      const now = 1_000_000;
+      recordSend("C123", now, config.windowMs);
+
+      // 1500ms later -- above the 1000ms minIntervalMs
+      const result = shouldThrottle("C123", "status_change", config, now + 1500);
+      expect(result.throttled).toBe(false);
+    });
+
+    it("throttles when burst limit is reached", () => {
+      const now = 1_000_000;
+      // Send 3 messages (hitting burst limit)
+      for (let i = 0; i < 3; i++) {
+        recordSend("C123", now + i * 2000, config.windowMs);
+      }
+
+      // 3 seconds after last send -- min interval satisfied but burst exceeded
+      const checkTime = now + 2 * 2000 + 3000;
+      const result = shouldThrottle("C123", "assignment", config, checkTime);
+      expect(result.throttled).toBe(true);
+      expect(result.reason).toContain("burst_limit");
+    });
+
+    it("clears burst after window expires", () => {
+      const now = 1_000_000;
+      for (let i = 0; i < 3; i++) {
+        recordSend("C123", now + i * 2000, config.windowMs);
+      }
+
+      // 61 seconds after first message -- all messages are outside window
+      const result = shouldThrottle(
+        "C123",
+        "assignment",
+        config,
+        now + 61_000
+      );
+      expect(result.throttled).toBe(false);
+    });
+
+    it("tracks channels independently", () => {
+      const now = 1_000_000;
+      for (let i = 0; i < 3; i++) {
+        recordSend("C_FULL", now + i * 2000, config.windowMs);
+      }
+
+      // C_FULL is burst-limited, C_EMPTY should not be
+      const fullResult = shouldThrottle("C_FULL", "status_change", config, now + 10_000);
+      const emptyResult = shouldThrottle("C_EMPTY", "status_change", config, now + 10_000);
+
+      expect(fullResult.throttled).toBe(true);
+      expect(emptyResult.throttled).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // recordSend
+  // -----------------------------------------------------------------------
+
+  describe("recordSend", () => {
+    it("creates a new entry for a channel", () => {
+      recordSend("C_NEW", 1000, 60_000);
+      const entry = getThrottleEntry("C_NEW");
+      expect(entry).toBeDefined();
+      expect(entry!.timestamps).toEqual([1000]);
+      expect(entry!.lastSentAt).toBe(1000);
+    });
+
+    it("prunes timestamps outside the window", () => {
+      recordSend("C_PRUNE", 1000, 5000);
+      recordSend("C_PRUNE", 3000, 5000);
+      recordSend("C_PRUNE", 7000, 5000); // Prunes anything < 2000
+
+      const entry = getThrottleEntry("C_PRUNE");
+      expect(entry!.timestamps).toEqual([3000, 7000]);
+      expect(entry!.lastSentAt).toBe(7000);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // renderNotificationMessage
+  // -----------------------------------------------------------------------
+
+  describe("renderNotificationMessage", () => {
+    const base: SlackNotificationPayload = {
+      type: "assignment",
+      taskId: "task-1",
+      taskTitle: "Implement feature X",
+      channelId: "C123",
+    };
+
+    it("renders assignment message", () => {
+      const msg = renderNotificationMessage({ ...base, type: "assignment" });
+      expect(msg).toContain("Implement feature X");
+      expect(msg).toContain("was assigned");
+      expect(msg).toContain(":bust_in_silhouette:");
+    });
+
+    it("renders assignment with actor", () => {
+      const msg = renderNotificationMessage({
+        ...base,
+        type: "assignment",
+        actorName: "Kyle",
+      });
+      expect(msg).toContain("by Kyle");
+    });
+
+    it("renders assignment with project", () => {
+      const msg = renderNotificationMessage({
+        ...base,
+        type: "assignment",
+        projectName: "Alpha",
+      });
+      expect(msg).toContain("(Alpha)");
+    });
+
+    it("renders status_change with transition", () => {
+      const msg = renderNotificationMessage({
+        ...base,
+        type: "status_change",
+        context: { oldStatus: "QUEUED", newStatus: "ACTIVE" },
+      });
+      expect(msg).toContain("QUEUED -> ACTIVE");
+      expect(msg).toContain(":arrows_counterclockwise:");
+    });
+
+    it("renders status_change without old status", () => {
+      const msg = renderNotificationMessage({
+        ...base,
+        type: "status_change",
+        context: { newStatus: "ACTIVE" },
+      });
+      expect(msg).toContain("ACTIVE");
+      expect(msg).not.toContain("->");
+    });
+
+    it("renders blocked with reason", () => {
+      const msg = renderNotificationMessage({
+        ...base,
+        type: "blocked",
+        context: { reason: "Waiting on API keys" },
+      });
+      expect(msg).toContain("BLOCKED");
+      expect(msg).toContain("Waiting on API keys");
+      expect(msg).toContain(":octagonal_sign:");
+    });
+
+    it("renders unblocked message", () => {
+      const msg = renderNotificationMessage({ ...base, type: "unblocked" });
+      expect(msg).toContain("no longer blocked");
+      expect(msg).toContain(":white_check_mark:");
+    });
+
+    it("renders mention with role", () => {
+      const msg = renderNotificationMessage({
+        ...base,
+        type: "mention",
+        context: { role: "accountable" },
+      });
+      expect(msg).toContain("accountable");
+      expect(msg).toContain(":speech_balloon:");
+    });
+
+    it("renders mention with default role", () => {
+      const msg = renderNotificationMessage({ ...base, type: "mention" });
+      expect(msg).toContain("mentioned");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // buildNotificationDedupeKey
+  // -----------------------------------------------------------------------
+
+  describe("buildNotificationDedupeKey", () => {
+    it("builds canonical key with thread", () => {
+      const key = buildNotificationDedupeKey({
+        type: "status_change",
+        taskId: "task-1",
+        taskTitle: "Test",
+        channelId: "C123",
+        threadTs: "1739470000.123456",
+      });
+
+      expect(key).toBe("slack:notification:C123:task-1:status_change:1739470000.123456");
+    });
+
+    it("builds canonical key without thread", () => {
+      const key = buildNotificationDedupeKey({
+        type: "blocked",
+        taskId: "task-2",
+        taskTitle: "Test",
+        channelId: "C456",
+      });
+
+      expect(key).toBe("slack:notification:C456:task-2:blocked:no-thread");
+    });
+
+    it("produces unique keys for different types on same task/channel", () => {
+      const base = {
+        taskId: "task-1",
+        taskTitle: "Test",
+        channelId: "C123",
+        threadTs: "1739470000.000000",
+      };
+
+      const key1 = buildNotificationDedupeKey({ ...base, type: "status_change" });
+      const key2 = buildNotificationDedupeKey({ ...base, type: "blocked" });
+      expect(key1).not.toBe(key2);
+    });
+  });
+});

--- a/src/lib/__tests__/slack-raci-bridge.test.ts
+++ b/src/lib/__tests__/slack-raci-bridge.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  getNotificationTypesForRole,
+  getRolesToNotify,
+} from "@/lib/integrations/slack-raci-bridge";
+
+describe("slack-raci-bridge helpers", () => {
+  // -----------------------------------------------------------------------
+  // getNotificationTypesForRole
+  // -----------------------------------------------------------------------
+
+  describe("getNotificationTypesForRole", () => {
+    // --- Responsible ---
+    it("responsible gets assignment on raci_change", () => {
+      expect(getNotificationTypesForRole("responsible", "raci_change")).toEqual([
+        "assignment",
+      ]);
+    });
+
+    it("responsible gets status_change on status_change", () => {
+      expect(getNotificationTypesForRole("responsible", "status_change")).toEqual([
+        "status_change",
+      ]);
+    });
+
+    it("responsible gets blocked on blocked", () => {
+      expect(getNotificationTypesForRole("responsible", "blocked")).toEqual([
+        "blocked",
+      ]);
+    });
+
+    it("responsible gets unblocked on unblocked", () => {
+      expect(getNotificationTypesForRole("responsible", "unblocked")).toEqual([
+        "unblocked",
+      ]);
+    });
+
+    it("responsible gets assignment on assignment", () => {
+      expect(getNotificationTypesForRole("responsible", "assignment")).toEqual([
+        "assignment",
+      ]);
+    });
+
+    // --- Accountable ---
+    it("accountable gets mention on raci_change", () => {
+      expect(getNotificationTypesForRole("accountable", "raci_change")).toEqual([
+        "mention",
+      ]);
+    });
+
+    it("accountable gets status_change on status_change", () => {
+      expect(getNotificationTypesForRole("accountable", "status_change")).toEqual([
+        "status_change",
+      ]);
+    });
+
+    it("accountable gets blocked on blocked", () => {
+      expect(getNotificationTypesForRole("accountable", "blocked")).toEqual([
+        "blocked",
+      ]);
+    });
+
+    it("accountable gets nothing on assignment", () => {
+      expect(getNotificationTypesForRole("accountable", "assignment")).toEqual(
+        []
+      );
+    });
+
+    // --- Consulted ---
+    it("consulted gets mention on raci_change only", () => {
+      expect(getNotificationTypesForRole("consulted", "raci_change")).toEqual([
+        "mention",
+      ]);
+      expect(getNotificationTypesForRole("consulted", "status_change")).toEqual(
+        []
+      );
+      expect(getNotificationTypesForRole("consulted", "blocked")).toEqual([]);
+      expect(getNotificationTypesForRole("consulted", "assignment")).toEqual([]);
+    });
+
+    // --- Informed ---
+    it("informed gets mention on raci_change", () => {
+      expect(getNotificationTypesForRole("informed", "raci_change")).toEqual([
+        "mention",
+      ]);
+    });
+
+    it("informed gets status_change on status_change", () => {
+      expect(getNotificationTypesForRole("informed", "status_change")).toEqual([
+        "status_change",
+      ]);
+    });
+
+    it("informed gets nothing on blocked/unblocked/assignment", () => {
+      expect(getNotificationTypesForRole("informed", "blocked")).toEqual([]);
+      expect(getNotificationTypesForRole("informed", "unblocked")).toEqual([]);
+      expect(getNotificationTypesForRole("informed", "assignment")).toEqual([]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getRolesToNotify
+  // -----------------------------------------------------------------------
+
+  describe("getRolesToNotify", () => {
+    it("raci_change returns empty (added users handled separately)", () => {
+      expect(getRolesToNotify("raci_change")).toEqual([]);
+    });
+
+    it("status_change notifies responsible, accountable, informed", () => {
+      const roles = getRolesToNotify("status_change");
+      expect(roles).toContain("responsible");
+      expect(roles).toContain("accountable");
+      expect(roles).toContain("informed");
+      expect(roles).not.toContain("consulted");
+    });
+
+    it("blocked notifies responsible and accountable", () => {
+      const roles = getRolesToNotify("blocked");
+      expect(roles).toEqual(["responsible", "accountable"]);
+    });
+
+    it("unblocked notifies responsible and accountable", () => {
+      const roles = getRolesToNotify("unblocked");
+      expect(roles).toEqual(["responsible", "accountable"]);
+    });
+
+    it("assignment notifies responsible only", () => {
+      expect(getRolesToNotify("assignment")).toEqual(["responsible"]);
+    });
+  });
+});

--- a/src/lib/__tests__/slack-task-creation.test.ts
+++ b/src/lib/__tests__/slack-task-creation.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSlackExternalId,
+  buildSlackTaskDedupeKey,
+  buildSlackThreadUrl,
+} from "@/lib/integrations/slack-task-creation";
+
+describe("slack-task-creation helpers", () => {
+  // -----------------------------------------------------------------------
+  // buildSlackExternalId
+  // -----------------------------------------------------------------------
+
+  describe("buildSlackExternalId", () => {
+    it("concatenates channelId and threadTs", () => {
+      expect(buildSlackExternalId("C123", "1739470000.123456")).toBe(
+        "C123:1739470000.123456"
+      );
+    });
+
+    it("handles different channel formats", () => {
+      expect(buildSlackExternalId("D_DM_CHAN", "1234567890.000000")).toBe(
+        "D_DM_CHAN:1234567890.000000"
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // buildSlackTaskDedupeKey
+  // -----------------------------------------------------------------------
+
+  describe("buildSlackTaskDedupeKey", () => {
+    it("builds key with trigger value (reaction)", () => {
+      const key = buildSlackTaskDedupeKey({
+        channelId: "C123",
+        threadTs: "1739470000.123456",
+        triggerType: "reaction",
+        triggerValue: "pushpin",
+      });
+
+      expect(key).toBe(
+        "slack:slack_task_create:C123:1739470000.123456:reaction:pushpin"
+      );
+    });
+
+    it("builds key without trigger value (shortcut)", () => {
+      const key = buildSlackTaskDedupeKey({
+        channelId: "C456",
+        threadTs: "1739470000.000000",
+        triggerType: "shortcut",
+      });
+
+      expect(key).toBe(
+        "slack:slack_task_create:C456:1739470000.000000:shortcut"
+      );
+    });
+
+    it("builds key for slash_command trigger", () => {
+      const key = buildSlackTaskDedupeKey({
+        channelId: "C789",
+        threadTs: "1234567890.000001",
+        triggerType: "slash_command",
+      });
+
+      expect(key).toBe(
+        "slack:slack_task_create:C789:1234567890.000001:slash_command"
+      );
+    });
+
+    it("produces different keys for different reactions on same thread", () => {
+      const base = {
+        channelId: "C123",
+        threadTs: "1739470000.123456",
+        triggerType: "reaction" as const,
+      };
+
+      const key1 = buildSlackTaskDedupeKey({ ...base, triggerValue: "pushpin" });
+      const key2 = buildSlackTaskDedupeKey({ ...base, triggerValue: "white_check_mark" });
+      expect(key1).not.toBe(key2);
+    });
+
+    it("produces different keys for different channels on same timestamp", () => {
+      const key1 = buildSlackTaskDedupeKey({
+        channelId: "C111",
+        threadTs: "1739470000.123456",
+        triggerType: "reaction",
+        triggerValue: "pushpin",
+      });
+      const key2 = buildSlackTaskDedupeKey({
+        channelId: "C222",
+        threadTs: "1739470000.123456",
+        triggerType: "reaction",
+        triggerValue: "pushpin",
+      });
+      expect(key1).not.toBe(key2);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // buildSlackThreadUrl
+  // -----------------------------------------------------------------------
+
+  describe("buildSlackThreadUrl", () => {
+    it("builds URL with custom workspace URL", () => {
+      const url = buildSlackThreadUrl(
+        "https://mycompany.slack.com",
+        "C123",
+        "1739470000.123456"
+      );
+
+      expect(url).toBe("https://mycompany.slack.com/archives/C123/p1739470000123456");
+    });
+
+    it("strips trailing slashes from workspace URL", () => {
+      const url = buildSlackThreadUrl(
+        "https://mycompany.slack.com///",
+        "C123",
+        "1739470000.123456"
+      );
+
+      expect(url).toBe("https://mycompany.slack.com/archives/C123/p1739470000123456");
+    });
+
+    it("falls back to app.slack.com when no workspace URL", () => {
+      const url = buildSlackThreadUrl(null, "C123", "1739470000.123456");
+
+      expect(url).toContain("app.slack.com");
+      expect(url).toContain("C123");
+    });
+
+    it("uses thread format for app.slack.com URLs", () => {
+      const url = buildSlackThreadUrl(
+        "https://app.slack.com/client/T123",
+        "C456",
+        "1739470000.123456"
+      );
+
+      expect(url).toContain("/thread/");
+      expect(url).toContain("C456");
+    });
+
+    it("removes dots from thread TS in URL", () => {
+      const url = buildSlackThreadUrl(
+        "https://mycompany.slack.com",
+        "C123",
+        "1739470000.123456"
+      );
+
+      // The dot should be removed from the URL path
+      expect(url).not.toContain("1739470000.123456");
+      expect(url).toContain("1739470000123456");
+    });
+  });
+});

--- a/src/lib/integrations/slack-channel-routing.ts
+++ b/src/lib/integrations/slack-channel-routing.ts
@@ -1,0 +1,408 @@
+/**
+ * Slack Channel Routing Policies
+ *
+ * Routes Slack notifications to the appropriate channel based on:
+ *  1. Project-specific channel mapping
+ *  2. Priority-based channel mapping (P0 -> #urgent, P1 -> #important, etc.)
+ *  3. Notification type routing (blocked -> #incidents, etc.)
+ *  4. Default fallback channel
+ *
+ * Policies are evaluated in priority order:
+ *  1. Exact project match
+ *  2. Priority match
+ *  3. Notification type match
+ *  4. Default channel
+ *
+ * Configuration is stored as JSON in the IntegrationRule config field.
+ */
+
+import {
+  IntegrationProvider,
+  Prisma,
+  type IntegrationRule,
+} from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ChannelRoutingPolicy {
+  /** Human-readable label for the policy */
+  label: string;
+  /** Match criteria — at least one must be specified */
+  match: {
+    projectId?: string;
+    priority?: string;
+    notificationType?: string;
+  };
+  /** The Slack channel ID to route to */
+  channelId: string;
+  /** Optional thread TS to post as a thread reply */
+  threadTs?: string;
+  /** Whether this policy is active */
+  enabled: boolean;
+}
+
+export interface ChannelRoutingConfig {
+  /** Ordered list of routing policies (first match wins) */
+  policies: ChannelRoutingPolicy[];
+  /** Default channel if no policy matches */
+  defaultChannelId: string | null;
+  /** Whether to fall back to DM if no channel matches */
+  fallbackToDm: boolean;
+}
+
+export interface ChannelRoutingContext {
+  projectId?: string;
+  priority?: string;
+  notificationType?: string;
+}
+
+export interface ResolvedChannel {
+  channelId: string;
+  threadTs?: string;
+  matchedPolicy?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const SLACK_CHANNEL_ROUTING_RULE_KEY = "slack_channel_routing";
+
+// ---------------------------------------------------------------------------
+// Config helpers
+// ---------------------------------------------------------------------------
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+export function defaultChannelRoutingConfig(): ChannelRoutingConfig {
+  return {
+    policies: [],
+    defaultChannelId: null,
+    fallbackToDm: true,
+  };
+}
+
+function normalizePolicy(raw: unknown): ChannelRoutingPolicy | null {
+  const input = asRecord(raw);
+
+  const channelId = typeof input.channelId === "string" ? input.channelId.trim() : null;
+  if (!channelId) return null;
+
+  const match = asRecord(input.match);
+  const hasMatch =
+    typeof match.projectId === "string" ||
+    typeof match.priority === "string" ||
+    typeof match.notificationType === "string";
+
+  if (!hasMatch) return null;
+
+  return {
+    label: typeof input.label === "string" ? input.label.trim() : "Unnamed policy",
+    match: {
+      projectId: typeof match.projectId === "string" ? match.projectId : undefined,
+      priority: typeof match.priority === "string" ? match.priority : undefined,
+      notificationType:
+        typeof match.notificationType === "string" ? match.notificationType : undefined,
+    },
+    channelId,
+    threadTs: typeof input.threadTs === "string" ? input.threadTs : undefined,
+    enabled: typeof input.enabled === "boolean" ? input.enabled : true,
+  };
+}
+
+export function normalizeChannelRoutingConfig(raw: unknown): ChannelRoutingConfig {
+  const input = asRecord(raw);
+  const fallback = defaultChannelRoutingConfig();
+
+  const rawPolicies = Array.isArray(input.policies) ? input.policies : [];
+  const policies = rawPolicies
+    .map((item) => normalizePolicy(item))
+    .filter((policy): policy is ChannelRoutingPolicy => policy !== null);
+
+  const defaultChannelId =
+    typeof input.defaultChannelId === "string" && input.defaultChannelId.trim().length > 0
+      ? input.defaultChannelId.trim()
+      : fallback.defaultChannelId;
+
+  const fallbackToDm =
+    typeof input.fallbackToDm === "boolean" ? input.fallbackToDm : fallback.fallbackToDm;
+
+  return {
+    policies,
+    defaultChannelId,
+    fallbackToDm,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// In-memory routing cache (loaded from DB, refreshed periodically)
+// ---------------------------------------------------------------------------
+
+let cachedConfig: ChannelRoutingConfig | null = null;
+let cacheTimestamp: number = 0;
+const CACHE_TTL_MS = 30_000; // 30 seconds
+
+/**
+ * Load routing config from the database for a given user.
+ */
+export async function loadChannelRoutingConfig(userId: string): Promise<ChannelRoutingConfig> {
+  const rule = await prisma.integrationRule.findUnique({
+    where: {
+      userId_provider_key: {
+        userId,
+        provider: IntegrationProvider.SLACK,
+        key: SLACK_CHANNEL_ROUTING_RULE_KEY,
+      },
+    },
+  });
+
+  if (!rule) {
+    return defaultChannelRoutingConfig();
+  }
+
+  return normalizeChannelRoutingConfig(rule.config);
+}
+
+/**
+ * Set the in-memory routing config (used by the notification bridge).
+ */
+export function setChannelRoutingConfig(config: ChannelRoutingConfig): void {
+  cachedConfig = config;
+  cacheTimestamp = Date.now();
+}
+
+/**
+ * Clear the in-memory cache (for testing).
+ */
+export function clearChannelRoutingCache(): void {
+  cachedConfig = null;
+  cacheTimestamp = 0;
+}
+
+/**
+ * Get the current routing config from cache.
+ */
+export function getCachedChannelRoutingConfig(): ChannelRoutingConfig | null {
+  if (!cachedConfig) return null;
+  if (Date.now() - cacheTimestamp > CACHE_TTL_MS) {
+    cachedConfig = null;
+    cacheTimestamp = 0;
+    return null;
+  }
+  return cachedConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Policy evaluation
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a single policy matches the given context.
+ */
+export function policyMatches(
+  policy: ChannelRoutingPolicy,
+  context: ChannelRoutingContext
+): boolean {
+  if (!policy.enabled) return false;
+
+  // All specified match criteria must pass (AND logic)
+  if (policy.match.projectId && policy.match.projectId !== context.projectId) {
+    return false;
+  }
+  if (policy.match.priority && policy.match.priority !== context.priority) {
+    return false;
+  }
+  if (
+    policy.match.notificationType &&
+    policy.match.notificationType !== context.notificationType
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Resolve the channel for a notification given a routing context.
+ * Returns null if no channel is resolved (caller should fall back to DM).
+ *
+ * Evaluation order (first match wins):
+ *  1. Policies ordered by specificity (more match criteria = higher priority)
+ *  2. Default channel
+ */
+export function resolveChannelForNotification(
+  context: ChannelRoutingContext,
+  config?: ChannelRoutingConfig | null
+): ResolvedChannel | null {
+  const effectiveConfig = config ?? cachedConfig;
+  if (!effectiveConfig) return null;
+
+  // Sort policies by specificity (more match criteria = higher priority)
+  const sortedPolicies = [...effectiveConfig.policies].sort((a, b) => {
+    const aSpecificity = countMatchCriteria(a);
+    const bSpecificity = countMatchCriteria(b);
+    return bSpecificity - aSpecificity;
+  });
+
+  for (const policy of sortedPolicies) {
+    if (policyMatches(policy, context)) {
+      return {
+        channelId: policy.channelId,
+        threadTs: policy.threadTs,
+        matchedPolicy: policy.label,
+      };
+    }
+  }
+
+  // Fallback to default channel
+  if (effectiveConfig.defaultChannelId) {
+    return {
+      channelId: effectiveConfig.defaultChannelId,
+      matchedPolicy: "default",
+    };
+  }
+
+  return null;
+}
+
+function countMatchCriteria(policy: ChannelRoutingPolicy): number {
+  let count = 0;
+  if (policy.match.projectId) count += 1;
+  if (policy.match.priority) count += 1;
+  if (policy.match.notificationType) count += 1;
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// CRUD operations for routing rules
+// ---------------------------------------------------------------------------
+
+export interface ChannelRoutingRuleState {
+  id: string;
+  key: string;
+  enabled: boolean;
+  config: ChannelRoutingConfig;
+  lastRunAt: string | null;
+  lastError: string | null;
+}
+
+export async function getOrCreateChannelRoutingRule(userId: string): Promise<IntegrationRule> {
+  return prisma.integrationRule.upsert({
+    where: {
+      userId_provider_key: {
+        userId,
+        provider: IntegrationProvider.SLACK,
+        key: SLACK_CHANNEL_ROUTING_RULE_KEY,
+      },
+    },
+    update: {},
+    create: {
+      userId,
+      provider: IntegrationProvider.SLACK,
+      key: SLACK_CHANNEL_ROUTING_RULE_KEY,
+      enabled: true,
+      statusOverride: null,
+      config: defaultChannelRoutingConfig() as unknown as Prisma.InputJsonValue,
+      checkpoint: {} as unknown as Prisma.InputJsonValue,
+    },
+  });
+}
+
+export function serializeChannelRoutingRule(rule: IntegrationRule): ChannelRoutingRuleState {
+  return {
+    id: rule.id,
+    key: rule.key,
+    enabled: rule.enabled,
+    config: normalizeChannelRoutingConfig(rule.config),
+    lastRunAt: rule.lastRunAt?.toISOString() ?? null,
+    lastError: rule.lastError,
+  };
+}
+
+export async function updateChannelRoutingConfig(
+  userId: string,
+  configPatch: Partial<ChannelRoutingConfig>
+): Promise<ChannelRoutingRuleState> {
+  const existing = await getOrCreateChannelRoutingRule(userId);
+  const baseConfig = normalizeChannelRoutingConfig(existing.config);
+
+  const nextConfig = normalizeChannelRoutingConfig({
+    ...baseConfig,
+    ...configPatch,
+    policies: configPatch.policies ?? baseConfig.policies,
+  });
+
+  const updated = await prisma.integrationRule.update({
+    where: { id: existing.id },
+    data: {
+      config: nextConfig as unknown as Prisma.InputJsonValue,
+      lastError: null,
+    },
+  });
+
+  // Update in-memory cache
+  setChannelRoutingConfig(nextConfig);
+
+  return serializeChannelRoutingRule(updated);
+}
+
+export async function addChannelRoutingPolicy(
+  userId: string,
+  policy: ChannelRoutingPolicy
+): Promise<ChannelRoutingRuleState> {
+  const existing = await getOrCreateChannelRoutingRule(userId);
+  const baseConfig = normalizeChannelRoutingConfig(existing.config);
+
+  const nextConfig: ChannelRoutingConfig = {
+    ...baseConfig,
+    policies: [...baseConfig.policies, policy],
+  };
+
+  const updated = await prisma.integrationRule.update({
+    where: { id: existing.id },
+    data: {
+      config: nextConfig as unknown as Prisma.InputJsonValue,
+      lastError: null,
+    },
+  });
+
+  setChannelRoutingConfig(nextConfig);
+  return serializeChannelRoutingRule(updated);
+}
+
+export async function removeChannelRoutingPolicy(
+  userId: string,
+  policyIndex: number
+): Promise<ChannelRoutingRuleState> {
+  const existing = await getOrCreateChannelRoutingRule(userId);
+  const baseConfig = normalizeChannelRoutingConfig(existing.config);
+
+  if (policyIndex < 0 || policyIndex >= baseConfig.policies.length) {
+    throw new Error(`Policy index ${policyIndex} out of range`);
+  }
+
+  const nextPolicies = baseConfig.policies.filter((_, idx) => idx !== policyIndex);
+  const nextConfig: ChannelRoutingConfig = {
+    ...baseConfig,
+    policies: nextPolicies,
+  };
+
+  const updated = await prisma.integrationRule.update({
+    where: { id: existing.id },
+    data: {
+      config: nextConfig as unknown as Prisma.InputJsonValue,
+      lastError: null,
+    },
+  });
+
+  setChannelRoutingConfig(nextConfig);
+  return serializeChannelRoutingRule(updated);
+}

--- a/src/lib/integrations/slack-notifications.ts
+++ b/src/lib/integrations/slack-notifications.ts
@@ -1,0 +1,533 @@
+/**
+ * Slack Notification Service
+ *
+ * Posts assignment, status, and blocked notifications to Slack channels.
+ * Implements throttling to keep updates actionable and non-spammy:
+ *
+ *  - Per-channel rate limiting with configurable window and max burst
+ *  - Deduplication via outbox idempotency keys
+ *  - Collapsible notifications: batches rapid updates into single messages
+ *  - Priority-based urgency: P0/blocked bypass throttle, P3 gets longer windows
+ */
+
+import {
+  IntegrationConnectionStatus,
+  IntegrationProvider,
+  Prisma,
+} from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+import { unprotectIntegrationSecret } from "@/lib/integrations/token-crypto";
+import { computeRetryDelayMs } from "@/lib/outbox-worker";
+import { buildOutboxIdempotencyKey, publishDomainEvent } from "@/lib/event-bus";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SlackNotificationType =
+  | "assignment"
+  | "status_change"
+  | "blocked"
+  | "unblocked"
+  | "mention";
+
+export interface SlackNotificationPayload {
+  type: SlackNotificationType;
+  taskId: string;
+  taskTitle: string;
+  projectId?: string | null;
+  projectName?: string | null;
+  priority?: string | null;
+  channelId: string;
+  threadTs?: string | null;
+  actorId?: string | null;
+  actorName?: string | null;
+  /** Additional context rendered into the message body */
+  context?: Record<string, string>;
+}
+
+export interface ThrottleConfig {
+  /** Sliding window in milliseconds (default 60_000 = 1 min) */
+  windowMs: number;
+  /** Max messages per channel per window (default 5) */
+  maxBurst: number;
+  /** Types that bypass the throttle entirely */
+  bypassTypes: SlackNotificationType[];
+  /** Minimum interval between any two messages to the same channel (ms) */
+  minIntervalMs: number;
+}
+
+export interface SlackNotificationResult {
+  sent: boolean;
+  throttled: boolean;
+  messageTs: string | null;
+  channelId: string;
+  dedupeKey: string;
+  reason?: string;
+}
+
+interface ThrottleEntry {
+  timestamps: number[];
+  lastSentAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const NOTIFICATION_EMOJIS: Record<SlackNotificationType, string> = {
+  assignment: ":bust_in_silhouette:",
+  status_change: ":arrows_counterclockwise:",
+  blocked: ":octagonal_sign:",
+  unblocked: ":white_check_mark:",
+  mention: ":speech_balloon:",
+};
+
+// ---------------------------------------------------------------------------
+// Throttle state (in-memory, per-process)
+// ---------------------------------------------------------------------------
+
+const throttleState = new Map<string, ThrottleEntry>();
+
+export function defaultThrottleConfig(): ThrottleConfig {
+  return {
+    windowMs: 60_000,
+    maxBurst: 5,
+    bypassTypes: ["blocked"],
+    minIntervalMs: 2_000,
+  };
+}
+
+/**
+ * Check whether a notification should be throttled.
+ * Pure function against the throttle map -- does NOT mutate state.
+ */
+export function shouldThrottle(
+  channelId: string,
+  type: SlackNotificationType,
+  config: ThrottleConfig,
+  now: number = Date.now()
+): { throttled: boolean; reason?: string } {
+  if (config.bypassTypes.includes(type)) {
+    return { throttled: false };
+  }
+
+  const entry = throttleState.get(channelId);
+  if (!entry) {
+    return { throttled: false };
+  }
+
+  // Check minimum interval
+  if (now - entry.lastSentAt < config.minIntervalMs) {
+    return {
+      throttled: true,
+      reason: `min_interval: ${now - entry.lastSentAt}ms < ${config.minIntervalMs}ms`,
+    };
+  }
+
+  // Check burst window
+  const windowStart = now - config.windowMs;
+  const recentCount = entry.timestamps.filter((ts) => ts > windowStart).length;
+  if (recentCount >= config.maxBurst) {
+    return {
+      throttled: true,
+      reason: `burst_limit: ${recentCount} >= ${config.maxBurst} in ${config.windowMs}ms window`,
+    };
+  }
+
+  return { throttled: false };
+}
+
+/**
+ * Record that a message was sent to a channel. Maintains the sliding window.
+ */
+export function recordSend(
+  channelId: string,
+  now: number = Date.now(),
+  windowMs: number = 60_000
+): void {
+  const entry = throttleState.get(channelId) ?? { timestamps: [], lastSentAt: 0 };
+  const windowStart = now - windowMs;
+
+  // Prune old timestamps outside the window
+  entry.timestamps = entry.timestamps.filter((ts) => ts > windowStart);
+  entry.timestamps.push(now);
+  entry.lastSentAt = now;
+
+  throttleState.set(channelId, entry);
+}
+
+/**
+ * Reset throttle state (useful for testing).
+ */
+export function resetThrottleState(): void {
+  throttleState.clear();
+}
+
+/**
+ * Get current throttle entry for a channel (useful for testing).
+ */
+export function getThrottleEntry(channelId: string): ThrottleEntry | undefined {
+  return throttleState.get(channelId);
+}
+
+// ---------------------------------------------------------------------------
+// Message rendering
+// ---------------------------------------------------------------------------
+
+export function renderNotificationMessage(payload: SlackNotificationPayload): string {
+  const emoji = NOTIFICATION_EMOJIS[payload.type];
+  const projectLabel = payload.projectName ? ` (${payload.projectName})` : "";
+  const actorLabel = payload.actorName ? ` by ${payload.actorName}` : "";
+
+  switch (payload.type) {
+    case "assignment":
+      return `${emoji} *${payload.taskTitle}*${projectLabel} was assigned${actorLabel}`;
+
+    case "status_change": {
+      const newStatus = payload.context?.newStatus ?? "updated";
+      const oldStatus = payload.context?.oldStatus;
+      const statusTransition = oldStatus ? `${oldStatus} -> ${newStatus}` : newStatus;
+      return `${emoji} *${payload.taskTitle}*${projectLabel} status changed to *${statusTransition}*${actorLabel}`;
+    }
+
+    case "blocked": {
+      const reason = payload.context?.reason;
+      const reasonSuffix = reason ? `\n> Reason: ${reason}` : "";
+      return `${emoji} *${payload.taskTitle}*${projectLabel} is *BLOCKED*${actorLabel}${reasonSuffix}`;
+    }
+
+    case "unblocked":
+      return `${emoji} *${payload.taskTitle}*${projectLabel} is no longer blocked${actorLabel}`;
+
+    case "mention": {
+      const role = payload.context?.role ?? "mentioned";
+      return `${emoji} You were ${role} on *${payload.taskTitle}*${projectLabel}${actorLabel}`;
+    }
+
+    default:
+      return `${emoji} Update on *${payload.taskTitle}*${projectLabel}${actorLabel}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dedupe key builder
+// ---------------------------------------------------------------------------
+
+export function buildNotificationDedupeKey(payload: SlackNotificationPayload): string {
+  return [
+    "slack",
+    "notification",
+    payload.channelId,
+    payload.taskId,
+    payload.type,
+    // Include threadTs to avoid deduping across different threads
+    payload.threadTs ?? "no-thread",
+  ].join(":");
+}
+
+// ---------------------------------------------------------------------------
+// Slack API helpers
+// ---------------------------------------------------------------------------
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withRetries<T>(fn: () => Promise<T>, maxAttempts = 3): Promise<T> {
+  let lastError: unknown = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt === maxAttempts) {
+        throw error;
+      }
+
+      const waitMs = computeRetryDelayMs(attempt, {
+        baseDelayMs: 250,
+        maxDelayMs: 3000,
+      });
+      await sleep(waitMs);
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error("Unknown retry failure");
+}
+
+class SlackAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SlackAuthError";
+  }
+}
+
+async function getSlackToken(userId: string): Promise<string> {
+  const connection = await prisma.integrationConnection.findUnique({
+    where: {
+      userId_provider: {
+        userId,
+        provider: IntegrationProvider.SLACK,
+      },
+    },
+  });
+
+  if (!connection || connection.status !== IntegrationConnectionStatus.CONNECTED) {
+    throw new SlackAuthError("Slack is not connected");
+  }
+
+  const token = unprotectIntegrationSecret(connection.accessToken);
+  if (!token) {
+    throw new SlackAuthError("Slack access token is missing");
+  }
+
+  return token;
+}
+
+interface SlackPostResult {
+  channel: string;
+  ts: string;
+}
+
+async function postSlackMessage(input: {
+  token: string;
+  channelId: string;
+  text: string;
+  threadTs?: string | null;
+}): Promise<SlackPostResult> {
+  const body: Record<string, unknown> = {
+    channel: input.channelId,
+    text: input.text,
+    unfurl_links: false,
+    unfurl_media: false,
+  };
+
+  if (input.threadTs) {
+    body.thread_ts = input.threadTs;
+  }
+
+  const response = await fetch("https://slack.com/api/chat.postMessage", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${input.token}`,
+      "Content-Type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify(body),
+    cache: "no-store",
+  });
+
+  if (response.status === 401) {
+    throw new SlackAuthError("Slack access token is invalid");
+  }
+
+  const payload = (await response.json().catch(() => null)) as
+    | { ok?: boolean; error?: string; ts?: string; channel?: string }
+    | null;
+
+  if (!response.ok || !payload || payload.ok === false) {
+    const reason = payload?.error ?? `Slack API error (${response.status})`;
+    throw new Error(reason);
+  }
+
+  if (!payload.ts || !payload.channel) {
+    throw new Error("Slack API response missing message timestamp");
+  }
+
+  return {
+    channel: payload.channel,
+    ts: payload.ts,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main notification sender
+// ---------------------------------------------------------------------------
+
+export async function sendSlackNotification(input: {
+  userId: string;
+  payload: SlackNotificationPayload;
+  throttleConfig?: ThrottleConfig;
+  dryRun?: boolean;
+}): Promise<SlackNotificationResult> {
+  const config = input.throttleConfig ?? defaultThrottleConfig();
+  const dedupeKey = buildNotificationDedupeKey(input.payload);
+  const now = Date.now();
+
+  // 1. Check throttle
+  const throttleResult = shouldThrottle(input.payload.channelId, input.payload.type, config, now);
+
+  if (throttleResult.throttled) {
+    console.info("integration.slack.notification.throttled", {
+      provider: "slack",
+      channelId: input.payload.channelId,
+      type: input.payload.type,
+      taskId: input.payload.taskId,
+      reason: throttleResult.reason,
+    });
+
+    return {
+      sent: false,
+      throttled: true,
+      messageTs: null,
+      channelId: input.payload.channelId,
+      dedupeKey,
+      reason: throttleResult.reason,
+    };
+  }
+
+  if (input.dryRun) {
+    return {
+      sent: false,
+      throttled: false,
+      messageTs: null,
+      channelId: input.payload.channelId,
+      dedupeKey,
+      reason: "dry_run",
+    };
+  }
+
+  // 2. Get Slack token
+  let token: string;
+  try {
+    token = await getSlackToken(input.userId);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await prisma.integrationConnection.updateMany({
+      where: {
+        userId: input.userId,
+        provider: IntegrationProvider.SLACK,
+      },
+      data: {
+        status: IntegrationConnectionStatus.ERROR,
+        lastError: message,
+      },
+    });
+    throw error;
+  }
+
+  // 3. Render message
+  const text = renderNotificationMessage(input.payload);
+
+  // 4. Post to Slack
+  try {
+    const posted = await withRetries(() =>
+      postSlackMessage({
+        token,
+        channelId: input.payload.channelId,
+        text,
+        threadTs: input.payload.threadTs,
+      })
+    );
+
+    // 5. Record throttle state
+    recordSend(input.payload.channelId, now, config.windowMs);
+
+    // 6. Publish domain event
+    await publishDomainEvent({
+      eventType: `integration.slack.notification.${input.payload.type}`,
+      aggregateType: "task",
+      aggregateId: input.payload.taskId,
+      payload: {
+        type: input.payload.type,
+        taskId: input.payload.taskId,
+        channelId: input.payload.channelId,
+        messageTs: posted.ts,
+        actorId: input.payload.actorId,
+      },
+      idempotencyKey: buildOutboxIdempotencyKey({
+        aggregateType: "task",
+        aggregateId: input.payload.taskId,
+        eventType: `slack_notification_${input.payload.type}_${now}`,
+      }),
+    });
+
+    console.info("integration.slack.notification.sent", {
+      provider: "slack",
+      channelId: input.payload.channelId,
+      type: input.payload.type,
+      taskId: input.payload.taskId,
+      messageTs: posted.ts,
+    });
+
+    return {
+      sent: true,
+      throttled: false,
+      messageTs: posted.ts,
+      channelId: input.payload.channelId,
+      dedupeKey,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    // Record dead letter
+    await prisma.outboxEvent.create({
+      data: {
+        eventType: "integration.slack.notification.failed",
+        aggregateType: "task",
+        aggregateId: input.payload.taskId,
+        schemaVersion: 1,
+        payload: {
+          type: input.payload.type,
+          channelId: input.payload.channelId,
+          error: message,
+        },
+        idempotencyKey: `dead-letter:slack-notification:${dedupeKey}:${now}`,
+        status: "DEAD_LETTER",
+        retryCount: 0,
+        nextAttemptAt: new Date(),
+        failedAt: new Date(),
+        error: message,
+        lastAttemptAt: new Date(),
+      },
+    });
+
+    console.error("integration.slack.notification.failed", {
+      provider: "slack",
+      channelId: input.payload.channelId,
+      type: input.payload.type,
+      taskId: input.payload.taskId,
+      error: message,
+    });
+
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Batch notification sender (for status change events that fire rapidly)
+// ---------------------------------------------------------------------------
+
+export async function sendBatchSlackNotifications(input: {
+  userId: string;
+  payloads: SlackNotificationPayload[];
+  throttleConfig?: ThrottleConfig;
+  dryRun?: boolean;
+}): Promise<SlackNotificationResult[]> {
+  const results: SlackNotificationResult[] = [];
+
+  for (const payload of input.payloads) {
+    try {
+      const result = await sendSlackNotification({
+        userId: input.userId,
+        payload,
+        throttleConfig: input.throttleConfig,
+        dryRun: input.dryRun,
+      });
+      results.push(result);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      results.push({
+        sent: false,
+        throttled: false,
+        messageTs: null,
+        channelId: payload.channelId,
+        dedupeKey: buildNotificationDedupeKey(payload),
+        reason: `error: ${message}`,
+      });
+    }
+  }
+
+  return results;
+}

--- a/src/lib/integrations/slack-raci-bridge.ts
+++ b/src/lib/integrations/slack-raci-bridge.ts
@@ -1,0 +1,341 @@
+/**
+ * Slack RACI Mention-to-Notification Bridge
+ *
+ * When a RACI field changes on a task (or a task event occurs), this bridge
+ * resolves which users should be notified and routes Slack notifications
+ * accordingly.
+ *
+ * RACI -> Notification mapping:
+ *  - Responsible: assignment + status_change + blocked
+ *  - Accountable: status_change + blocked
+ *  - Consulted:   mention (when added)
+ *  - Informed:    status_change (major transitions only)
+ *
+ * Uses the channel routing service to determine where to send each
+ * notification (DM vs. project channel vs. priority channel).
+ */
+
+import { prisma } from "@/lib/prisma";
+import { IntegrationConnectionStatus, IntegrationProvider } from "@/generated/prisma/client";
+import type { RaciUser, ResolvedRaci } from "@/lib/raci-inheritance";
+import {
+  sendSlackNotification,
+  type SlackNotificationPayload,
+  type SlackNotificationType,
+  type ThrottleConfig,
+} from "@/lib/integrations/slack-notifications";
+import {
+  resolveChannelForNotification,
+  type ChannelRoutingContext,
+} from "@/lib/integrations/slack-channel-routing";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type RaciRole = "responsible" | "accountable" | "consulted" | "informed";
+
+export interface RaciBridgeEvent {
+  /** The type of event that occurred */
+  eventType: "raci_change" | "status_change" | "blocked" | "unblocked" | "assignment";
+  /** The task this event relates to */
+  taskId: string;
+  taskTitle: string;
+  /** Project context for channel routing */
+  projectId?: string | null;
+  projectName?: string | null;
+  /** Priority for channel routing */
+  priority?: string | null;
+  /** Who caused the event */
+  actorId?: string | null;
+  actorName?: string | null;
+  /** Additional context */
+  context?: Record<string, string>;
+  /** For raci_change events: which role was changed */
+  changedRole?: RaciRole;
+  /** For raci_change events: which users were added */
+  addedUsers?: RaciUser[];
+  /** For raci_change events: which users were removed */
+  removedUsers?: RaciUser[];
+}
+
+export interface RaciBridgeResult {
+  notificationsSent: number;
+  notificationsThrottled: number;
+  notificationsFailed: number;
+  details: Array<{
+    userId: string;
+    role: RaciRole;
+    notificationType: SlackNotificationType;
+    sent: boolean;
+    throttled: boolean;
+    channelId: string | null;
+    error?: string;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// RACI -> Notification type mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine which notification types to send for each RACI role
+ * given a particular event type.
+ */
+export function getNotificationTypesForRole(
+  role: RaciRole,
+  eventType: RaciBridgeEvent["eventType"]
+): SlackNotificationType[] {
+  const mapping: Record<RaciRole, Record<RaciBridgeEvent["eventType"], SlackNotificationType[]>> = {
+    responsible: {
+      raci_change: ["assignment"],
+      status_change: ["status_change"],
+      blocked: ["blocked"],
+      unblocked: ["unblocked"],
+      assignment: ["assignment"],
+    },
+    accountable: {
+      raci_change: ["mention"],
+      status_change: ["status_change"],
+      blocked: ["blocked"],
+      unblocked: ["unblocked"],
+      assignment: [],
+    },
+    consulted: {
+      raci_change: ["mention"],
+      status_change: [],
+      blocked: [],
+      unblocked: [],
+      assignment: [],
+    },
+    informed: {
+      raci_change: ["mention"],
+      status_change: ["status_change"],
+      blocked: [],
+      unblocked: [],
+      assignment: [],
+    },
+  };
+
+  return mapping[role]?.[eventType] ?? [];
+}
+
+/**
+ * Determine which RACI roles should be notified for a given event type.
+ */
+export function getRolesToNotify(
+  eventType: RaciBridgeEvent["eventType"]
+): RaciRole[] {
+  switch (eventType) {
+    case "raci_change":
+      // Only notify the users who were specifically added
+      return [];
+    case "status_change":
+      return ["responsible", "accountable", "informed"];
+    case "blocked":
+      return ["responsible", "accountable"];
+    case "unblocked":
+      return ["responsible", "accountable"];
+    case "assignment":
+      return ["responsible"];
+    default:
+      return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// User -> Slack channel resolution
+// ---------------------------------------------------------------------------
+
+async function getUserSlackChannelId(userId: string): Promise<string | null> {
+  // For DM notifications, we look up the user's Slack connection
+  // and use the Slack user ID to open a DM channel
+  const connection = await prisma.integrationConnection.findUnique({
+    where: {
+      userId_provider: {
+        userId,
+        provider: IntegrationProvider.SLACK,
+      },
+    },
+    select: {
+      status: true,
+      providerAccountId: true,
+      metadata: true,
+    },
+  });
+
+  if (!connection || connection.status !== IntegrationConnectionStatus.CONNECTED) {
+    return null;
+  }
+
+  // The providerAccountId typically stores the Slack user ID
+  return connection.providerAccountId ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Bridge main function
+// ---------------------------------------------------------------------------
+
+/**
+ * Process a RACI-related event and send appropriate Slack notifications
+ * to all affected users based on their RACI roles.
+ */
+export async function processRaciBridgeEvent(input: {
+  event: RaciBridgeEvent;
+  raci: ResolvedRaci;
+  throttleConfig?: ThrottleConfig;
+  dryRun?: boolean;
+}): Promise<RaciBridgeResult> {
+  const { event, raci } = input;
+  const result: RaciBridgeResult = {
+    notificationsSent: 0,
+    notificationsThrottled: 0,
+    notificationsFailed: 0,
+    details: [],
+  };
+
+  // Build routing context
+  const routingContext: ChannelRoutingContext = {
+    projectId: event.projectId ?? undefined,
+    priority: event.priority ?? undefined,
+    notificationType: event.eventType === "blocked" ? "blocked" : "status_change",
+  };
+
+  // For raci_change events, only notify the newly added users
+  if (event.eventType === "raci_change" && event.addedUsers && event.changedRole) {
+    for (const user of event.addedUsers) {
+      const notificationTypes = getNotificationTypesForRole(event.changedRole, event.eventType);
+      for (const notificationType of notificationTypes) {
+        await sendNotificationForUser({
+          userId: user.id,
+          role: event.changedRole,
+          notificationType,
+          event,
+          routingContext,
+          throttleConfig: input.throttleConfig,
+          dryRun: input.dryRun,
+          result,
+        });
+      }
+    }
+    return result;
+  }
+
+  // For other events, notify all relevant RACI roles
+  const rolesToNotify = getRolesToNotify(event.eventType);
+
+  for (const role of rolesToNotify) {
+    const users = raci.effective[role];
+    for (const user of users) {
+      // Skip the actor (don't notify yourself)
+      if (event.actorId && user.id === event.actorId) {
+        continue;
+      }
+
+      const notificationTypes = getNotificationTypesForRole(role, event.eventType);
+      for (const notificationType of notificationTypes) {
+        await sendNotificationForUser({
+          userId: user.id,
+          role,
+          notificationType,
+          event,
+          routingContext,
+          throttleConfig: input.throttleConfig,
+          dryRun: input.dryRun,
+          result,
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
+async function sendNotificationForUser(input: {
+  userId: string;
+  role: RaciRole;
+  notificationType: SlackNotificationType;
+  event: RaciBridgeEvent;
+  routingContext: ChannelRoutingContext;
+  throttleConfig?: ThrottleConfig;
+  dryRun?: boolean;
+  result: RaciBridgeResult;
+}): Promise<void> {
+  const { userId, role, notificationType, event, result } = input;
+
+  // Resolve which channel to send to
+  let channelId: string | null = null;
+
+  try {
+    // First try channel routing (project/priority channel)
+    const routed = resolveChannelForNotification(input.routingContext);
+    channelId = routed?.channelId ?? null;
+
+    // Fall back to user DM if no channel routing match
+    if (!channelId) {
+      channelId = await getUserSlackChannelId(userId);
+    }
+
+    if (!channelId) {
+      result.details.push({
+        userId,
+        role,
+        notificationType,
+        sent: false,
+        throttled: false,
+        channelId: null,
+        error: "No Slack channel or DM available",
+      });
+      return;
+    }
+
+    const payload: SlackNotificationPayload = {
+      type: notificationType,
+      taskId: event.taskId,
+      taskTitle: event.taskTitle,
+      projectId: event.projectId,
+      projectName: event.projectName,
+      priority: event.priority,
+      channelId,
+      actorId: event.actorId,
+      actorName: event.actorName,
+      context: {
+        ...event.context,
+        role,
+      },
+    };
+
+    const notifResult = await sendSlackNotification({
+      userId,
+      payload,
+      throttleConfig: input.throttleConfig,
+      dryRun: input.dryRun,
+    });
+
+    if (notifResult.throttled) {
+      result.notificationsThrottled += 1;
+    } else if (notifResult.sent) {
+      result.notificationsSent += 1;
+    }
+
+    result.details.push({
+      userId,
+      role,
+      notificationType,
+      sent: notifResult.sent,
+      throttled: notifResult.throttled,
+      channelId,
+    });
+  } catch (error) {
+    result.notificationsFailed += 1;
+    result.details.push({
+      userId,
+      role,
+      notificationType,
+      sent: false,
+      throttled: false,
+      channelId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/src/lib/integrations/slack-task-creation.ts
+++ b/src/lib/integrations/slack-task-creation.ts
@@ -1,0 +1,547 @@
+/**
+ * Slack Task Creation Service
+ *
+ * Creates WIPGuard tasks from Slack messages via:
+ *  - Reaction triggers (e.g., :pushpin: on a message)
+ *  - Slack shortcuts / slash commands
+ *  - Webhook event payloads from Slack Event API
+ *
+ * Every created task includes full source traceability back to the
+ * originating Slack message, channel, and user.
+ */
+
+import {
+  IntegrationConnectionStatus,
+  IntegrationProvider,
+  Prisma,
+  type TaskStatus,
+} from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+import { unprotectIntegrationSecret } from "@/lib/integrations/token-crypto";
+import { computeRetryDelayMs } from "@/lib/outbox-worker";
+import { buildOutboxIdempotencyKey, publishDomainEvent } from "@/lib/event-bus";
+import { getNextColumnOrder } from "@/lib/task-order";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SlackTaskTrigger = "reaction" | "shortcut" | "slash_command" | "webhook";
+
+export interface SlackTaskCreationInput {
+  /** How the task creation was triggered */
+  triggerType: SlackTaskTrigger;
+  /** The Slack channel ID */
+  channelId: string;
+  /** Thread timestamp (root message ts) */
+  threadTs: string;
+  /** Message timestamp (for reactions, the message that was reacted to) */
+  messageTs?: string;
+  /** Reaction emoji name (for reaction triggers) */
+  reaction?: string;
+  /** Raw message text from Slack */
+  text?: string;
+  /** User-supplied title override */
+  title?: string;
+  /** Slack user ID of the person who triggered creation */
+  slackUserId?: string;
+  /** Optional project to associate the task with */
+  projectId?: string;
+  /** Optional priority assignment */
+  priority?: "P0" | "P1" | "P2" | "P3";
+}
+
+export interface SlackTaskCreationResult {
+  created: boolean;
+  deduped: boolean;
+  taskId: string | null;
+  taskTitle: string;
+  sourceUrl: string;
+  externalId: string;
+  triggerType: SlackTaskTrigger;
+  sourceTraceability: SlackSourceTraceability;
+}
+
+export interface SlackSourceTraceability {
+  provider: "slack";
+  channelId: string;
+  threadTs: string;
+  messageTs: string | null;
+  triggerType: SlackTaskTrigger;
+  triggerValue: string | null;
+  slackUserId: string | null;
+  sourceUrl: string;
+  capturedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withRetries<T>(fn: () => Promise<T>, maxAttempts = 3): Promise<T> {
+  let lastError: unknown = null;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt === maxAttempts) {
+        throw error;
+      }
+      const waitMs = computeRetryDelayMs(attempt, {
+        baseDelayMs: 250,
+        maxDelayMs: 3000,
+      });
+      await sleep(waitMs);
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error("Unknown retry failure");
+}
+
+class SlackAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SlackAuthError";
+  }
+}
+
+export function buildSlackExternalId(channelId: string, threadTs: string): string {
+  return `${channelId}:${threadTs}`;
+}
+
+export function buildSlackTaskDedupeKey(input: {
+  channelId: string;
+  threadTs: string;
+  triggerType: SlackTaskTrigger;
+  triggerValue?: string;
+}): string {
+  const triggerPart = input.triggerValue
+    ? `${input.triggerType}:${input.triggerValue}`
+    : input.triggerType;
+  return [
+    "slack",
+    "slack_task_create",
+    buildSlackExternalId(input.channelId, input.threadTs),
+    triggerPart,
+  ].join(":");
+}
+
+export function buildSlackThreadUrl(
+  workspaceUrl: string | null,
+  channelId: string,
+  threadTs: string
+): string {
+  const sanitized = workspaceUrl?.replace(/\/+$/, "") ?? "https://app.slack.com/client";
+  const messageId = threadTs.replace(".", "");
+
+  if (sanitized.startsWith("https://app.slack.com/client")) {
+    return `${sanitized}/${channelId}/thread/${channelId}-${messageId}`;
+  }
+
+  return `${sanitized}/archives/${channelId}/p${messageId}`;
+}
+
+function buildTaskTitle(input: {
+  text?: string;
+  title?: string;
+  triggerType: SlackTaskTrigger;
+}): string {
+  if (input.title && input.title.trim().length > 0) {
+    return `[Slack] ${input.title.trim()}`;
+  }
+
+  if (input.text && input.text.trim().length > 0) {
+    // Truncate long messages for titles
+    const cleaned = input.text.trim().replace(/\n/g, " ");
+    const truncated = cleaned.length > 100 ? `${cleaned.slice(0, 97)}...` : cleaned;
+    return `[Slack] ${truncated}`;
+  }
+
+  const triggerLabels: Record<SlackTaskTrigger, string> = {
+    reaction: "Slack reaction task",
+    shortcut: "Slack shortcut task",
+    slash_command: "Slack command task",
+    webhook: "Slack webhook task",
+  };
+
+  return `[Slack] ${triggerLabels[input.triggerType]}`;
+}
+
+function buildTaskNotes(input: {
+  sourceUrl: string;
+  text?: string;
+  triggerType: SlackTaskTrigger;
+  triggerValue?: string;
+  channelId: string;
+  threadTs: string;
+  slackUserId?: string;
+}): string {
+  const lines = [
+    "Created from Slack message",
+    `Trigger: ${input.triggerType}${input.triggerValue ? ` (${input.triggerValue})` : ""}`,
+    `Channel: ${input.channelId}`,
+    `Thread TS: ${input.threadTs}`,
+    input.slackUserId ? `Slack User: ${input.slackUserId}` : null,
+    `Source: ${input.sourceUrl}`,
+  ];
+
+  if (input.text) {
+    lines.push("", "Original message:", input.text);
+  }
+
+  return lines.filter((line) => line !== null).join("\n");
+}
+
+function toValidTaskStatus(priority?: string): TaskStatus {
+  // Default new Slack tasks to QUEUED status
+  return "QUEUED";
+}
+
+// ---------------------------------------------------------------------------
+// Slack API - fetch message details
+// ---------------------------------------------------------------------------
+
+interface SlackMessageInfo {
+  text: string;
+  user: string | null;
+  ts: string;
+}
+
+async function fetchSlackMessage(input: {
+  token: string;
+  channelId: string;
+  messageTs: string;
+}): Promise<SlackMessageInfo> {
+  const params = new URLSearchParams({
+    channel: input.channelId,
+    latest: input.messageTs,
+    inclusive: "true",
+    limit: "1",
+  });
+
+  const response = await fetch(
+    `https://slack.com/api/conversations.history?${params.toString()}`,
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${input.token}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      cache: "no-store",
+    }
+  );
+
+  if (response.status === 401) {
+    throw new SlackAuthError("Slack access token is invalid");
+  }
+
+  const payload = (await response.json().catch(() => null)) as
+    | {
+        ok?: boolean;
+        error?: string;
+        messages?: Array<{ text?: string; user?: string; ts?: string }>;
+      }
+    | null;
+
+  if (!response.ok || !payload || payload.ok === false) {
+    throw new Error(payload?.error ?? `Slack API error (${response.status})`);
+  }
+
+  const message = payload.messages?.[0];
+  return {
+    text: message?.text?.trim() || "(No message text)",
+    user: message?.user ?? null,
+    ts: message?.ts ?? input.messageTs,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main task creation function
+// ---------------------------------------------------------------------------
+
+export async function createTaskFromSlack(input: {
+  userId: string;
+  payload: SlackTaskCreationInput;
+}): Promise<SlackTaskCreationResult> {
+  const { payload } = input;
+
+  // 1. Get Slack auth context
+  const connection = await prisma.integrationConnection.findUnique({
+    where: {
+      userId_provider: {
+        userId: input.userId,
+        provider: IntegrationProvider.SLACK,
+      },
+    },
+  });
+
+  if (!connection || connection.status !== IntegrationConnectionStatus.CONNECTED) {
+    throw new SlackAuthError("Slack is not connected");
+  }
+
+  const token = unprotectIntegrationSecret(connection.accessToken);
+  if (!token) {
+    throw new SlackAuthError("Slack access token is missing");
+  }
+
+  const metadata = asRecord(connection.metadata);
+  const workspaceUrl = typeof metadata.url === "string" ? metadata.url : null;
+
+  // 2. Build identifiers
+  const externalId = buildSlackExternalId(payload.channelId, payload.threadTs);
+  const triggerValue =
+    payload.triggerType === "reaction"
+      ? payload.reaction?.trim().replace(/^:+|:+$/g, "")
+      : payload.triggerType;
+
+  const dedupeKey = buildSlackTaskDedupeKey({
+    channelId: payload.channelId,
+    threadTs: payload.threadTs,
+    triggerType: payload.triggerType,
+    triggerValue,
+  });
+
+  const sourceUrl = buildSlackThreadUrl(workspaceUrl, payload.channelId, payload.threadTs);
+
+  // 3. Optionally fetch message details from Slack
+  let messageText = payload.text;
+  if (!messageText && payload.messageTs) {
+    try {
+      const messageInfo = await withRetries(() =>
+        fetchSlackMessage({
+          token,
+          channelId: payload.channelId,
+          messageTs: payload.messageTs!,
+        })
+      );
+      messageText = messageInfo.text;
+    } catch {
+      // Non-fatal: we can still create the task without message text
+      messageText = undefined;
+    }
+  }
+
+  // 4. Build task data
+  const taskTitle = buildTaskTitle({
+    text: messageText,
+    title: payload.title,
+    triggerType: payload.triggerType,
+  });
+
+  const taskNotes = buildTaskNotes({
+    sourceUrl,
+    text: messageText,
+    triggerType: payload.triggerType,
+    triggerValue,
+    channelId: payload.channelId,
+    threadTs: payload.threadTs,
+    slackUserId: payload.slackUserId,
+  });
+
+  const status = toValidTaskStatus(payload.priority);
+
+  const sourceTraceability: SlackSourceTraceability = {
+    provider: "slack",
+    channelId: payload.channelId,
+    threadTs: payload.threadTs,
+    messageTs: payload.messageTs ?? null,
+    triggerType: payload.triggerType,
+    triggerValue: triggerValue ?? null,
+    slackUserId: payload.slackUserId ?? null,
+    sourceUrl,
+    capturedAt: new Date().toISOString(),
+  };
+
+  // 5. Create task in transaction with dedupe
+  try {
+    const createdTask = await withRetries(async () => {
+      try {
+        return await prisma.$transaction(async (tx) => {
+          // Create receipt for deduplication
+          await tx.integrationReceipt.create({
+            data: {
+              ruleId: "slack-task-creation", // Virtual rule ID for direct task creation
+              dedupeKey,
+              externalObjectType: "slack_message",
+              externalObjectId: externalId,
+              sourceUrl,
+              lastObservedAt: new Date(),
+              metadata: sourceTraceability as unknown as Prisma.InputJsonValue,
+            },
+          });
+
+          const nextColumnOrder = await getNextColumnOrder(
+            tx as unknown as typeof prisma,
+            status
+          );
+
+          const taskData: Prisma.TaskCreateInput = {
+            title: taskTitle,
+            notes: taskNotes,
+            status,
+            assignedOn: new Date(),
+            columnOrder: nextColumnOrder,
+            slackThread: payload.threadTs,
+            metadata: {
+              integration: {
+                provider: "slack",
+                externalId,
+                externalObjectType: "slack_message",
+                sourceUrl,
+                sourceTraceability,
+                dedupeKey,
+                lastObservedAt: new Date().toISOString(),
+              },
+            },
+            responsible: {
+              connect: [{ id: input.userId }],
+            },
+            statusHistory: {
+              create: {
+                fromStatus: null,
+                toStatus: status,
+                changedBy: input.userId,
+              },
+            },
+          };
+
+          // Optionally link to project
+          if (payload.projectId) {
+            taskData.project = { connect: { id: payload.projectId } };
+          }
+
+          // Optionally set priority
+          if (payload.priority) {
+            taskData.priority = payload.priority;
+          }
+
+          const task = await tx.task.create({
+            data: taskData,
+            select: { id: true, title: true },
+          });
+
+          // Update receipt with task ID
+          await tx.integrationReceipt.updateMany({
+            where: { dedupeKey },
+            data: { taskId: task.id },
+          });
+
+          // Publish domain event
+          await publishDomainEvent(
+            {
+              eventType: "integration.slack.task_created",
+              aggregateType: "task",
+              aggregateId: task.id,
+              payload: {
+                taskId: task.id,
+                externalId,
+                sourceUrl,
+                triggerType: payload.triggerType,
+                channelId: payload.channelId,
+              },
+              idempotencyKey: buildOutboxIdempotencyKey({
+                aggregateType: "task",
+                aggregateId: task.id,
+                eventType: `slack_task_created_${externalId}`,
+              }),
+            },
+            tx
+          );
+
+          console.info("integration.slack.task_creation.created", {
+            provider: "slack",
+            taskId: task.id,
+            externalId,
+            triggerType: payload.triggerType,
+            channelId: payload.channelId,
+          });
+
+          return task;
+        });
+      } catch (error) {
+        // Dedupe: receipt already exists for this channel:thread:trigger combo
+        if (
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error.code === "P2002"
+        ) {
+          return null;
+        }
+        throw error;
+      }
+    });
+
+    if (!createdTask) {
+      console.info("integration.slack.task_creation.deduped", {
+        provider: "slack",
+        externalId,
+        dedupeKey,
+      });
+
+      return {
+        created: false,
+        deduped: true,
+        taskId: null,
+        taskTitle,
+        sourceUrl,
+        externalId,
+        triggerType: payload.triggerType,
+        sourceTraceability,
+      };
+    }
+
+    return {
+      created: true,
+      deduped: false,
+      taskId: createdTask.id,
+      taskTitle: createdTask.title,
+      sourceUrl,
+      externalId,
+      triggerType: payload.triggerType,
+      sourceTraceability,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    // Dead letter for failed creation
+    await prisma.outboxEvent.create({
+      data: {
+        eventType: "integration.slack.task_creation.failed",
+        aggregateType: "integration_connection",
+        aggregateId: connection.id,
+        schemaVersion: 1,
+        payload: {
+          externalId,
+          channelId: payload.channelId,
+          triggerType: payload.triggerType,
+          error: message,
+        },
+        idempotencyKey: `dead-letter:slack-task-create:${dedupeKey}:${Date.now()}`,
+        status: "DEAD_LETTER",
+        retryCount: 0,
+        nextAttemptAt: new Date(),
+        failedAt: new Date(),
+        error: message,
+        lastAttemptAt: new Date(),
+      },
+    });
+
+    console.error("integration.slack.task_creation.failed", {
+      provider: "slack",
+      externalId,
+      error: message,
+    });
+
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the Slack integration for flow events and task capture as specified in issue #10 (WGX-010).

### Four core services added:

- **Notification service** (`slack-notifications.ts`) -- Posts assignment, status, blocked, and mention notifications to Slack channels with per-channel throttling (sliding window, burst limits, min interval). Blocked/P0 notifications bypass the throttle. Includes dead letter recording for failures.

- **Task creation from Slack** (`slack-task-creation.ts`) -- Creates WIPGuard tasks from Slack messages via reaction triggers, shortcuts, slash commands, or webhooks. Every task includes full source traceability (provider, channelId, threadTs, triggerType, slackUserId, sourceUrl, capturedAt). Uses transactional receipt + task creation with P2002 deduplication.

- **RACI mention-to-notification bridge** (`slack-raci-bridge.ts`) -- Maps RACI role changes and task events to appropriate Slack notifications:
  - Responsible: assignment + status_change + blocked
  - Accountable: status_change + blocked
  - Consulted: mention
  - Informed: status_change
  - Self-notifications are skipped (actor != recipient)

- **Channel routing policies** (`slack-channel-routing.ts`) -- Routes notifications to the right Slack channel based on project, priority, or notification type. Uses first-match-wins with specificity sorting, falls back to default channel then user DM. Config stored in IntegrationRule with 30s in-memory cache.

### API Routes:

- `POST /api/integrations/slack/notifications` -- Single or batch notification sending
- `POST /api/integrations/slack/task-create` -- Task creation from Slack payloads
- `GET/POST /api/integrations/slack/channel-routing` -- Channel routing CRUD
- `POST /api/integrations/slack/events` -- Slack Event API webhook with HMAC verification

### Tests:

- 74 unit tests across 4 test files covering all pure helper functions
- Notification throttling (shouldThrottle, recordSend, burst limits, bypass, min interval)
- Task creation helpers (buildSlackExternalId, buildSlackTaskDedupeKey, buildSlackThreadUrl)
- Channel routing (policyMatches, resolveChannelForNotification, normalizeChannelRoutingConfig)
- RACI bridge (getNotificationTypesForRole, getRolesToNotify)

## Test plan

- [x] All 74 unit tests pass (`npx vitest run`)
- [x] Throttling correctly limits per-channel burst and enforces min interval
- [x] Blocked notifications bypass throttle
- [x] Task dedupe keys are unique per channel+thread+trigger combo
- [x] Channel routing prefers more specific policies over less specific
- [x] RACI bridge maps all roles correctly for all event types
- [ ] Manual: Verify Slack webhook signature verification with real Slack events
- [ ] Manual: End-to-end task creation from Slack reaction

Closes #10

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>