### PR TITLE
fix(projects): add error state with retry for failed project fetch

### DIFF
--- a/src/components/projects/project-detail.tsx
+++ b/src/components/projects/project-detail.tsx
@@ -430,6 +430,7 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
   const router = useRouter();
   const [project, setProject] = useState<ProjectFull | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [taskFilter, setTaskFilter] = useState<string>("");
   const [saving, setSaving] = useState(false);
   const toast = useToast();
@@ -441,6 +442,7 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
   const cacheKey = `dashboard:project-detail:v1:${projectId}`;
 
   const fetchProject = useCallback(async (signal?: AbortSignal) => {
+    setError(null);
     try {
       const res = await fetch(`/api/projects/${projectId}`, { signal });
       if (res.ok) {
@@ -448,9 +450,14 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
         if (signal?.aborted) return;
         setProject(payload);
         writeSessionCache<ProjectFull>(cacheKey, payload);
+      } else if (!signal?.aborted) {
+        setError("Failed to load project");
       }
-    } catch {
-      // Handle silently
+    } catch (err) {
+      if (!signal?.aborted) {
+        console.error(err);
+        setError("Failed to load project");
+      }
     } finally {
       if (!signal?.aborted) {
         setLoading(false);
@@ -593,6 +600,34 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
     return (
       <div className="flex h-[50vh] items-center justify-center">
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16">
+        <div className="flex items-center gap-3 rounded-xl border border-red-300 bg-red-50 px-6 py-4 dark:border-red-500/30 dark:bg-red-500/10">
+          <AlertTriangle className="h-5 w-5 flex-shrink-0 text-red-500" />
+          <p className="text-sm font-medium text-red-700 dark:text-red-400">
+            {error}
+          </p>
+        </div>
+        <button
+          onClick={() => {
+            setLoading(true);
+            fetchProject();
+          }}
+          className="mt-4 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+        >
+          Retry
+        </button>
+        <button
+          onClick={() => router.push("/projects")}
+          className="mt-2 text-sm text-muted-foreground hover:text-foreground hover:underline"
+        >
+          Back to projects
+        </button>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Replace empty `catch {}` with proper error state in `fetchProject`
- Show error banner with AlertTriangle icon, Retry and Back to projects buttons
- Handle both non-OK response and network errors

## Test plan
- [ ] Simulate network failure — error banner appears with Retry button
- [ ] Click Retry — loading state shown, error clears on success
- [ ] Normal load — no error banner visible

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)