### PR TITLE
Align Reddit reports range to calendar days

### DIFF
--- a/src/lib/__tests__/analytics-fetchers-ads.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-ads.test.ts
@@ -222,7 +222,7 @@ describe("analytics ads fetchers", () => {
     const payload = JSON.parse(reportInit.body as string) as {
       data?: { starts_at?: string; ends_at?: string };
     };
-    expect(payload.data?.starts_at).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
+    expect(payload.data?.starts_at).toMatch(/^\d{4}-\d{2}-\d{2}T00:00:00\.000Z$/);
     expect(payload.data?.ends_at).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
 
     for (const [, init] of fetchMock.mock.calls as Array<[unknown, RequestInit]>) {

--- a/src/lib/analytics/fetchers-ads.ts
+++ b/src/lib/analytics/fetchers-ads.ts
@@ -694,7 +694,9 @@ export async function fetchRedditAdsData(
   }
 
   const now = new Date();
-  const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const startsAt = new Date(now);
+  startsAt.setUTCDate(startsAt.getUTCDate() - 29);
+  startsAt.setUTCHours(0, 0, 0, 0);
   const reportsResponse = await fetch(
     `https://ads-api.reddit.com/api/v3/ad_accounts/${cleanAccountId}/reports`,
     {
@@ -706,7 +708,7 @@ export async function fetchRedditAdsData(
       },
       body: JSON.stringify({
         data: {
-          starts_at: thirtyDaysAgo.toISOString(),
+          starts_at: startsAt.toISOString(),
           ends_at: now.toISOString(),
           breakdowns: ["CAMPAIGN_ID"],
           fields: ["CAMPAIGN_ID", "SPEND", "IMPRESSIONS", "CLICKS"],


### PR DESCRIPTION
Adjust Reddit Ads v3 /reports range semantics to match the UI's "last 30 days" calendar-day expectation:\n\n- starts_at is now the UTC start-of-day 29 days ago (inclusive 30 calendar days including today)\n- ends_at remains now (RFC3339)\n- unit test asserts starts_at is midnight UTC\n\nThis keeps the date-time formatting fix while making the range consistent with other providers' day-based presets.