### PR TITLE
Restore sub-dashboards, customer journey, and standup hub

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "prisma": "^7.4.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "recharts": "^3.7.0",
         "socket.io": "^4.8.3",
         "socket.io-client": "^4.8.3",
         "zustand": "^5.0.11"
@@ -2356,6 +2357,42 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
@@ -2723,6 +2760,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -3143,6 +3186,69 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
@@ -4727,6 +4833,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -4834,6 +5061,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-is": {
@@ -5353,6 +5586,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -5851,6 +6094,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -6522,6 +6771,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6562,6 +6821,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -8732,7 +9000,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {
@@ -8771,11 +9038,50 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
+      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -8845,6 +9151,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -10086,6 +10398,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "prisma": "^7.4.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "recharts": "^3.7.0",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3",
     "zustand": "^5.0.11"

--- a/src/app/(dashboard)/analytics/ai-insights/page.tsx
+++ b/src/app/(dashboard)/analytics/ai-insights/page.tsx
@@ -1,0 +1,5 @@
+import { AiInsightsPage } from "@/components/analytics/ai-insights-page";
+
+export default function Page() {
+  return <AiInsightsPage />;
+}

--- a/src/app/(dashboard)/analytics/customer-journey/page.tsx
+++ b/src/app/(dashboard)/analytics/customer-journey/page.tsx
@@ -1,0 +1,5 @@
+import { CustomerJourneyPage } from "@/components/analytics/customer-journey-page";
+
+export default function Page() {
+  return <CustomerJourneyPage />;
+}

--- a/src/app/(dashboard)/standup/page.tsx
+++ b/src/app/(dashboard)/standup/page.tsx
@@ -1,5 +1,202 @@
-import { redirect } from "next/navigation";
+"use client";
 
-export default function StandupCompatibilityRoute() {
-  redirect("/today");
+import { useCallback, useMemo, useRef, useState } from "react";
+import { clsx } from "clsx";
+import { Monitor, MonitorOff } from "lucide-react";
+
+import { StandupTimer } from "@/components/standup/standup-timer";
+import { FlowCoachingPromptPanel } from "@/components/standup/flow-coaching-prompt";
+import { StandupMemberCard } from "@/components/standup/standup-member-card";
+import { StandupSummary } from "@/components/standup/standup-summary";
+import {
+  groupTasksByOwner,
+  generateCoachingPrompts,
+  calculateStandupMetrics,
+  formatStandupForSlack,
+  DEFAULT_COACHING_CONFIG,
+} from "@/lib/standup-engine";
+import type {
+  StandupAction,
+  StandupMetrics,
+  OwnerGroup,
+  TeamMember,
+  TaskSummary,
+  SuggestedAction,
+  CoachingPrompt,
+} from "@/lib/standup-engine";
+
+// ---------------------------------------------------------------------------
+// Demo data  (replace with real API / SWR hook once backend is wired)
+// ---------------------------------------------------------------------------
+
+const DEMO_MEMBERS: TeamMember[] = [
+  { id: "u1", name: "Alice Chen" },
+  { id: "u2", name: "Bob Park" },
+  { id: "u3", name: "Carol Rivera" },
+  { id: "u4", name: "Dan Kim" },
+];
+
+const DEMO_TASKS: TaskSummary[] = [
+  { id: "t1", title: "Migrate auth to NextAuth v5", status: "in_progress", ownerId: "u1", priority: "high", ageDays: 3 },
+  { id: "t2", title: "Fix Safari layout bug", status: "in_progress", ownerId: "u1", priority: "medium", ageDays: 1 },
+  { id: "t3", title: "Write integration tests for billing", status: "in_progress", ownerId: "u1", priority: "medium", ageDays: 6 },
+  { id: "t4", title: "Design onboarding flow v2", status: "in_progress", ownerId: "u1", priority: "low" },
+  { id: "t5", title: "API rate-limiter middleware", status: "blocked", ownerId: "u2", priority: "high", blockedReason: "Waiting on infra team", ageDays: 4 },
+  { id: "t6", title: "Dashboard performance audit", status: "in_progress", ownerId: "u2", priority: "medium" },
+  { id: "t7", title: "Update Stripe webhook handler", status: "done", ownerId: "u3", priority: "high" },
+  { id: "t8", title: "Customer export CSV feature", status: "in_progress", ownerId: "u3", priority: "medium" },
+  { id: "t9", title: "Docs: API authentication guide", status: "todo", ownerId: "u4", priority: "low" },
+  { id: "t10", title: "Set up staging environment", status: "in_progress", ownerId: "u4", priority: "high", ageDays: 8 },
+];
+
+// ---------------------------------------------------------------------------
+// Page Component
+// ---------------------------------------------------------------------------
+
+export default function StandupPage() {
+  const [facilitatorMode, setFacilitatorMode] = useState(false);
+  const [activeMemberId, setActiveMemberId] = useState<string | null>(null);
+  const [metrics, setMetrics] = useState<StandupMetrics | null>(null);
+  const [slackMessage, setSlackMessage] = useState<string>("");
+  const startTimeRef = useRef<Date | null>(null);
+
+  // Mutable group actions tracked via state
+  const [groupActions, setGroupActions] = useState<Record<string, StandupAction>>({});
+
+  const groups: OwnerGroup[] = useMemo(() => {
+    const base = groupTasksByOwner(DEMO_TASKS, DEMO_MEMBERS);
+    return base.map((g) => ({
+      ...g,
+      action: groupActions[g.member.id] ?? g.action,
+    }));
+  }, [groupActions]);
+
+  const prompts: CoachingPrompt[] = useMemo(
+    () => generateCoachingPrompts(DEMO_TASKS, DEMO_MEMBERS, DEFAULT_COACHING_CONFIG),
+    [],
+  );
+
+  // --- Handlers ---
+
+  const handleTimerStart = useCallback(() => {
+    startTimeRef.current = new Date();
+    if (groups.length > 0) setActiveMemberId(groups[0].member.id);
+  }, [groups]);
+
+  const handleTimerStop = useCallback(
+    (elapsedSeconds: number) => {
+      const endTime = new Date();
+      const startTime = startTimeRef.current ?? new Date(endTime.getTime() - elapsedSeconds * 1000);
+      const m = calculateStandupMetrics({
+        startTime,
+        endTime,
+        groups,
+        coachingPromptsShown: prompts.length,
+      });
+      setMetrics(m);
+      setSlackMessage(formatStandupForSlack(groups, m, prompts));
+      setActiveMemberId(null);
+    },
+    [groups, prompts],
+  );
+
+  const handleMemberAction = useCallback(
+    (memberId: string, action: StandupAction) => {
+      setGroupActions((prev) => ({ ...prev, [memberId]: action }));
+
+      // Advance to next member
+      const idx = groups.findIndex((g) => g.member.id === memberId);
+      if (idx >= 0 && idx < groups.length - 1) {
+        setActiveMemberId(groups[idx + 1].member.id);
+      } else {
+        setActiveMemberId(null);
+      }
+    },
+    [groups],
+  );
+
+  const handleCoachingAction = useCallback((action: SuggestedAction) => {
+    // In a real app this would dispatch to the backend
+    // eslint-disable-next-line no-console
+    console.log("Coaching action:", action);
+  }, []);
+
+  const handleCopySlack = useCallback(() => {
+    void navigator.clipboard.writeText(slackMessage);
+  }, [slackMessage]);
+
+  // --- Render ---
+
+  return (
+    <div className="space-y-6 p-6">
+      {/* Header */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-foreground">
+            Standup Cockpit
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Run your daily standup with flow coaching and automatic metrics
+          </p>
+        </div>
+        <button
+          onClick={() => setFacilitatorMode((v) => !v)}
+          className={clsx(
+            "inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            facilitatorMode
+              ? "border-primary bg-primary/10 text-primary"
+              : "border-border text-muted-foreground hover:bg-muted",
+          )}
+          aria-pressed={facilitatorMode}
+        >
+          {facilitatorMode ? (
+            <MonitorOff className="h-3.5 w-3.5" aria-hidden="true" />
+          ) : (
+            <Monitor className="h-3.5 w-3.5" aria-hidden="true" />
+          )}
+          {facilitatorMode ? "Exit Facilitator" : "Facilitator Mode"}
+        </button>
+      </div>
+
+      {/* Timer */}
+      <StandupTimer
+        onStart={handleTimerStart}
+        onStop={handleTimerStop}
+        facilitatorMode={facilitatorMode}
+      />
+
+      {/* Coaching prompts */}
+      <FlowCoachingPromptPanel
+        prompts={prompts}
+        onAction={handleCoachingAction}
+        facilitatorMode={facilitatorMode}
+      />
+
+      {/* Member cards */}
+      <section aria-label="Team members" className="space-y-3">
+        <h2 className="text-sm font-semibold text-muted-foreground">
+          Team ({groups.length} members)
+        </h2>
+        <div className={clsx("space-y-3", facilitatorMode && "space-y-4")}>
+          {groups.map((group) => (
+            <StandupMemberCard
+              key={group.member.id}
+              group={group}
+              isActive={group.member.id === activeMemberId}
+              facilitatorMode={facilitatorMode}
+              onActionChange={handleMemberAction}
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* Summary (visible after standup ends) */}
+      <StandupSummary
+        metrics={metrics}
+        slackMessage={slackMessage}
+        facilitatorMode={facilitatorMode}
+        onCopyToClipboard={handleCopySlack}
+      />
+    </div>
+  );
 }

--- a/src/components/analytics/ai-insights-page.tsx
+++ b/src/components/analytics/ai-insights-page.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { InsightCardFull } from "./insight-card-full";
+import { StatCard } from "./stat-card";
+import type { AnalyticsDashboardData, AnalyticsSectionId } from "@/lib/analytics/types";
+import { AlertTriangle, AlertCircle, Info, BarChart3 } from "lucide-react";
+import { populateConnectionStatus } from "@/hooks/use-connection-status";
+
+type SeverityFilter = "all" | "critical" | "warning" | "info";
+type SectionFilter = "all" | AnalyticsSectionId;
+type SortMode = "severity" | "confidence";
+
+const SEVERITY_ORDER: Record<string, number> = { critical: 0, warning: 1, info: 2 };
+
+function readOverviewCache(): AnalyticsDashboardData | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = sessionStorage.getItem("analytics:overview");
+    return raw ? (JSON.parse(raw) as AnalyticsDashboardData) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function AiInsightsPage() {
+  const [data, setData] = useState<AnalyticsDashboardData | null>(readOverviewCache);
+  const [loading, setLoading] = useState(() => readOverviewCache() === null);
+  const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("all");
+  const [sectionFilter, setSectionFilter] = useState<SectionFilter>("all");
+  const [sortMode, setSortMode] = useState<SortMode>("severity");
+
+  useEffect(() => {
+    const cached = readOverviewCache();
+    if (cached) {
+      populateConnectionStatus(cached.freshness, cached);
+    }
+
+    let active = true;
+    const controller = new AbortController();
+
+    fetch("/api/analytics?section=overview", { signal: controller.signal })
+      .then((r) => r.json())
+      .then((json: AnalyticsDashboardData) => {
+        if (!active) return;
+        setData(json);
+        populateConnectionStatus(json.freshness, json);
+        sessionStorage.setItem("analytics:overview", JSON.stringify(json));
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, []);
+
+  const allInsights = data?.aiInsights?.global ?? [];
+
+  const filtered = useMemo(() => {
+    let result = allInsights;
+    if (severityFilter !== "all") {
+      result = result.filter((i) => i.severity === severityFilter);
+    }
+    if (sectionFilter !== "all") {
+      result = result.filter((i) => i.section === sectionFilter);
+    }
+    if (sortMode === "severity") {
+      result = [...result].sort((a, b) => (SEVERITY_ORDER[a.severity] ?? 9) - (SEVERITY_ORDER[b.severity] ?? 9));
+    } else {
+      result = [...result].sort((a, b) => b.confidence - a.confidence);
+    }
+    return result;
+  }, [allInsights, severityFilter, sectionFilter, sortMode]);
+
+  const criticalCount = allInsights.filter((i) => i.severity === "critical").length;
+  const warningCount = allInsights.filter((i) => i.severity === "warning").length;
+  const infoCount = allInsights.filter((i) => i.severity === "info").length;
+  const avgConfidence = allInsights.length > 0
+    ? allInsights.reduce((sum, i) => sum + i.confidence, 0) / allInsights.length
+    : 0;
+
+  if (loading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p className="text-sm text-muted-foreground">Loading insights…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-bold text-foreground">AI Insights</h2>
+        <p className="text-sm text-muted-foreground">
+          Cross-functional recommendations based on all connected data sources
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatCard label="Critical" value={String(criticalCount)} icon={AlertTriangle} iconColor="text-red-500" />
+        <StatCard label="Warnings" value={String(warningCount)} icon={AlertCircle} iconColor="text-yellow-500" />
+        <StatCard label="Info" value={String(infoCount)} icon={Info} iconColor="text-blue-500" />
+        <StatCard label="Avg Confidence" value={`${(avgConfidence * 100).toFixed(0)}%`} icon={BarChart3} />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex gap-1 rounded-lg bg-secondary/50 p-0.5">
+          {(["all", "critical", "warning", "info"] as SeverityFilter[]).map((sev) => (
+            <button
+              key={sev}
+              onClick={() => setSeverityFilter(sev)}
+              className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                severityFilter === sev ? "bg-card text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {sev === "all" ? "All" : sev.charAt(0).toUpperCase() + sev.slice(1)}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex gap-1 rounded-lg bg-secondary/50 p-0.5">
+          {(["all", "ads-traffic", "finance", "sales-pipeline", "customer-success"] as SectionFilter[]).map((sec) => (
+            <button
+              key={sec}
+              onClick={() => setSectionFilter(sec)}
+              className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                sectionFilter === sec ? "bg-card text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {sec === "all" ? "All" : sec === "ads-traffic" ? "Ads" : sec === "sales-pipeline" ? "Sales" : sec === "customer-success" ? "CS" : "Finance"}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex gap-1 rounded-lg bg-secondary/50 p-0.5">
+          {(["severity", "confidence"] as SortMode[]).map((mode) => (
+            <button
+              key={mode}
+              onClick={() => setSortMode(mode)}
+              className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                sortMode === mode ? "bg-card text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {mode.charAt(0).toUpperCase() + mode.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        {filtered.length === 0 ? (
+          <div className="flex h-32 items-center justify-center rounded-xl border border-border bg-card">
+            <p className="text-sm text-muted-foreground">No insights match current filters</p>
+          </div>
+        ) : (
+          filtered.map((insight) => <InsightCardFull key={insight.id} insight={insight} />)
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/analytics/analytics-section-page.tsx
+++ b/src/components/analytics/analytics-section-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import React, { useMemo } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { MarketingTabNew } from "@/components/analytics/marketing-tab-new";
@@ -33,6 +33,9 @@ import {
 } from "@/components/analytics/ops-insights";
 import { LifecycleFunnelPanel } from "@/components/analytics/lifecycle-funnel-panel";
 import { AiInsightsPanel } from "@/components/analytics/ai-insights-panel";
+import { GoogleAnalyticsDashboard } from "./sub-dashboards/google-analytics-dashboard";
+import { StripeDashboard } from "./sub-dashboards/stripe-dashboard";
+import { HubspotSalesDashboard } from "./sub-dashboards/hubspot-sales-dashboard";
 import type { AnalyticsDashboardData } from "@/lib/analytics/types";
 import {
   getAnalyticsPrimaryForSection,
@@ -44,6 +47,7 @@ import { DashboardLoadingState } from "@/components/dashboard/dashboard-loading-
 import { DashboardErrorBanner } from "@/components/dashboard/dashboard-error-banner";
 import { DashboardStaleBanner } from "@/components/dashboard/dashboard-stale-banner";
 import { DashboardEmptyState } from "@/components/dashboard/dashboard-empty-state";
+import { populateConnectionStatus } from "@/hooks/use-connection-status";
 
 interface AnalyticsSectionPageProps {
   sectionId: string;
@@ -57,6 +61,14 @@ interface SectionViewModel {
 const SECTION_CACHE_PREFIX = "analytics:section:v2:";
 const OPS_DOMAINS = ["decisionDashboard", "flowMetrics", "flowRisk", "observability"] as const;
 type ChildDataDomain = "decisionDashboard" | "flowMetrics" | "flowRisk" | "observability" | string;
+
+const SUB_DASHBOARD_MAP: Record<string, React.ComponentType<{ data: AnalyticsDashboardData | null }>> = {
+  "ads-google-analytics": GoogleAnalyticsDashboard,
+  "finance-stripe": StripeDashboard,
+  "sales-stripe": StripeDashboard,
+  "sales-hubspot": HubspotSalesDashboard,
+  "finance-hubspot": HubspotSalesDashboard,
+};
 
 export type AnalyticsChildRenderKind =
   | "finance-stripe"
@@ -319,8 +331,13 @@ export function AnalyticsSectionPage({ sectionId }: AnalyticsSectionPageProps) {
         throw new Error(`Analytics section request failed (${response.status})`);
       }
 
+      const analyticsData = (await response.json()) as AnalyticsDashboardData;
+
+      // Populate connection status store with freshness data
+      populateConnectionStatus(analyticsData?.freshness, analyticsData);
+
       return {
-        analyticsData: (await response.json()) as AnalyticsDashboardData,
+        analyticsData,
         auxPayload: null,
       };
     },
@@ -388,6 +405,12 @@ export function AnalyticsSectionPage({ sectionId }: AnalyticsSectionPageProps) {
     if (renderKind === "flowMetrics") return <FlowMetricsView payload={auxPayload} />;
     if (renderKind === "flowRisk") return <FlowRiskView payload={auxPayload} />;
     if (renderKind === "observability") return <ObservabilityView payload={auxPayload} />;
+
+    // Check for dedicated sub-dashboard component
+    const SubDashboard = SUB_DASHBOARD_MAP[sectionId];
+    if (SubDashboard) {
+      return <SubDashboard data={analyticsData} />;
+    }
 
     // Fallback for any unrecognized sub-sections
     const payload = (analyticsData as unknown as Record<string, unknown>) || null;

--- a/src/components/analytics/connection-dot.tsx
+++ b/src/components/analytics/connection-dot.tsx
@@ -1,0 +1,41 @@
+// src/components/analytics/connection-dot.tsx
+"use client";
+
+interface ConnectionDotProps {
+  status: "connected" | "stale" | "disconnected";
+  provider?: string;
+  lastSync?: string;
+  size?: "sm" | "md";
+}
+
+const STATUS_STYLES = {
+  connected: "bg-emerald-500",
+  stale: "bg-amber-500",
+  disconnected: "bg-red-500",
+} as const;
+
+const STATUS_LABELS = {
+  connected: "Connected",
+  stale: "Stale",
+  disconnected: "Disconnected",
+} as const;
+
+export function ConnectionDot({
+  status,
+  provider,
+  lastSync,
+  size = "sm",
+}: ConnectionDotProps) {
+  const dotSize = size === "sm" ? "h-1.5 w-1.5" : "h-2 w-2";
+
+  return (
+    <span
+      className={`inline-block rounded-full ${dotSize} ${STATUS_STYLES[status]}`}
+      title={
+        provider
+          ? `${provider}: ${STATUS_LABELS[status]}${lastSync ? ` — ${lastSync}` : ""}`
+          : STATUS_LABELS[status]
+      }
+    />
+  );
+}

--- a/src/components/analytics/customer-journey-page.tsx
+++ b/src/components/analytics/customer-journey-page.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { HorizontalFunnel } from "@/components/charts";
+import { StatCard } from "./stat-card";
+import { DashboardSectionCard } from "./dashboard-section-card";
+import type {
+  AnalyticsDashboardData,
+  LifecycleStageId,
+} from "@/lib/analytics/types";
+import { Users, TrendingUp, ArrowRight, Sparkles } from "lucide-react";
+import { populateConnectionStatus } from "@/hooks/use-connection-status";
+
+function readOverviewCache(): AnalyticsDashboardData | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = sessionStorage.getItem("analytics:overview");
+    return raw ? (JSON.parse(raw) as AnalyticsDashboardData) : null;
+  } catch {
+    return null;
+  }
+}
+
+const STAGE_COLORS: Record<LifecycleStageId, string> = {
+  awareness: "#3b82f6",
+  acquisition: "#14b8a6",
+  activation: "#6366f1",
+  revenue: "#22c55e",
+  retention: "#f97316",
+  expansion: "#a855f7",
+};
+
+const STAGE_ORDER: LifecycleStageId[] = [
+  "awareness", "acquisition", "activation", "revenue", "retention", "expansion",
+];
+
+export function CustomerJourneyPage() {
+  const [data, setData] = useState<AnalyticsDashboardData | null>(readOverviewCache);
+  const [selectedStage, setSelectedStage] = useState<LifecycleStageId | null>(null);
+  const [loading, setLoading] = useState(() => readOverviewCache() === null);
+
+  useEffect(() => {
+    const cached = readOverviewCache();
+    if (cached) {
+      populateConnectionStatus(cached.freshness, cached);
+    }
+
+    let active = true;
+    const controller = new AbortController();
+
+    fetch("/api/analytics?section=overview", { signal: controller.signal })
+      .then((r) => r.json())
+      .then((json: AnalyticsDashboardData) => {
+        if (!active) return;
+        setData(json);
+        populateConnectionStatus(json.freshness, json);
+        sessionStorage.setItem("analytics:overview", JSON.stringify(json));
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, []);
+
+  const lifecycle = data?.lifecycleFunnel ?? null;
+  const insights = data?.aiInsights?.global ?? [];
+
+  if (loading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p className="text-sm text-muted-foreground">Loading journey data…</p>
+      </div>
+    );
+  }
+
+  if (!lifecycle) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <div className="text-center">
+          <ArrowRight className="mx-auto mb-3 h-10 w-10 text-muted-foreground/40" />
+          <p className="text-sm text-muted-foreground">No lifecycle data available</p>
+          <p className="text-xs text-muted-foreground">Connect integrations to see the customer journey</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Build funnel stages
+  const stages = STAGE_ORDER.map((id) => {
+    const stage = lifecycle.stages.find((s) => s.id === id);
+    return {
+      label: stage?.label ?? id,
+      value: stage?.volume ?? 0,
+      color: STAGE_COLORS[id],
+    };
+  });
+
+  // Compute avg conversion from stages (conversionFromPrevious is already a %, e.g. 45.2)
+  const conversionValues = lifecycle.stages
+    .map((s) => s.conversionFromPrevious)
+    .filter((v): v is number => v !== null);
+  const avgConversion = conversionValues.length > 0
+    ? conversionValues.reduce((sum, v) => sum + v, 0) / conversionValues.length
+    : null;
+
+  const selectedStageData = selectedStage
+    ? lifecycle.stages.find((s) => s.id === selectedStage)
+    : null;
+
+  // Get transitions FROM the selected stage
+  const selectedTransitions = selectedStage
+    ? lifecycle.transitions.filter((t) => t.fromStageId === selectedStage)
+    : [];
+
+  const totalVolume = stages.reduce((sum, s) => sum + s.value, 0);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h2 className="text-lg font-bold text-foreground">Customer Journey</h2>
+        <p className="text-sm text-muted-foreground">
+          Full lifecycle funnel from awareness to expansion — click a stage to inspect
+        </p>
+      </div>
+
+      {/* KPI Strip */}
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatCard label="Total Contacts" value={totalVolume.toLocaleString()} icon={Users} />
+        <StatCard
+          label="Avg Conversion"
+          value={avgConversion !== null ? `${avgConversion.toFixed(1)}%` : "—"}
+          icon={TrendingUp}
+        />
+        <StatCard label="Stages" value={String(lifecycle.stages.length)} icon={ArrowRight} />
+        <StatCard label="Active Insights" value={String(insights.length)} icon={Sparkles} />
+      </div>
+
+      {/* Hero Funnel */}
+      <DashboardSectionCard title="Lifecycle Funnel" subtitle="Click a stage to see details">
+        <HorizontalFunnel stages={stages} height={360} />
+        <div className="mt-3 flex flex-wrap gap-2">
+          {STAGE_ORDER.map((id) => {
+            const stage = lifecycle.stages.find((s) => s.id === id);
+            return (
+              <button
+                key={id}
+                onClick={() => setSelectedStage(selectedStage === id ? null : id)}
+                className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
+                  selectedStage === id
+                    ? "border-primary bg-primary/10 text-primary"
+                    : "border-border text-muted-foreground hover:border-primary/50"
+                }`}
+              >
+                <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: STAGE_COLORS[id] }} />
+                {stage?.label ?? id}
+              </button>
+            );
+          })}
+        </div>
+      </DashboardSectionCard>
+
+      {/* Stage Detail Panel */}
+      {selectedStageData && (
+        <DashboardSectionCard title={selectedStageData.label} subtitle="Stage evidence and transitions">
+          <div className="grid gap-4 lg:grid-cols-2">
+            {/* Evidence (LifecycleSegment[]) */}
+            <div>
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">Evidence Sources</h4>
+              <div className="space-y-2">
+                {selectedStageData.evidence.length > 0 ? (
+                  selectedStageData.evidence.map((ev, i) => (
+                    <div key={i} className="flex items-center justify-between rounded-lg bg-secondary/40 px-3 py-2 text-sm">
+                      <span className="text-foreground">{ev.source}: {ev.detail}</span>
+                      <span className="font-semibold tabular-nums text-foreground">{ev.contribution}</span>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-xs text-muted-foreground">No evidence data for this stage</p>
+                )}
+              </div>
+            </div>
+            {/* Transitions (from LifecycleFunnelData.transitions filtered by fromStageId) */}
+            <div>
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">Transitions</h4>
+              <div className="space-y-2">
+                {selectedTransitions.length > 0 ? (
+                  selectedTransitions.map((tr) => (
+                    <div key={tr.id} className="flex items-center justify-between rounded-lg bg-secondary/40 px-3 py-2 text-sm">
+                      <span className="text-muted-foreground">→ {tr.toStageId}</span>
+                      <span className="font-semibold tabular-nums text-foreground">
+                        {tr.conversionRate !== null ? `${tr.conversionRate.toFixed(1)}%` : "—"}
+                      </span>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-xs text-muted-foreground">No transition data for this stage</p>
+                )}
+              </div>
+            </div>
+          </div>
+        </DashboardSectionCard>
+      )}
+
+      {/* Journey Insights */}
+      {insights.length > 0 && (
+        <DashboardSectionCard title="Journey Insights" subtitle="AI-generated recommendations based on lifecycle data">
+          <div className="grid gap-3 lg:grid-cols-2">
+            {insights.slice(0, 4).map((insight) => (
+              <div
+                key={insight.id}
+                className={`rounded-lg border px-4 py-3 ${
+                  insight.severity === "critical"
+                    ? "border-red-500/20 bg-red-500/5"
+                    : insight.severity === "warning"
+                      ? "border-yellow-500/20 bg-yellow-500/5"
+                      : "border-blue-500/20 bg-blue-500/5"
+                }`}
+              >
+                <p className="text-sm font-semibold text-foreground">{insight.title}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{insight.why}</p>
+              </div>
+            ))}
+          </div>
+        </DashboardSectionCard>
+      )}
+    </div>
+  );
+}

--- a/src/components/analytics/dashboard-section-card.tsx
+++ b/src/components/analytics/dashboard-section-card.tsx
@@ -1,0 +1,59 @@
+// src/components/analytics/dashboard-section-card.tsx
+"use client";
+
+import { useState } from "react";
+
+interface DashboardSectionCardProps {
+  title: string;
+  subtitle?: string;
+  tabs?: { id: string; label: string }[];
+  activeTab?: string;
+  onTabChange?: (tabId: string) => void;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function DashboardSectionCard({
+  title,
+  subtitle,
+  tabs,
+  activeTab,
+  onTabChange,
+  children,
+  className,
+}: DashboardSectionCardProps) {
+  const [internalTab, setInternalTab] = useState(tabs?.[0]?.id ?? "");
+  const currentTab = activeTab ?? internalTab;
+  const handleTabChange = onTabChange ?? setInternalTab;
+
+  return (
+    <div className={`rounded-xl border border-border bg-card p-5 ${className ?? ""}`}>
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+          {subtitle && (
+            <p className="mt-0.5 text-xs text-muted-foreground">{subtitle}</p>
+          )}
+        </div>
+        {tabs && tabs.length > 1 && (
+          <div className="flex gap-1 rounded-lg bg-secondary/50 p-0.5">
+            {tabs.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => handleTabChange(tab.id)}
+                className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                  currentTab === tab.id
+                    ? "bg-card text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/components/analytics/insight-card-full.tsx
+++ b/src/components/analytics/insight-card-full.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import type { AiInsight } from "@/lib/analytics/types";
+import { AlertTriangle, AlertCircle, Info, ExternalLink } from "lucide-react";
+
+const SEVERITY_CONFIG = {
+  critical: { border: "border-red-500/20", bg: "bg-red-500/5", icon: AlertTriangle, color: "text-red-500", badge: "bg-red-500/10 text-red-500" },
+  warning: { border: "border-yellow-500/20", bg: "bg-yellow-500/5", icon: AlertCircle, color: "text-yellow-500", badge: "bg-yellow-500/10 text-yellow-500" },
+  info: { border: "border-blue-500/20", bg: "bg-blue-500/5", icon: Info, color: "text-blue-500", badge: "bg-blue-500/10 text-blue-500" },
+} as const;
+
+export function InsightCardFull({ insight }: { insight: AiInsight }) {
+  const cfg = SEVERITY_CONFIG[insight.severity];
+  const Icon = cfg.icon;
+
+  return (
+    <div className={`rounded-xl border ${cfg.border} ${cfg.bg} p-5`}>
+      <div className="flex items-start gap-3">
+        <Icon className={`mt-0.5 h-5 w-5 ${cfg.color}`} />
+        <div className="flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="text-sm font-semibold text-foreground">{insight.title}</h3>
+            <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${cfg.badge}`}>
+              {insight.severity}
+            </span>
+            <span className="rounded-full bg-secondary px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+              {insight.section}
+            </span>
+            {insight.stale && (
+              <span className="rounded-full bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-500">
+                stale data
+              </span>
+            )}
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">{insight.why}</p>
+        </div>
+      </div>
+
+      <div className="mt-4 flex items-center gap-3">
+        <span className="text-xs text-muted-foreground">Confidence</span>
+        <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-secondary">
+          <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${insight.confidence * 100}%` }} />
+        </div>
+        <span className="text-xs font-medium tabular-nums text-foreground">{(insight.confidence * 100).toFixed(0)}%</span>
+      </div>
+
+      {insight.evidence.length > 0 && (
+        <div className="mt-4">
+          <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">Evidence</h4>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border/50 text-xs text-muted-foreground">
+                  <th className="pb-1.5 text-left font-medium">Source</th>
+                  <th className="pb-1.5 text-left font-medium">Metric</th>
+                  <th className="pb-1.5 text-right font-medium">Value</th>
+                  <th className="pb-1.5 text-right font-medium">Change</th>
+                </tr>
+              </thead>
+              <tbody>
+                {insight.evidence.map((ev, i) => (
+                  <tr key={i} className="border-b border-border/30 last:border-0">
+                    <td className="py-1.5 text-foreground">{ev.source}</td>
+                    <td className="py-1.5 text-muted-foreground">{ev.metric}</td>
+                    <td className="py-1.5 text-right font-medium tabular-nums text-foreground">{ev.value}</td>
+                    <td className="py-1.5 text-right text-xs tabular-nums text-muted-foreground">{ev.delta}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {insight.expectedImpact && (
+        <div className="mt-4 rounded-lg bg-secondary/40 px-3 py-2">
+          <span className="text-xs font-medium text-muted-foreground">Expected Impact: </span>
+          <span className="text-xs text-foreground">{insight.expectedImpact}</span>
+        </div>
+      )}
+
+      {insight.actions.length > 0 && (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {insight.actions.map((action, i) => (
+            <button
+              key={i}
+              className="flex items-center gap-1.5 rounded-lg border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-secondary"
+            >
+              {action.label}
+              <ExternalLink className="h-3 w-3 text-muted-foreground" />
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/analytics/stat-card.tsx
+++ b/src/components/analytics/stat-card.tsx
@@ -14,6 +14,8 @@ interface StatCardProps {
   subtitle?: string;
   icon?: StatCardIcon;
   iconColor?: string;
+  /** Optional trend data for sparkline rendering */
+  trend?: { data: number[] };
 }
 
 export function StatCard({

--- a/src/components/analytics/sub-dashboard-template.tsx
+++ b/src/components/analytics/sub-dashboard-template.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { ConnectionDot } from "./connection-dot";
+import type { ConnectionStatus } from "@/hooks/use-connection-status";
+
+interface SubDashboardTemplateProps {
+  title: string;
+  connectionStatus: ConnectionStatus;
+  kpis: ReactNode;
+  heroChart: ReactNode;
+  panels: ReactNode;
+}
+
+export function SubDashboardTemplate({
+  title,
+  connectionStatus,
+  kpis,
+  heroChart,
+  panels,
+}: SubDashboardTemplateProps) {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2">
+        <h2 className="text-lg font-bold text-foreground">{title}</h2>
+        <ConnectionDot status={connectionStatus} size="md" />
+      </div>
+      {kpis}
+      <div className="rounded-xl border border-border bg-card p-5">{heroChart}</div>
+      {panels}
+    </div>
+  );
+}

--- a/src/components/analytics/sub-dashboards/google-analytics-dashboard.tsx
+++ b/src/components/analytics/sub-dashboards/google-analytics-dashboard.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import type { AnalyticsDashboardData } from "@/lib/analytics/types";
+import { useConnectionStatus } from "@/hooks/use-connection-status";
+import { SubDashboardTemplate } from "../sub-dashboard-template";
+import { StatCard } from "../stat-card";
+import { DashboardSectionCard } from "../dashboard-section-card";
+import { AreaTrend, StackedBarChart } from "@/components/charts";
+
+/* ── Formatting helpers ────────────────────────────── */
+
+function fmtNum(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString();
+}
+
+function fmtPct(n: number): string {
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+function fmtDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  return `${m}m ${s}s`;
+}
+
+function calculateChange(
+  current: number,
+  previous: number,
+): { text: string; type: "positive" | "negative" | "neutral" } {
+  if (previous === 0) return { text: "N/A", type: "neutral" };
+  const pct = ((current - previous) / previous) * 100;
+  const sign = pct >= 0 ? "+" : "";
+  return {
+    text: `${sign}${pct.toFixed(1)}%`,
+    type: pct > 0 ? "positive" : pct < 0 ? "negative" : "neutral",
+  };
+}
+
+/* ── Component ─────────────────────────────────────── */
+
+interface GoogleAnalyticsDashboardProps {
+  data: AnalyticsDashboardData | null;
+}
+
+export function GoogleAnalyticsDashboard({ data }: GoogleAnalyticsDashboardProps) {
+  const connectionStatus = useConnectionStatus((s) => s.getStatus("googleAnalytics"));
+  const ga = data?.googleAnalytics ?? null;
+
+  if (!ga) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <p className="text-muted-foreground">No Google Analytics data available</p>
+      </div>
+    );
+  }
+
+  const sessionsChange = calculateChange(ga.sessions30d, ga.sessionsPrev30d);
+  const usersChange = calculateChange(ga.users30d, ga.usersPrev30d);
+
+  /* ── Channel breakdown data for StackedBarChart ─── */
+  const channelData = ga.trafficByChannel.map((ch) => ({
+    channel: ch.channel,
+    sessions: ch.sessions,
+    users: ch.users,
+    pageviews: ch.pageviews,
+  }));
+
+  return (
+    <SubDashboardTemplate
+      title="Google Analytics"
+      connectionStatus={connectionStatus}
+      kpis={
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <StatCard
+            label="Sessions (30d)"
+            value={fmtNum(ga.sessions30d)}
+            change={sessionsChange.text}
+            changeType={sessionsChange.type}
+            trend={{
+              data: ga.dailyTrend.map((d) => d.sessions),
+            }}
+          />
+          <StatCard
+            label="Users (30d)"
+            value={fmtNum(ga.users30d)}
+            change={usersChange.text}
+            changeType={usersChange.type}
+          />
+          <StatCard
+            label="Bounce Rate"
+            value={fmtPct(ga.bounceRate)}
+            changeType={ga.bounceRate > 0.6 ? "negative" : "neutral"}
+          />
+          <StatCard
+            label="Avg Duration"
+            value={fmtDuration(ga.avgSessionDuration)}
+          />
+        </div>
+      }
+      heroChart={
+        <AreaTrend
+          data={ga.dailyTrend}
+          xKey="date"
+          yKeys={["sessions"]}
+          height={280}
+          yFormatter={(v) => fmtNum(v)}
+        />
+      }
+      panels={
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <DashboardSectionCard title="Channel Breakdown">
+            <StackedBarChart
+              data={channelData}
+              xKey="channel"
+              barKeys={["sessions", "users", "pageviews"]}
+              height={260}
+              stacked={false}
+              yFormatter={(v) => fmtNum(v)}
+            />
+          </DashboardSectionCard>
+
+          <DashboardSectionCard title="Top Pages">
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b border-border text-left text-muted-foreground">
+                    <th className="pb-2 font-medium">Path</th>
+                    <th className="pb-2 text-right font-medium">Pageviews</th>
+                    <th className="pb-2 text-right font-medium">Avg Duration</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {ga.topPages.slice(0, 10).map((page) => (
+                    <tr key={page.path} className="border-b border-border/50">
+                      <td className="max-w-[200px] truncate py-2 text-foreground">{page.path}</td>
+                      <td className="py-2 text-right tabular-nums text-foreground">
+                        {page.pageviews.toLocaleString()}
+                      </td>
+                      <td className="py-2 text-right tabular-nums text-muted-foreground">
+                        {fmtDuration(page.avgDuration)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </DashboardSectionCard>
+        </div>
+      }
+    />
+  );
+}

--- a/src/components/analytics/sub-dashboards/hubspot-sales-dashboard.tsx
+++ b/src/components/analytics/sub-dashboards/hubspot-sales-dashboard.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import type { AnalyticsDashboardData } from "@/lib/analytics/types";
+import { useConnectionStatus } from "@/hooks/use-connection-status";
+import { SubDashboardTemplate } from "../sub-dashboard-template";
+import { StatCard } from "../stat-card";
+import { DashboardSectionCard } from "../dashboard-section-card";
+import { HorizontalFunnel, DonutChart, CHART_PALETTE } from "@/components/charts";
+
+/* ── Formatting helpers ────────────────────────────── */
+
+function fmt$(n: number): string {
+  if (n === 0) return "$0";
+  const abs = Math.abs(n);
+  const sign = n < 0 ? "-" : "";
+  if (abs >= 1_000_000) return `${sign}$${(abs / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `${sign}$${(abs / 1_000).toFixed(1)}K`;
+  return `${sign}$${abs.toFixed(0)}`;
+}
+
+function fmtPct(n: number): string {
+  return `${n.toFixed(1)}%`;
+}
+
+/* ── Funnel stage colors ───────────────────────────── */
+
+const STAGE_COLORS: Record<string, string> = {
+  "Prospect": "#4379f0",
+  "Lead": "#60a5fa",
+  "Demo Scheduled": "#34d399",
+  "No-Show/Reschedule": "#fbbf24",
+  "Demo Follow-Up": "#a78bfa",
+  "Budgetary Quote Sent": "#f472b6",
+  "Payment Link Sent": "#2dd4bf",
+  "Free Trial": "#818cf8",
+  "Freemium": "#c084fc",
+  "Subscription": "#22d3ee",
+  "Closed Won": "#22c55e",
+  "Closed Lost": "#ef4444",
+  "Unlikely": "#f97316",
+  "Churn": "#dc2626",
+};
+
+/* ── Component ─────────────────────────────────────── */
+
+interface HubspotSalesDashboardProps {
+  data: AnalyticsDashboardData | null;
+}
+
+export function HubspotSalesDashboard({ data }: HubspotSalesDashboardProps) {
+  const connectionStatus = useConnectionStatus((s) => s.getStatus("hubspot"));
+  const hubspot = data?.hubspot ?? null;
+
+  if (!hubspot) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <p className="text-muted-foreground">No HubSpot data available</p>
+      </div>
+    );
+  }
+
+  const { funnel, deals } = hubspot;
+
+  /* ── Funnel stages for HorizontalFunnel ─── */
+  const funnelStages = funnel.stages.map((stage) => ({
+    label: stage.label,
+    value: stage.count,
+    color: STAGE_COLORS[stage.label] ?? CHART_PALETTE[0],
+  }));
+
+  /* ── Source attribution donut ─── */
+  const sourceSegments = funnel.dealsBySource.map((src, i) => ({
+    name: src.source || "Unknown",
+    value: src.count,
+    color: CHART_PALETTE[i % CHART_PALETTE.length],
+  }));
+  const totalSourceDeals = funnel.dealsBySource.reduce((sum, s) => sum + s.count, 0);
+
+  /* ── Top deals ─── */
+  const topDeals = (deals ?? []).slice(0, 10);
+
+  return (
+    <SubDashboardTemplate
+      title="HubSpot Sales"
+      connectionStatus={connectionStatus}
+      kpis={
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <StatCard
+            label="Total Deals"
+            value={funnel.totalDeals.toLocaleString()}
+            subtitle={`${funnel.closedWon} won / ${funnel.closedLost} lost`}
+          />
+          <StatCard
+            label="Win Rate"
+            value={fmtPct(funnel.winRate)}
+            changeType={funnel.winRate > 20 ? "positive" : "neutral"}
+            subtitle={`Effective: ${fmtPct(funnel.effectiveWinRate)}`}
+          />
+          <StatCard
+            label="No-Show Rate"
+            value={fmtPct(funnel.noShowRate)}
+            changeType={funnel.noShowRate > 30 ? "negative" : "neutral"}
+            subtitle={`${funnel.noShows} no-shows of ${funnel.demoScheduled} demos`}
+          />
+          <StatCard
+            label="Avg Deal Size"
+            value={fmt$(funnel.avgDealSize)}
+          />
+        </div>
+      }
+      heroChart={
+        <HorizontalFunnel
+          stages={funnelStages}
+          height={Math.max(280, funnelStages.length * 36)}
+          valueFormatter={(v) => v.toLocaleString()}
+        />
+      }
+      panels={
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <DashboardSectionCard title="Source Attribution">
+            {sourceSegments.length === 0 ? (
+              <p className="py-4 text-center text-xs text-muted-foreground">No source data</p>
+            ) : (
+              <div className="flex items-center justify-center gap-6">
+                <DonutChart
+                  segments={sourceSegments}
+                  size={180}
+                  centerValue={totalSourceDeals.toLocaleString()}
+                  centerLabel="Deals"
+                />
+                <div className="space-y-2">
+                  {sourceSegments.map((seg) => (
+                    <div key={seg.name} className="flex items-center gap-2 text-xs">
+                      <span
+                        className="inline-block h-2.5 w-2.5 rounded-full"
+                        style={{ backgroundColor: seg.color }}
+                      />
+                      <span className="text-muted-foreground">{seg.name}</span>
+                      <span className="font-medium tabular-nums text-foreground">{seg.value}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </DashboardSectionCard>
+
+          <DashboardSectionCard title="Top Deals">
+            {topDeals.length === 0 ? (
+              <p className="py-4 text-center text-xs text-muted-foreground">No deal data available</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b border-border text-left text-muted-foreground">
+                      <th className="pb-2 font-medium">Deal</th>
+                      <th className="pb-2 font-medium">Stage</th>
+                      <th className="pb-2 text-right font-medium">Amount</th>
+                      <th className="pb-2 font-medium">Source</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {topDeals.map((deal) => (
+                      <tr key={deal.dealId} className="border-b border-border/50">
+                        <td className="max-w-[140px] truncate py-2 text-foreground">{deal.dealName}</td>
+                        <td className="py-2 text-muted-foreground">{deal.stageLabel}</td>
+                        <td className="py-2 text-right tabular-nums text-foreground">{fmt$(deal.amount)}</td>
+                        <td className="py-2 text-muted-foreground">{deal.source || "—"}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </DashboardSectionCard>
+        </div>
+      }
+    />
+  );
+}

--- a/src/components/analytics/sub-dashboards/stripe-dashboard.tsx
+++ b/src/components/analytics/sub-dashboards/stripe-dashboard.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import type { AnalyticsDashboardData } from "@/lib/analytics/types";
+import { useConnectionStatus } from "@/hooks/use-connection-status";
+import { SubDashboardTemplate } from "../sub-dashboard-template";
+import { StatCard } from "../stat-card";
+import { DashboardSectionCard } from "../dashboard-section-card";
+import { AreaTrend, DonutChart, CHART_PALETTE } from "@/components/charts";
+
+/* ── Formatting helpers ────────────────────────────── */
+
+function fmt$(n: number): string {
+  if (n === 0) return "$0";
+  const abs = Math.abs(n);
+  const sign = n < 0 ? "-" : "";
+  if (abs >= 1_000_000) return `${sign}$${(abs / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `${sign}$${(abs / 1_000).toFixed(1)}K`;
+  return `${sign}$${abs.toFixed(0)}`;
+}
+
+function fmtPct(n: number): string {
+  return `${n.toFixed(1)}%`;
+}
+
+/* ── Component ─────────────────────────────────────── */
+
+interface StripeDashboardProps {
+  data: AnalyticsDashboardData | null;
+}
+
+export function StripeDashboard({ data }: StripeDashboardProps) {
+  const connectionStatus = useConnectionStatus((s) => s.getStatus("stripe"));
+  const stripe = data?.stripe ?? null;
+
+  if (!stripe) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <p className="text-muted-foreground">No Stripe data available</p>
+      </div>
+    );
+  }
+
+  const { revenue, subscriptions, payments, revenueTrend } = stripe;
+
+  /* ── Subscription health donut ─── */
+  const subSegments = [
+    { name: "Active", value: subscriptions.active, color: CHART_PALETTE[2] },
+    { name: "Past Due", value: subscriptions.pastDue, color: CHART_PALETTE[4] },
+    { name: "Trialing", value: subscriptions.trialing, color: CHART_PALETTE[3] },
+    { name: "Canceled", value: subscriptions.canceled, color: CHART_PALETTE[5] },
+  ].filter((s) => s.value > 0);
+
+  const totalSubs = subscriptions.active + subscriptions.pastDue + subscriptions.trialing + subscriptions.canceled;
+
+  return (
+    <SubDashboardTemplate
+      title="Stripe Revenue"
+      connectionStatus={connectionStatus}
+      kpis={
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <StatCard
+            label="MRR"
+            value={fmt$(revenue.mrr)}
+            change={revenue.mrrChange !== 0 ? fmt$(revenue.mrrChange) : undefined}
+            changeType={revenue.mrrChange > 0 ? "positive" : revenue.mrrChange < 0 ? "negative" : "neutral"}
+            trend={{
+              data: revenueTrend.map((t) => t.revenue),
+            }}
+          />
+          <StatCard
+            label="Active Subscriptions"
+            value={subscriptions.active.toLocaleString()}
+            subtitle={subscriptions.pastDue > 0 ? `${subscriptions.pastDue} past due` : undefined}
+          />
+          <StatCard
+            label="Payment Success"
+            value={fmtPct(payments.successRate * 100)}
+            changeType={payments.successRate >= 0.95 ? "positive" : "negative"}
+            subtitle={`${payments.succeeded.toLocaleString()} succeeded / ${payments.failed.toLocaleString()} failed`}
+          />
+          <StatCard
+            label="Revenue Growth"
+            value={fmtPct(revenue.revenueGrowth)}
+            changeType={revenue.revenueGrowth > 0 ? "positive" : revenue.revenueGrowth < 0 ? "negative" : "neutral"}
+          />
+        </div>
+      }
+      heroChart={
+        <AreaTrend
+          data={revenueTrend.map((t) => ({ month: t.month, revenue: t.revenue }))}
+          xKey="month"
+          yKeys={["revenue"]}
+          height={280}
+          yFormatter={(v) => fmt$(v)}
+        />
+      }
+      panels={
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <DashboardSectionCard title="Subscription Health">
+            <div className="flex items-center justify-center gap-6">
+              <DonutChart
+                segments={subSegments}
+                size={180}
+                centerValue={totalSubs.toLocaleString()}
+                centerLabel="Total"
+              />
+              <div className="space-y-2">
+                {subSegments.map((seg) => (
+                  <div key={seg.name} className="flex items-center gap-2 text-xs">
+                    <span
+                      className="inline-block h-2.5 w-2.5 rounded-full"
+                      style={{ backgroundColor: seg.color }}
+                    />
+                    <span className="text-muted-foreground">{seg.name}</span>
+                    <span className="font-medium tabular-nums text-foreground">{seg.value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </DashboardSectionCard>
+
+          <DashboardSectionCard title="Recent Churn">
+            {subscriptions.recentChurnEvents.length === 0 ? (
+              <p className="py-4 text-center text-xs text-muted-foreground">No recent churn events</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b border-border text-left text-muted-foreground">
+                      <th className="pb-2 font-medium">Customer</th>
+                      <th className="pb-2 text-right font-medium">Canceled</th>
+                      <th className="pb-2 text-right font-medium">Amount</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {subscriptions.recentChurnEvents.slice(0, 10).map((evt, i) => (
+                      <tr key={i} className="border-b border-border/50">
+                        <td className="max-w-[180px] truncate py-2 text-foreground">{evt.customer}</td>
+                        <td className="py-2 text-right tabular-nums text-muted-foreground">
+                          {new Date(evt.canceledAt).toLocaleDateString()}
+                        </td>
+                        <td className="py-2 text-right tabular-nums text-foreground">{fmt$(evt.amount)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </DashboardSectionCard>
+        </div>
+      }
+    />
+  );
+}

--- a/src/components/charts/area-trend.tsx
+++ b/src/components/charts/area-trend.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { CustomTooltip } from "./custom-tooltip";
+import { CHART_DEFAULTS, CHART_PALETTE } from "./chart-theme";
+
+interface AreaTrendProps {
+  data: Array<Record<string, unknown>>;
+  xKey: string;
+  yKeys: string[];
+  colors?: string[];
+  height?: number;
+  yFormatter?: (value: number) => string;
+  xFormatter?: (value: string) => string;
+  stacked?: boolean;
+  showGrid?: boolean;
+}
+
+export function AreaTrend({
+  data,
+  xKey,
+  yKeys,
+  colors,
+  height = 280,
+  yFormatter,
+  xFormatter,
+  stacked = false,
+  showGrid = true,
+}: AreaTrendProps) {
+  const palette = colors ?? CHART_PALETTE;
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <AreaChart data={data}>
+        {showGrid && (
+          <CartesianGrid
+            strokeDasharray={CHART_DEFAULTS.gridStrokeDasharray}
+            stroke="hsl(var(--border))"
+            strokeOpacity={0.5}
+          />
+        )}
+        <XAxis
+          dataKey={xKey}
+          tickFormatter={xFormatter}
+          tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+          axisLine={false}
+          tickLine={false}
+        />
+        <YAxis
+          tickFormatter={yFormatter}
+          tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+          axisLine={false}
+          tickLine={false}
+          width={50}
+        />
+        <Tooltip
+          content={
+            <CustomTooltip
+              valueFormatter={yFormatter ? (v) => yFormatter(v as number) : undefined}
+              labelFormatter={xFormatter}
+            />
+          }
+        />
+        {yKeys.map((key, i) => (
+          <Area
+            key={key}
+            type="monotone"
+            dataKey={key}
+            stackId={stacked ? "stack" : undefined}
+            stroke={palette[i % palette.length]}
+            fill={palette[i % palette.length]}
+            fillOpacity={0.15}
+            strokeWidth={CHART_DEFAULTS.strokeWidth}
+            dot={false}
+            activeDot={{ r: CHART_DEFAULTS.activeDotRadius }}
+            animationDuration={CHART_DEFAULTS.animationDuration}
+          />
+        ))}
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/charts/chart-theme.ts
+++ b/src/components/charts/chart-theme.ts
@@ -1,0 +1,36 @@
+"use client";
+
+/**
+ * Static palette for Recharts — matches Arda design system.
+ * Brand orange first, then blue, emerald, violet, amber, pink.
+ */
+export const CHART_PALETTE = [
+  "#FC5A29", // primary orange
+  "#3b82f6", // blue-500
+  "#10b981", // emerald-500
+  "#8b5cf6", // violet-500
+  "#f59e0b", // amber-500
+  "#ec4899", // pink-500
+  "#06b6d4", // cyan-500
+  "#6366f1", // indigo-500
+];
+
+export function getChartColor(index: number): string {
+  return CHART_PALETTE[index % CHART_PALETTE.length];
+}
+
+/**
+ * Shared Recharts config constants.
+ * CSS variable reads happen at render time so dark mode works automatically.
+ */
+export const CHART_DEFAULTS = {
+  animationDuration: 400,
+  strokeWidth: 2,
+  dotRadius: 3,
+  activeDotRadius: 5,
+  gridStrokeDasharray: "3 3",
+  tooltipBg: "hsl(var(--card))",
+  tooltipBorder: "hsl(var(--border))",
+  tooltipText: "hsl(var(--foreground))",
+  tooltipMuted: "hsl(var(--muted-foreground))",
+} as const;

--- a/src/components/charts/composed-metric.tsx
+++ b/src/components/charts/composed-metric.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import {
+  ComposedChart,
+  Bar,
+  Line,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+import { CustomTooltip } from "./custom-tooltip";
+import { CHART_DEFAULTS, CHART_PALETTE } from "./chart-theme";
+
+interface SeriesConfig {
+  key: string;
+  type: "bar" | "line" | "area";
+  color?: string;
+  yAxisId?: "left" | "right";
+  name?: string;
+}
+
+interface ComposedMetricProps {
+  data: Array<Record<string, unknown>>;
+  xKey: string;
+  series: SeriesConfig[];
+  height?: number;
+  yLeftFormatter?: (value: number) => string;
+  yRightFormatter?: (value: number) => string;
+  showLegend?: boolean;
+}
+
+export function ComposedMetric({
+  data,
+  xKey,
+  series,
+  height = 280,
+  yLeftFormatter,
+  yRightFormatter,
+  showLegend = true,
+}: ComposedMetricProps) {
+  const hasRight = series.some((s) => s.yAxisId === "right");
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <ComposedChart data={data}>
+        <CartesianGrid
+          strokeDasharray={CHART_DEFAULTS.gridStrokeDasharray}
+          stroke="hsl(var(--border))"
+          strokeOpacity={0.5}
+        />
+        <XAxis
+          dataKey={xKey}
+          tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+          axisLine={false}
+          tickLine={false}
+        />
+        <YAxis
+          yAxisId="left"
+          tickFormatter={yLeftFormatter}
+          tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+          axisLine={false}
+          tickLine={false}
+          width={50}
+        />
+        {hasRight && (
+          <YAxis
+            yAxisId="right"
+            orientation="right"
+            tickFormatter={yRightFormatter}
+            tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+            axisLine={false}
+            tickLine={false}
+            width={50}
+          />
+        )}
+        <Tooltip content={<CustomTooltip />} />
+        {showLegend && (
+          <Legend wrapperStyle={{ fontSize: 11, color: "hsl(var(--muted-foreground))" }} />
+        )}
+        {series.map((s, i) => {
+          const color = s.color ?? CHART_PALETTE[i % CHART_PALETTE.length];
+          const yAxisId = s.yAxisId ?? "left";
+          const name = s.name ?? s.key;
+
+          if (s.type === "bar") {
+            return (
+              <Bar
+                key={s.key}
+                dataKey={s.key}
+                name={name}
+                yAxisId={yAxisId}
+                fill={color}
+                radius={[4, 4, 0, 0]}
+                animationDuration={CHART_DEFAULTS.animationDuration}
+              />
+            );
+          }
+          if (s.type === "area") {
+            return (
+              <Area
+                key={s.key}
+                type="monotone"
+                dataKey={s.key}
+                name={name}
+                yAxisId={yAxisId}
+                stroke={color}
+                fill={color}
+                fillOpacity={0.15}
+                strokeWidth={CHART_DEFAULTS.strokeWidth}
+                dot={false}
+                animationDuration={CHART_DEFAULTS.animationDuration}
+              />
+            );
+          }
+          return (
+            <Line
+              key={s.key}
+              type="monotone"
+              dataKey={s.key}
+              name={name}
+              yAxisId={yAxisId}
+              stroke={color}
+              strokeWidth={CHART_DEFAULTS.strokeWidth}
+              dot={false}
+              activeDot={{ r: CHART_DEFAULTS.activeDotRadius }}
+              animationDuration={CHART_DEFAULTS.animationDuration}
+            />
+          );
+        })}
+      </ComposedChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/charts/custom-tooltip.tsx
+++ b/src/components/charts/custom-tooltip.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+interface TooltipPayloadEntry {
+  name?: string;
+  value?: number | string;
+  color?: string;
+  dataKey?: string | number;
+  payload?: Record<string, unknown>;
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: TooltipPayloadEntry[];
+  label?: string | number;
+  labelFormatter?: (label: string) => string;
+  valueFormatter?: (value: number, name: string) => string;
+}
+
+export function CustomTooltip({
+  active,
+  payload,
+  label,
+  labelFormatter,
+  valueFormatter,
+}: CustomTooltipProps) {
+  if (!active || !payload?.length) return null;
+
+  return (
+    <div className="rounded-lg border border-border bg-card px-3 py-2 shadow-lg">
+      {label != null && (
+        <p className="mb-1 text-xs font-medium text-muted-foreground">
+          {labelFormatter ? labelFormatter(String(label)) : String(label)}
+        </p>
+      )}
+      {payload.map((entry: TooltipPayloadEntry, i: number) => (
+        <div key={i} className="flex items-center gap-2 text-sm">
+          <span
+            className="inline-block h-2.5 w-2.5 rounded-full"
+            style={{ backgroundColor: entry.color }}
+          />
+          <span className="text-muted-foreground">{entry.name}:</span>
+          <span className="font-semibold tabular-nums text-foreground">
+            {valueFormatter
+              ? valueFormatter(entry.value as number, entry.name ?? "")
+              : entry.value}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/charts/donut-chart.tsx
+++ b/src/components/charts/donut-chart.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
+import { CustomTooltip } from "./custom-tooltip";
+import { CHART_DEFAULTS, CHART_PALETTE } from "./chart-theme";
+
+interface DonutSegment {
+  name: string;
+  value: number;
+  color?: string;
+}
+
+interface DonutChartProps {
+  segments: DonutSegment[];
+  size?: number;
+  innerRadius?: number;
+  centerLabel?: string;
+  centerValue?: string;
+  valueFormatter?: (value: number) => string;
+}
+
+export function DonutChart({
+  segments,
+  size = 180,
+  innerRadius = 55,
+  centerLabel,
+  centerValue,
+  valueFormatter,
+}: DonutChartProps) {
+  const outerRadius = size / 2 - 10;
+
+  return (
+    <div className="relative" style={{ width: size, height: size }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Pie
+            data={segments}
+            dataKey="value"
+            cx="50%"
+            cy="50%"
+            innerRadius={innerRadius}
+            outerRadius={outerRadius}
+            paddingAngle={2}
+            animationDuration={CHART_DEFAULTS.animationDuration}
+          >
+            {segments.map((seg, i) => (
+              <Cell key={i} fill={seg.color ?? CHART_PALETTE[i % CHART_PALETTE.length]} />
+            ))}
+          </Pie>
+          <Tooltip
+            content={
+              <CustomTooltip
+                valueFormatter={valueFormatter ? (v) => valueFormatter(v as number) : undefined}
+              />
+            }
+          />
+        </PieChart>
+      </ResponsiveContainer>
+      {(centerLabel || centerValue) && (
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+          {centerValue && (
+            <span className="text-lg font-bold tabular-nums text-foreground">{centerValue}</span>
+          )}
+          {centerLabel && (
+            <span className="text-[10px] text-muted-foreground">{centerLabel}</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/charts/horizontal-funnel.tsx
+++ b/src/components/charts/horizontal-funnel.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Cell,
+  ResponsiveContainer,
+} from "recharts";
+import { CustomTooltip } from "./custom-tooltip";
+import { CHART_DEFAULTS } from "./chart-theme";
+
+interface FunnelStage {
+  label: string;
+  value: number;
+  color: string;
+  extra?: Record<string, string | number>;
+}
+
+interface HorizontalFunnelProps {
+  stages: FunnelStage[];
+  height?: number;
+  valueFormatter?: (value: number) => string;
+}
+
+export function HorizontalFunnel({
+  stages,
+  height = 320,
+  valueFormatter,
+}: HorizontalFunnelProps) {
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <BarChart data={stages} layout="vertical" barCategoryGap="20%">
+        <XAxis
+          type="number"
+          tickFormatter={valueFormatter}
+          tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+          axisLine={false}
+          tickLine={false}
+        />
+        <YAxis
+          dataKey="label"
+          type="category"
+          tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+          axisLine={false}
+          tickLine={false}
+          width={140}
+        />
+        <Tooltip
+          content={
+            <CustomTooltip
+              valueFormatter={valueFormatter ? (v) => valueFormatter(v as number) : undefined}
+            />
+          }
+        />
+        <Bar
+          dataKey="value"
+          radius={[0, 4, 4, 0]}
+          animationDuration={CHART_DEFAULTS.animationDuration}
+        >
+          {stages.map((stage, idx) => (
+            <Cell key={idx} fill={stage.color} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/charts/index.ts
+++ b/src/components/charts/index.ts
@@ -1,0 +1,8 @@
+export { CHART_PALETTE, getChartColor, CHART_DEFAULTS } from "./chart-theme";
+export { CustomTooltip } from "./custom-tooltip";
+export { SparkLine } from "./spark-line";
+export { AreaTrend } from "./area-trend";
+export { StackedBarChart } from "./stacked-bar-chart";
+export { HorizontalFunnel } from "./horizontal-funnel";
+export { DonutChart } from "./donut-chart";
+export { ComposedMetric } from "./composed-metric";

--- a/src/components/charts/spark-line.tsx
+++ b/src/components/charts/spark-line.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { LineChart, Line, ResponsiveContainer } from "recharts";
+import { CHART_PALETTE } from "./chart-theme";
+
+interface SparkLineProps {
+  data: number[];
+  color?: string;
+  width?: number;
+  height?: number;
+}
+
+export function SparkLine({
+  data,
+  color = CHART_PALETTE[0],
+  width = 48,
+  height = 24,
+}: SparkLineProps) {
+  if (data.length < 2) return null;
+
+  const points = data.map((value, index) => ({ index, value }));
+
+  return (
+    <div style={{ width, height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={points}>
+          <Line
+            type="monotone"
+            dataKey="value"
+            stroke={color}
+            strokeWidth={1.5}
+            dot={false}
+            isAnimationActive={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/charts/stacked-bar-chart.tsx
+++ b/src/components/charts/stacked-bar-chart.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+import { CustomTooltip } from "./custom-tooltip";
+import { CHART_DEFAULTS, CHART_PALETTE } from "./chart-theme";
+
+interface StackedBarChartProps {
+  data: Array<Record<string, unknown>>;
+  xKey: string;
+  barKeys: string[];
+  colors?: string[];
+  height?: number;
+  yFormatter?: (value: number) => string;
+  stacked?: boolean;
+  layout?: "horizontal" | "vertical";
+  showLegend?: boolean;
+}
+
+export function StackedBarChart({
+  data,
+  xKey,
+  barKeys,
+  colors,
+  height = 280,
+  yFormatter,
+  stacked = true,
+  layout = "horizontal",
+  showLegend = true,
+}: StackedBarChartProps) {
+  const palette = colors ?? CHART_PALETTE;
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <BarChart data={data} layout={layout === "vertical" ? "vertical" : "horizontal"}>
+        <CartesianGrid
+          strokeDasharray={CHART_DEFAULTS.gridStrokeDasharray}
+          stroke="hsl(var(--border))"
+          strokeOpacity={0.5}
+        />
+        {layout === "vertical" ? (
+          <>
+            <XAxis
+              type="number"
+              tickFormatter={yFormatter}
+              tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis
+              dataKey={xKey}
+              type="category"
+              tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+              axisLine={false}
+              tickLine={false}
+              width={120}
+            />
+          </>
+        ) : (
+          <>
+            <XAxis
+              dataKey={xKey}
+              tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis
+              tickFormatter={yFormatter}
+              tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+              axisLine={false}
+              tickLine={false}
+              width={50}
+            />
+          </>
+        )}
+        <Tooltip
+          content={
+            <CustomTooltip
+              valueFormatter={yFormatter ? (v) => yFormatter(v as number) : undefined}
+            />
+          }
+        />
+        {showLegend && (
+          <Legend
+            wrapperStyle={{ fontSize: 11, color: "hsl(var(--muted-foreground))" }}
+          />
+        )}
+        {barKeys.map((key, i) => (
+          <Bar
+            key={key}
+            dataKey={key}
+            stackId={stacked ? "stack" : undefined}
+            fill={palette[i % palette.length]}
+            radius={stacked ? undefined : [4, 4, 0, 0]}
+            animationDuration={CHART_DEFAULTS.animationDuration}
+          />
+        ))}
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/layout/sidebar-nav-config.ts
+++ b/src/components/layout/sidebar-nav-config.ts
@@ -8,6 +8,8 @@ import {
   Target,
   HeartHandshake,
   Bot,
+  Route,
+  Sparkles,
   Users,
   type LucideIcon,
 } from "lucide-react";
@@ -63,10 +65,15 @@ export function buildNavItems(): NavItem[] {
     };
   });
 
+  const newPages: NavItem[] = [
+    { id: "customer-journey", href: "/analytics/customer-journey", label: "Customer Journey", icon: Route },
+    { id: "ai-insights", href: "/analytics/ai-insights", label: "AI Insights", icon: Sparkles },
+  ];
+
   const bottomStatic: NavItem[] = [
     { id: "standup", href: "/today", label: "Standup Hub", icon: Users },
     { id: "automations", href: "/automations", label: "Automations", icon: Bot },
   ];
 
-  return [...topStatic, ...analyticsGroups, ...bottomStatic];
+  return [...topStatic, ...analyticsGroups, ...newPages, ...bottomStatic];
 }

--- a/src/components/layout/sidebar-nav-group.tsx
+++ b/src/components/layout/sidebar-nav-group.tsx
@@ -6,6 +6,8 @@ import { usePathname } from "next/navigation";
 import { ChevronRight, ChevronDown } from "lucide-react";
 import { clsx } from "clsx";
 import type { NavItem } from "./sidebar-nav-config";
+import { ConnectionDot } from "@/components/analytics/connection-dot";
+import { useConnectionStatus } from "@/hooks/use-connection-status";
 
 const STORAGE_KEY = "sidebar:expanded";
 
@@ -29,6 +31,7 @@ function writeExpanded(ids: Set<string>): void {
 
 export function SidebarNavGroup({ item }: { item: NavItem }) {
   const pathname = usePathname() ?? "";
+  const getStatus = useConnectionStatus((s) => s.getStatus);
 
   const isChildActive = item.children?.some((child) => {
     return pathname === child.href || pathname.startsWith(`${child.href}/`);
@@ -89,11 +92,12 @@ export function SidebarNavGroup({ item }: { item: NavItem }) {
                 href={child.href}
                 aria-current={childActive ? "page" : undefined}
                 className={clsx(
-                  "flex items-center rounded-md py-1.5 pl-10 pr-3 text-[13px]",
+                  "flex items-center justify-between rounded-md py-1.5 pl-10 pr-3 text-[13px]",
                   childActive ? "font-medium text-foreground" : "text-muted-foreground hover:text-foreground"
                 )}
               >
-                {child.label}
+                <span>{child.label}</span>
+                <ConnectionDot status={getStatus(child.dataDomain)} size="sm" />
               </Link>
             );
           })}

--- a/src/hooks/use-connection-status.ts
+++ b/src/hooks/use-connection-status.ts
@@ -1,0 +1,136 @@
+"use client";
+
+import { create } from "zustand";
+import type { AnalyticsDashboardData, IntegrationProviderKey, ProviderFreshness } from "@/lib/analytics/types";
+
+export type ConnectionStatus = "connected" | "stale" | "disconnected";
+
+interface ConnectionEntry {
+  dataDomain: string;
+  status: ConnectionStatus;
+  provider?: string;
+  lastSync?: string;
+}
+
+interface ConnectionStatusStore {
+  entries: ConnectionEntry[];
+  setEntries: (entries: ConnectionEntry[]) => void;
+  getStatus: (dataDomain: string) => ConnectionStatus;
+}
+
+export const useConnectionStatus = create<ConnectionStatusStore>((set, get) => ({
+  entries: [],
+  setEntries: (entries) => set({ entries }),
+  getStatus: (dataDomain) => {
+    const entry = get().entries.find((e) => e.dataDomain === dataDomain);
+    return entry?.status ?? "disconnected";
+  },
+}));
+
+export function mapFreshnessToStatus(freshness: {
+  status: string | null;
+  stale: boolean;
+}): ConnectionStatus {
+  if (!freshness.status || freshness.status === "DISCONNECTED" || freshness.status === "ERROR") {
+    return "disconnected";
+  }
+  if (freshness.stale) {
+    return "stale";
+  }
+  return "connected";
+}
+
+/**
+ * Maps IntegrationProviderKey (snake_case) → dataDomain (camelCase) used in the
+ * section registry and sidebar. A single provider can map to multiple dataDomains
+ * (e.g. google_workspace → googleWorkspace, but Google Analytics / Ads use env keys
+ * not provider connections, so they are omitted).
+ */
+const PROVIDER_TO_DOMAINS: Record<IntegrationProviderKey, string[]> = {
+  google_workspace: ["googleWorkspace"],
+  hubspot: ["hubspot"],
+  slack: ["slack"],
+  coda: ["coda"],
+  reddit: ["redditAds"],
+  stripe: ["stripe"],
+  mercury: ["mercury"],
+};
+
+const DASHBOARD_DATA_DOMAINS = [
+  "hubspot",
+  "stripe",
+  "mercury",
+  "googleAnalytics",
+  "googleAds",
+  "metaAds",
+  "metaPage",
+  "redditAds",
+  "webflow",
+  "coda",
+  "semrush",
+  "pylon",
+  "product",
+  "googleWorkspace",
+  "slack",
+  "hubspotOps",
+  "codaOps",
+  "redditOps",
+] as const;
+
+function statusFromDomainPayload(
+  dashboard: AnalyticsDashboardData,
+  domain: (typeof DASHBOARD_DATA_DOMAINS)[number],
+): ConnectionStatus {
+  const payload = dashboard[domain];
+  if (payload === null || payload === undefined) {
+    return "disconnected";
+  }
+  const staleDomains = Array.isArray(dashboard.staleDomains) ? dashboard.staleDomains : [];
+  if (staleDomains.includes(domain)) {
+    return "stale";
+  }
+  return "connected";
+}
+
+/**
+ * Convert a freshness map from the API into ConnectionEntry[] and populate
+ * the store.  Safe to call multiple times — last call wins.
+ */
+export function populateConnectionStatus(
+  freshness: Partial<Record<IntegrationProviderKey, ProviderFreshness>> | undefined,
+  dashboard?: AnalyticsDashboardData | null,
+): void {
+  const entriesByDomain = new Map<string, ConnectionEntry>();
+
+  if (freshness) {
+    for (const [providerKey, info] of Object.entries(freshness)) {
+      if (!info) continue;
+      const domains = PROVIDER_TO_DOMAINS[providerKey as IntegrationProviderKey] ?? [];
+      const status = mapFreshnessToStatus(info);
+
+      for (const domain of domains) {
+        entriesByDomain.set(domain, {
+          dataDomain: domain,
+          status,
+          provider: info.provider,
+          lastSync: info.lastSyncedAt ?? undefined,
+        });
+      }
+    }
+  }
+
+  if (dashboard) {
+    for (const domain of DASHBOARD_DATA_DOMAINS) {
+      const inferredStatus = statusFromDomainPayload(dashboard, domain);
+      const existing = entriesByDomain.get(domain);
+      if (!existing) {
+        entriesByDomain.set(domain, {
+          dataDomain: domain,
+          status: inferredStatus,
+        });
+      }
+    }
+  }
+
+  useConnectionStatus.getState().setEntries(Array.from(entriesByDomain.values()));
+}

--- a/src/lib/__tests__/sidebar-analytics-nav.test.ts
+++ b/src/lib/__tests__/sidebar-analytics-nav.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import { buildNavItems } from "@/components/layout/sidebar-nav-config";
 
 describe("sidebar analytics navigation", () => {
-  it("builds analytics as grouped entries with nested children", () => {
-    const navItems = buildNavItems();
+  const navItems = buildNavItems();
 
+  it("builds analytics as grouped entries with nested children", () => {
     const ads = navItems.find((item) => item.id === "ads-traffic");
     const finance = navItems.find((item) => item.id === "finance");
     const sales = navItems.find((item) => item.id === "sales-pipeline");
@@ -16,11 +16,27 @@ describe("sidebar analytics navigation", () => {
     expect(cs?.children?.length).toBeGreaterThan(0);
   });
 
+  it("includes nested links for each tier-1 analytics dashboard", () => {
+    const analyticsGroups = navItems.filter((item) => item.children && item.children.length > 0);
+    const hrefs = new Set(analyticsGroups.map((item) => item.href));
+
+    expect(hrefs.size).toBeGreaterThan(0);
+  });
+
   it("keeps standup command center in nav and points it to /today", () => {
-    const navItems = buildNavItems();
     const standup = navItems.find((item) => item.id === "standup");
 
     expect(standup).toBeTruthy();
     expect(standup?.href).toBe("/today");
+  });
+
+  it("includes customer journey and AI insights pages", () => {
+    const customerJourney = navItems.find((item) => item.id === "customer-journey");
+    const aiInsights = navItems.find((item) => item.id === "ai-insights");
+
+    expect(customerJourney).toBeTruthy();
+    expect(customerJourney?.href).toBe("/analytics/customer-journey");
+    expect(aiInsights).toBeTruthy();
+    expect(aiInsights?.href).toBe("/analytics/ai-insights");
   });
 });

--- a/src/lib/__tests__/standup-engine.test.ts
+++ b/src/lib/__tests__/standup-engine.test.ts
@@ -12,6 +12,7 @@ import type {
   TeamMember,
   OwnerGroup,
   CoachingConfig,
+  WipLimits,
 } from "@/lib/standup-engine";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Restores three features that existed on feature branches (`claude/heuristic-elbakyan`, `claude/ecstatic-pasteur`) but were never merged: connection-aware sidebar with status indicator dots, customer journey/AI insights pages, and standup hub
- Adds recharts-powered charts library (area, bar, donut, funnel, sparkline, composed) and sub-dashboard components for Google Analytics, Stripe, and HubSpot
- Surgically merges `SUB_DASHBOARD_MAP` fallback into `analytics-section-page.tsx` alongside existing `resolveAnalyticsChildRenderKind` system

## Test plan
- [ ] Verify sidebar renders collapsible nav groups with ConnectionDot indicators per integration
- [ ] Navigate to `/analytics/ads-traffic` and confirm Google Analytics sub-dashboard renders with sparkline stat cards
- [ ] Navigate to `/analytics/finance` and confirm Stripe sub-dashboard renders
- [ ] Navigate to `/analytics/customer-journey` and confirm interactive lifecycle funnel page
- [ ] Navigate to `/standup` and confirm standup hub with timer, member cards, flow coaching
- [ ] Run `npx tsc --noEmit` — 0 errors in new/modified files (pre-existing Prisma errors unrelated)
- [ ] Run `npx vitest run` — 370/370 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)