### PR TITLE
feat: add class of service lanes with badges, filtering, and expedite debt (WGX-003)

### DIFF
--- a/src/components/board/service-class-badge.tsx
+++ b/src/components/board/service-class-badge.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { Clock, Calendar, Zap, Wrench } from "lucide-react";
+import { clsx } from "clsx";
+import {
+  type ClassOfService,
+  SERVICE_CLASS_META,
+  getServiceClassColors,
+  isDateBreachRisk,
+  type ExpediteDebtResult,
+} from "@/lib/class-of-service";
+
+// ---------------------------------------------------------------------------
+// Icon resolver
+// ---------------------------------------------------------------------------
+
+const ICON_MAP = {
+  Clock,
+  Calendar,
+  Zap,
+  Wrench,
+} as const;
+
+function ServiceClassIcon({
+  cls,
+  className,
+}: {
+  cls: ClassOfService;
+  className?: string;
+}) {
+  const meta = SERVICE_CLASS_META[cls];
+  const Icon = ICON_MAP[meta.iconName];
+  return <Icon className={className} />;
+}
+
+// ---------------------------------------------------------------------------
+// ServiceClassBadge
+// ---------------------------------------------------------------------------
+
+interface ServiceClassBadgeProps {
+  classOfService: ClassOfService;
+  /** Due date (ISO string or Date) — only relevant for fixed-date items */
+  dueDate?: string | Date | null;
+  /** Expedite debt summary — shown as a secondary indicator on expedite items */
+  expediteDebt?: ExpediteDebtResult | null;
+  /** Override the current time for testing / SSR */
+  now?: Date;
+  /** Compact mode hides the label text */
+  compact?: boolean;
+}
+
+/**
+ * Color-coded pill badge for class-of-service designation.
+ *
+ * Renders:
+ * - Icon + label for the service class
+ * - Fixed-date: days remaining, turns red when at risk
+ * - Expedite: debt indicator (% of WIP used by expedites)
+ */
+export function ServiceClassBadge({
+  classOfService,
+  dueDate,
+  expediteDebt,
+  now,
+  compact = false,
+}: ServiceClassBadgeProps) {
+  const meta = SERVICE_CLASS_META[classOfService];
+  const colors = getServiceClassColors(classOfService);
+  const breachRisk = isDateBreachRisk(dueDate, classOfService, { now });
+
+  // When a fixed-date item is at risk, override to red styling
+  const isBreaching = breachRisk?.atRisk ?? false;
+
+  const badgeBg = isBreaching ? "bg-red-500/15" : colors.bg;
+  const badgeText = isBreaching
+    ? "text-red-600 dark:text-red-400"
+    : colors.text;
+  const badgeBorder = isBreaching ? "border-red-500/25" : colors.border;
+
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center gap-0.5 rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none",
+        badgeBg,
+        badgeText,
+        badgeBorder
+      )}
+      title={`${meta.label}: ${meta.policy}`}
+      role="status"
+      aria-label={buildAriaLabel(classOfService, breachRisk, expediteDebt)}
+    >
+      <ServiceClassIcon cls={classOfService} className="h-2.5 w-2.5" />
+
+      {!compact && <span>{meta.label}</span>}
+
+      {/* Fixed-date: show days remaining */}
+      {breachRisk && (
+        <span
+          className={clsx(
+            "ml-0.5 tabular-nums",
+            isBreaching && "font-semibold"
+          )}
+        >
+          {breachRisk.label}
+        </span>
+      )}
+
+      {/* Expedite: show debt percentage */}
+      {classOfService === "expedite" && expediteDebt && (
+        <span
+          className={clsx(
+            "ml-0.5 tabular-nums",
+            expediteDebt.isOverThreshold && "font-semibold"
+          )}
+          title={`Expedite debt: ${expediteDebt.label}`}
+        >
+          {expediteDebt.expeditePercent}% debt
+        </span>
+      )}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildAriaLabel(
+  cls: ClassOfService,
+  breachRisk: ReturnType<typeof isDateBreachRisk>,
+  expediteDebt?: ExpediteDebtResult | null
+): string {
+  const meta = SERVICE_CLASS_META[cls];
+  const parts = [`Class of service: ${meta.label}`];
+
+  if (breachRisk) {
+    parts.push(breachRisk.atRisk ? `At risk: ${breachRisk.label}` : breachRisk.label);
+  }
+
+  if (cls === "expedite" && expediteDebt) {
+    parts.push(`Expedite debt: ${expediteDebt.label}`);
+  }
+
+  return parts.join(". ");
+}

--- a/src/components/board/service-class-filter.tsx
+++ b/src/components/board/service-class-filter.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { Clock, Calendar, Zap, Wrench, ChevronDown, X } from "lucide-react";
+import { clsx } from "clsx";
+import {
+  type ClassOfService,
+  CLASS_OF_SERVICE_VALUES,
+  SERVICE_CLASS_META,
+  getServiceClassColors,
+} from "@/lib/class-of-service";
+
+// ---------------------------------------------------------------------------
+// Icon resolver (matches service-class-badge.tsx)
+// ---------------------------------------------------------------------------
+
+const ICON_MAP = {
+  Clock,
+  Calendar,
+  Zap,
+  Wrench,
+} as const;
+
+// ---------------------------------------------------------------------------
+// ServiceClassFilter
+// ---------------------------------------------------------------------------
+
+interface ServiceClassFilterProps {
+  /** Currently selected service classes (empty = show all) */
+  selected: ClassOfService[];
+  /** Callback when selection changes */
+  onChange: (selected: ClassOfService[]) => void;
+  /** Count of items per class — used to show badges */
+  counts?: Partial<Record<ClassOfService, number>>;
+}
+
+/**
+ * Multi-select dropdown filter for class of service.
+ *
+ * Renders as a compact button that opens a checkbox popover.
+ * Designed to sit alongside existing BoardFilters.
+ */
+export function ServiceClassFilter({
+  selected,
+  onChange,
+  counts,
+}: ServiceClassFilterProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  // Close on Escape
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpen(false);
+      }
+    },
+    []
+  );
+
+  const toggle = (cls: ClassOfService) => {
+    if (selected.includes(cls)) {
+      onChange(selected.filter((c) => c !== cls));
+    } else {
+      onChange([...selected, cls]);
+    }
+  };
+
+  const clearAll = () => onChange([]);
+
+  const buttonLabel =
+    selected.length === 0
+      ? "All Classes"
+      : selected.length === 1
+        ? SERVICE_CLASS_META[selected[0]].label
+        : `${selected.length} Classes`;
+
+  return (
+    <div ref={containerRef} className="relative" onKeyDown={handleKeyDown}>
+      {/* Trigger button */}
+      <button
+        onClick={() => setOpen((prev) => !prev)}
+        aria-label="Filter by class of service"
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        className={clsx(
+          "flex items-center gap-1 rounded-md border border-border bg-secondary px-2 py-1 text-xs transition-colors",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2",
+          selected.length > 0
+            ? "text-foreground"
+            : "text-muted-foreground"
+        )}
+      >
+        <span>{buttonLabel}</span>
+        <ChevronDown
+          className={clsx(
+            "h-3 w-3 transition-transform",
+            open && "rotate-180"
+          )}
+          aria-hidden="true"
+        />
+      </button>
+
+      {/* Clear button — visible when filters are active */}
+      {selected.length > 0 && (
+        <button
+          onClick={clearAll}
+          aria-label="Clear class of service filter"
+          className="ml-1 rounded p-0.5 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+        >
+          <X className="h-3 w-3" aria-hidden="true" />
+        </button>
+      )}
+
+      {/* Dropdown popover */}
+      {open && (
+        <div
+          role="listbox"
+          aria-label="Class of service options"
+          aria-multiselectable="true"
+          className="absolute left-0 top-full z-50 mt-1 w-56 rounded-md border border-border bg-card shadow-lg"
+        >
+          <div className="p-1.5">
+            {CLASS_OF_SERVICE_VALUES.map((cls) => {
+              const meta = SERVICE_CLASS_META[cls];
+              const colors = getServiceClassColors(cls);
+              const Icon = ICON_MAP[meta.iconName];
+              const isSelected = selected.includes(cls);
+              const count = counts?.[cls] ?? 0;
+
+              return (
+                <button
+                  key={cls}
+                  role="option"
+                  aria-selected={isSelected}
+                  onClick={() => toggle(cls)}
+                  className={clsx(
+                    "flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs transition-colors",
+                    "hover:bg-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)]",
+                    isSelected && "bg-secondary/60"
+                  )}
+                >
+                  {/* Checkbox indicator */}
+                  <span
+                    className={clsx(
+                      "flex h-3.5 w-3.5 items-center justify-center rounded-sm border",
+                      isSelected
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-muted-foreground/40"
+                    )}
+                    aria-hidden="true"
+                  >
+                    {isSelected && (
+                      <svg
+                        viewBox="0 0 12 12"
+                        className="h-2.5 w-2.5"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                      >
+                        <path d="M2 6l3 3 5-5" />
+                      </svg>
+                    )}
+                  </span>
+
+                  {/* Icon */}
+                  <span
+                    className={clsx(
+                      "flex h-4 w-4 items-center justify-center rounded",
+                      colors.bg,
+                      colors.text
+                    )}
+                  >
+                    <Icon className="h-2.5 w-2.5" />
+                  </span>
+
+                  {/* Label */}
+                  <span className="flex-1 text-left text-foreground">
+                    {meta.label}
+                  </span>
+
+                  {/* Count */}
+                  {count > 0 && (
+                    <span className="rounded-full bg-tag-bg px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground tabular-nums">
+                      {count}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Description footer */}
+          <div className="border-t border-border px-2.5 py-1.5">
+            <p className="text-[10px] text-muted-foreground">
+              Filter tasks by their scheduling policy lane.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/__tests__/class-of-service.test.ts
+++ b/src/lib/__tests__/class-of-service.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ClassOfService,
+  CLASS_OF_SERVICE_VALUES,
+  SERVICE_CLASS_META,
+  getServiceClassColors,
+  isDateBreachRisk,
+  calculateExpediteDebt,
+  parseClassOfService,
+  DEFAULT_BREACH_THRESHOLD_DAYS,
+  DEFAULT_EXPEDITE_THRESHOLD_PERCENT,
+} from "@/lib/class-of-service";
+
+// ---------------------------------------------------------------------------
+// getServiceClassColors
+// ---------------------------------------------------------------------------
+
+describe("getServiceClassColors", () => {
+  it.each(CLASS_OF_SERVICE_VALUES)(
+    "returns color tokens for %s",
+    (cls) => {
+      const colors = getServiceClassColors(cls);
+      expect(colors).toHaveProperty("bg");
+      expect(colors).toHaveProperty("text");
+      expect(colors).toHaveProperty("border");
+      expect(colors).toHaveProperty("dot");
+      expect(typeof colors.dot).toBe("string");
+    }
+  );
+
+  it("expedite returns red-based colors", () => {
+    const colors = getServiceClassColors("expedite");
+    expect(colors.bg).toContain("red");
+    expect(colors.text).toContain("red");
+  });
+
+  it("fixed-date returns blue-based colors", () => {
+    const colors = getServiceClassColors("fixed-date");
+    expect(colors.bg).toContain("blue");
+  });
+
+  it("intangible returns violet-based colors", () => {
+    const colors = getServiceClassColors("intangible");
+    expect(colors.bg).toContain("violet");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SERVICE_CLASS_META
+// ---------------------------------------------------------------------------
+
+describe("SERVICE_CLASS_META", () => {
+  it("defines metadata for all service classes", () => {
+    for (const cls of CLASS_OF_SERVICE_VALUES) {
+      const meta = SERVICE_CLASS_META[cls];
+      expect(meta.label).toBeTruthy();
+      expect(meta.description).toBeTruthy();
+      expect(meta.policy).toBeTruthy();
+      expect(meta.iconName).toBeTruthy();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isDateBreachRisk
+// ---------------------------------------------------------------------------
+
+describe("isDateBreachRisk", () => {
+  const now = new Date("2025-06-15T12:00:00Z");
+
+  it("returns null for non-fixed-date classes", () => {
+    expect(isDateBreachRisk("2025-06-16", "standard", { now })).toBeNull();
+    expect(isDateBreachRisk("2025-06-16", "expedite", { now })).toBeNull();
+    expect(isDateBreachRisk("2025-06-16", "intangible", { now })).toBeNull();
+  });
+
+  it("returns null when dueDate is null/undefined", () => {
+    expect(isDateBreachRisk(null, "fixed-date", { now })).toBeNull();
+    expect(isDateBreachRisk(undefined, "fixed-date", { now })).toBeNull();
+  });
+
+  it("detects overdue items", () => {
+    const result = isDateBreachRisk("2025-06-14T00:00:00Z", "fixed-date", {
+      now,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.atRisk).toBe(true);
+    expect(result!.daysRemaining).toBeLessThan(0);
+    expect(result!.label).toContain("overdue");
+  });
+
+  it("detects items due today", () => {
+    // Due date is earlier in the same day
+    const result = isDateBreachRisk("2025-06-15T12:00:00Z", "fixed-date", {
+      now,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.daysRemaining).toBe(0);
+    expect(result!.atRisk).toBe(true);
+    expect(result!.label).toBe("Due today");
+  });
+
+  it("marks items within threshold as at-risk", () => {
+    // 2 days remaining, default threshold is 3
+    const result = isDateBreachRisk("2025-06-17T12:00:00Z", "fixed-date", {
+      now,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.daysRemaining).toBe(2);
+    expect(result!.atRisk).toBe(true);
+  });
+
+  it("marks items beyond threshold as not at-risk", () => {
+    // 10 days remaining
+    const result = isDateBreachRisk("2025-06-25T12:00:00Z", "fixed-date", {
+      now,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.daysRemaining).toBe(10);
+    expect(result!.atRisk).toBe(false);
+    expect(result!.label).toBe("10d remaining");
+  });
+
+  it("respects custom threshold", () => {
+    // 5 days remaining, threshold = 7 => at risk
+    const result = isDateBreachRisk("2025-06-20T12:00:00Z", "fixed-date", {
+      now,
+      thresholdDays: 7,
+    });
+    expect(result!.atRisk).toBe(true);
+
+    // Same date with threshold = 3 => not at risk
+    const result2 = isDateBreachRisk("2025-06-20T12:00:00Z", "fixed-date", {
+      now,
+      thresholdDays: 3,
+    });
+    expect(result2!.atRisk).toBe(false);
+  });
+
+  it("accepts Date objects for dueDate", () => {
+    const due = new Date("2025-06-25T00:00:00Z");
+    const result = isDateBreachRisk(due, "fixed-date", { now });
+    expect(result).not.toBeNull();
+    expect(result!.daysRemaining).toBeGreaterThan(0);
+  });
+
+  it("has a sensible default threshold", () => {
+    expect(DEFAULT_BREACH_THRESHOLD_DAYS).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculateExpediteDebt
+// ---------------------------------------------------------------------------
+
+describe("calculateExpediteDebt", () => {
+  interface MockTask {
+    id: string;
+    cls: ClassOfService;
+  }
+
+  const accessor = (t: MockTask) => t.cls;
+
+  it("returns zero debt for empty task list", () => {
+    const result = calculateExpediteDebt([], accessor);
+    expect(result.totalTasks).toBe(0);
+    expect(result.expediteCount).toBe(0);
+    expect(result.expeditePercent).toBe(0);
+    expect(result.isOverThreshold).toBe(false);
+    expect(result.label).toBe("No tasks");
+  });
+
+  it("calculates correct percentage for mixed tasks", () => {
+    const tasks: MockTask[] = [
+      { id: "1", cls: "standard" },
+      { id: "2", cls: "expedite" },
+      { id: "3", cls: "fixed-date" },
+      { id: "4", cls: "intangible" },
+      { id: "5", cls: "standard" },
+    ];
+
+    const result = calculateExpediteDebt(tasks, accessor);
+    expect(result.totalTasks).toBe(5);
+    expect(result.expediteCount).toBe(1);
+    expect(result.expeditePercent).toBe(20); // 1/5 = 20%
+    expect(result.isOverThreshold).toBe(true); // 20% > 10% default
+  });
+
+  it("reports under-threshold correctly", () => {
+    const tasks: MockTask[] = [
+      { id: "1", cls: "standard" },
+      { id: "2", cls: "standard" },
+      { id: "3", cls: "standard" },
+      { id: "4", cls: "standard" },
+      { id: "5", cls: "standard" },
+      { id: "6", cls: "standard" },
+      { id: "7", cls: "standard" },
+      { id: "8", cls: "standard" },
+      { id: "9", cls: "standard" },
+      { id: "10", cls: "expedite" },
+    ];
+
+    const result = calculateExpediteDebt(tasks, accessor);
+    expect(result.expeditePercent).toBe(10);
+    // 10% is not OVER 10%, so should not be flagged
+    expect(result.isOverThreshold).toBe(false);
+  });
+
+  it("respects custom threshold", () => {
+    const tasks: MockTask[] = [
+      { id: "1", cls: "standard" },
+      { id: "2", cls: "expedite" },
+    ];
+
+    // 50% expedite, threshold 60% => not over
+    const result = calculateExpediteDebt(tasks, accessor, {
+      thresholdPercent: 60,
+    });
+    expect(result.expeditePercent).toBe(50);
+    expect(result.isOverThreshold).toBe(false);
+
+    // Same tasks, threshold 40% => over
+    const result2 = calculateExpediteDebt(tasks, accessor, {
+      thresholdPercent: 40,
+    });
+    expect(result2.isOverThreshold).toBe(true);
+  });
+
+  it("handles all-expedite tasks", () => {
+    const tasks: MockTask[] = [
+      { id: "1", cls: "expedite" },
+      { id: "2", cls: "expedite" },
+    ];
+
+    const result = calculateExpediteDebt(tasks, accessor);
+    expect(result.expeditePercent).toBe(100);
+    expect(result.isOverThreshold).toBe(true);
+  });
+
+  it("handles no-expedite tasks", () => {
+    const tasks: MockTask[] = [
+      { id: "1", cls: "standard" },
+      { id: "2", cls: "fixed-date" },
+    ];
+
+    const result = calculateExpediteDebt(tasks, accessor);
+    expect(result.expeditePercent).toBe(0);
+    expect(result.isOverThreshold).toBe(false);
+  });
+
+  it("generates a readable label", () => {
+    const tasks: MockTask[] = [
+      { id: "1", cls: "standard" },
+      { id: "2", cls: "expedite" },
+      { id: "3", cls: "standard" },
+      { id: "4", cls: "expedite" },
+    ];
+
+    const result = calculateExpediteDebt(tasks, accessor);
+    expect(result.label).toBe("50% expedite (2/4)");
+  });
+
+  it("has a sensible default threshold", () => {
+    expect(DEFAULT_EXPEDITE_THRESHOLD_PERCENT).toBe(10);
+  });
+
+  it("handles null/undefined class-of-service values", () => {
+    const tasks = [
+      { id: "1", cls: null },
+      { id: "2", cls: undefined },
+      { id: "3", cls: "expedite" as ClassOfService },
+    ];
+
+    const result = calculateExpediteDebt(
+      tasks,
+      (t) => t.cls as ClassOfService | null | undefined
+    );
+    expect(result.expediteCount).toBe(1);
+    expect(result.totalTasks).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseClassOfService
+// ---------------------------------------------------------------------------
+
+describe("parseClassOfService", () => {
+  it("returns the correct class for valid values", () => {
+    expect(parseClassOfService("standard")).toBe("standard");
+    expect(parseClassOfService("fixed-date")).toBe("fixed-date");
+    expect(parseClassOfService("expedite")).toBe("expedite");
+    expect(parseClassOfService("intangible")).toBe("intangible");
+  });
+
+  it("is case-insensitive", () => {
+    expect(parseClassOfService("EXPEDITE")).toBe("expedite");
+    expect(parseClassOfService("Fixed-Date")).toBe("fixed-date");
+    expect(parseClassOfService("INTANGIBLE")).toBe("intangible");
+  });
+
+  it("trims whitespace", () => {
+    expect(parseClassOfService("  expedite  ")).toBe("expedite");
+  });
+
+  it("returns 'standard' for null/undefined", () => {
+    expect(parseClassOfService(null)).toBe("standard");
+    expect(parseClassOfService(undefined)).toBe("standard");
+  });
+
+  it("returns 'standard' for unrecognized values", () => {
+    expect(parseClassOfService("urgent")).toBe("standard");
+    expect(parseClassOfService("")).toBe("standard");
+    expect(parseClassOfService("custom-class")).toBe("standard");
+  });
+});

--- a/src/lib/class-of-service.ts
+++ b/src/lib/class-of-service.ts
@@ -1,0 +1,277 @@
+/**
+ * Class of Service — lane classification for Kanban tasks.
+ *
+ * Each task may carry a class-of-service designation that determines
+ * scheduling policy, visual styling, and WIP-level constraints.
+ *
+ * See David Anderson's "Kanban" for the canonical definitions:
+ *   standard   — normal FIFO; no special treatment
+ *   fixed-date — hard external deadline; must be tracked for breach risk
+ *   expedite   — drop-everything lane; limited to ~1 per board at a time
+ *   intangible — tech-debt / maintenance; scheduled during slack capacity
+ */
+
+import type {
+  Calendar,
+  Zap,
+  Clock,
+  Wrench,
+} from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ClassOfService =
+  | "standard"
+  | "fixed-date"
+  | "expedite"
+  | "intangible";
+
+export const CLASS_OF_SERVICE_VALUES: ClassOfService[] = [
+  "standard",
+  "fixed-date",
+  "expedite",
+  "intangible",
+];
+
+export interface ServiceClassMeta {
+  label: string;
+  description: string;
+  /** Policy tooltip shown on hover */
+  policy: string;
+  /** Lucide icon name (resolved at render time) */
+  iconName: "Clock" | "Calendar" | "Zap" | "Wrench";
+}
+
+export const SERVICE_CLASS_META: Record<ClassOfService, ServiceClassMeta> = {
+  standard: {
+    label: "Standard",
+    description: "Normal priority, FIFO scheduling",
+    policy:
+      "Pulled in order from the backlog. No special treatment or scheduling override.",
+    iconName: "Clock",
+  },
+  "fixed-date": {
+    label: "Fixed Date",
+    description: "Hard external deadline",
+    policy:
+      "Must be completed by its due date. Breach risk is highlighted when the remaining time drops below a configurable threshold.",
+    iconName: "Calendar",
+  },
+  expedite: {
+    label: "Expedite",
+    description: "Drop everything — emergency lane",
+    policy:
+      "Limited to at most one active expedite per board at a time. Every active expedite increases flow debt and should be tracked as a process smell.",
+    iconName: "Zap",
+  },
+  intangible: {
+    label: "Intangible",
+    description: "Tech debt, maintenance, enablers",
+    policy:
+      "Scheduled during slack capacity. Should represent ~20% of throughput to prevent infrastructure erosion.",
+    iconName: "Wrench",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Styling tokens
+// ---------------------------------------------------------------------------
+
+export interface ServiceClassColors {
+  /** Tailwind bg class for the badge */
+  bg: string;
+  /** Tailwind text class for the badge */
+  text: string;
+  /** Tailwind border class for the badge */
+  border: string;
+  /** CSS color value for dot/accent */
+  dot: string;
+}
+
+export function getServiceClassColors(
+  cls: ClassOfService
+): ServiceClassColors {
+  switch (cls) {
+    case "standard":
+      return {
+        bg: "bg-slate-500/10",
+        text: "text-slate-600 dark:text-slate-400",
+        border: "border-slate-500/20",
+        dot: "#64748b",
+      };
+    case "fixed-date":
+      return {
+        bg: "bg-blue-500/10",
+        text: "text-blue-600 dark:text-blue-400",
+        border: "border-blue-500/20",
+        dot: "#3b82f6",
+      };
+    case "expedite":
+      return {
+        bg: "bg-red-500/15",
+        text: "text-red-600 dark:text-red-400",
+        border: "border-red-500/25",
+        dot: "#ef4444",
+      };
+    case "intangible":
+      return {
+        bg: "bg-violet-500/10",
+        text: "text-violet-600 dark:text-violet-400",
+        border: "border-violet-500/20",
+        dot: "#8b5cf6",
+      };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Breach risk calculation
+// ---------------------------------------------------------------------------
+
+/** Default threshold in days — items with fewer days remaining are "at risk". */
+export const DEFAULT_BREACH_THRESHOLD_DAYS = 3;
+
+export interface BreachRiskResult {
+  /** Whether the item is at risk of breaching its due date */
+  atRisk: boolean;
+  /** Days remaining (negative = overdue) */
+  daysRemaining: number;
+  /** Human-readable label */
+  label: string;
+}
+
+/**
+ * Check whether a fixed-date item is at risk of breaching its due date.
+ *
+ * Only meaningful when `classOfService === "fixed-date"` and `dueDate` is set.
+ * Returns `null` for non-fixed-date items or when no due date exists.
+ */
+export function isDateBreachRisk(
+  dueDate: string | Date | null | undefined,
+  classOfService: ClassOfService,
+  options?: {
+    now?: Date;
+    thresholdDays?: number;
+  }
+): BreachRiskResult | null {
+  if (classOfService !== "fixed-date") return null;
+  if (!dueDate) return null;
+
+  const now = options?.now ?? new Date();
+  const threshold = options?.thresholdDays ?? DEFAULT_BREACH_THRESHOLD_DAYS;
+
+  const due = typeof dueDate === "string" ? new Date(dueDate) : dueDate;
+  const diffMs = due.getTime() - now.getTime();
+  const daysRemaining = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+
+  if (daysRemaining < 0) {
+    return {
+      atRisk: true,
+      daysRemaining,
+      label: `${Math.abs(daysRemaining)}d overdue`,
+    };
+  }
+
+  if (daysRemaining === 0) {
+    return {
+      atRisk: true,
+      daysRemaining: 0,
+      label: "Due today",
+    };
+  }
+
+  return {
+    atRisk: daysRemaining <= threshold,
+    daysRemaining,
+    label: `${daysRemaining}d remaining`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Expedite debt calculation
+// ---------------------------------------------------------------------------
+
+export interface ExpediteDebtResult {
+  /** Total task count */
+  totalTasks: number;
+  /** Number of expedite tasks */
+  expediteCount: number;
+  /** Percentage of tasks that are expedite (0-100) */
+  expeditePercent: number;
+  /** Whether the percentage exceeds the healthy threshold */
+  isOverThreshold: boolean;
+  /** Human-readable label */
+  label: string;
+}
+
+/** Healthy expedite threshold — anything above this is "debt". */
+export const DEFAULT_EXPEDITE_THRESHOLD_PERCENT = 10;
+
+/**
+ * Calculate the expedite "debt" for a set of tasks.
+ *
+ * In Kanban practice, expedite items should be rare exceptions —
+ * typically <10% of active WIP. When the percentage exceeds the
+ * threshold, it indicates a process problem.
+ *
+ * Accepts a `getClassOfService` accessor to remain decoupled from
+ * any particular data shape.
+ */
+export function calculateExpediteDebt<T>(
+  tasks: T[],
+  getClassOfService: (task: T) => ClassOfService | undefined | null,
+  options?: { thresholdPercent?: number }
+): ExpediteDebtResult {
+  const threshold =
+    options?.thresholdPercent ?? DEFAULT_EXPEDITE_THRESHOLD_PERCENT;
+
+  const totalTasks = tasks.length;
+  if (totalTasks === 0) {
+    return {
+      totalTasks: 0,
+      expediteCount: 0,
+      expeditePercent: 0,
+      isOverThreshold: false,
+      label: "No tasks",
+    };
+  }
+
+  const expediteCount = tasks.filter(
+    (t) => getClassOfService(t) === "expedite"
+  ).length;
+  const expeditePercent = Math.round((expediteCount / totalTasks) * 100);
+  const isOverThreshold = expeditePercent > threshold;
+
+  return {
+    totalTasks,
+    expediteCount,
+    expeditePercent,
+    isOverThreshold,
+    label: `${expeditePercent}% expedite (${expediteCount}/${totalTasks})`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a class-of-service string, returning "standard" as the default
+ * when the value is missing or unrecognized.
+ */
+export function parseClassOfService(
+  value: string | null | undefined
+): ClassOfService {
+  if (!value) return "standard";
+  const normalized = value.toLowerCase().trim();
+  if (
+    normalized === "standard" ||
+    normalized === "fixed-date" ||
+    normalized === "expedite" ||
+    normalized === "intangible"
+  ) {
+    return normalized as ClassOfService;
+  }
+  return "standard";
+}


### PR DESCRIPTION
## Summary
- Adds Kanban class-of-service type system (`standard`, `fixed-date`, `expedite`, `intangible`) with styling tokens, breach risk detection, and expedite debt calculation
- Creates `ServiceClassBadge` component — color-coded pill with icon, tooltip, fixed-date countdown, and expedite debt indicator
- Creates `ServiceClassFilter` component — multi-select dropdown with per-class item counts for board-level filtering
- Includes 31 pure-function unit tests for all utility functions (zero database/HTTP dependencies)

## Files Added
| File | Purpose |
|------|---------|
| `src/lib/class-of-service.ts` | Type definitions, styling tokens, `isDateBreachRisk()`, `calculateExpediteDebt()`, `parseClassOfService()` |
| `src/components/board/service-class-badge.tsx` | Visual badge component for task cards |
| `src/components/board/service-class-filter.tsx` | Filter dropdown for board toolbar |
| `src/lib/__tests__/class-of-service.test.ts` | 31 unit tests |

## Integration Instructions (for merging with other agents' work)

### 1. Add `ServiceClassBadge` to `task-card.tsx`

In the tags row (around line 168, inside the `{revealMetadata && ...}` block), add after the commitment badges:

```tsx
import { ServiceClassBadge } from "./service-class-badge";
import { parseClassOfService } from "@/lib/class-of-service";

// Inside the tags row div:
<ServiceClassBadge
  classOfService={parseClassOfService((task.metadata as any)?.classOfService)}
  dueDate={task.dueDate}
/>
```

### 2. Add `ServiceClassFilter` to `board-filters.tsx`

```tsx
import { ServiceClassFilter } from "./service-class-filter";

// Add state in KanbanBoard (or lift to board store):
const [filterServiceClass, setFilterServiceClass] = useState<ClassOfService[]>([]);

// Add alongside existing filter dropdowns:
<ServiceClassFilter
  selected={filterServiceClass}
  onChange={setFilterServiceClass}
  counts={serviceClassCounts}
/>
```

### 3. Store the class-of-service value

Until a dedicated Prisma field is added, the value can be stored in `task.metadata.classOfService`. When a schema migration adds the field, update `parseClassOfService` calls to read from the new column.

## Test plan
- [x] `npx vitest run src/lib/__tests__/class-of-service` — 31/31 passing
- [ ] Visual verification: import `ServiceClassBadge` in Storybook or dev page to confirm rendering
- [ ] Verify `ServiceClassFilter` dropdown opens/closes, selects/deselects, and shows counts
- [ ] Confirm fixed-date breach risk turns red when within threshold
- [ ] Confirm expedite debt indicator shows percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)