### PR TITLE
fix: anchor New Task button to board content area (WGX-025)

### DIFF
--- a/src/components/board/kanban-board.tsx
+++ b/src/components/board/kanban-board.tsx
@@ -527,7 +527,8 @@ export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) 
 
   /* ----- Render ----- */
   return (
-    <div className="flex h-full flex-col" onKeyDown={handleBoardKeyDown} tabIndex={0}>
+    <div className="h-full overflow-x-auto overflow-y-auto" onKeyDown={handleBoardKeyDown} tabIndex={0}>
+      <div className="inline-flex min-w-full flex-col">
       <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
         <div className="flex min-w-0 flex-1 items-center gap-3">
           <BoardFilters />
@@ -588,7 +589,7 @@ export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) 
         </button>
       </div>
 
-      <div className="flex-1 overflow-x-auto overflow-y-auto px-4 pb-4">
+      <div className="px-4 pb-4">
         <DragDropContext onDragEnd={handleDragEnd}>
           {groupBy === "status" && (
             <div className="flex h-full gap-3">
@@ -724,6 +725,7 @@ export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) 
             </div>
           )}
         </DragDropContext>
+      </div>
       </div>
 
       {isTaskModalOpen && (

--- a/src/lib/__tests__/kanban-toolbar-layout.test.ts
+++ b/src/lib/__tests__/kanban-toolbar-layout.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * WGX-025: Verify that the Kanban board layout classes anchor the
+ * toolbar (and its New Task button) to the board content width rather
+ * than the viewport width.
+ *
+ * This is a static analysis test — it reads the component source and
+ * asserts the expected Tailwind class patterns are present.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const SRC = readFileSync(
+  join(__dirname, "../../components/board/kanban-board.tsx"),
+  "utf-8"
+);
+
+describe("KanbanBoard toolbar layout (WGX-025)", () => {
+  it("uses an inline-flex content-sizing wrapper so the toolbar matches column width", () => {
+    // The content wrapper must use inline-flex + min-w-full so it sizes to
+    // its children (the columns) rather than stretching to the viewport.
+    expect(SRC).toContain("inline-flex min-w-full flex-col");
+  });
+
+  it("outer container provides horizontal scroll", () => {
+    // The outermost board div should handle overflow scrolling.
+    expect(SRC).toContain("overflow-x-auto overflow-y-auto");
+  });
+
+  it("toolbar still uses justify-between within the content wrapper", () => {
+    // The toolbar flex container keeps justify-between — it just operates
+    // within the inline-flex wrapper now instead of the full viewport.
+    expect(SRC).toContain("justify-between");
+  });
+
+  it("column containers still use flex layout for horizontal columns", () => {
+    // All three grouping modes (status, project, department) render columns
+    // inside a flex row.
+    const flexColumnMatches = SRC.match(/className="flex h-full gap-3"/g);
+    expect(flexColumnMatches).not.toBeNull();
+    expect(flexColumnMatches!.length).toBeGreaterThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Wraps the Kanban board toolbar and column area in an `inline-flex min-w-full flex-col` container so the toolbar (including the New Task button) sizes to the actual column content width rather than the browser viewport width
- Moves horizontal/vertical overflow scrolling to the outermost board container so toolbar and columns scroll together
- Adds static analysis test verifying the expected layout class patterns

## Test plan
- [x] Vitest test passes (4/4 assertions)
- [ ] Visually verify New Task button aligns with rightmost column on wide screens
- [ ] Verify all 3 display presets (standard, dense, triage) render correctly
- [ ] Verify all 3 group-by modes (status, project, department) render correctly
- [ ] Verify drag-and-drop still works
- [ ] Verify horizontal scroll still works when columns exceed viewport

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)