### PR TITLE
Guard missing finance provider fields

### DIFF
--- a/src/lib/analytics/budget-variance.ts
+++ b/src/lib/analytics/budget-variance.ts
@@ -68,7 +68,7 @@ export function computeBudgetActuals(
   mercury: AnalyticsDashboardData["mercury"],
   budgetAmounts?: Record<string, number>,
 ): BudgetActualItem[] {
-  const totalOutflows = mercury?.cashFlow.outflows30d ?? 0;
+  const totalOutflows = mercury?.cashFlow?.outflows30d ?? 0;
   const items: BudgetActualItem[] = [];
 
   const ratioKeys = Object.keys(DEFAULT_EXPENSE_RATIOS) as Array<

--- a/src/lib/analytics/forecast-engine.ts
+++ b/src/lib/analytics/forecast-engine.ts
@@ -101,11 +101,11 @@ export function buildForecastScenario(
   assumptions: ForecastAssumptions,
   opts: { id?: string; name?: string; months?: number } = {},
 ): ForecastScenarioData {
-  const currentMrr = stripe?.revenue.mrr ?? 0;
-  const baseGrowthRate = (stripe?.revenue.revenueGrowth ?? 0) / 100;
-  const baseChurnRate = (stripe?.subscriptions.churnRate ?? 0) / 100;
-  const cashBalance = mercury?.cashFlow.totalBalance ?? 0;
-  const baseBurnRate = mercury?.cashFlow.burnRate ?? 0;
+  const currentMrr = stripe?.revenue?.mrr ?? 0;
+  const baseGrowthRate = (stripe?.revenue?.revenueGrowth ?? 0) / 100;
+  const baseChurnRate = (stripe?.subscriptions?.churnRate ?? 0) / 100;
+  const cashBalance = mercury?.cashFlow?.totalBalance ?? 0;
+  const baseBurnRate = mercury?.cashFlow?.burnRate ?? 0;
 
   // Apply assumption deltas
   const growthRate = baseGrowthRate + assumptions.revenueGrowthRate / 100;
@@ -156,7 +156,7 @@ export function buildDefaultScenarios(
   mercury: MercuryData | null,
   months: number = 18,
 ): ForecastScenarioData[] {
-  const baseBurn = mercury?.cashFlow.burnRate ?? 0;
+  const baseBurn = mercury?.cashFlow?.burnRate ?? 0;
 
   const base: ForecastAssumptions = {
     revenueGrowthRate: 0,

--- a/src/lib/analytics/pnl-builder.ts
+++ b/src/lib/analytics/pnl-builder.ts
@@ -59,11 +59,11 @@ export function buildProfitAndLoss(
   const ratios = opts?.ratios ?? DEFAULT_EXPENSE_RATIOS;
 
   // Revenue figures from Stripe
-  const currentRevenue = stripe?.revenue.totalRevenue30d ?? 0;
-  const previousRevenue = stripe?.revenue.totalRevenuePrev30d ?? 0;
+  const currentRevenue = stripe?.revenue?.totalRevenue30d ?? 0;
+  const previousRevenue = stripe?.revenue?.totalRevenuePrev30d ?? 0;
 
   // Total outflows from Mercury (used to estimate expenses)
-  const currentOutflows = mercury?.cashFlow.outflows30d ?? 0;
+  const currentOutflows = mercury?.cashFlow?.outflows30d ?? 0;
   // Estimate previous outflows from current (no historical data available)
   const previousOutflows = currentOutflows;
 

--- a/src/lib/analytics/unit-economics.ts
+++ b/src/lib/analytics/unit-economics.ts
@@ -52,26 +52,22 @@ export function computeUnitEconomics(
   hubspot: AnalyticsDashboardData["hubspot"],
 ): UnitEconomicsData {
   // ── ARPA ──
-  const arpa = stripe?.revenue.avgRevenuePerCustomer ?? 0;
+  const arpa = stripe?.revenue?.avgRevenuePerCustomer ?? 0;
 
   // ── Churn (monthly, as a decimal) ──
-  const churnDecimal = stripe
-    ? stripe.subscriptions.churnRate / 100
-    : 0;
+  const churnDecimal = (stripe?.subscriptions?.churnRate ?? 0) / 100;
   const effectiveChurn = Math.max(churnDecimal, 0.01);
 
   // ── LTV ──
   const ltv = Math.round((arpa / effectiveChurn) * 100) / 100;
 
   // ── CAC ──
-  const totalOutflows = mercury?.cashFlow.outflows30d ?? 0;
+  const totalOutflows = mercury?.cashFlow?.outflows30d ?? 0;
   const marketingSpend = totalOutflows * DEFAULT_EXPENSE_RATIOS.marketing;
 
   // Estimate new customers from HubSpot recentContacts, fallback to 10
-  const newCustomers =
-    hubspot && hubspot.contacts.recentContacts > 0
-      ? hubspot.contacts.recentContacts
-      : 10;
+  const recentContacts = hubspot?.contacts?.recentContacts ?? 0;
+  const newCustomers = recentContacts > 0 ? recentContacts : 10;
 
   const cac =
     newCustomers > 0
@@ -89,7 +85,7 @@ export function computeUnitEconomics(
       : 0;
 
   // ── Gross margin ──
-  const revenue = stripe?.revenue.totalRevenue30d ?? 0;
+  const revenue = stripe?.revenue?.totalRevenue30d ?? 0;
   const cogs = totalOutflows * DEFAULT_EXPENSE_RATIOS.cogs;
   const grossMarginPct =
     revenue > 0


### PR DESCRIPTION
## Summary\n- add null-safe access for Stripe/Mercury nested fields in finance computations\n- prevent budget/forecast/P&L from crashing on partial snapshots\n\n## Testing\n- not run (null-guard change)