### PR TITLE
fix(projects): make table rows keyboard-accessible

### DIFF
--- a/src/components/projects/project-dashboard.tsx
+++ b/src/components/projects/project-dashboard.tsx
@@ -508,7 +508,15 @@ export function ProjectDashboard() {
                 <tr
                   key={project.id}
                   onClick={() => router.push(`/projects/${project.id}`)}
-                  className="cursor-pointer hover:bg-secondary/40"
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      router.push(`/projects/${project.id}`);
+                    }
+                  }}
+                  tabIndex={0}
+                  role="link"
+                  className="cursor-pointer hover:bg-secondary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
                 >
                   <td className="px-4 py-2.5 font-medium text-foreground">{project.name}</td>
                   <td className="px-4 py-2.5 text-xs text-muted-foreground">{project.status}</td>


### PR DESCRIPTION
## Summary
- Add `tabIndex={0}` to project table rows for keyboard focus
- Add `onKeyDown` handler for Enter/Space navigation to project detail
- Add `role="link"` for assistive technology
- Add `focus-visible:ring-2` styling for visible keyboard focus

## Test plan
- [ ] Tab through list view rows — each row receives focus
- [ ] Press Enter on focused row — navigates to project detail
- [ ] Press Space on focused row — navigates to project detail
- [ ] Focus ring only appears on keyboard navigation, not mouse click
- [ ] Existing click navigation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)