### PR TITLE
WGX-002/WGX-026: replenishment protocol UX + persistent task card actions

### DIFF
--- a/src/components/board/kanban-board.tsx
+++ b/src/components/board/kanban-board.tsx
@@ -65,6 +65,14 @@ interface KanbanSnapshot {
   projects: BoardProjectLite[];
   sprints: SprintSummary[];
   departments: DepartmentSummary[];
+  activeSprintId?: string | null;
+  committedTaskIds?: string[];
+}
+
+interface ReplenishmentNotice {
+  taskId: string;
+  title: string;
+  updatedAt?: string;
 }
 
 export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) {
@@ -99,6 +107,9 @@ export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) 
   >(new Map());
   const [allTasks, setAllTasks] = useState<TaskWithRelations[]>([]);
   const [projectList, setProjectList] = useState<{ id: string; name: string; departmentId: string | null }[]>([]);
+  const [activeSprintId, setActiveSprintId] = useState<string | null>(null);
+  const [committedTaskIds, setCommittedTaskIds] = useState<Set<string>>(new Set());
+  const [replenishmentNotice, setReplenishmentNotice] = useState<ReplenishmentNotice | null>(null);
   const boardCacheKey = useMemo(() => {
     const statusKey = filterByStatus && filterByStatus.length > 0 ? filterByStatus.join(",") : "all";
     return [
@@ -125,6 +136,10 @@ export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) 
       setProjects(projects);
       setSprints(sprints);
       setDepartments(depts);
+      const derivedActiveSprintId =
+        snapshot.activeSprintId ?? sprints.find((s) => s.isActive)?.id ?? null;
+      setActiveSprintId(derivedActiveSprintId);
+      setCommittedTaskIds(new Set(snapshot.committedTaskIds ?? []));
       setAllTasks(tasks);
       setProjectList(
         projects.map((p) => ({
@@ -207,6 +222,19 @@ export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) 
       const projects: BoardProjectLite[] = await projectsRes.json();
       const sprints = await sprintsRes.json();
       const depts: DepartmentSummary[] = deptsRes.ok ? await deptsRes.json() : [];
+      const activeSprint = Array.isArray(sprints)
+        ? (sprints as SprintSummary[]).find((s) => s.isActive)
+        : null;
+
+      let committedTaskIds: string[] = [];
+      if (activeSprint?.id) {
+        const reportRes = await fetch(`/api/sprints/${activeSprint.id}/report`, { signal });
+        if (reportRes.ok) {
+          const report = await reportRes.json();
+          committedTaskIds =
+            report?.plannedVsUnplanned?.commitmentSnapshot?.committedTaskIds ?? [];
+        }
+      }
 
       if (signal?.aborted) return;
 
@@ -217,6 +245,8 @@ export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) 
         projects: Array.isArray(projects) ? projects : [],
         sprints: Array.isArray(sprints) ? (sprints as SprintSummary[]) : [],
         departments: depts,
+        activeSprintId: activeSprint?.id ?? null,
+        committedTaskIds,
       };
 
       applyBoardSnapshot(snapshot);
@@ -517,6 +547,88 @@ export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) 
     openTaskModal(null);
   };
 
+  const queuedTaskCount = useMemo(
+    () => columns.find((column) => column.id === "QUEUED")?.tasks.length ?? 0,
+    [columns]
+  );
+
+  const handleReplenishTask = useCallback(
+    async (task: TaskWithRelations) => {
+      if (task.status !== "BACKLOG") return;
+
+      const queuedLimit = wipLimits.QUEUED;
+      if (queuedLimit > 0 && queuedTaskCount >= queuedLimit) {
+        const proceed = window.confirm(
+          `Queued WIP budget is full (${queuedTaskCount}/${queuedLimit}). Replenish anyway?`
+        );
+        if (!proceed) return;
+      }
+
+      const response = await fetch(`/api/tasks/${task.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          status: "QUEUED",
+          expectedUpdatedAt: task.updatedAt,
+        }),
+      });
+
+      if (!response.ok) {
+        if (response.status === 409) {
+          const conflict = await response.json().catch(() => null);
+          window.alert(
+            conflict?.conflict?.message ||
+              conflict?.error ||
+              "Task changed before replenish was applied. Refreshing board."
+          );
+        } else {
+          window.alert("Failed to replenish task. Please try again.");
+        }
+        void fetchBoard();
+        return;
+      }
+
+      const updated = await response.json().catch(() => null);
+      setReplenishmentNotice({
+        taskId: task.id,
+        title: task.title,
+        updatedAt: updated?.updatedAt,
+      });
+      void fetchBoard();
+    },
+    [fetchBoard, queuedTaskCount, wipLimits.QUEUED]
+  );
+
+  const handleUndoReplenish = useCallback(async () => {
+    if (!replenishmentNotice) return;
+
+    const response = await fetch(`/api/tasks/${replenishmentNotice.taskId}/retreat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(
+        replenishmentNotice.updatedAt
+          ? { expectedUpdatedAt: replenishmentNotice.updatedAt }
+          : {}
+      ),
+    });
+
+    if (!response.ok) {
+      if (response.status === 409) {
+        const conflict = await response.json().catch(() => null);
+        window.alert(
+          conflict?.conflict?.message ||
+            conflict?.error ||
+            "Task changed before undo was applied. Refreshing board."
+        );
+      } else {
+        window.alert("Failed to undo replenish action.");
+      }
+    }
+
+    setReplenishmentNotice(null);
+    void fetchBoard();
+  }, [fetchBoard, replenishmentNotice]);
+
   if (loading) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -588,6 +700,27 @@ export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) 
           New Task
         </button>
       </div>
+      {replenishmentNotice && (
+        <div className="mx-4 mb-3 flex flex-wrap items-center justify-between gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs">
+          <span className="text-emerald-700">
+            Replenished <strong>{replenishmentNotice.title}</strong> to Queued. Logged in status history.
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleUndoReplenish}
+              className="rounded border border-emerald-600/40 px-2 py-0.5 font-medium text-emerald-700 hover:bg-emerald-500/20"
+            >
+              Undo
+            </button>
+            <button
+              onClick={() => setReplenishmentNotice(null)}
+              className="rounded px-2 py-0.5 text-emerald-700 hover:bg-emerald-500/20"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
 
       <div className="px-4 pb-4">
         <DragDropContext onDragEnd={handleDragEnd}>
@@ -606,6 +739,12 @@ export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) 
                   onSelectTask={setSelectedTaskId}
                   groupBy="status"
                   getDeptForTask={getDeptForTask}
+                  currentUserId={session?.user?.id ?? null}
+                  activeSprintId={activeSprintId}
+                  committedTaskIds={committedTaskIds}
+                  queuedCount={queuedTaskCount}
+                  queuedWipLimit={wipLimits.QUEUED}
+                  onReplenishTask={handleReplenishTask}
                 />
               ))}
             </div>
@@ -668,6 +807,12 @@ export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) 
                       droppableIdPrefix={`proj-${col.id}:`}
                       getDeptForTask={getDeptForTask}
                       hideHeader
+                      currentUserId={session?.user?.id ?? null}
+                      activeSprintId={activeSprintId}
+                      committedTaskIds={committedTaskIds}
+                      queuedCount={queuedTaskCount}
+                      queuedWipLimit={wipLimits.QUEUED}
+                      onReplenishTask={handleReplenishTask}
                     />
                   </div>
                 );
@@ -719,6 +864,12 @@ export function KanbanBoard({ filterByUser, filterByStatus }: KanbanBoardProps) 
                     droppableIdPrefix={`dept-${col.id}:`}
                     getDeptForTask={getDeptForTask}
                     hideHeader
+                    currentUserId={session?.user?.id ?? null}
+                    activeSprintId={activeSprintId}
+                    committedTaskIds={committedTaskIds}
+                    queuedCount={queuedTaskCount}
+                    queuedWipLimit={wipLimits.QUEUED}
+                    onReplenishTask={handleReplenishTask}
                   />
                 </div>
               ))}

--- a/src/components/board/kanban-column.tsx
+++ b/src/components/board/kanban-column.tsx
@@ -3,7 +3,7 @@
 import { Droppable } from "@hello-pangea/dnd";
 import { clsx } from "clsx";
 import { TaskCard, type GroupByMode } from "./task-card";
-import type { BoardColumn, TaskWithRelations } from "@/types";
+import type { BoardColumn, Priority, TaskWithRelations } from "@/types";
 
 interface KanbanColumnProps {
   column: BoardColumn;
@@ -20,6 +20,12 @@ interface KanbanColumnProps {
   droppableIdPrefix?: string;
   getDeptForTask?: (task: TaskWithRelations) => { name: string; color: string | null } | null;
   hideHeader?: boolean;
+  currentUserId?: string | null;
+  activeSprintId?: string | null;
+  committedTaskIds?: Set<string>;
+  queuedCount?: number;
+  queuedWipLimit?: number;
+  onReplenishTask?: (task: TaskWithRelations) => Promise<void>;
 }
 
 export function KanbanColumn({
@@ -37,10 +43,53 @@ export function KanbanColumn({
   droppableIdPrefix = "",
   getDeptForTask,
   hideHeader = false,
+  currentUserId = null,
+  activeSprintId = null,
+  committedTaskIds = new Set<string>(),
+  queuedCount = 0,
+  queuedWipLimit = 0,
+  onReplenishTask,
 }: KanbanColumnProps) {
   const isOverLimit = wipLimit > 0 && column.tasks.length > wipLimit;
   const isAtLimit = wipLimit > 0 && column.tasks.length === wipLimit;
   const isCompact = displayPreset !== "standard";
+  const queuedBudgetExceeded =
+    queuedWipLimit > 0 && queuedCount >= queuedWipLimit;
+
+  const nextPriority = (current: Priority): Priority => {
+    const order: Priority[] = ["P3", "P2", "P1", "P0"];
+    const index = order.indexOf(current);
+    return order[(index + 1) % order.length];
+  };
+
+  const patchTask = async (
+    task: TaskWithRelations,
+    payload: Record<string, unknown>,
+    conflictFallbackMessage: string
+  ): Promise<boolean> => {
+    const response = await fetch(`/api/tasks/${task.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...payload,
+        expectedUpdatedAt: task.updatedAt,
+      }),
+    });
+    if (!response.ok) {
+      if (response.status === 409) {
+        const conflict = await response.json().catch(() => null);
+        window.alert(
+          conflict?.conflict?.message ||
+            conflict?.error ||
+            conflictFallbackMessage
+        );
+      } else {
+        window.alert("Task update failed. Please try again.");
+      }
+      return false;
+    }
+    return true;
+  };
 
   return (
     <div
@@ -108,6 +157,20 @@ export function KanbanColumn({
           >
             {column.tasks.map((task, index) => {
               const taskDept = getDeptForTask ? getDeptForTask(task) : null;
+              const commitmentState =
+                activeSprintId && task.sprintId === activeSprintId
+                  ? committedTaskIds.has(task.id)
+                    ? "committed"
+                    : "opportunistic"
+                  : null;
+              const isAssignedToMe = Boolean(
+                currentUserId &&
+                  task.responsible?.some((member) => member.id === currentUserId)
+              );
+              const replenishWarning =
+                task.status === "BACKLOG" && queuedBudgetExceeded
+                  ? `Queued WIP budget is full (${queuedCount}/${queuedWipLimit}).`
+                  : null;
               return (
               <TaskCard
                 key={task.id}
@@ -121,7 +184,14 @@ export function KanbanColumn({
                 groupBy={groupBy}
                 departmentName={departmentName || taskDept?.name}
                 departmentColor={departmentColor || taskDept?.color}
+                commitmentState={commitmentState}
+                isAssignedToMe={isAssignedToMe}
+                replenishWarning={replenishWarning}
                 onAdvance={async () => {
+                  if (task.status === "BACKLOG" && onReplenishTask) {
+                    await onReplenishTask(task);
+                    return;
+                  }
                   const response = await fetch(`/api/tasks/${task.id}/advance`, {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
@@ -139,6 +209,13 @@ export function KanbanColumn({
                   }
                   onRefresh();
                 }}
+                onReplenish={
+                  onReplenishTask
+                    ? async () => {
+                        await onReplenishTask(task);
+                      }
+                    : undefined
+                }
                 onRetreat={async () => {
                   const response = await fetch(`/api/tasks/${task.id}/retreat`, {
                     method: "POST",
@@ -156,6 +233,42 @@ export function KanbanColumn({
                     );
                   }
                   onRefresh();
+                }}
+                onAssignToMe={
+                  currentUserId
+                    ? async () => {
+                        if (isAssignedToMe) return;
+                        const currentResponsible =
+                          task.responsible?.map((member) => member.id) ?? [];
+                        const ok = await patchTask(
+                          task,
+                          {
+                            responsibleIds: Array.from(
+                              new Set([...currentResponsible, currentUserId])
+                            ),
+                          },
+                          "Task changed before assignment was applied. Refreshing board."
+                        );
+                        if (ok) onRefresh();
+                      }
+                    : undefined
+                }
+                onCyclePriority={async () => {
+                  const ok = await patchTask(
+                    task,
+                    { priority: nextPriority(task.priority) },
+                    "Task changed before priority update was applied. Refreshing board."
+                  );
+                  if (ok) onRefresh();
+                }}
+                onComplete={async () => {
+                  if (task.status === "DONE") return;
+                  const ok = await patchTask(
+                    task,
+                    { status: "DONE" },
+                    "Task changed before completion was applied. Refreshing board."
+                  );
+                  if (ok) onRefresh();
                 }}
                 onDelete={async () => {
                   const confirmed = window.confirm(

--- a/src/components/board/task-card.tsx
+++ b/src/components/board/task-card.tsx
@@ -13,6 +13,9 @@ import {
   MoreHorizontal,
   Pencil,
   Trash2,
+  Check,
+  Flag,
+  UserPlus,
 } from "lucide-react";
 import type { TaskWithRelations } from "@/types";
 import {
@@ -33,6 +36,10 @@ interface TaskCardProps {
   onClick: () => void;
   onAdvance: () => void;
   onRetreat?: () => void;
+  onReplenish?: () => void;
+  onAssignToMe?: () => void;
+  onCyclePriority?: () => void;
+  onComplete?: () => void;
   onDelete: () => void;
   displayPreset: "standard" | "dense" | "triage";
   showMetadata: boolean;
@@ -41,6 +48,9 @@ interface TaskCardProps {
   groupBy?: GroupByMode;
   departmentName?: string | null;
   departmentColor?: string | null;
+  commitmentState?: "committed" | "opportunistic" | null;
+  isAssignedToMe?: boolean;
+  replenishWarning?: string | null;
 }
 
 export function TaskCard({
@@ -49,6 +59,10 @@ export function TaskCard({
   onClick,
   onAdvance,
   onRetreat,
+  onReplenish,
+  onAssignToMe,
+  onCyclePriority,
+  onComplete,
   onDelete,
   displayPreset,
   showMetadata,
@@ -57,6 +71,9 @@ export function TaskCard({
   groupBy = "status",
   departmentName,
   departmentColor,
+  commitmentState = null,
+  isAssignedToMe = false,
+  replenishWarning = null,
 }: TaskCardProps) {
   const colIdx = COLUMN_ORDER.indexOf(task.status);
   const canRetreat = colIdx > 0;
@@ -142,6 +159,23 @@ export function TaskCard({
             >
               {task.title}
             </h4>
+            {commitmentState && (
+              <span
+                className={clsx(
+                  "mt-0.5 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+                  commitmentState === "committed"
+                    ? "bg-emerald-500/15 text-emerald-600"
+                    : "bg-amber-500/15 text-amber-700"
+                )}
+                title={
+                  commitmentState === "committed"
+                    ? "Committed sprint work"
+                    : "Opportunistic sprint work"
+                }
+              >
+                {commitmentState === "committed" ? "Committed" : "Opportunistic"}
+              </span>
+            )}
             {displayPreset !== "standard" && (
               <button
                 onClick={(e) => {
@@ -241,17 +275,6 @@ export function TaskCard({
 
             {/* Action buttons — visible on hover */}
             <div className="flex items-center gap-0.5">
-              {/* Edit button */}
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onClick();
-                }}
-                className="rounded p-0.5 text-muted-foreground opacity-0 hover:bg-tag-bg hover:text-foreground group-hover:opacity-100"
-                title="Edit task"
-              >
-                <Pencil className="h-3.5 w-3.5" />
-              </button>
               {/* Retreat button */}
               {canRetreat && (
                 <button
@@ -266,7 +289,7 @@ export function TaskCard({
                 </button>
               )}
               {/* Advance button */}
-              {canAdvance && (
+              {canAdvance && task.status !== "BACKLOG" && (
                 <button
                   onClick={(e) => {
                     e.stopPropagation();
@@ -278,17 +301,6 @@ export function TaskCard({
                   <ChevronRight className="h-4 w-4" />
                 </button>
               )}
-              {/* Delete button */}
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDelete();
-                }}
-                className="rounded p-0.5 text-muted-foreground opacity-0 hover:bg-red-500/10 hover:text-red-500 group-hover:opacity-100"
-                title="Delete task"
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-              </button>
             </div>
           </div>
 
@@ -298,6 +310,122 @@ export function TaskCard({
               Due {new Date(task.dueDate).toLocaleDateString()}
             </div>
           )}
+
+          {/* Persistent footer actions */}
+          <div
+            className={clsx(
+              "mt-2 flex items-center justify-between gap-1 border-t border-border/60 pt-1.5",
+              isCompact && "gap-0.5"
+            )}
+          >
+            <div className="flex items-center gap-1">
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onClick();
+                }}
+                className="rounded px-1.5 py-1 text-[11px] text-muted-foreground hover:bg-tag-bg hover:text-foreground"
+                title="Edit task"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </button>
+              {onAssignToMe && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAssignToMe();
+                  }}
+                  className={clsx(
+                    "rounded px-1.5 py-1 text-[11px] text-muted-foreground hover:bg-tag-bg hover:text-foreground",
+                    isAssignedToMe && "text-primary"
+                  )}
+                  title={isAssignedToMe ? "Already assigned to you" : "Assign to me"}
+                >
+                  <UserPlus className="h-3.5 w-3.5" />
+                </button>
+              )}
+              {onCyclePriority && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onCyclePriority();
+                  }}
+                  className="rounded px-1.5 py-1 text-[11px] text-muted-foreground hover:bg-tag-bg hover:text-foreground"
+                  title={`Cycle priority (current: ${task.priority})`}
+                >
+                  <Flag className="h-3.5 w-3.5" />
+                </button>
+              )}
+            </div>
+
+            <div className="flex items-center gap-1">
+              {task.status === "BACKLOG" && onReplenish && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onReplenish();
+                  }}
+                  className={clsx(
+                    "action-btn-advance rounded px-1.5 py-1 text-[11px]",
+                    replenishWarning && "text-amber-600"
+                  )}
+                  title={replenishWarning || "Replenish to Queued"}
+                >
+                  {replenishWarning ? (
+                    <AlertTriangle className="h-3.5 w-3.5" />
+                  ) : (
+                    <ChevronRight className="h-3.5 w-3.5" />
+                  )}
+                </button>
+              )}
+              {canRetreat && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRetreat?.();
+                  }}
+                  className="action-btn-retreat rounded px-1.5 py-1 text-[11px]"
+                  title="Move back"
+                >
+                  <ChevronLeft className="h-3.5 w-3.5" />
+                </button>
+              )}
+              {canAdvance && task.status !== "BACKLOG" && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAdvance();
+                  }}
+                  className="action-btn-advance rounded px-1.5 py-1 text-[11px]"
+                  title="Advance status"
+                >
+                  <ChevronRight className="h-3.5 w-3.5" />
+                </button>
+              )}
+              {task.status !== "DONE" && onComplete && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onComplete();
+                  }}
+                  className="rounded px-1.5 py-1 text-[11px] text-muted-foreground hover:bg-tag-bg hover:text-foreground"
+                  title="Mark done"
+                >
+                  <Check className="h-3.5 w-3.5" />
+                </button>
+              )}
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete();
+                }}
+                className="rounded px-1.5 py-1 text-[11px] text-muted-foreground hover:bg-red-500/10 hover:text-red-500"
+                title="Delete task"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </Draggable>


### PR DESCRIPTION
## Summary\n- add explicit **Replenish** action for BACKLOG -> QUEUED with queued WIP budget warning\n- add reversible replenish UX via board banner with **Undo** action\n- load active sprint commitment snapshot and mark tasks as **Committed** vs **Opportunistic**\n- add persistent footer action row on every task card (edit, assign-to-me, quick priority cycle, done, move, delete)\n- keep quick actions stopPropagation-safe so card click/modal behavior remains intact\n\n## Why\nImplements remaining frontend kanban tickets for commitment/replenishment and card action ergonomics.\n\n## Validation\n- 
> app@0.1.0 test
> vitest run src/lib/__tests__/policy-engine.test.ts


 RUN  v4.0.18 /private/tmp/wgx-remaining

 ✓ src/lib/__tests__/policy-engine.test.ts (15 tests) 3ms

 Test Files  1 passed (1)
      Tests  15 passed (15)
   Start at  01:51:35
   Duration  173ms (transform 24ms, setup 0ms, import 31ms, tests 3ms, environment 0ms)\n- 
> app@0.1.0 lint
> eslint


/private/tmp/wgx-remaining/src/app/(dashboard)/standup/page.tsx
  120:5  warning  Unused eslint-disable directive (no problems were reported from 'no-console')

/private/tmp/wgx-remaining/src/app/api/ops/oncall-dashboard/route.ts
  13:32  warning  'getAllRunbooks' is defined but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/app/api/projects/route.ts
  43:22  warning  '_tasks' is assigned a value but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/components/analytics/lifecycle-funnel-panel.tsx
  8:3  warning  'LifecycleStage' is defined but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/components/analytics/sales-funnel-tab.tsx
  5:3  warning  'XCircle' is defined but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/components/projects/project-detail.tsx
   18:3  warning  'Trash2' is defined but never used                                                                          @typescript-eslint/no-unused-vars
  532:5  warning  React Hook useCallback has a missing dependency: 'toast'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
  615:9  warning  'statusColor' is assigned a value but never used                                                            @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/components/tasks/task-modal.tsx
  308:5  warning  Unused eslint-disable directive (no problems were reported from 'jsx-a11y/click-events-have-key-events' or 'jsx-a11y/no-static-element-interactions')
  310:8  warning  Unused eslint-disable directive (no problems were reported from 'jsx-a11y/click-events-have-key-events' or 'jsx-a11y/no-static-element-interactions')

/private/tmp/wgx-remaining/src/components/whip/scope-timeline.tsx
   4:15  warning  'DailyDelta' is defined but never used                                                                                                                                                       @typescript-eslint/no-unused-vars
  25:9   warning  The 'deltas' logical expression could make the dependencies of useMemo Hook (at line 34) change on every render. To fix this, wrap the initialization of 'deltas' in its own useMemo() Hook  react-hooks/exhaustive-deps

/private/tmp/wgx-remaining/src/lib/__tests__/coda-migration.test.ts
  603:9  warning  'config' is assigned a value but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/__tests__/hubspot-sync.test.ts
   14:8   warning  'HubSpotWebhookEvent' is defined but never used    @typescript-eslint/no-unused-vars
   15:8   warning  'ParsedDealStageChange' is defined but never used  @typescript-eslint/no-unused-vars
   16:8   warning  'ReconciliationInput' is defined but never used    @typescript-eslint/no-unused-vars
   18:8   warning  'DriftDetectionInput' is defined but never used    @typescript-eslint/no-unused-vars
  699:13  warning  'BACKLOG' is assigned a value but never used       @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/__tests__/mobile-responsive.test.ts
   2:44  warning  'vi' is defined but never used                @typescript-eslint/no-unused-vars
   7:8   warning  'Breakpoint' is defined but never used        @typescript-eslint/no-unused-vars
   8:8   warning  'CardSize' is defined but never used          @typescript-eslint/no-unused-vars
   9:8   warning  'ColumnLayout' is defined but never used      @typescript-eslint/no-unused-vars
  18:8   warning  'SwipeDirection' is defined but never used    @typescript-eslint/no-unused-vars
  19:8   warning  'TouchGesture' is defined but never used      @typescript-eslint/no-unused-vars
  28:8   warning  'ConflictType' is defined but never used      @typescript-eslint/no-unused-vars
  29:8   warning  'ConflictStrategy' is defined but never used  @typescript-eslint/no-unused-vars
  37:8   warning  'SyncResult' is defined but never used        @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/__tests__/observability-slos.test.ts
  47:8   warning  'SystemComponentHealth' is defined but never used  @typescript-eslint/no-unused-vars
  51:39  warning  'ObservabilitySlo' is defined but never used       @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/__tests__/outbox-event-bus.test.ts
    8:3   warning  'DomainEventType' is defined but never used         @typescript-eslint/no-unused-vars
    9:3   warning  'HandlerRegistry' is defined but never used         @typescript-eslint/no-unused-vars
  236:11  warning  'findCallCount' is assigned a value but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/__tests__/release-train.test.ts
  28:3  warning  'getPromotionBlockers' is defined but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/__tests__/sprint-commitment-ledger.test.ts
  6:8  warning  'CommitmentChange' is defined but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/__tests__/standup-engine.test.ts
  15:3  warning  'WipLimits' is defined but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/analytics/fetchers-ads.ts
  131:17  warning  'totalCostPerConversion' is assigned a value but never used  @typescript-eslint/no-unused-vars
  132:17  warning  'campaignCount' is assigned a value but never used           @typescript-eslint/no-unused-vars
  147:16  warning  'e' is defined but never used                                @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/analytics/fetchers.ts
  146:11  warning  'thirtyDaysAgo' is assigned a value but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/analytics/snapshots.ts
  33:10  warning  'asRecord' is defined but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/automations/runtime.ts
  15:8  warning  'WorkflowExecutionContext' is defined but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/class-of-service.ts
  15:3  warning  'Calendar' is defined but never used  @typescript-eslint/no-unused-vars
  16:3  warning  'Zap' is defined but never used       @typescript-eslint/no-unused-vars
  17:3  warning  'Clock' is defined but never used     @typescript-eslint/no-unused-vars
  18:3  warning  'Wrench' is defined but never used    @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/hierarchy-engine.ts
  66:9  warning  'originalParentId' is assigned a value but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/integrations/hubspot-sync.ts
   35:7  warning  'HUBSPOT_SIGNATURE_HEADER_V3' is assigned a value but never used  @typescript-eslint/no-unused-vars
   36:7  warning  'HUBSPOT_TIMESTAMP_HEADER' is assigned a value but never used     @typescript-eslint/no-unused-vars
  282:9  warning  'conflict' is assigned a value but never used                     @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/integrations/slack-notifications.ts
  16:3  warning  'Prisma' is defined but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/integrations/slack-task-creation.ts
  206:28  warning  'priority' is defined but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/migration/reconciliation.ts
  16:10  warning  'computeContentHash' is defined but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/observability/breach-detector.ts
  13:15  warning  'ObservabilitySlo' is defined but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/performance/websocket-resilience.ts
  264:3  warning  'rand' is defined but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/qa/__tests__/quality-gate.test.ts
  5:3  warning  'formatGateReport' is defined but never used  @typescript-eslint/no-unused-vars

/private/tmp/wgx-remaining/src/lib/raci-inheritance.ts
  56:6  warning  'RaciRole' is defined but never used  @typescript-eslint/no-unused-vars

✖ 56 problems (0 errors, 56 warnings)
  0 errors and 3 warnings potentially fixable with the `--fix` option. (passes with pre-existing warnings only)\n- 
> app@0.1.0 prebuild
> npm run db:generate


> app@0.1.0 db:generate
> prisma generate --schema prisma/schema.prisma


✔ Generated Prisma Client (7.4.0) to ./src/generated/prisma in 196ms


> app@0.1.0 build
> next build

▲ Next.js 16.1.6 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 3.6s
  Running TypeScript ...
  Collecting page data using 13 workers ...
  Generating static pages using 13 workers (0/21) ...
  Generating static pages using 13 workers (5/21) 
  Generating static pages using 13 workers (10/21) 
  Generating static pages using 13 workers (15/21) 
✓ Generating static pages using 13 workers (21/21) in 197.7ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /analytics
├ ƒ /analytics/[section]
├ ƒ /api/analytics
├ ƒ /api/analytics/decision-dashboard
├ ƒ /api/analytics/refresh
├ ƒ /api/analytics/summary
├ ƒ /api/auth/[...nextauth]
├ ƒ /api/automations
├ ƒ /api/automations/[id]
├ ƒ /api/automations/[id]/publish
├ ƒ /api/automations/[id]/runs
├ ƒ /api/automations/[id]/test-run
├ ƒ /api/automations/approvals
├ ƒ /api/automations/approvals/[approvalId]/approve
├ ƒ /api/automations/approvals/[approvalId]/reject
├ ƒ /api/automations/dispatch
├ ƒ /api/automations/ingest/[provider]
├ ƒ /api/automations/runs/[runId]
├ ƒ /api/board-settings
├ ƒ /api/dashboard
├ ƒ /api/dashboard/personalized
├ ƒ /api/departments
├ ƒ /api/departments/[id]
├ ƒ /api/dev/users
├ ƒ /api/events
├ ƒ /api/events/dashboard
├ ƒ /api/events/replay
├ ƒ /api/flow/metrics
├ ƒ /api/flow/risk
├ ƒ /api/hierarchy
├ ƒ /api/integrations
├ ƒ /api/integrations/[provider]
├ ƒ /api/integrations/callback/[provider]
├ ƒ /api/integrations/coda/decision-actions
├ ƒ /api/integrations/coda/dependency-gates
├ ƒ /api/integrations/coda/row-sync
├ ƒ /api/integrations/coda/token
├ ƒ /api/integrations/connect/[provider]
├ ƒ /api/integrations/google-workspace/calendar-followup
├ ƒ /api/integrations/google-workspace/drive-comment-escalation
├ ƒ /api/integrations/google-workspace/gmail-capture
├ ƒ /api/integrations/hubspot/bidirectional-sync
├ ƒ /api/integrations/hubspot/customer-signals
├ ƒ /api/integrations/hubspot/risk-intervention
├ ƒ /api/integrations/hubspot/stage-checklist
├ ƒ /api/integrations/hubspot/sync
├ ƒ /api/integrations/hubspot/webhook
├ ƒ /api/integrations/slack/channel-routing
├ ƒ /api/integrations/slack/events
├ ƒ /api/integrations/slack/notifications
├ ƒ /api/integrations/slack/status-sync
├ ƒ /api/integrations/slack/task-create
├ ƒ /api/integrations/slack/thread-capture
├ ƒ /api/integrations/slack/unanswered-requests
├ ƒ /api/logbook
├ ƒ /api/migration/coda
├ ƒ /api/ops/observability
├ ƒ /api/ops/oncall-dashboard
├ ƒ /api/policy
├ ƒ /api/policy/audit
├ ƒ /api/policy/override
├ ƒ /api/priorities
├ ƒ /api/priorities/[id]
├ ƒ /api/profile
├ ƒ /api/projects
├ ƒ /api/projects/[id]
├ ƒ /api/release/status
├ ƒ /api/security/audit
├ ƒ /api/sprints
├ ƒ /api/sprints/[id]
├ ƒ /api/sprints/[id]/commit
├ ƒ /api/sprints/[id]/commitment-log
├ ƒ /api/sprints/[id]/planned-vs-unplanned
├ ƒ /api/sprints/[id]/planning-session
├ ƒ /api/sprints/[id]/report
├ ƒ /api/sprints/unplanned-reasons
├ ƒ /api/tasks
├ ƒ /api/tasks/[id]
├ ƒ /api/tasks/[id]/advance
├ ƒ /api/tasks/[id]/retreat
├ ƒ /api/tasks/reorder
├ ƒ /api/team
├ ƒ /api/team/invite
├ ƒ /api/ui/preferences
├ ƒ /api/views
├ ƒ /api/views/[id]
├ ○ /automations
├ ƒ /automations/[id]
├ ƒ /automations/[id]/runs
├ ○ /automations/approvals
├ ○ /board
├ ○ /dashboard
├ ○ /logbook
├ ○ /login
├ ○ /my-tasks
├ ○ /projects
├ ƒ /projects/[id]
├ ○ /settings
├ ○ /standup
├ ○ /table
├ ○ /tasks
├ ○ /today
└ ○ /whip

Route (pages)
─ ƒ /api/socketio

○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand\n\nCloses #2\nCloses #36