### PR TITLE
fix: remove overly aggressive date filter from HubSpot deal aggregation

### DIFF
--- a/src/lib/analytics/fetchers.ts
+++ b/src/lib/analytics/fetchers.ts
@@ -156,15 +156,6 @@ export async function fetchHubSpotData(
 
   for (const deal of activeDeals) {
     const props = deal.properties || {};
-    // Skip if deal is not within the date range depending on stage type
-    // We typically want to filter closed deals by closedate, created deals by createdate
-    const rawCloseDate = props.closedate ? new Date(props.closedate) : null;
-    const rawCreateDate = props.createdate ? new Date(props.createdate) : null;
-    
-    // Simple filter: only include if it was created before 'to' 
-    // AND (not closed OR closed after 'from')
-    if (rawCreateDate && rawCreateDate > to) continue;
-    if (rawCloseDate && rawCloseDate < from) continue;
 
     const stage = props.dealstage || "unknown";
     const mappedLabel = HUBSPOT_STAGE_MAP[stage] || stage;
@@ -186,9 +177,9 @@ export async function fetchHubSpotData(
     if (mappedLabel === "Churn") {
       sourceAgg[source].churned++;
       
-      const createdMs = rawCreateDate ? rawCreateDate.getTime() : 0;
+      const createdMs = props.createdate ? new Date(props.createdate).getTime() : 0;
       const updatedMs = props.hs_lastmodifieddate ? new Date(props.hs_lastmodifieddate).getTime() 
-        : rawCloseDate ? rawCloseDate.getTime() 
+        : props.closedate ? new Date(props.closedate).getTime() 
         : new Date().getTime();
       
       const daysSinceCreation = createdMs > 0 ? (updatedMs - createdMs) / 86_400_000 : Infinity;


### PR DESCRIPTION
## Problem
HubSpot analytics showed only ~100 deals, zero closed deals, and zero no-shows/demos.

## Root Cause
The date filter in `fetchHubSpotData` was skipping any deal closed before the `from` date (default: 30 days ago), removing all historical Closed Won, Closed Lost, No-Show, and Churn deals from aggregation.

## Fix
- Removed the 9-line date filter from the aggregation loop so all pipeline deals are counted
- Updated churn-detection block to parse dates from props directly

## Testing
All 145 tests pass across 10 HubSpot-related test files with zero regressions.