### PR TITLE
feat: standup cockpit with flow coaching prompts (WGX-012)

### DIFF
--- a/src/app/(dashboard)/standup/page.tsx
+++ b/src/app/(dashboard)/standup/page.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import { clsx } from "clsx";
+import { Monitor, MonitorOff } from "lucide-react";
+
+import { StandupTimer } from "@/components/standup/standup-timer";
+import { FlowCoachingPromptPanel } from "@/components/standup/flow-coaching-prompt";
+import { StandupMemberCard } from "@/components/standup/standup-member-card";
+import { StandupSummary } from "@/components/standup/standup-summary";
+import {
+  groupTasksByOwner,
+  generateCoachingPrompts,
+  calculateStandupMetrics,
+  formatStandupForSlack,
+  DEFAULT_COACHING_CONFIG,
+} from "@/lib/standup-engine";
+import type {
+  StandupAction,
+  StandupMetrics,
+  OwnerGroup,
+  TeamMember,
+  TaskSummary,
+  SuggestedAction,
+  CoachingPrompt,
+} from "@/lib/standup-engine";
+
+// ---------------------------------------------------------------------------
+// Demo data  (replace with real API / SWR hook once backend is wired)
+// ---------------------------------------------------------------------------
+
+const DEMO_MEMBERS: TeamMember[] = [
+  { id: "u1", name: "Alice Chen" },
+  { id: "u2", name: "Bob Park" },
+  { id: "u3", name: "Carol Rivera" },
+  { id: "u4", name: "Dan Kim" },
+];
+
+const DEMO_TASKS: TaskSummary[] = [
+  { id: "t1", title: "Migrate auth to NextAuth v5", status: "in_progress", ownerId: "u1", priority: "high", ageDays: 3 },
+  { id: "t2", title: "Fix Safari layout bug", status: "in_progress", ownerId: "u1", priority: "medium", ageDays: 1 },
+  { id: "t3", title: "Write integration tests for billing", status: "in_progress", ownerId: "u1", priority: "medium", ageDays: 6 },
+  { id: "t4", title: "Design onboarding flow v2", status: "in_progress", ownerId: "u1", priority: "low" },
+  { id: "t5", title: "API rate-limiter middleware", status: "blocked", ownerId: "u2", priority: "high", blockedReason: "Waiting on infra team", ageDays: 4 },
+  { id: "t6", title: "Dashboard performance audit", status: "in_progress", ownerId: "u2", priority: "medium" },
+  { id: "t7", title: "Update Stripe webhook handler", status: "done", ownerId: "u3", priority: "high" },
+  { id: "t8", title: "Customer export CSV feature", status: "in_progress", ownerId: "u3", priority: "medium" },
+  { id: "t9", title: "Docs: API authentication guide", status: "todo", ownerId: "u4", priority: "low" },
+  { id: "t10", title: "Set up staging environment", status: "in_progress", ownerId: "u4", priority: "high", ageDays: 8 },
+];
+
+// ---------------------------------------------------------------------------
+// Page Component
+// ---------------------------------------------------------------------------
+
+export default function StandupPage() {
+  const [facilitatorMode, setFacilitatorMode] = useState(false);
+  const [activeMemberId, setActiveMemberId] = useState<string | null>(null);
+  const [metrics, setMetrics] = useState<StandupMetrics | null>(null);
+  const [slackMessage, setSlackMessage] = useState<string>("");
+  const startTimeRef = useRef<Date | null>(null);
+
+  // Mutable group actions tracked via state
+  const [groupActions, setGroupActions] = useState<Record<string, StandupAction>>({});
+
+  const groups: OwnerGroup[] = useMemo(() => {
+    const base = groupTasksByOwner(DEMO_TASKS, DEMO_MEMBERS);
+    return base.map((g) => ({
+      ...g,
+      action: groupActions[g.member.id] ?? g.action,
+    }));
+  }, [groupActions]);
+
+  const prompts: CoachingPrompt[] = useMemo(
+    () => generateCoachingPrompts(DEMO_TASKS, DEMO_MEMBERS, DEFAULT_COACHING_CONFIG),
+    [],
+  );
+
+  // --- Handlers ---
+
+  const handleTimerStart = useCallback(() => {
+    startTimeRef.current = new Date();
+    if (groups.length > 0) setActiveMemberId(groups[0].member.id);
+  }, [groups]);
+
+  const handleTimerStop = useCallback(
+    (elapsedSeconds: number) => {
+      const endTime = new Date();
+      const startTime = startTimeRef.current ?? new Date(endTime.getTime() - elapsedSeconds * 1000);
+      const m = calculateStandupMetrics({
+        startTime,
+        endTime,
+        groups,
+        coachingPromptsShown: prompts.length,
+      });
+      setMetrics(m);
+      setSlackMessage(formatStandupForSlack(groups, m, prompts));
+      setActiveMemberId(null);
+    },
+    [groups, prompts],
+  );
+
+  const handleMemberAction = useCallback(
+    (memberId: string, action: StandupAction) => {
+      setGroupActions((prev) => ({ ...prev, [memberId]: action }));
+
+      // Advance to next member
+      const idx = groups.findIndex((g) => g.member.id === memberId);
+      if (idx >= 0 && idx < groups.length - 1) {
+        setActiveMemberId(groups[idx + 1].member.id);
+      } else {
+        setActiveMemberId(null);
+      }
+    },
+    [groups],
+  );
+
+  const handleCoachingAction = useCallback((action: SuggestedAction) => {
+    // In a real app this would dispatch to the backend
+    // eslint-disable-next-line no-console
+    console.log("Coaching action:", action);
+  }, []);
+
+  const handleCopySlack = useCallback(() => {
+    void navigator.clipboard.writeText(slackMessage);
+  }, [slackMessage]);
+
+  // --- Render ---
+
+  return (
+    <div className="space-y-6 p-6">
+      {/* Header */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-foreground">
+            Standup Cockpit
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Run your daily standup with flow coaching and automatic metrics
+          </p>
+        </div>
+        <button
+          onClick={() => setFacilitatorMode((v) => !v)}
+          className={clsx(
+            "inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            facilitatorMode
+              ? "border-primary bg-primary/10 text-primary"
+              : "border-border text-muted-foreground hover:bg-muted",
+          )}
+          aria-pressed={facilitatorMode}
+        >
+          {facilitatorMode ? (
+            <MonitorOff className="h-3.5 w-3.5" aria-hidden="true" />
+          ) : (
+            <Monitor className="h-3.5 w-3.5" aria-hidden="true" />
+          )}
+          {facilitatorMode ? "Exit Facilitator" : "Facilitator Mode"}
+        </button>
+      </div>
+
+      {/* Timer */}
+      <StandupTimer
+        onStart={handleTimerStart}
+        onStop={handleTimerStop}
+        facilitatorMode={facilitatorMode}
+      />
+
+      {/* Coaching prompts */}
+      <FlowCoachingPromptPanel
+        prompts={prompts}
+        onAction={handleCoachingAction}
+        facilitatorMode={facilitatorMode}
+      />
+
+      {/* Member cards */}
+      <section aria-label="Team members" className="space-y-3">
+        <h2 className="text-sm font-semibold text-muted-foreground">
+          Team ({groups.length} members)
+        </h2>
+        <div className={clsx("space-y-3", facilitatorMode && "space-y-4")}>
+          {groups.map((group) => (
+            <StandupMemberCard
+              key={group.member.id}
+              group={group}
+              isActive={group.member.id === activeMemberId}
+              facilitatorMode={facilitatorMode}
+              onActionChange={handleMemberAction}
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* Summary (visible after standup ends) */}
+      <StandupSummary
+        metrics={metrics}
+        slackMessage={slackMessage}
+        facilitatorMode={facilitatorMode}
+        onCopyToClipboard={handleCopySlack}
+      />
+    </div>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -15,6 +15,7 @@ import {
   BookOpen,
   Settings,
   Gauge,
+  Users,
 } from "lucide-react";
 
 export const PRIMARY_NAV_ITEMS = [
@@ -26,6 +27,7 @@ export const PRIMARY_NAV_ITEMS = [
   { href: "/analytics/sales-pipeline", label: "Sales & Pipeline", icon: Target },
   { href: "/analytics/customer-success", label: "Customer Success", icon: HeartHandshake },
   { href: "/whip", label: "Whip View", icon: Gauge },
+  { href: "/standup", label: "Standup", icon: Users },
   { href: "/automations", label: "Automations", icon: Bot },
 ];
 

--- a/src/components/standup/flow-coaching-prompt.tsx
+++ b/src/components/standup/flow-coaching-prompt.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { clsx } from "clsx";
+import {
+  AlertTriangle,
+  Lightbulb,
+  AlertOctagon,
+  ArrowRightCircle,
+} from "lucide-react";
+import type { CoachingPrompt, SuggestedAction } from "@/lib/standup-engine";
+
+interface FlowCoachingPromptProps {
+  prompts: CoachingPrompt[];
+  onAction?: (action: SuggestedAction) => void;
+  /** Collapse to one-liner in facilitator mode */
+  facilitatorMode?: boolean;
+}
+
+const SEVERITY_STYLES = {
+  critical: {
+    border: "border-red-400/50",
+    bg: "bg-red-50 dark:bg-red-950/30",
+    icon: AlertOctagon,
+    iconColor: "text-red-500",
+    badge: "bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300",
+  },
+  warning: {
+    border: "border-amber-400/50",
+    bg: "bg-amber-50 dark:bg-amber-950/30",
+    icon: AlertTriangle,
+    iconColor: "text-amber-500",
+    badge: "bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-300",
+  },
+  info: {
+    border: "border-blue-400/50",
+    bg: "bg-blue-50 dark:bg-blue-950/30",
+    icon: Lightbulb,
+    iconColor: "text-blue-500",
+    badge: "bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300",
+  },
+} as const;
+
+export function FlowCoachingPromptPanel({
+  prompts,
+  onAction,
+  facilitatorMode = false,
+}: FlowCoachingPromptProps) {
+  if (prompts.length === 0) return null;
+
+  return (
+    <section aria-label="Flow coaching prompts" className="space-y-2">
+      <h2 className="text-sm font-semibold text-muted-foreground">
+        Flow Coaching
+      </h2>
+      <ul className="space-y-2">
+        {prompts.map((prompt, idx) => {
+          const style = SEVERITY_STYLES[prompt.severity];
+          const Icon = style.icon;
+
+          return (
+            <li
+              key={`${prompt.type}-${prompt.targetTaskId ?? prompt.targetMemberId ?? idx}`}
+              className={clsx(
+                "rounded-lg border p-3",
+                style.border,
+                style.bg,
+              )}
+            >
+              <div className="flex items-start gap-2">
+                <Icon
+                  className={clsx("mt-0.5 h-4 w-4 shrink-0", style.iconColor)}
+                  aria-hidden="true"
+                />
+                <div className="flex-1 space-y-1.5">
+                  <p className="text-sm font-medium text-foreground">
+                    {prompt.message}
+                  </p>
+
+                  {!facilitatorMode && prompt.suggestedActions.length > 0 && (
+                    <div className="flex flex-wrap gap-1.5">
+                      {prompt.suggestedActions.map((action) => (
+                        <button
+                          key={`${action.kind}-${action.taskId}`}
+                          onClick={() => onAction?.(action)}
+                          className="inline-flex items-center gap-1 rounded-full border border-border bg-card px-2.5 py-0.5 text-xs font-medium text-foreground shadow-sm hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        >
+                          <ArrowRightCircle
+                            className="h-3 w-3"
+                            aria-hidden="true"
+                          />
+                          {action.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                <span
+                  className={clsx(
+                    "shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase",
+                    style.badge,
+                  )}
+                >
+                  {prompt.severity}
+                </span>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/standup/standup-member-card.tsx
+++ b/src/components/standup/standup-member-card.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { clsx } from "clsx";
+import {
+  CheckCircle2,
+  Circle,
+  AlertCircle,
+  PauseCircle,
+  SkipForward,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+import { useState } from "react";
+import type {
+  OwnerGroup,
+  StandupAction,
+  TaskSummary,
+} from "@/lib/standup-engine";
+
+interface StandupMemberCardProps {
+  group: OwnerGroup;
+  /** Currently active member for facilitator highlight */
+  isActive?: boolean;
+  /** Facilitator mode for screen-share */
+  facilitatorMode?: boolean;
+  onActionChange?: (memberId: string, action: StandupAction) => void;
+}
+
+const STATUS_ICON: Record<TaskSummary["status"], typeof Circle> = {
+  todo: Circle,
+  in_progress: AlertCircle,
+  blocked: AlertCircle,
+  done: CheckCircle2,
+  deferred: PauseCircle,
+};
+
+const STATUS_COLOR: Record<TaskSummary["status"], string> = {
+  todo: "text-muted-foreground",
+  in_progress: "text-blue-500",
+  blocked: "text-red-500",
+  done: "text-emerald-500",
+  deferred: "text-muted-foreground",
+};
+
+const PRIORITY_DOT: Record<string, string> = {
+  urgent: "bg-red-500",
+  high: "bg-amber-500",
+  medium: "bg-blue-400",
+  low: "bg-muted-foreground",
+};
+
+export function StandupMemberCard({
+  group,
+  isActive = false,
+  facilitatorMode = false,
+  onActionChange,
+}: StandupMemberCardProps) {
+  const [expanded, setExpanded] = useState(true);
+
+  const actionLabel =
+    group.action === "completed"
+      ? "Done"
+      : group.action === "skipped"
+        ? "Skipped"
+        : "In progress";
+
+  return (
+    <article
+      className={clsx(
+        "rounded-lg border bg-card transition-shadow",
+        isActive
+          ? "border-primary shadow-md ring-2 ring-primary/20"
+          : "border-border",
+        facilitatorMode && "text-base",
+      )}
+    >
+      {/* Header */}
+      <div
+        className="flex items-center gap-3 px-4 py-3 cursor-pointer select-none"
+        onClick={() => setExpanded(!expanded)}
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setExpanded(!expanded);
+          }
+        }}
+      >
+        {/* Avatar placeholder */}
+        <div
+          className={clsx(
+            "flex h-8 w-8 shrink-0 items-center justify-center rounded-full font-semibold text-white",
+            group.blockedCount > 0 ? "bg-red-500" : "bg-primary",
+          )}
+          aria-hidden="true"
+        >
+          {group.member.name.charAt(0).toUpperCase()}
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <span className="font-semibold text-foreground">
+            {group.member.name}
+          </span>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span>{group.inProgressCount} active</span>
+            {group.blockedCount > 0 && (
+              <span className="text-red-500 font-medium">
+                {group.blockedCount} blocked
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Action selector */}
+        <div className="flex items-center gap-2">
+          {onActionChange && group.action === "started" && (
+            <>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onActionChange(group.member.id, "completed");
+                }}
+                className="inline-flex items-center gap-1 rounded-md bg-emerald-600 px-2 py-1 text-xs font-medium text-white hover:bg-emerald-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+                aria-label={`Mark ${group.member.name} as done`}
+              >
+                <CheckCircle2 className="h-3 w-3" aria-hidden="true" />
+                Done
+              </button>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onActionChange(group.member.id, "skipped");
+                }}
+                className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                aria-label={`Skip ${group.member.name}`}
+              >
+                <SkipForward className="h-3 w-3" aria-hidden="true" />
+                Skip
+              </button>
+            </>
+          )}
+
+          {group.action !== "started" && (
+            <span
+              className={clsx(
+                "rounded-full px-2 py-0.5 text-xs font-medium",
+                group.action === "completed"
+                  ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
+                  : "bg-muted text-muted-foreground",
+              )}
+            >
+              {actionLabel}
+            </span>
+          )}
+
+          {expanded ? (
+            <ChevronUp className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          ) : (
+            <ChevronDown className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          )}
+        </div>
+      </div>
+
+      {/* Task list */}
+      {expanded && group.tasks.length > 0 && (
+        <ul className="border-t border-border divide-y divide-border">
+          {group.tasks.map((t) => {
+            const Icon = STATUS_ICON[t.status];
+            return (
+              <li key={t.id} className="flex items-center gap-2.5 px-4 py-2">
+                <Icon
+                  className={clsx("h-4 w-4 shrink-0", STATUS_COLOR[t.status])}
+                  aria-hidden="true"
+                />
+                <span className="flex-1 truncate text-sm text-foreground">
+                  {t.title}
+                </span>
+                <span
+                  className={clsx(
+                    "h-2 w-2 shrink-0 rounded-full",
+                    PRIORITY_DOT[t.priority] ?? "bg-muted-foreground",
+                  )}
+                  title={t.priority}
+                  aria-label={`Priority: ${t.priority}`}
+                />
+                {t.status === "blocked" && t.blockedReason && (
+                  <span className="max-w-[140px] truncate text-[11px] text-red-500">
+                    {t.blockedReason}
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </article>
+  );
+}

--- a/src/components/standup/standup-summary.tsx
+++ b/src/components/standup/standup-summary.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { clsx } from "clsx";
+import {
+  Clock,
+  Users,
+  AlertCircle,
+  ListChecks,
+  Lightbulb,
+  Share2,
+} from "lucide-react";
+import type { StandupMetrics } from "@/lib/standup-engine";
+
+interface StandupSummaryProps {
+  metrics: StandupMetrics | null;
+  slackMessage?: string;
+  facilitatorMode?: boolean;
+  onCopyToClipboard?: () => void;
+}
+
+function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}m ${s}s`;
+}
+
+export function StandupSummary({
+  metrics,
+  slackMessage,
+  facilitatorMode = false,
+  onCopyToClipboard,
+}: StandupSummaryProps) {
+  if (!metrics) return null;
+
+  const stats = [
+    {
+      label: "Duration",
+      value: formatDuration(metrics.totalDurationSeconds),
+      icon: Clock,
+      color: metrics.totalDurationSeconds < 900 ? "text-emerald-500" : "text-amber-500",
+    },
+    {
+      label: "Members",
+      value: String(metrics.memberCount),
+      icon: Users,
+      color: "text-blue-500",
+    },
+    {
+      label: "Avg / member",
+      value: formatDuration(metrics.avgSecondsPerMember),
+      icon: Clock,
+      color: "text-muted-foreground",
+    },
+    {
+      label: "Blockers",
+      value: String(metrics.blockerCount),
+      icon: AlertCircle,
+      color: metrics.blockerCount > 0 ? "text-red-500" : "text-emerald-500",
+    },
+    {
+      label: "Tasks discussed",
+      value: String(metrics.tasksDiscussed),
+      icon: ListChecks,
+      color: "text-muted-foreground",
+    },
+    {
+      label: "Coaching prompts",
+      value: String(metrics.coachingPromptsShown),
+      icon: Lightbulb,
+      color: "text-amber-500",
+    },
+  ];
+
+  return (
+    <section aria-label="Standup summary" className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-muted-foreground">
+          Standup Summary
+        </h2>
+        {slackMessage && onCopyToClipboard && (
+          <button
+            onClick={onCopyToClipboard}
+            className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <Share2 className="h-3.5 w-3.5" aria-hidden="true" />
+            Copy for Slack
+          </button>
+        )}
+      </div>
+
+      <div
+        className={clsx(
+          "grid gap-3",
+          facilitatorMode
+            ? "grid-cols-2 sm:grid-cols-3"
+            : "grid-cols-2 sm:grid-cols-3 lg:grid-cols-6",
+        )}
+      >
+        {stats.map((stat) => (
+          <div
+            key={stat.label}
+            className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2.5"
+          >
+            <stat.icon
+              className={clsx("h-4 w-4 shrink-0", stat.color)}
+              aria-hidden="true"
+            />
+            <div>
+              <p className="text-xs text-muted-foreground">{stat.label}</p>
+              <p className="text-sm font-bold text-foreground">{stat.value}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/standup/standup-timer.tsx
+++ b/src/components/standup/standup-timer.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { clsx } from "clsx";
+import { Play, Pause, RotateCcw, Timer } from "lucide-react";
+
+interface StandupTimerProps {
+  /** Called once when timer is first started */
+  onStart?: () => void;
+  /** Called when timer is stopped / standup ends */
+  onStop?: (elapsedSeconds: number) => void;
+  /** Facilitator mode: larger display for screen-share */
+  facilitatorMode?: boolean;
+}
+
+export function StandupTimer({
+  onStart,
+  onStop,
+  facilitatorMode = false,
+}: StandupTimerProps) {
+  const [elapsed, setElapsed] = useState(0);
+  const [running, setRunning] = useState(false);
+  const [started, setStarted] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Tick every second while running
+  useEffect(() => {
+    if (running) {
+      intervalRef.current = setInterval(() => {
+        setElapsed((prev) => prev + 1);
+      }, 1000);
+    }
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [running]);
+
+  const handleStart = useCallback(() => {
+    if (!started) {
+      setStarted(true);
+      onStart?.();
+    }
+    setRunning(true);
+  }, [started, onStart]);
+
+  const handlePause = useCallback(() => {
+    setRunning(false);
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setRunning(false);
+    if (started && elapsed > 0) onStop?.(elapsed);
+    setElapsed(0);
+    setStarted(false);
+  }, [started, elapsed, onStop]);
+
+  const minutes = Math.floor(elapsed / 60);
+  const seconds = elapsed % 60;
+  const display = `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+
+  // Color coding: green < 10 min, amber 10-15 min, red > 15 min
+  const timerColor =
+    elapsed < 600
+      ? "text-emerald-500"
+      : elapsed < 900
+        ? "text-amber-500"
+        : "text-red-500";
+
+  return (
+    <div
+      className={clsx(
+        "flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3",
+        facilitatorMode && "px-6 py-5",
+      )}
+    >
+      <Timer
+        className={clsx("h-5 w-5 text-muted-foreground", facilitatorMode && "h-7 w-7")}
+        aria-hidden="true"
+      />
+      <span
+        className={clsx(
+          "font-mono font-bold tabular-nums",
+          timerColor,
+          facilitatorMode ? "text-4xl" : "text-xl",
+        )}
+        aria-live="polite"
+        aria-label={`${minutes} minutes ${seconds} seconds`}
+      >
+        {display}
+      </span>
+
+      <div className="ml-auto flex items-center gap-1.5">
+        {!running ? (
+          <button
+            onClick={handleStart}
+            className="inline-flex items-center gap-1.5 rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+            aria-label="Start standup timer"
+          >
+            <Play className="h-3.5 w-3.5" aria-hidden="true" />
+            {started ? "Resume" : "Start"}
+          </button>
+        ) : (
+          <button
+            onClick={handlePause}
+            className="inline-flex items-center gap-1.5 rounded-md bg-amber-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-amber-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+            aria-label="Pause standup timer"
+          >
+            <Pause className="h-3.5 w-3.5" aria-hidden="true" />
+            Pause
+          </button>
+        )}
+
+        <button
+          onClick={handleReset}
+          disabled={!started}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Reset standup timer"
+        >
+          <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
+          Reset
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/__tests__/standup-engine.test.ts
+++ b/src/lib/__tests__/standup-engine.test.ts
@@ -1,0 +1,496 @@
+import { describe, expect, it } from "vitest";
+import {
+  groupTasksByOwner,
+  identifyBlockers,
+  generateCoachingPrompts,
+  calculateStandupMetrics,
+  formatStandupForSlack,
+  DEFAULT_COACHING_CONFIG,
+} from "@/lib/standup-engine";
+import type {
+  TaskSummary,
+  TeamMember,
+  OwnerGroup,
+  CoachingConfig,
+  WipLimits,
+} from "@/lib/standup-engine";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const alice: TeamMember = { id: "u1", name: "Alice" };
+const bob: TeamMember = { id: "u2", name: "Bob" };
+const carol: TeamMember = { id: "u3", name: "Carol" };
+
+const members: TeamMember[] = [alice, bob, carol];
+
+function task(overrides: Partial<TaskSummary> & { id: string }): TaskSummary {
+  return {
+    title: `Task ${overrides.id}`,
+    status: "in_progress",
+    ownerId: "u1",
+    priority: "medium",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// groupTasksByOwner
+// ---------------------------------------------------------------------------
+
+describe("groupTasksByOwner", () => {
+  it("groups tasks by owner id", () => {
+    const tasks = [
+      task({ id: "t1", ownerId: "u1" }),
+      task({ id: "t2", ownerId: "u2" }),
+      task({ id: "t3", ownerId: "u1" }),
+    ];
+    const groups = groupTasksByOwner(tasks, members);
+    const aliceGroup = groups.find((g) => g.member.id === "u1");
+    expect(aliceGroup).toBeDefined();
+    expect(aliceGroup!.tasks).toHaveLength(2);
+  });
+
+  it("returns members with blocked tasks first", () => {
+    const tasks = [
+      task({ id: "t1", ownerId: "u1", status: "in_progress" }),
+      task({ id: "t2", ownerId: "u2", status: "blocked", blockedReason: "waiting on API" }),
+    ];
+    const groups = groupTasksByOwner(tasks, members);
+    expect(groups[0].member.id).toBe("u2");
+  });
+
+  it("puts unassigned tasks under synthetic Unassigned member", () => {
+    const tasks = [task({ id: "t1", ownerId: "" })];
+    const groups = groupTasksByOwner(tasks, members);
+    expect(groups[0].member.name).toBe("Unassigned");
+  });
+
+  it("counts in-progress and blocked separately", () => {
+    const tasks = [
+      task({ id: "t1", ownerId: "u1", status: "in_progress" }),
+      task({ id: "t2", ownerId: "u1", status: "blocked" }),
+      task({ id: "t3", ownerId: "u1", status: "done" }),
+    ];
+    const groups = groupTasksByOwner(tasks, members);
+    const g = groups.find((g) => g.member.id === "u1")!;
+    expect(g.inProgressCount).toBe(1);
+    expect(g.blockedCount).toBe(1);
+  });
+
+  it("returns empty array when no tasks exist", () => {
+    expect(groupTasksByOwner([], members)).toEqual([]);
+  });
+
+  it("handles unknown owner ids gracefully", () => {
+    const tasks = [task({ id: "t1", ownerId: "unknown-user" })];
+    const groups = groupTasksByOwner(tasks, members);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].member.id).toBe("unknown-user");
+  });
+
+  it("sorts by in-progress count when blocked counts are equal", () => {
+    const tasks = [
+      task({ id: "t1", ownerId: "u1", status: "in_progress" }),
+      task({ id: "t2", ownerId: "u1", status: "in_progress" }),
+      task({ id: "t3", ownerId: "u2", status: "in_progress" }),
+    ];
+    const groups = groupTasksByOwner(tasks, members);
+    expect(groups[0].member.id).toBe("u1"); // 2 in progress > 1
+  });
+
+  it("initialises each group action as started", () => {
+    const tasks = [task({ id: "t1", ownerId: "u1" })];
+    const groups = groupTasksByOwner(tasks, members);
+    expect(groups.every((g) => g.action === "started")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// identifyBlockers
+// ---------------------------------------------------------------------------
+
+describe("identifyBlockers", () => {
+  it("returns only blocked tasks", () => {
+    const tasks = [
+      task({ id: "t1", status: "in_progress" }),
+      task({ id: "t2", status: "blocked", blockedReason: "waiting" }),
+      task({ id: "t3", status: "done" }),
+    ];
+    const blockers = identifyBlockers(tasks);
+    expect(blockers).toHaveLength(1);
+    expect(blockers[0].id).toBe("t2");
+  });
+
+  it("returns empty array when nothing is blocked", () => {
+    const tasks = [task({ id: "t1", status: "in_progress" })];
+    expect(identifyBlockers(tasks)).toEqual([]);
+  });
+
+  it("returns multiple blocked tasks", () => {
+    const tasks = [
+      task({ id: "t1", status: "blocked" }),
+      task({ id: "t2", status: "blocked" }),
+    ];
+    expect(identifyBlockers(tasks)).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateCoachingPrompts
+// ---------------------------------------------------------------------------
+
+describe("generateCoachingPrompts", () => {
+  const now = new Date("2026-02-16T10:00:00Z");
+
+  it("warns when member WIP exceeds per-member limit", () => {
+    const tasks = [
+      task({ id: "t1", ownerId: "u1", status: "in_progress" }),
+      task({ id: "t2", ownerId: "u1", status: "in_progress" }),
+      task({ id: "t3", ownerId: "u1", status: "in_progress" }),
+      task({ id: "t4", ownerId: "u1", status: "in_progress" }),
+    ];
+    const config: CoachingConfig = {
+      ...DEFAULT_COACHING_CONFIG,
+      wipLimits: { perMember: 3, team: 20 },
+    };
+    const prompts = generateCoachingPrompts(tasks, members, config, now);
+    expect(prompts.some((p) => p.type === "wip_exceeded")).toBe(true);
+  });
+
+  it("emits critical when team WIP exceeds team limit", () => {
+    const tasks = Array.from({ length: 5 }, (_, i) =>
+      task({ id: `t${i}`, ownerId: "u1", status: "in_progress" }),
+    );
+    const config: CoachingConfig = {
+      ...DEFAULT_COACHING_CONFIG,
+      wipLimits: { perMember: 10, team: 4 },
+    };
+    const prompts = generateCoachingPrompts(tasks, members, config, now);
+    const teamPrompt = prompts.find((p) => p.type === "finish_first");
+    expect(teamPrompt).toBeDefined();
+    expect(teamPrompt!.severity).toBe("critical");
+  });
+
+  it("flags aging tasks over threshold", () => {
+    const tasks = [
+      task({
+        id: "t1",
+        ownerId: "u1",
+        status: "in_progress",
+        statusChangedAt: "2026-02-10T10:00:00Z",
+      }),
+    ];
+    const config: CoachingConfig = {
+      ...DEFAULT_COACHING_CONFIG,
+      agingThresholdDays: 5,
+    };
+    const prompts = generateCoachingPrompts(tasks, members, config, now);
+    expect(prompts.some((p) => p.type === "aging_task")).toBe(true);
+  });
+
+  it("uses ageDays when provided instead of computing from date", () => {
+    const tasks = [
+      task({
+        id: "t1",
+        ownerId: "u1",
+        status: "in_progress",
+        ageDays: 10,
+      }),
+    ];
+    const config: CoachingConfig = {
+      ...DEFAULT_COACHING_CONFIG,
+      agingThresholdDays: 5,
+    };
+    const prompts = generateCoachingPrompts(tasks, members, config, now);
+    expect(prompts.some((p) => p.type === "aging_task")).toBe(true);
+  });
+
+  it("flags blockers stuck too long", () => {
+    const tasks = [
+      task({
+        id: "t1",
+        ownerId: "u1",
+        status: "blocked",
+        blockedReason: "waiting on vendor",
+        statusChangedAt: "2026-02-13T10:00:00Z",
+      }),
+    ];
+    const config: CoachingConfig = {
+      ...DEFAULT_COACHING_CONFIG,
+      blockedThresholdDays: 2,
+    };
+    const prompts = generateCoachingPrompts(tasks, members, config, now);
+    const bp = prompts.find((p) => p.type === "blocked_too_long");
+    expect(bp).toBeDefined();
+    expect(bp!.severity).toBe("critical");
+  });
+
+  it("suggests defer actions for WIP exceeded", () => {
+    const tasks = [
+      task({ id: "t1", ownerId: "u1", status: "in_progress" }),
+      task({ id: "t2", ownerId: "u1", status: "in_progress" }),
+      task({ id: "t3", ownerId: "u1", status: "in_progress" }),
+      task({ id: "t4", ownerId: "u1", status: "in_progress" }),
+    ];
+    const config: CoachingConfig = {
+      ...DEFAULT_COACHING_CONFIG,
+      wipLimits: { perMember: 3, team: 20 },
+    };
+    const prompts = generateCoachingPrompts(tasks, members, config, now);
+    const wipPrompt = prompts.find((p) => p.type === "wip_exceeded");
+    expect(wipPrompt!.suggestedActions.length).toBeGreaterThan(0);
+    expect(wipPrompt!.suggestedActions[0].kind).toBe("defer");
+  });
+
+  it("suggests split and pair for aging tasks", () => {
+    const tasks = [
+      task({
+        id: "t1",
+        ownerId: "u1",
+        status: "in_progress",
+        ageDays: 10,
+      }),
+    ];
+    const prompts = generateCoachingPrompts(tasks, members, DEFAULT_COACHING_CONFIG, now);
+    const aging = prompts.find((p) => p.type === "aging_task");
+    expect(aging!.suggestedActions.map((a) => a.kind)).toEqual(["split", "pair"]);
+  });
+
+  it("suggests unblock and drop for long-blocked tasks", () => {
+    const tasks = [
+      task({
+        id: "t1",
+        ownerId: "u1",
+        status: "blocked",
+        ageDays: 5,
+      }),
+    ];
+    const prompts = generateCoachingPrompts(tasks, members, DEFAULT_COACHING_CONFIG, now);
+    const bp = prompts.find((p) => p.type === "blocked_too_long");
+    expect(bp!.suggestedActions.map((a) => a.kind)).toEqual(["unblock", "drop"]);
+  });
+
+  it("returns empty prompts when everything is within limits", () => {
+    const tasks = [
+      task({ id: "t1", ownerId: "u1", status: "in_progress" }),
+    ];
+    const prompts = generateCoachingPrompts(tasks, members, DEFAULT_COACHING_CONFIG, now);
+    expect(prompts).toHaveLength(0);
+  });
+
+  it("sorts critical prompts before warnings", () => {
+    const tasks = [
+      // aging (warning)
+      task({ id: "t1", ownerId: "u1", status: "in_progress", ageDays: 10 }),
+      // blocked too long (critical)
+      task({ id: "t2", ownerId: "u2", status: "blocked", ageDays: 5 }),
+    ];
+    const prompts = generateCoachingPrompts(tasks, members, DEFAULT_COACHING_CONFIG, now);
+    expect(prompts.length).toBeGreaterThanOrEqual(2);
+    expect(prompts[0].severity).toBe("critical");
+  });
+
+  it("handles tasks without statusChangedAt or ageDays", () => {
+    const tasks = [
+      task({ id: "t1", ownerId: "u1", status: "in_progress" }),
+    ];
+    const config: CoachingConfig = {
+      ...DEFAULT_COACHING_CONFIG,
+      agingThresholdDays: 0,
+    };
+    // ageDays=0, threshold=0 -> 0 >= 0 -> should flag
+    const prompts = generateCoachingPrompts(tasks, members, config, now);
+    expect(prompts.some((p) => p.type === "aging_task")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculateStandupMetrics
+// ---------------------------------------------------------------------------
+
+describe("calculateStandupMetrics", () => {
+  it("calculates total duration in seconds", () => {
+    const metrics = calculateStandupMetrics({
+      startTime: new Date("2026-02-16T09:00:00Z"),
+      endTime: new Date("2026-02-16T09:15:00Z"),
+      groups: [],
+      coachingPromptsShown: 0,
+    });
+    expect(metrics.totalDurationSeconds).toBe(900);
+  });
+
+  it("computes average seconds per member", () => {
+    const groups: OwnerGroup[] = [
+      { member: alice, tasks: [], inProgressCount: 0, blockedCount: 0, action: "completed" },
+      { member: bob, tasks: [], inProgressCount: 0, blockedCount: 0, action: "completed" },
+    ];
+    const metrics = calculateStandupMetrics({
+      startTime: new Date("2026-02-16T09:00:00Z"),
+      endTime: new Date("2026-02-16T09:10:00Z"),
+      groups,
+      coachingPromptsShown: 0,
+    });
+    expect(metrics.avgSecondsPerMember).toBe(300); // 600 / 2
+  });
+
+  it("sums blocker count across groups", () => {
+    const groups: OwnerGroup[] = [
+      { member: alice, tasks: [task({ id: "t1", status: "blocked" })], inProgressCount: 0, blockedCount: 1, action: "completed" },
+      { member: bob, tasks: [task({ id: "t2", status: "blocked" })], inProgressCount: 0, blockedCount: 1, action: "completed" },
+    ];
+    const metrics = calculateStandupMetrics({
+      startTime: new Date("2026-02-16T09:00:00Z"),
+      endTime: new Date("2026-02-16T09:10:00Z"),
+      groups,
+      coachingPromptsShown: 3,
+    });
+    expect(metrics.blockerCount).toBe(2);
+    expect(metrics.coachingPromptsShown).toBe(3);
+  });
+
+  it("counts total tasks discussed", () => {
+    const groups: OwnerGroup[] = [
+      { member: alice, tasks: [task({ id: "t1" }), task({ id: "t2" })], inProgressCount: 2, blockedCount: 0, action: "completed" },
+      { member: bob, tasks: [task({ id: "t3" })], inProgressCount: 1, blockedCount: 0, action: "completed" },
+    ];
+    const metrics = calculateStandupMetrics({
+      startTime: new Date("2026-02-16T09:00:00Z"),
+      endTime: new Date("2026-02-16T09:05:00Z"),
+      groups,
+      coachingPromptsShown: 0,
+    });
+    expect(metrics.tasksDiscussed).toBe(3);
+  });
+
+  it("handles zero members without dividing by zero", () => {
+    const metrics = calculateStandupMetrics({
+      startTime: new Date("2026-02-16T09:00:00Z"),
+      endTime: new Date("2026-02-16T09:10:00Z"),
+      groups: [],
+      coachingPromptsShown: 0,
+    });
+    expect(metrics.avgSecondsPerMember).toBe(0);
+  });
+
+  it("clamps negative duration to zero", () => {
+    const metrics = calculateStandupMetrics({
+      startTime: new Date("2026-02-16T09:10:00Z"),
+      endTime: new Date("2026-02-16T09:00:00Z"),
+      groups: [],
+      coachingPromptsShown: 0,
+    });
+    expect(metrics.totalDurationSeconds).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatStandupForSlack
+// ---------------------------------------------------------------------------
+
+describe("formatStandupForSlack", () => {
+  it("includes header and duration line", () => {
+    const groups: OwnerGroup[] = [];
+    const metrics = calculateStandupMetrics({
+      startTime: new Date("2026-02-16T09:00:00Z"),
+      endTime: new Date("2026-02-16T09:12:30Z"),
+      groups,
+      coachingPromptsShown: 0,
+    });
+    const text = formatStandupForSlack(groups, metrics, []);
+    expect(text).toContain("Daily Standup Summary");
+    expect(text).toContain("12m 30s");
+  });
+
+  it("lists member names with tasks", () => {
+    const groups: OwnerGroup[] = [
+      {
+        member: alice,
+        tasks: [task({ id: "t1", ownerId: "u1", title: "Fix auth bug" })],
+        inProgressCount: 1,
+        blockedCount: 0,
+        action: "completed",
+      },
+    ];
+    const metrics = calculateStandupMetrics({
+      startTime: new Date("2026-02-16T09:00:00Z"),
+      endTime: new Date("2026-02-16T09:05:00Z"),
+      groups,
+      coachingPromptsShown: 0,
+    });
+    const text = formatStandupForSlack(groups, metrics, []);
+    expect(text).toContain("Alice");
+    expect(text).toContain("Fix auth bug");
+  });
+
+  it("shows blocked tasks with reason", () => {
+    const groups: OwnerGroup[] = [
+      {
+        member: bob,
+        tasks: [
+          task({
+            id: "t1",
+            ownerId: "u2",
+            status: "blocked",
+            title: "Deploy",
+            blockedReason: "CI broken",
+          }),
+        ],
+        inProgressCount: 0,
+        blockedCount: 1,
+        action: "completed",
+      },
+    ];
+    const metrics = calculateStandupMetrics({
+      startTime: new Date("2026-02-16T09:00:00Z"),
+      endTime: new Date("2026-02-16T09:01:00Z"),
+      groups,
+      coachingPromptsShown: 0,
+    });
+    const text = formatStandupForSlack(groups, metrics, []);
+    expect(text).toContain(":red_circle:");
+    expect(text).toContain("CI broken");
+  });
+
+  it("appends coaching notes when prompts are present", () => {
+    const prompts = [
+      {
+        type: "wip_exceeded" as const,
+        severity: "warning" as const,
+        message: "Alice has too many tasks",
+        suggestedActions: [],
+      },
+    ];
+    const text = formatStandupForSlack([], {
+      totalDurationSeconds: 60,
+      memberCount: 0,
+      avgSecondsPerMember: 0,
+      blockerCount: 0,
+      tasksDiscussed: 0,
+      coachingPromptsShown: 1,
+    }, prompts);
+    expect(text).toContain("Coaching Notes");
+    expect(text).toContain("Alice has too many tasks");
+  });
+
+  it("uses correct emoji for skipped members", () => {
+    const groups: OwnerGroup[] = [
+      {
+        member: carol,
+        tasks: [],
+        inProgressCount: 0,
+        blockedCount: 0,
+        action: "skipped",
+      },
+    ];
+    const metrics = calculateStandupMetrics({
+      startTime: new Date("2026-02-16T09:00:00Z"),
+      endTime: new Date("2026-02-16T09:01:00Z"),
+      groups,
+      coachingPromptsShown: 0,
+    });
+    const text = formatStandupForSlack(groups, metrics, []);
+    expect(text).toContain(":fast_forward:");
+  });
+});

--- a/src/lib/standup-engine.ts
+++ b/src/lib/standup-engine.ts
@@ -1,0 +1,335 @@
+// ---------------------------------------------------------------------------
+// Standup Cockpit Engine  (WGX-012)
+// Pure functions for standup grouping, blocker detection, coaching prompts,
+// metrics, and Slack formatting.  Zero side-effects.
+// ---------------------------------------------------------------------------
+
+// ---- Types ----------------------------------------------------------------
+
+export type StandupAction = "started" | "completed" | "skipped";
+
+export interface TeamMember {
+  id: string;
+  name: string;
+  avatarUrl?: string;
+}
+
+export type TaskPriority = "urgent" | "high" | "medium" | "low";
+
+export interface TaskSummary {
+  id: string;
+  title: string;
+  status: "todo" | "in_progress" | "blocked" | "done" | "deferred";
+  ownerId: string;
+  priority: TaskPriority;
+  blockedReason?: string;
+  /** ISO-8601 date string when the task entered its current status */
+  statusChangedAt?: string;
+  /** Number of days the task has been in-progress (computed externally) */
+  ageDays?: number;
+}
+
+export interface WipLimits {
+  /** Max tasks a single member should have in-progress */
+  perMember: number;
+  /** Max tasks the whole team should have in-progress */
+  team: number;
+}
+
+export interface CoachingPrompt {
+  type: "finish_first" | "wip_exceeded" | "aging_task" | "blocked_too_long";
+  severity: "info" | "warning" | "critical";
+  message: string;
+  targetMemberId?: string;
+  targetTaskId?: string;
+  suggestedActions: SuggestedAction[];
+}
+
+export type SuggestedActionKind = "unblock" | "defer" | "split" | "pair" | "drop";
+
+export interface SuggestedAction {
+  kind: SuggestedActionKind;
+  label: string;
+  taskId: string;
+}
+
+export interface StandupMetrics {
+  totalDurationSeconds: number;
+  memberCount: number;
+  avgSecondsPerMember: number;
+  blockerCount: number;
+  tasksDiscussed: number;
+  coachingPromptsShown: number;
+}
+
+export interface OwnerGroup {
+  member: TeamMember;
+  tasks: TaskSummary[];
+  inProgressCount: number;
+  blockedCount: number;
+  action: StandupAction;
+}
+
+export interface CoachingConfig {
+  wipLimits: WipLimits;
+  /** Days after which an in-progress task is considered "aging" */
+  agingThresholdDays: number;
+  /** Days after which a blocker is considered "stuck too long" */
+  blockedThresholdDays: number;
+}
+
+// Default coaching configuration
+export const DEFAULT_COACHING_CONFIG: CoachingConfig = {
+  wipLimits: { perMember: 3, team: 12 },
+  agingThresholdDays: 5,
+  blockedThresholdDays: 2,
+};
+
+// ---- Helpers ---------------------------------------------------------------
+
+function daysBetween(from: string | Date, to: Date): number {
+  const start = typeof from === "string" ? new Date(from) : from;
+  const diffMs = to.getTime() - start.getTime();
+  return Math.max(0, Math.floor(diffMs / (1000 * 60 * 60 * 24)));
+}
+
+// ---- Core Functions -------------------------------------------------------
+
+/**
+ * Group tasks by owner (TeamMember).  Unassigned tasks get grouped under a
+ * synthetic "Unassigned" member.
+ */
+export function groupTasksByOwner(
+  tasks: TaskSummary[],
+  members: TeamMember[],
+): OwnerGroup[] {
+  const memberMap = new Map<string, TeamMember>(members.map((m) => [m.id, m]));
+
+  const groups = new Map<string, TaskSummary[]>();
+
+  for (const task of tasks) {
+    const key = task.ownerId || "__unassigned__";
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(task);
+  }
+
+  const result: OwnerGroup[] = [];
+
+  for (const [ownerId, ownerTasks] of groups) {
+    const member: TeamMember =
+      memberMap.get(ownerId) ?? { id: ownerId, name: "Unassigned" };
+
+    const inProgressCount = ownerTasks.filter(
+      (t) => t.status === "in_progress",
+    ).length;
+    const blockedCount = ownerTasks.filter(
+      (t) => t.status === "blocked",
+    ).length;
+
+    result.push({
+      member,
+      tasks: ownerTasks,
+      inProgressCount,
+      blockedCount,
+      action: "started",
+    });
+  }
+
+  // Sort: blocked owners first, then by number of in-progress tasks desc
+  result.sort((a, b) => {
+    if (a.blockedCount !== b.blockedCount) return b.blockedCount - a.blockedCount;
+    return b.inProgressCount - a.inProgressCount;
+  });
+
+  return result;
+}
+
+/**
+ * Identify all blocked tasks across the team.
+ */
+export function identifyBlockers(tasks: TaskSummary[]): TaskSummary[] {
+  return tasks.filter((t) => t.status === "blocked");
+}
+
+/**
+ * Generate coaching prompts based on WIP limits, aging tasks, and blockers.
+ */
+export function generateCoachingPrompts(
+  tasks: TaskSummary[],
+  members: TeamMember[],
+  config: CoachingConfig = DEFAULT_COACHING_CONFIG,
+  now: Date = new Date(),
+): CoachingPrompt[] {
+  const prompts: CoachingPrompt[] = [];
+
+  // --- Per-member WIP checks ---
+  const memberMap = new Map<string, TeamMember>(members.map((m) => [m.id, m]));
+  const byOwner = new Map<string, TaskSummary[]>();
+  for (const t of tasks) {
+    if (!byOwner.has(t.ownerId)) byOwner.set(t.ownerId, []);
+    byOwner.get(t.ownerId)!.push(t);
+  }
+
+  for (const [ownerId, ownerTasks] of byOwner) {
+    const inProgress = ownerTasks.filter((t) => t.status === "in_progress");
+    const memberName = memberMap.get(ownerId)?.name ?? "Unknown";
+
+    if (inProgress.length > config.wipLimits.perMember) {
+      prompts.push({
+        type: "wip_exceeded",
+        severity: "warning",
+        message: `${memberName} has ${inProgress.length} tasks in progress (limit: ${config.wipLimits.perMember}). Finish one before starting another.`,
+        targetMemberId: ownerId,
+        suggestedActions: inProgress.slice(config.wipLimits.perMember).map((t) => ({
+          kind: "defer" as const,
+          label: `Defer "${t.title}"`,
+          taskId: t.id,
+        })),
+      });
+    }
+  }
+
+  // --- Team-level WIP check ---
+  const teamInProgress = tasks.filter((t) => t.status === "in_progress");
+  if (teamInProgress.length > config.wipLimits.team) {
+    prompts.push({
+      type: "finish_first",
+      severity: "critical",
+      message: `Team WIP is ${teamInProgress.length} (limit: ${config.wipLimits.team}). Focus on finishing before starting new work.`,
+      suggestedActions: teamInProgress.slice(config.wipLimits.team).map((t) => ({
+        kind: "defer" as const,
+        label: `Defer "${t.title}"`,
+        taskId: t.id,
+      })),
+    });
+  }
+
+  // --- Aging tasks ---
+  for (const task of teamInProgress) {
+    const age = task.ageDays ?? (task.statusChangedAt ? daysBetween(task.statusChangedAt, now) : 0);
+    if (age >= config.agingThresholdDays) {
+      prompts.push({
+        type: "aging_task",
+        severity: "warning",
+        message: `"${task.title}" has been in progress for ${age} days. Consider splitting or pairing.`,
+        targetTaskId: task.id,
+        targetMemberId: task.ownerId,
+        suggestedActions: [
+          { kind: "split", label: `Split "${task.title}"`, taskId: task.id },
+          { kind: "pair", label: `Pair on "${task.title}"`, taskId: task.id },
+        ],
+      });
+    }
+  }
+
+  // --- Blocked too long ---
+  const blockedTasks = tasks.filter((t) => t.status === "blocked");
+  for (const task of blockedTasks) {
+    const blockedDays = task.ageDays ?? (task.statusChangedAt ? daysBetween(task.statusChangedAt, now) : 0);
+    if (blockedDays >= config.blockedThresholdDays) {
+      prompts.push({
+        type: "blocked_too_long",
+        severity: "critical",
+        message: `"${task.title}" has been blocked for ${blockedDays} days: ${task.blockedReason ?? "no reason given"}.`,
+        targetTaskId: task.id,
+        targetMemberId: task.ownerId,
+        suggestedActions: [
+          { kind: "unblock", label: `Unblock "${task.title}"`, taskId: task.id },
+          { kind: "drop", label: `Drop "${task.title}"`, taskId: task.id },
+        ],
+      });
+    }
+  }
+
+  // Sort by severity: critical first
+  const severityOrder: Record<string, number> = { critical: 0, warning: 1, info: 2 };
+  prompts.sort(
+    (a, b) => (severityOrder[a.severity] ?? 9) - (severityOrder[b.severity] ?? 9),
+  );
+
+  return prompts;
+}
+
+/**
+ * Calculate standup metrics from timing and task data.
+ */
+export function calculateStandupMetrics(opts: {
+  startTime: Date;
+  endTime: Date;
+  groups: OwnerGroup[];
+  coachingPromptsShown: number;
+}): StandupMetrics {
+  const totalDurationSeconds = Math.max(
+    0,
+    Math.round((opts.endTime.getTime() - opts.startTime.getTime()) / 1000),
+  );
+  const memberCount = opts.groups.length;
+  const avgSecondsPerMember =
+    memberCount > 0 ? Math.round(totalDurationSeconds / memberCount) : 0;
+  const blockerCount = opts.groups.reduce((acc, g) => acc + g.blockedCount, 0);
+  const tasksDiscussed = opts.groups.reduce((acc, g) => acc + g.tasks.length, 0);
+
+  return {
+    totalDurationSeconds,
+    memberCount,
+    avgSecondsPerMember,
+    blockerCount,
+    tasksDiscussed,
+    coachingPromptsShown: opts.coachingPromptsShown,
+  };
+}
+
+/**
+ * Format standup results for posting to Slack.
+ */
+export function formatStandupForSlack(
+  groups: OwnerGroup[],
+  metrics: StandupMetrics,
+  prompts: CoachingPrompt[],
+): string {
+  const lines: string[] = [];
+
+  lines.push(":clipboard: *Daily Standup Summary*");
+  lines.push("");
+
+  const mins = Math.floor(metrics.totalDurationSeconds / 60);
+  const secs = metrics.totalDurationSeconds % 60;
+  lines.push(
+    `*Duration:* ${mins}m ${secs}s | *Members:* ${metrics.memberCount} | *Blockers:* ${metrics.blockerCount}`,
+  );
+  lines.push("");
+
+  for (const group of groups) {
+    const statusEmoji =
+      group.action === "completed" ? ":white_check_mark:" :
+      group.action === "skipped" ? ":fast_forward:" :
+      ":speaking_head_in_silhouette:";
+    lines.push(`${statusEmoji} *${group.member.name}*`);
+
+    for (const task of group.tasks) {
+      const taskEmoji =
+        task.status === "blocked" ? ":red_circle:" :
+        task.status === "in_progress" ? ":large_blue_circle:" :
+        task.status === "done" ? ":white_check_mark:" :
+        task.status === "deferred" ? ":pause_button:" :
+        ":white_circle:";
+      const blockedNote =
+        task.status === "blocked" && task.blockedReason
+          ? ` _(blocked: ${task.blockedReason})_`
+          : "";
+      lines.push(`  ${taskEmoji} ${task.title}${blockedNote}`);
+    }
+    lines.push("");
+  }
+
+  if (prompts.length > 0) {
+    lines.push(":bulb: *Coaching Notes*");
+    for (const p of prompts) {
+      const icon = p.severity === "critical" ? ":rotating_light:" : ":warning:";
+      lines.push(`  ${icon} ${p.message}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary
- Built standup cockpit page at `/standup` with full daily standup workflow
- Added pure-function standup engine with task grouping by owner, blocker detection, configurable coaching prompts, metrics calculation, and Slack formatting
- Created flow coaching prompts that warn when WIP exceeds per-member/team limits, flag aging tasks, and surface stuck blockers with one-click action suggestions (unblock, defer, split, pair, drop)
- Added standup timer with start/pause/reset, color-coded duration warnings, and facilitator mode for screen-share use
- Added per-member cards with expandable task lists, Done/Skip actions, and automatic active-member advancement
- Added post-standup summary with duration, blocker count, tasks discussed, and copy-to-Slack export
- Added "Standup" entry to sidebar navigation

## Test plan
- [x] 33 vitest tests covering all engine functions (groupTasksByOwner, identifyBlockers, generateCoachingPrompts, calculateStandupMetrics, formatStandupForSlack)
- [ ] Manual: navigate to /standup, start timer, walk through members, verify coaching prompts appear
- [ ] Manual: toggle facilitator mode and confirm larger display
- [ ] Manual: complete standup and verify summary + Slack copy

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)