### PR TITLE
fix(ai-insights): deduplicate useEffect hooks and add aria-pressed

### DIFF
--- a/src/components/analytics/ai-insights-page.tsx
+++ b/src/components/analytics/ai-insights-page.tsx
@@ -112,6 +112,7 @@ export function AiInsightsPage() {
           {(["all", "critical", "warning", "info"] as SeverityFilter[]).map((sev) => (
             <button
               key={sev}
+              aria-pressed={severityFilter === sev}
               onClick={() => setSeverityFilter(sev)}
               className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
                 severityFilter === sev ? "bg-card text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
@@ -126,6 +127,7 @@ export function AiInsightsPage() {
           {(["all", "ads-traffic", "finance", "sales-pipeline", "customer-success"] as SectionFilter[]).map((sec) => (
             <button
               key={sec}
+              aria-pressed={sectionFilter === sec}
               onClick={() => setSectionFilter(sec)}
               className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
                 sectionFilter === sec ? "bg-card text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
@@ -140,6 +142,7 @@ export function AiInsightsPage() {
           {(["severity", "confidence"] as SortMode[]).map((mode) => (
             <button
               key={mode}
+              aria-pressed={sortMode === mode}
               onClick={() => setSortMode(mode)}
               className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
                 sortMode === mode ? "bg-card text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"

--- a/src/components/analytics/ai-insights-panel.tsx
+++ b/src/components/analytics/ai-insights-panel.tsx
@@ -122,22 +122,6 @@ export function AiInsightsPanel({ bundle, defaultFilter = "all", compact = false
     setFilter(defaultFilter);
   }, [defaultFilter]);
 
-  useEffect(() => {
-    setFilter(defaultFilter);
-  }, [defaultFilter]);
-
-  useEffect(() => {
-    setFilter(defaultFilter);
-  }, [defaultFilter]);
-
-  useEffect(() => {
-    setFilter(defaultFilter);
-  }, [defaultFilter]);
-
-  useEffect(() => {
-    setFilter(defaultFilter);
-  }, [defaultFilter]);
-
   const visible = useMemo(() => {
     if (!bundle) return [];
     const items = filter === "all" ? bundle.global : bundle.bySection[filter];
@@ -198,6 +182,7 @@ export function AiInsightsPanel({ bundle, defaultFilter = "all", compact = false
             <button
               key={item.id}
               type="button"
+              aria-pressed={filter === item.id}
               onClick={() => setFilter(item.id)}
               className={`rounded-md px-2 py-1 text-xs ${
                 filter === item.id ? "bg-primary text-primary-foreground" : "bg-background text-muted-foreground"


### PR DESCRIPTION
## Summary
- Remove 4 duplicate `useEffect` hooks in `ai-insights-panel.tsx` (was 5 identical blocks)
- Add `aria-pressed` to filter tab buttons in panel component
- Add `aria-pressed` to severity, section, and sort buttons in page component

## Test plan
- [ ] Filter tabs still toggle correctly in AI Insights panel
- [ ] Screen reader announces pressed/not-pressed state for all tab buttons
- [ ] No regressions in AI Insights page functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)