### PR TITLE
fix(automations): add error state with retry for failed workflow fetch

### DIFF
--- a/src/app/(dashboard)/automations/page.tsx
+++ b/src/app/(dashboard)/automations/page.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
-import { Bot, Filter, PlusCircle, ShieldCheck } from "lucide-react";
+import { AlertTriangle, Bot, Filter, PlusCircle, ShieldCheck } from "lucide-react";
 import { readSessionCache, writeSessionCache } from "@/lib/client/session-cache";
 
 type WorkflowListItem = {
@@ -47,20 +47,24 @@ export default function AutomationsPage() {
   const router = useRouter();
   const [data, setData] = useState<AutomationsResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [scopeFilter, setScopeFilter] = useState<"all" | "PRIVATE" | "SHARED">("all");
   const [statusFilter, setStatusFilter] = useState<"all" | WorkflowListItem["status"]>("all");
   const [providerFilter, setProviderFilter] = useState<string>("all");
   const [healthFilter, setHealthFilter] = useState<"all" | "healthy" | "needs-attention" | "never-run">("all");
 
   const fetchData = async (signal?: AbortSignal) => {
+    setError(null);
     try {
       const response = await fetch("/api/automations", { signal });
       const payload = (await response.json()) as AutomationsResponse;
       if (signal?.aborted) return;
       setData(payload);
       writeSessionCache<AutomationsResponse>(AUTOMATIONS_CACHE_KEY, payload);
-    } catch {
+    } catch (err) {
       if (!signal?.aborted) {
+        setError("Failed to load workflows");
+        console.error(err);
         setData(null);
       }
     } finally {
@@ -247,6 +251,22 @@ export default function AutomationsPage() {
           <option value="never-run">Never Run</option>
         </select>
       </div>
+
+      {error && (
+        <div className="flex items-center gap-3 rounded-xl border border-destructive/50 bg-destructive/10 px-4 py-3">
+          <AlertTriangle className="h-4 w-4 shrink-0 text-destructive" />
+          <p className="flex-1 text-sm text-destructive">{error}</p>
+          <button
+            onClick={() => {
+              setLoading(true);
+              void fetchData();
+            }}
+            className="rounded-md border border-destructive/30 px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10"
+          >
+            Retry
+          </button>
+        </div>
+      )}
 
       <section className="space-y-2">
         <h2 className="text-sm font-semibold text-foreground">Workflows</h2>


### PR DESCRIPTION
## Summary
- Replace empty `catch {}` block with proper error state management
- Show error banner with AlertTriangle icon and "Retry" button when fetch fails
- Error clears on retry or successful fetch

## Test plan
- [ ] Simulate network failure — error banner appears with retry button
- [ ] Click Retry — loading state shown, error clears on success
- [ ] Normal load — no error banner visible

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)