### PR TITLE
fix(analytics): add ARIA labels to interactive chart elements

### DIFF
--- a/src/components/analytics/analytics-summary-page.tsx
+++ b/src/components/analytics/analytics-summary-page.tsx
@@ -186,6 +186,7 @@ export function AnalyticsSummaryPage() {
             type="button"
             onClick={resource.refresh}
             disabled={resource.refreshing}
+            aria-label="Refresh analytics data"
             className="rounded-md border border-border bg-card px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground disabled:opacity-70"
           >
             {resource.refreshing ? "Refreshing..." : "Refresh now"}
@@ -193,24 +194,26 @@ export function AnalyticsSummaryPage() {
         </div>
       </div>
 
-      {(resource.stale || staleDomains.length > 0) && (
-        <DashboardStaleBanner
-          lastUpdatedAt={resource.lastUpdatedAt}
-          refreshing={resource.refreshing}
-          onRefresh={resource.refresh}
-          label="Showing cached analytics while background refresh completes or retries."
-        />
-      )}
+      <div aria-live="polite">
+        {(resource.stale || staleDomains.length > 0) && (
+          <DashboardStaleBanner
+            lastUpdatedAt={resource.lastUpdatedAt}
+            refreshing={resource.refreshing}
+            onRefresh={resource.refresh}
+            label="Showing cached analytics while background refresh completes or retries."
+          />
+        )}
 
-      {resource.error ? (
-        <DashboardErrorBanner
-          message={resource.error}
-          onRetry={resource.refresh}
-          settingsHref="/settings?tab=integrations"
-        />
-      ) : null}
+        {resource.error ? (
+          <DashboardErrorBanner
+            message={resource.error}
+            onRetry={resource.refresh}
+            settingsHref="/settings?tab=integrations"
+          />
+        ) : null}
+      </div>
 
-      <div className="rounded-xl border border-border bg-card px-4 py-3">
+      <div role="region" aria-label="Section status summary" className="rounded-xl border border-border bg-card px-4 py-3">
         <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
           <span>
             Sections: <span className="font-semibold text-foreground">{connected}</span> connected
@@ -230,7 +233,7 @@ export function AnalyticsSummaryPage() {
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-3 lg:grid-cols-5">
+      <div role="region" aria-label="Key metrics" className="grid grid-cols-2 gap-3 lg:grid-cols-5">
         <div className="rounded-xl border border-border bg-card px-4 py-3">
           <p className="text-xs text-muted-foreground">Discipline Coverage</p>
           <p className="mt-1 text-2xl font-semibold text-foreground">{summary.highlights.disciplineCoverage}%</p>
@@ -266,6 +269,7 @@ export function AnalyticsSummaryPage() {
             <Link
               key={primary.id}
               href={`${primary.path}${rangeQuery ? `?${rangeQuery}` : ""}`}
+              aria-label={`${primary.label}: ${section?.status ?? "missing"}`}
               className="rounded-xl border border-border bg-card p-4 transition-colors hover:border-primary/40"
             >
               <div className="flex items-center justify-between gap-2">


### PR DESCRIPTION
## Summary
- Add `aria-label="Refresh analytics data"` to refresh button
- Wrap stale/error banners in `aria-live="polite"` for screen reader announcements
- Add `role="region"` with `aria-label` to status summary and key metrics grid
- Add descriptive `aria-label` to each section Link card (e.g., "Ads: connected")

## Test plan
- [ ] Screen reader announces refresh button purpose
- [ ] Stale/error banner changes announced to screen readers
- [ ] Section cards announced with name and status

🤖 Generated with [Claude Code](https://claude.com/claude-code)