### PR TITLE
Surface rep scoreboard + analytics fixes

### DIFF
--- a/src/components/analytics/rep-scoreboard-card.test.tsx
+++ b/src/components/analytics/rep-scoreboard-card.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RepScoreboardCard } from "@/components/analytics/rep-scoreboard-card";
+
+describe("RepScoreboardCard", () => {
+  it("renders empty state when rows are missing", () => {
+    render(<RepScoreboardCard />);
+    expect(screen.getByText("No rep data available")).toBeTruthy();
+  });
+
+  it("renders table headers", () => {
+    render(
+      <RepScoreboardCard
+        rows={[
+          { repName: "Alice", count: 1, value: 1000, closedWon: 0, closedWonValue: 0 },
+        ]}
+      />
+    );
+
+    expect(screen.getByText("Rep Name")).toBeTruthy();
+    expect(screen.getByText("Total Deals")).toBeTruthy();
+    expect(screen.getByText("Total Pipeline")).toBeTruthy();
+    expect(screen.getByText("Won Count")).toBeTruthy();
+    expect(screen.getByText("Won Revenue")).toBeTruthy();
+  });
+
+  it("sorts reps by pipeline value descending", () => {
+    render(
+      <RepScoreboardCard
+        rows={[
+          { repName: "Low", count: 2, value: 100, closedWon: 1, closedWonValue: 50 },
+          { repName: "High", count: 3, value: 5000, closedWon: 2, closedWonValue: 2000 },
+          { repName: "Mid", count: 1, value: 900, closedWon: 0, closedWonValue: 0 },
+        ]}
+      />
+    );
+
+    const tableRows = screen.getAllByRole("row");
+    expect(tableRows[1]?.textContent).toContain("High");
+    expect(tableRows[2]?.textContent).toContain("Mid");
+    expect(tableRows[3]?.textContent).toContain("Low");
+  });
+});
+

--- a/src/components/analytics/rep-scoreboard-card.tsx
+++ b/src/components/analytics/rep-scoreboard-card.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import type { DealsByRep } from "@/lib/analytics/types";
+import { DataTable, type DataTableColumn, fmt$, fmtN, SectionCard } from "./dashboard-primitives";
+
+export function RepScoreboardCard({
+  rows,
+  title = "Sales Rep Scoreboard",
+  subtitle = "Pipeline and win metrics by team member",
+  emptyMessage = "No rep data available",
+}: {
+  rows?: DealsByRep[];
+  title?: string;
+  subtitle?: string;
+  emptyMessage?: string;
+}) {
+  const repRows = [...(rows ?? [])].sort((a, b) => b.value - a.value);
+
+  const columns: DataTableColumn<DealsByRep>[] = [
+    { key: "repName", label: "Rep Name" },
+    { key: "count", label: "Total Deals", align: "right", render: (row) => fmtN(row.count) },
+    { key: "value", label: "Total Pipeline", align: "right", render: (row) => fmt$(row.value) },
+    { key: "closedWon", label: "Won Count", align: "right", render: (row) => fmtN(row.closedWon) },
+    {
+      key: "closedWonValue",
+      label: "Won Revenue",
+      align: "right",
+      render: (row) => (
+        <span className="font-medium tabular-nums text-emerald-600 dark:text-emerald-400">
+          {fmt$(row.closedWonValue)}
+        </span>
+      ),
+    },
+  ];
+
+  return (
+    <SectionCard title={title} subtitle={subtitle}>
+      <DataTable columns={columns} rows={repRows} emptyMessage={emptyMessage} />
+    </SectionCard>
+  );
+}
+

--- a/src/components/analytics/sales-funnel-tab.tsx
+++ b/src/components/analytics/sales-funnel-tab.tsx
@@ -7,6 +7,7 @@ import {
 import type { AnalyticsDashboardData, DealStage } from "@/lib/analytics/types";
 import { StatCard } from "./stat-card";
 import { RingStat } from "./bar-display";
+import { RepScoreboardCard } from "./rep-scoreboard-card";
 
 function fmt$(n: number) {
   if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
@@ -128,6 +129,8 @@ export function SalesFunnelTab({ data }: { data: AnalyticsDashboardData | null }
           })}
         </div>
       </div>
+
+      <RepScoreboardCard rows={funnel.dealsByRep ?? []} />
 
       {/* Bottleneck Analysis + Terminal Stages */}
       <div className="grid gap-4 lg:grid-cols-2">

--- a/src/components/analytics/sales-hubspot-tab.tsx
+++ b/src/components/analytics/sales-hubspot-tab.tsx
@@ -8,6 +8,7 @@ import type { AnalyticsDashboardData } from "@/lib/analytics/types";
 import { FinanceDataEmptyState } from "@/components/analytics/finance-empty-state";
 import { StatCard } from "@/components/analytics/stat-card";
 import { BarDisplay, RingStat } from "@/components/analytics/bar-display";
+import { RepScoreboardCard } from "./rep-scoreboard-card";
 import {
   fmt$, fmtN, fmtPct,
   AlertBanner, DataTable, InsightCard,
@@ -35,6 +36,7 @@ export function SalesHubspotTab({ data }: SalesHubspotTabProps) {
 
   const funnel = hs.funnel;
   const deals = hs.deals ?? [];
+  const repRows = funnel.dealsByRep ?? [];
 
   /* ── Alerts ──────────────────────────────────────── */
 
@@ -201,6 +203,8 @@ export function SalesHubspotTab({ data }: SalesHubspotTabProps) {
           icon={<Target className="h-4 w-4" />}
         />
       </div>
+
+      <RepScoreboardCard rows={repRows} />
 
       {/* ── Sales Funnel ──────────────────────────── */}
       <SectionCard title="Sales Pipeline Funnel" subtitle="Deal progression through stages">

--- a/src/lib/__tests__/analytics-fetchers-stripe.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-stripe.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchStripeData } from "@/lib/analytics/fetchers";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("analytics stripe fetcher", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("counts past_due and trialing subscriptions by paginating results", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+
+      if (url.pathname === "/v1/subscriptions") {
+        const status = url.searchParams.get("status");
+        const startingAfter = url.searchParams.get("starting_after");
+
+        if (status === "active") {
+          return jsonResponse({ data: [], has_more: false });
+        }
+
+        if (status === "canceled") {
+          return jsonResponse({ data: [], has_more: false });
+        }
+
+        if (status === "past_due") {
+          if (!startingAfter) {
+            return jsonResponse({
+              data: [{ id: "sub_pd_1" }, { id: "sub_pd_2" }],
+              has_more: true,
+            });
+          }
+          if (startingAfter === "sub_pd_2") {
+            return jsonResponse({
+              data: [{ id: "sub_pd_3" }],
+              has_more: false,
+            });
+          }
+          return jsonResponse({ data: [], has_more: false });
+        }
+
+        if (status === "trialing") {
+          return jsonResponse({
+            data: [{ id: "sub_tr_1" }, { id: "sub_tr_2" }, { id: "sub_tr_3" }, { id: "sub_tr_4" }],
+            has_more: false,
+          });
+        }
+      }
+
+      if (url.pathname === "/v1/charges") {
+        return jsonResponse({ data: [], has_more: false });
+      }
+
+      return jsonResponse({ error: "unexpected request", url: String(url) }, 500);
+    });
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const data = await fetchStripeData(
+      "sk_test_123",
+      new Date("2026-01-01T00:00:00.000Z"),
+      new Date("2026-02-01T00:00:00.000Z")
+    );
+
+    expect(data.subscriptions.pastDue).toBe(3);
+    expect(data.subscriptions.trialing).toBe(4);
+
+    const requestUrls = fetchMock.mock.calls.map(([url]) => String(url));
+    expect(requestUrls.some((url) => url.includes("status=past_due") && url.includes("limit=100"))).toBe(true);
+    expect(requestUrls.some((url) => url.includes("status=trialing") && url.includes("limit=100"))).toBe(true);
+  });
+});
+

--- a/src/lib/analytics/demo-analytics.ts
+++ b/src/lib/analytics/demo-analytics.ts
@@ -314,15 +314,7 @@ function buildJourneyPathAnalysis(data: AnalyticsDashboardData): JourneyPathRow[
     });
     const notActivated = notActivatedDeals.length;
 
-    // Actual Churned: churned > 60 days of deal creation OR missing dates
-    const actualChurnedDeals = churnedDeals.filter(({ deal, churnedAt }) => {
-      if (!deal.createdAt || !churnedAt) return true;
-      const createdMs = new Date(deal.createdAt).getTime();
-      const churnedMs = new Date(churnedAt).getTime();
-      const daysSinceCreation = (churnedMs - createdMs) / 86_400_000;
-      return daysSinceCreation > 60;
-    });
-    const churned = actualChurnedDeals.length;
+    const churned = churnedDeals.length;
 
     rows.push({
       source,

--- a/src/lib/analytics/fetchers-ads.ts
+++ b/src/lib/analytics/fetchers-ads.ts
@@ -152,7 +152,7 @@ function extractRedditSpend(metric: UnknownRecord): number {
     metric.total_spend ??
     null;
   if (direct !== null) {
-    return readNumber(direct) / 1_000_000;
+    return readNumber(direct);
   }
 
   const micros =

--- a/src/lib/analytics/fetchers.ts
+++ b/src/lib/analytics/fetchers.ts
@@ -305,6 +305,7 @@ interface StripeSubItem {
 }
 
 interface StripeSub {
+  id: string;
   items: { data: StripeSubItem[] };
   customer: string;
   canceled_at: number;
@@ -350,28 +351,41 @@ export async function fetchStripeData(
     pastDueCount: number;
     trialingCount: number;
   }> => {
-    let pastDueCount = 0;
-    let trialingCount = 0;
     try {
-      const [pastDueRes, trialingRes] = await Promise.all([
-        fetchStripe(`${baseUrl}/subscriptions?limit=1&status=past_due`),
-        fetchStripe(`${baseUrl}/subscriptions?limit=1&status=trialing`),
+      const countSubscriptionsByStatus = async (status: string): Promise<number> => {
+        let count = 0;
+        let startingAfter: string | undefined;
+
+        for (let page = 0; page < 1000; page++) {
+          let url = `${baseUrl}/subscriptions?limit=100&status=${encodeURIComponent(status)}`;
+          if (startingAfter) url += `&starting_after=${startingAfter}`;
+
+          const res = await fetchStripe(url);
+          if (!res.ok) {
+            throw new Error(`Stripe subscriptions(${status}) error ${res.status}`);
+          }
+
+          const data = await res.json();
+          const batch = (data?.data || []) as StripeSub[];
+          count += batch.length;
+
+          if (!data?.has_more || batch.length === 0) break;
+          startingAfter = batch[batch.length - 1]?.id;
+          if (!startingAfter) break;
+        }
+
+        return count;
+      };
+
+      const [pastDueCount, trialingCount] = await Promise.all([
+        countSubscriptionsByStatus("past_due"),
+        countSubscriptionsByStatus("trialing"),
       ]);
-      if (pastDueRes.ok) {
-        const pd = await pastDueRes.json();
-        pastDueCount = pd.data?.length || 0;
-        // Stripe doesn't return total count on list, but we fetch all if needed
-        if (pd.has_more) pastDueCount = 99; // approximate; indicates "many"
-      }
-      if (trialingRes.ok) {
-        const tr = await trialingRes.json();
-        trialingCount = tr.data?.length || 0;
-        if (tr.has_more) trialingCount = 99;
-      }
+      return { pastDueCount, trialingCount };
     } catch {
       // Non-critical
     }
-    return { pastDueCount, trialingCount };
+    return { pastDueCount: 0, trialingCount: 0 };
   };
 
   const fetchChargesSixMonths = async (): Promise<StripeCharge[]> => {


### PR DESCRIPTION
- Surface Sales Rep Scoreboard on /analytics/sales-hubspot and /analytics/sales-pipeline\n- Fix demo analytics churn counts (include all churn events)\n- Fix Reddit spend parsing for v3 report shape\n- Improve Stripe past_due/trialing counts via pagination + add coverage\n\nTests: npm test