### PR TITLE
fix(logbook): add error state with retry for failed fetches

### DIFF
--- a/src/app/(dashboard)/logbook/page.tsx
+++ b/src/app/(dashboard)/logbook/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { BookOpen, Calendar, ChevronLeft, ChevronRight } from "lucide-react";
+import { AlertTriangle, BookOpen, Calendar, ChevronLeft, ChevronRight } from "lucide-react";
 import { readSessionCache, writeSessionCache } from "@/lib/client/session-cache";
 
 interface LogbookEntry {
@@ -21,6 +21,7 @@ interface LogbookEntry {
 export default function LogbookPage() {
   const [entries, setEntries] = useState<LogbookEntry[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [page, setPage] = useState(1);
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
@@ -54,21 +55,29 @@ export default function LogbookPage() {
     if (endDate) params.set("endDate", endDate);
 
     fetch(`/api/logbook?${params}`, { signal: controller.signal })
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed to fetch");
+        return r.json();
+      })
       .then((data) => {
         if (active && id === fetchIdRef.current) {
           const nextEntries = (data?.entries ?? (Array.isArray(data) ? data : [])) as LogbookEntry[];
           setEntries(nextEntries);
+          setError(null);
           writeSessionCache<LogbookEntry[]>(cacheKey, nextEntries);
           setLoading(false);
         }
       })
-      .catch((error) => {
-        if (!active || (error instanceof Error && error.name === "AbortError")) {
+      .catch((err) => {
+        if (!active || (err instanceof Error && err.name === "AbortError")) {
           return;
         }
-        if (id === fetchIdRef.current && !cached) {
-          setLoading(false);
+        if (id === fetchIdRef.current) {
+          setError("Failed to load log entries");
+          console.error("Logbook fetch failed:", err);
+          if (!cached) {
+            setLoading(false);
+          }
         }
       });
 
@@ -120,6 +129,49 @@ export default function LogbookPage() {
         {loading ? (
           <div className="flex h-32 items-center justify-center">
             <div className="h-6 w-6 animate-spin rounded-full border-2 border-border border-t-primary" />
+          </div>
+        ) : error ? (
+          <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+            <AlertTriangle className="h-8 w-8 text-yellow-500" />
+            <p className="text-sm text-muted-foreground">{error}</p>
+            <button
+              onClick={() => {
+                setError(null);
+                setLoading(true);
+                fetchIdRef.current++;
+                const retryParams = new URLSearchParams({
+                  page: page.toString(),
+                  limit: "25",
+                });
+                if (startDate) retryParams.set("startDate", startDate);
+                if (endDate) retryParams.set("endDate", endDate);
+                const retryId = fetchIdRef.current;
+                fetch(`/api/logbook?${retryParams}`)
+                  .then((r) => {
+                    if (!r.ok) throw new Error("Failed to fetch");
+                    return r.json();
+                  })
+                  .then((data) => {
+                    if (retryId === fetchIdRef.current) {
+                      const nextEntries = (data?.entries ?? (Array.isArray(data) ? data : [])) as LogbookEntry[];
+                      setEntries(nextEntries);
+                      setError(null);
+                      writeSessionCache<LogbookEntry[]>(cacheKey, nextEntries);
+                      setLoading(false);
+                    }
+                  })
+                  .catch((err) => {
+                    if (retryId === fetchIdRef.current) {
+                      setError("Failed to load log entries");
+                      console.error("Logbook fetch failed:", err);
+                      setLoading(false);
+                    }
+                  });
+              }}
+              className="rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground hover:bg-primary/90"
+            >
+              Retry
+            </button>
           </div>
         ) : entries.length === 0 ? (
           <div className="mt-12 text-center text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- Adds proper error handling with `AlertTriangle` icon and retry button when logbook fetch fails
- Checks `response.ok` before parsing JSON to catch HTTP errors
- Retry button triggers a fresh fetch with current filters and pagination

Closes #178

## Test plan
- [ ] Simulate API failure (e.g. network tab block) and verify error state appears
- [ ] Click Retry and verify data loads successfully
- [ ] Verify date filters and pagination state are preserved across retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)