### PR TITLE
fix(login): replace window.location.search with useSearchParams

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { getProviders, signIn } from "next-auth/react";
+import { useSearchParams } from "next/navigation";
 import { Shield } from "lucide-react";
-import { useState, useEffect } from "react";
+import { Suspense, useState, useEffect } from "react";
 
 interface DevUser {
   id: string;
@@ -30,6 +31,15 @@ const authErrors: Record<string, string> = {
 };
 
 export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginPageContent />
+    </Suspense>
+  );
+}
+
+function LoginPageContent() {
+  const searchParams = useSearchParams();
   const [devUsers, setDevUsers] = useState<DevUser[]>([]);
   const [loadingProviders, setLoadingProviders] = useState(true);
   const [googleEnabled, setGoogleEnabled] = useState(false);
@@ -71,16 +81,14 @@ export default function LoginPage() {
   }, [isDev]);
 
   useEffect(() => {
-    const error = new URLSearchParams(window.location.search).get("error");
+    const error = searchParams.get("error");
     if (error) {
       Promise.resolve().then(() => setAuthErrorCode(error));
     }
-  }, []);
+  }, [searchParams]);
 
   useEffect(() => {
-    const inviteToken = new URLSearchParams(window.location.search).get(
-      "inviteToken"
-    );
+    const inviteToken = searchParams.get("inviteToken");
     if (!inviteToken) return;
 
     fetch(`/api/team/invite?token=${encodeURIComponent(inviteToken)}`)
@@ -103,7 +111,7 @@ export default function LoginPage() {
       .catch(() => {
         setInviteMessage("Invite link is invalid or expired.");
       });
-  }, []);
+  }, [searchParams]);
 
   const handleDevLogin = async () => {
     if (!selectedEmail) return;


### PR DESCRIPTION
## Summary
- Replace direct `window.location.search` access with Next.js `useSearchParams` hook
- Wrap login content in `<Suspense>` boundary as required by useSearchParams
- Prevents hydration mismatch between server and client renders

## Test plan
- [ ] Login page renders without hydration warnings
- [ ] Error parameter from OAuth redirect displays correctly
- [ ] Invite token passed via URL is captured and sent with sign-in

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)