### PR TITLE
Fix Stripe analytics timeouts

### DIFF
--- a/src/app/api/analytics/route.test.ts
+++ b/src/app/api/analytics/route.test.ts
@@ -424,4 +424,36 @@ describe("GET /api/analytics", () => {
     expect(body.processAnalytics).toBeTruthy();
     expect(body.processAnalytics.healthScore).toBeGreaterThanOrEqual(0);
   });
+
+  it("does not time out stripe at the default 8.5s budget", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const { fetchStripeData } = await import("@/lib/analytics/fetchers");
+      vi.mocked(fetchStripeData).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => resolve(STRIPE_DATA as never), 9_000);
+          }) as never
+      );
+
+      const { GET } = await import("@/app/api/analytics/route");
+      const responsePromise = GET(
+        new Request("http://localhost/api/analytics?section=finance-stripe")
+      );
+
+      await vi.advanceTimersByTimeAsync(9_000);
+
+      const response = await responsePromise;
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.stripe).toBeTruthy();
+      expect(
+        body.errors.some((entry: { source: string }) => entry.source === "stripe")
+      ).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -221,6 +221,13 @@ function requiredDomainsForSection(section: string | null): Set<DomainKey> {
   return new Set(SECTION_DOMAINS[section] ?? ALL_DOMAINS);
 }
 
+const DEFAULT_DOMAIN_TIMEOUT_MS = 8_500;
+const STRIPE_DOMAIN_TIMEOUT_MS = 20_000;
+
+function timeoutMsForDomain(domain: DomainKey): number {
+  return domain === "stripe" ? STRIPE_DOMAIN_TIMEOUT_MS : DEFAULT_DOMAIN_TIMEOUT_MS;
+}
+
 function withTimeout<T>(fn: () => Promise<T>, timeoutMs: number, label: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timeout = setTimeout(() => reject(new Error(`${label} timed out`)), timeoutMs);
@@ -434,7 +441,11 @@ function staleRefreshKey(input: RefreshInput): string {
 
 async function refreshDomainSnapshot(input: RefreshInput): Promise<void> {
   try {
-    const live = await withTimeout(input.entry.fn, 8_500, input.entry.key);
+    const live = await withTimeout(
+      input.entry.fn,
+      timeoutMsForDomain(input.entry.key),
+      input.entry.key
+    );
     await storeAnalyticsSnapshot({
       userId: input.userId,
       providerKey: input.entry.key,
@@ -725,7 +736,7 @@ export async function GET(request: Request) {
       }
 
       try {
-        const live = await withTimeout(entry.fn, 8_500, entry.key);
+        const live = await withTimeout(entry.fn, timeoutMsForDomain(entry.key), entry.key);
         await storeAnalyticsSnapshot({
           userId,
           providerKey: entry.key,

--- a/src/lib/analytics/fetchers.ts
+++ b/src/lib/analytics/fetchers.ts
@@ -206,6 +206,7 @@ interface StripeSub {
 }
 
 interface StripeCharge {
+  id?: string;
   amount: number;
   created: number;
   status: string;
@@ -214,14 +215,81 @@ interface StripeCharge {
 export async function fetchStripeData(apiKey: string): Promise<StripeData> {
   const headers = { Authorization: `Bearer ${apiKey}` };
   const baseUrl = "https://api.stripe.com/v1";
+  const now = Math.floor(Date.now() / 1000);
+  const sixMonthsAgo = now - 180 * 24 * 60 * 60;
 
-  // ── Fetch active subscriptions ──
-  const subsRes = await fetch(`${baseUrl}/subscriptions?limit=100&status=active`, { headers });
-  if (!subsRes.ok) {
-    throw new Error(`Stripe subscriptions error ${subsRes.status}`);
-  }
-  const subsData = await subsRes.json();
-  const activeSubs: StripeSub[] = subsData.data || [];
+  const fetchStripe = async (url: string): Promise<Response> =>
+    fetch(url, { headers, cache: "no-store" });
+
+  const fetchActiveSubscriptions = async (): Promise<StripeSub[]> => {
+    const subsRes = await fetchStripe(`${baseUrl}/subscriptions?limit=100&status=active`);
+    if (!subsRes.ok) {
+      throw new Error(`Stripe subscriptions error ${subsRes.status}`);
+    }
+    const subsData = await subsRes.json();
+    return subsData.data || [];
+  };
+
+  const fetchCanceledSubscriptions = async (): Promise<StripeSub[]> => {
+    const canceledRes = await fetchStripe(`${baseUrl}/subscriptions?limit=50&status=canceled`);
+    const canceledData = await canceledRes.json();
+    return canceledData.data || [];
+  };
+
+  const fetchPastDueAndTrialingCounts = async (): Promise<{
+    pastDueCount: number;
+    trialingCount: number;
+  }> => {
+    let pastDueCount = 0;
+    let trialingCount = 0;
+    try {
+      const [pastDueRes, trialingRes] = await Promise.all([
+        fetchStripe(`${baseUrl}/subscriptions?limit=1&status=past_due`),
+        fetchStripe(`${baseUrl}/subscriptions?limit=1&status=trialing`),
+      ]);
+      if (pastDueRes.ok) {
+        const pd = await pastDueRes.json();
+        pastDueCount = pd.data?.length || 0;
+        // Stripe doesn't return total count on list, but we fetch all if needed
+        if (pd.has_more) pastDueCount = 99; // approximate; indicates "many"
+      }
+      if (trialingRes.ok) {
+        const tr = await trialingRes.json();
+        trialingCount = tr.data?.length || 0;
+        if (tr.has_more) trialingCount = 99;
+      }
+    } catch {
+      // Non-critical
+    }
+    return { pastDueCount, trialingCount };
+  };
+
+  const fetchChargesSixMonths = async (): Promise<StripeCharge[]> => {
+    // Paginate through all charges in the last 6 months
+    const allCharges: StripeCharge[] = [];
+    let startingAfter: string | undefined;
+    for (let page = 0; page < 10; page++) {
+      let chargesUrl = `${baseUrl}/charges?limit=100&created[gte]=${sixMonthsAgo}`;
+      if (startingAfter) chargesUrl += `&starting_after=${startingAfter}`;
+
+      const chargesRes = await fetchStripe(chargesUrl);
+      if (!chargesRes.ok) break;
+      const chargesData = await chargesRes.json();
+      const batch = chargesData.data || [];
+      allCharges.push(...batch);
+
+      if (!chargesData.has_more || batch.length === 0) break;
+      startingAfter = batch[batch.length - 1].id;
+    }
+    return allCharges;
+  };
+
+  const [activeSubs, canceledSubs, counts, allCharges] = await Promise.all([
+    fetchActiveSubscriptions(),
+    fetchCanceledSubscriptions(),
+    fetchPastDueAndTrialingCounts(),
+    fetchChargesSixMonths(),
+  ]);
 
   // ── Calculate MRR — normalize yearly/quarterly subscriptions to monthly ──
   const mrr = activeSubs.reduce((sum: number, s: StripeSub) => {
@@ -246,54 +314,7 @@ export async function fetchStripeData(apiKey: string): Promise<StripeData> {
     return sum + monthlyAmount;
   }, 0);
 
-  // ── Fetch past_due + trialing subscriptions counts ──
-  let pastDueCount = 0;
-  let trialingCount = 0;
-  try {
-    const [pastDueRes, trialingRes] = await Promise.all([
-      fetch(`${baseUrl}/subscriptions?limit=1&status=past_due`, { headers }),
-      fetch(`${baseUrl}/subscriptions?limit=1&status=trialing`, { headers }),
-    ]);
-    if (pastDueRes.ok) {
-      const pd = await pastDueRes.json();
-      pastDueCount = pd.data?.length || 0;
-      // Stripe doesn't return total count on list, but we fetch all if needed
-      if (pd.has_more) pastDueCount = 99; // approximate; indicates "many"
-    }
-    if (trialingRes.ok) {
-      const tr = await trialingRes.json();
-      trialingCount = tr.data?.length || 0;
-      if (tr.has_more) trialingCount = 99;
-    }
-  } catch {
-    // Non-critical
-  }
-
-  // ── Fetch canceled subscriptions (recent) ──
-  const canceledRes = await fetch(`${baseUrl}/subscriptions?limit=50&status=canceled`, { headers });
-  const canceledData = await canceledRes.json();
-  const canceledSubs: StripeSub[] = canceledData.data || [];
-
-  // ── Fetch charges for revenue across 6 months ──
-  const now = Math.floor(Date.now() / 1000);
-  const sixMonthsAgo = now - 180 * 24 * 60 * 60;
-
-  // Paginate through all charges in the last 6 months
-  const allCharges: StripeCharge[] = [];
-  let startingAfter: string | undefined;
-  for (let page = 0; page < 10; page++) {
-    let chargesUrl = `${baseUrl}/charges?limit=100&created[gte]=${sixMonthsAgo}`;
-    if (startingAfter) chargesUrl += `&starting_after=${startingAfter}`;
-
-    const chargesRes = await fetch(chargesUrl, { headers });
-    if (!chargesRes.ok) break;
-    const chargesData = await chargesRes.json();
-    const batch = chargesData.data || [];
-    allCharges.push(...batch);
-
-    if (!chargesData.has_more || batch.length === 0) break;
-    startingAfter = batch[batch.length - 1].id;
-  }
+  const { pastDueCount, trialingCount } = counts;
 
   // ── Bucket charges by month for trend ──
   const thirtyDaysAgo = now - 30 * 24 * 60 * 60;

--- a/src/lib/analytics/refresh-runner.ts
+++ b/src/lib/analytics/refresh-runner.ts
@@ -31,6 +31,11 @@ function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   });
 }
 
+function timeoutMsForRefreshJob(providerKey: string): number {
+  if (providerKey === "stripe") return 25_000;
+  return 10_000;
+}
+
 async function computeProductSnapshot(userId: string, fromDate: Date, toDate: Date) {
   const [createdTasksInRange, completedTasksInRange, overdueOpenTasks, contributors] = await Promise.all([
     prisma.task.count({ where: { createdAt: { gte: fromDate, lte: toDate } } }),
@@ -260,7 +265,7 @@ async function refreshForUserAndRange(input: {
     const provider = providerForSnapshotKey(job.providerKey);
 
     try {
-      const payload = await timeout(job.run(), 10_000);
+      const payload = await timeout(job.run(), timeoutMsForRefreshJob(job.providerKey));
       await storeAnalyticsSnapshot({
         userId: input.userId,
         providerKey: job.providerKey,


### PR DESCRIPTION
- Increase Stripe timeout in /api/analytics (20s)\n- Increase Stripe timeout in analytics refresh runner (25s)\n- Parallelize Stripe fetcher calls + force no-store\n- Add regression test for >8.5s Stripe fetch