### PR TITLE
fix(projects): replace window.prompt for save view with modal dialog

### DIFF
--- a/src/components/projects/project-dashboard.tsx
+++ b/src/components/projects/project-dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   Plus,
@@ -12,6 +12,8 @@ import {
   CheckCircle2,
   Circle,
   FilterX,
+  Loader2,
+  X,
 } from "lucide-react";
 import { ProjectCard } from "./project-card";
 import { useDashboardResource } from "@/components/dashboard/use-dashboard-resource";
@@ -102,6 +104,10 @@ export function ProjectDashboard() {
   const [filterDepartment, setFilterDepartment] = useState("");
   const [selectedViewId, setSelectedViewId] = useState("");
   const [actionError, setActionError] = useState<string | null>(null);
+  const [showSaveViewModal, setShowSaveViewModal] = useState(false);
+  const [saveViewName, setSaveViewName] = useState("");
+  const [savingView, setSavingView] = useState(false);
+  const saveViewInputRef = useRef<HTMLInputElement>(null);
 
   const resource = useDashboardResource<ProjectDashboardData>({
     cacheKey: PROJECT_DASHBOARD_CACHE_KEY,
@@ -233,32 +239,64 @@ export function ProjectDashboard() {
     setFilterDepartment(defaults.filterDepartment);
   };
 
-  const saveCurrentAsView = async () => {
+  const openSaveViewModal = () => {
     setActionError(null);
-    const name = window.prompt("Saved view name");
-    if (!name) return;
-
-    const response = await fetch("/api/views", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        scope: "projects",
-        name,
-        config: {
-          defaultLayout: viewMode,
-          filterStatus: filterStatus || null,
-          filterDepartment: filterDepartment || null,
-        },
-      }),
-    });
-
-    if (!response.ok) {
-      setActionError(`Could not save view (${response.status}).`);
-      return;
-    }
-
-    await resource.refresh();
+    setSaveViewName("");
+    setShowSaveViewModal(true);
   };
+
+  const closeSaveViewModal = () => {
+    if (savingView) return;
+    setShowSaveViewModal(false);
+    setSaveViewName("");
+  };
+
+  const submitSaveView = async () => {
+    const trimmed = saveViewName.trim();
+    if (!trimmed) return;
+
+    setSavingView(true);
+    try {
+      const response = await fetch("/api/views", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          scope: "projects",
+          name: trimmed,
+          config: {
+            defaultLayout: viewMode,
+            filterStatus: filterStatus || null,
+            filterDepartment: filterDepartment || null,
+          },
+        }),
+      });
+
+      if (!response.ok) {
+        setActionError(`Could not save view (${response.status}).`);
+        return;
+      }
+
+      await resource.refresh();
+      setShowSaveViewModal(false);
+      setSaveViewName("");
+    } catch {
+      setActionError("Could not save view. Please try again.");
+    } finally {
+      setSavingView(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!showSaveViewModal) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeSaveViewModal();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    // Auto-focus the input after the modal renders
+    requestAnimationFrame(() => saveViewInputRef.current?.focus());
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [showSaveViewModal]);
 
   if (resource.loading && !resource.data) {
     return <DashboardLoadingState message="Loading projects dashboard..." className="h-[50vh]" />;
@@ -364,7 +402,7 @@ export function ProjectDashboard() {
         </select>
 
         <button
-          onClick={saveCurrentAsView}
+          onClick={openSaveViewModal}
           className="flex items-center gap-1.5 rounded-lg border border-border bg-card px-3 py-2 text-sm text-muted-foreground hover:text-foreground"
         >
           <BookmarkPlus className="h-3.5 w-3.5" />
@@ -525,6 +563,84 @@ export function ProjectDashboard() {
           </table>
         </div>
       )}
+
+      {showSaveViewModal ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+          onClick={closeSaveViewModal}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="save-view-title"
+            className="relative w-full max-w-md rounded-xl border border-border bg-card shadow-lg focus:outline-none"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between border-b border-border px-6 py-4">
+              <h2 id="save-view-title" className="text-lg font-semibold text-foreground">
+                Save Current View
+              </h2>
+              <button
+                onClick={closeSaveViewModal}
+                disabled={savingView}
+                className="rounded-md p-2 text-muted-foreground hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+                aria-label="Close dialog"
+                title="Close"
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </div>
+
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                submitSaveView();
+              }}
+              className="space-y-5 px-6 py-5"
+            >
+              <div>
+                <label htmlFor="save-view-name" className="mb-1 block text-xs font-medium text-muted-foreground">
+                  View Name
+                </label>
+                <input
+                  ref={saveViewInputRef}
+                  id="save-view-name"
+                  value={saveViewName}
+                  onChange={(e) => setSaveViewName(e.target.value)}
+                  className="modal-input w-full rounded-md border px-3 py-2 text-sm"
+                  placeholder="e.g. Active Engineering"
+                  disabled={savingView}
+                />
+              </div>
+
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={closeSaveViewModal}
+                  disabled={savingView}
+                  className="btn-ghost-muted rounded-lg border border-border px-4 py-2 text-sm disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={savingView || !saveViewName.trim()}
+                  className="btn-primary-theme flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium disabled:opacity-50"
+                >
+                  {savingView ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Saving...
+                    </>
+                  ) : (
+                    "Save View"
+                  )}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace `window.prompt` with a React modal matching ConferenceCreateModal pattern
- Modal: labeled input, Cancel/Save buttons, Loader2 spinner while saving
- Escape key and backdrop click to close

## Test plan
- [ ] Click "Save View" button — modal opens with auto-focused input
- [ ] Enter name and save — view created, modal closes, resource refreshes
- [ ] Cancel/Escape/backdrop click — modal closes cleanly
- [ ] API failure — error banner shown

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)