### PR TITLE
fix(settings): add error feedback for failed save/fetch operations

### DIFF
--- a/src/components/settings/board-settings-tab.tsx
+++ b/src/components/settings/board-settings-tab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { Save, RotateCcw } from "lucide-react";
+import { Save, RotateCcw, AlertTriangle, X } from "lucide-react";
 import { COLUMN_ORDER, COLUMN_LABELS } from "@/types";
 import type { TaskStatus } from "@/types";
 
@@ -34,8 +34,10 @@ export function BoardSettingsTab() {
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const fetchSettings = useCallback(async () => {
+    setError(null);
     try {
       const res = await fetch("/api/board-settings");
       if (res.ok) {
@@ -44,8 +46,9 @@ export function BoardSettingsTab() {
           setSettings(data);
         }
       }
-    } catch {
-      // Use defaults
+    } catch (err) {
+      setError("Failed to load settings");
+      console.error(err);
     } finally {
       setLoading(false);
     }
@@ -73,6 +76,7 @@ export function BoardSettingsTab() {
 
   const handleSave = async () => {
     setSaving(true);
+    setError(null);
     try {
       const res = await fetch("/api/board-settings", {
         method: "PUT",
@@ -90,8 +94,9 @@ export function BoardSettingsTab() {
         setSaved(true);
         setTimeout(() => setSaved(false), 2000);
       }
-    } catch {
-      // Handle error silently
+    } catch (err) {
+      setError("Failed to save settings");
+      console.error(err);
     } finally {
       setSaving(false);
     }
@@ -120,6 +125,37 @@ export function BoardSettingsTab() {
 
   return (
     <div className="max-w-2xl space-y-6">
+      {error && (
+        <div className="flex items-center justify-between gap-3 rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3">
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-destructive" />
+            <span className="text-sm text-destructive">{error}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => {
+                setError(null);
+                if (error === "Failed to load settings") {
+                  setLoading(true);
+                  fetchSettings();
+                } else {
+                  handleSave();
+                }
+              }}
+              className="rounded-md px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/20"
+            >
+              Retry
+            </button>
+            <button
+              onClick={() => setError(null)}
+              className="rounded-md p-1 text-destructive hover:bg-destructive/20"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      )}
+
       <div>
         <h2 className="text-base font-semibold text-foreground">
           WIP Limits & Column Settings

--- a/src/components/settings/team-tab.tsx
+++ b/src/components/settings/team-tab.tsx
@@ -12,6 +12,8 @@ import {
   Send,
   Save,
   User,
+  AlertTriangle,
+  X,
 } from "lucide-react";
 
 interface TeamMember {
@@ -40,16 +42,19 @@ export function TeamTab() {
   const [profileName, setProfileName] = useState("");
   const [savingProfile, setSavingProfile] = useState(false);
   const [profileSaved, setProfileSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const canInvite = session?.user?.role === "admin";
 
   const fetchMembers = useCallback(async () => {
+    setError(null);
     try {
       const res = await fetch("/api/team");
       if (res.ok) {
         setMembers(await res.json());
       }
-    } catch {
-      // Silently handle
+    } catch (err) {
+      setError("Failed to load team members");
+      console.error(err);
     } finally {
       setLoading(false);
     }
@@ -119,6 +124,7 @@ export function TeamTab() {
   const handleSaveProfile = async () => {
     setSavingProfile(true);
     setProfileSaved(false);
+    setError(null);
     try {
       const res = await fetch("/api/profile", {
         method: "PATCH",
@@ -131,8 +137,9 @@ export function TeamTab() {
         await updateSession();
         fetchMembers();
       }
-    } catch {
-      // silently handle
+    } catch (err) {
+      setError("Failed to save profile");
+      console.error(err);
     } finally {
       setSavingProfile(false);
     }
@@ -156,6 +163,37 @@ export function TeamTab() {
 
   return (
     <div className="max-w-3xl space-y-8">
+      {error && (
+        <div className="flex items-center justify-between gap-3 rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3">
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-destructive" />
+            <span className="text-sm text-destructive">{error}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => {
+                setError(null);
+                if (error === "Failed to load team members") {
+                  setLoading(true);
+                  fetchMembers();
+                } else {
+                  handleSaveProfile();
+                }
+              }}
+              className="rounded-md px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/20"
+            >
+              Retry
+            </button>
+            <button
+              onClick={() => setError(null)}
+              className="rounded-md p-1 text-destructive hover:bg-destructive/20"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      )}
+
       {/* ── Profile section ── */}
       <section className="space-y-3">
         <div className="flex items-center gap-2 text-foreground">


### PR DESCRIPTION
## Summary
- Replace empty catch blocks in both board-settings-tab and team-tab
- Show dismissable error banner with AlertTriangle icon
- Retry button re-invokes the failed operation
- Covers fetchSettings, handleSave, fetchMembers, handleSaveProfile

## Test plan
- [ ] Simulate fetch failure on board settings — error banner appears
- [ ] Click Retry — settings reload attempted
- [ ] Simulate save failure — "Failed to save" error shown
- [ ] Dismiss error — banner clears
- [ ] Same patterns work on team tab

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)