### PR TITLE
Fix Reddit Ads report date-time format

### DIFF
--- a/src/lib/__tests__/analytics-fetchers-ads.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-ads.test.ts
@@ -195,6 +195,13 @@ describe("analytics ads fetchers", () => {
     expect(reportsCall?.[0]).toContain("/api/v3/ad_accounts/acc-1/reports");
     const reportInit = reportsCall?.[1] as RequestInit;
     expect(reportInit.method).toBe("POST");
+    expect(typeof reportInit.body).toBe("string");
+
+    const payload = JSON.parse(reportInit.body as string) as {
+      data?: { starts_at?: string; ends_at?: string };
+    };
+    expect(payload.data?.starts_at).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
+    expect(payload.data?.ends_at).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
 
     for (const [, init] of fetchMock.mock.calls as Array<[unknown, RequestInit]>) {
       const headers = (init?.headers || {}) as Record<string, string>;

--- a/src/lib/analytics/fetchers-ads.ts
+++ b/src/lib/analytics/fetchers-ads.ts
@@ -646,16 +646,16 @@ export async function fetchRedditAdsData(
         Authorization: `Bearer ${accessToken}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({
-        data: {
-          starts_at: thirtyDaysAgo.toISOString().slice(0, 10),
-          ends_at: now.toISOString().slice(0, 10),
-          breakdowns: ["CAMPAIGN_ID"],
-          fields: ["CAMPAIGN_ID", "SPEND", "IMPRESSIONS", "CLICKS"],
-        },
-      }),
-    }
-  );
+	      body: JSON.stringify({
+	        data: {
+	          starts_at: thirtyDaysAgo.toISOString(),
+	          ends_at: now.toISOString(),
+	          breakdowns: ["CAMPAIGN_ID"],
+	          fields: ["CAMPAIGN_ID", "SPEND", "IMPRESSIONS", "CLICKS"],
+	        },
+	      }),
+	    }
+	  );
 
   if (!reportsResponse.ok) {
     throw new Error(


### PR DESCRIPTION
Reddit Ads API v3 /reports requires RFC3339 date-time values for data.starts_at and data.ends_at. WIPGuard was sending YYYY-MM-DD via toISOString().slice(0,10), causing 400 Bad Request.\n\n- Send full ISO-8601 timestamps (toISOString())\n- Add unit test to assert date-time format in request payload\n\nDeploy: merge to main (Railway auto-deploy on push to main after CI).