### PR TITLE
fix(whip): add confirmation dialog for descope and defer actions

### DIFF
--- a/src/components/whip/quick-actions-panel.tsx
+++ b/src/components/whip/quick-actions-panel.tsx
@@ -37,6 +37,11 @@ function statusDotColor(status: string): string {
 export function QuickActionsPanel({ tasks, updateTask }: QuickActionsPanelProps) {
   const [actionInFlight, setActionInFlight] = useState<string | null>(null);
   const [actionResult, setActionResult] = useState<Record<string, "success" | "error">>({});
+  const [confirmAction, setConfirmAction] = useState<{
+    type: "defer" | "descope";
+    taskId: string;
+    taskTitle: string;
+  } | null>(null);
 
   // Show unplanned tasks that are NOT done -- prime candidates for de-scope/defer
   const unplannedActive = tasks
@@ -147,7 +152,9 @@ export function QuickActionsPanel({ tasks, updateTask }: QuickActionsPanelProps)
                   <button
                     type="button"
                     disabled={isBusy}
-                    onClick={() => handleAction(task.id, "defer")}
+                    onClick={() =>
+                      setConfirmAction({ type: "defer", taskId: task.id, taskTitle: task.title })
+                    }
                     className="rounded px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground disabled:opacity-50"
                     title="Defer to backlog (keep in sprint)"
                   >
@@ -156,7 +163,9 @@ export function QuickActionsPanel({ tasks, updateTask }: QuickActionsPanelProps)
                   <button
                     type="button"
                     disabled={isBusy}
-                    onClick={() => handleAction(task.id, "descope")}
+                    onClick={() =>
+                      setConfirmAction({ type: "descope", taskId: task.id, taskTitle: task.title })
+                    }
                     className="rounded px-2 py-1 text-xs font-medium text-wip-over-text transition-colors hover:bg-wip-over-bg disabled:opacity-50"
                     title="De-scope from sprint entirely"
                   >
@@ -168,6 +177,60 @@ export function QuickActionsPanel({ tasks, updateTask }: QuickActionsPanelProps)
           );
         })}
       </div>
+
+      {/* Confirmation dialog */}
+      {confirmAction && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={() => setConfirmAction(null)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") setConfirmAction(null);
+          }}
+        >
+          <div
+            className="mx-4 w-full max-w-sm rounded-lg border border-border bg-card p-5 shadow-lg"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+          >
+            <h4 className="text-sm font-semibold text-foreground">
+              {confirmAction.type === "defer" ? "Defer Task?" : "De-scope Task?"}
+            </h4>
+            <p className="mt-2 text-sm text-muted-foreground">
+              <span className="font-medium text-foreground">
+                {confirmAction.taskTitle}
+              </span>
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {confirmAction.type === "defer"
+                ? "This will move the task back to Backlog."
+                : "This will remove the task from the current sprint and move it to Backlog."}
+            </p>
+            <div className="mt-4 flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirmAction(null)}
+                className="rounded px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  handleAction(confirmAction.taskId, confirmAction.type);
+                  setConfirmAction(null);
+                }}
+                className={`rounded px-3 py-1.5 text-xs font-medium transition-colors ${
+                  confirmAction.type === "descope"
+                    ? "bg-wip-over-bg text-wip-over-text hover:bg-wip-over-bg/80"
+                    : "bg-secondary text-foreground hover:bg-secondary/80"
+                }`}
+              >
+                {confirmAction.type === "defer" ? "Defer" : "De-scope"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add confirmation modal before Defer and De-scope actions
- Dialog explains impact: move to Backlog vs remove from sprint
- Cancel/Confirm buttons, backdrop click to dismiss

## Test plan
- [ ] Click Defer — confirmation dialog appears with impact explanation
- [ ] Click De-scope — confirmation dialog appears
- [ ] Cancel or backdrop click — dialog closes, no action taken
- [ ] Confirm — action executes, dialog closes

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)