### PR TITLE
fix(approvals): add double-click protection to approve/reject buttons

### DIFF
--- a/src/app/(dashboard)/automations/approvals/page.tsx
+++ b/src/app/(dashboard)/automations/approvals/page.tsx
@@ -34,6 +34,8 @@ export default function AutomationApprovalsPage() {
   const [notesFor, setNotesFor] = useState<{ id: string; action: "approve" | "reject" } | null>(null);
   const [notesText, setNotesText] = useState("");
   const notesRef = useRef<HTMLTextAreaElement>(null);
+  const [processingId, setProcessingId] = useState<string | null>(null);
+  const [processingAction, setProcessingAction] = useState<"approve" | "reject" | null>(null);
 
   const fetchApprovals = async (options?: { preserveExisting?: boolean; signal?: AbortSignal }) => {
     if (!options?.preserveExisting) {
@@ -85,24 +87,34 @@ export default function AutomationApprovalsPage() {
   }, []);
 
   const decide = async (approvalId: string, action: "approve" | "reject", note?: string) => {
-    const response = await fetch(`/api/automations/approvals/${approvalId}/${action}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ note: note || undefined }),
-    });
+    if (processingId) return;
 
-    if (!response.ok) {
-      const payload = (await response.json().catch(() => null)) as { error?: string } | null;
-      setError(payload?.error || "Decision failed");
-      return;
+    setProcessingId(approvalId);
+    setProcessingAction(action);
+    try {
+      const response = await fetch(`/api/automations/approvals/${approvalId}/${action}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ note: note || undefined }),
+      });
+
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+        setError(payload?.error || "Decision failed");
+        return;
+      }
+
+      setNotesFor(null);
+      setNotesText("");
+      await fetchApprovals({ preserveExisting: true });
+    } finally {
+      setProcessingId(null);
+      setProcessingAction(null);
     }
-
-    setNotesFor(null);
-    setNotesText("");
-    await fetchApprovals({ preserveExisting: true });
   };
 
   const openNotes = (id: string, action: "approve" | "reject") => {
+    if (processingId) return;
     setNotesFor({ id, action });
     setNotesText("");
     // Auto-focus textarea on next render
@@ -110,6 +122,7 @@ export default function AutomationApprovalsPage() {
   };
 
   const cancelNotes = () => {
+    if (processingId) return;
     setNotesFor(null);
     setNotesText("");
   };
@@ -166,15 +179,31 @@ export default function AutomationApprovalsPage() {
                   </Link>
                   <button
                     onClick={() => openNotes(approval.id, "reject")}
-                    className="rounded-md border border-red-500/40 bg-red-500/10 px-2 py-1 text-xs text-red-500"
+                    disabled={processingId === approval.id}
+                    className="rounded-md border border-red-500/40 bg-red-500/10 px-2 py-1 text-xs text-red-500 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
-                    Reject
+                    {processingId === approval.id && processingAction === "reject" ? (
+                      <span className="flex items-center gap-1">
+                        <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                        Rejecting…
+                      </span>
+                    ) : (
+                      "Reject"
+                    )}
                   </button>
                   <button
                     onClick={() => openNotes(approval.id, "approve")}
-                    className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-2 py-1 text-xs text-emerald-600"
+                    disabled={processingId === approval.id}
+                    className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-2 py-1 text-xs text-emerald-600 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
-                    Approve
+                    {processingId === approval.id && processingAction === "approve" ? (
+                      <span className="flex items-center gap-1">
+                        <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                        Approving…
+                      </span>
+                    ) : (
+                      "Approve"
+                    )}
                   </button>
                 </div>
               </div>
@@ -187,22 +216,32 @@ export default function AutomationApprovalsPage() {
                     onChange={(e) => setNotesText(e.target.value)}
                     placeholder="Add notes (optional)..."
                     rows={2}
-                    className="w-full resize-none rounded-md border border-border bg-background px-3 py-2 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                    disabled={processingId === approval.id}
+                    className="w-full resize-none rounded-md border border-border bg-background px-3 py-2 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50"
                   />
                   <div className="flex items-center gap-2">
                     <button
                       onClick={submitNotes}
-                      className={`rounded-md px-3 py-1 text-xs font-medium ${
+                      disabled={processingId === approval.id}
+                      className={`rounded-md px-3 py-1 text-xs font-medium disabled:opacity-50 disabled:cursor-not-allowed ${
                         notesFor.action === "approve"
                           ? "border border-emerald-500/40 bg-emerald-500/10 text-emerald-600"
                           : "border border-red-500/40 bg-red-500/10 text-red-500"
                       }`}
                     >
-                      {notesFor.action === "approve" ? "Confirm Approve" : "Confirm Reject"}
+                      {processingId === approval.id ? (
+                        <span className="flex items-center gap-1">
+                          <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                          {notesFor.action === "approve" ? "Approving…" : "Rejecting…"}
+                        </span>
+                      ) : (
+                        notesFor.action === "approve" ? "Confirm Approve" : "Confirm Reject"
+                      )}
                     </button>
                     <button
                       onClick={cancelNotes}
-                      className="rounded-md border border-border bg-background px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
+                      disabled={processingId === approval.id}
+                      className="rounded-md border border-border bg-background px-3 py-1 text-xs text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       Cancel
                     </button>


### PR DESCRIPTION
## Summary
- Add `processingId`/`processingAction` state to prevent duplicate API submissions
- Buttons show loading spinner and "Approving…"/"Rejecting…" text while in-flight
- Both buttons disabled with visual feedback during processing

## Test plan
- [ ] Click approve — button shows spinner, other buttons disabled
- [ ] Rapid-click approve — only one API call fires
- [ ] Click reject — spinner shown, resets on completion
- [ ] API failure — buttons re-enable after error

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)