### PR TITLE
style: increase background contrast

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,7 +14,7 @@
   --accent-light: #fef7f5;
 
   /* Backgrounds */
-  --background: #ffffff;
+  --background: #f0f0f0;
   --card: #ffffff;
   --popover: #ffffff;
   --secondary: #f5f5f5;


### PR DESCRIPTION
Adjust light-mode theme so the app background is slightly darker than cards/fields.

- Sets `--background` to `#f0f0f0` so white fields + table rows are visually distinct.

Verified locally: `npm test`.