### PR TITLE
fix(migrations): make AnalyticsSnapshot unique index idempotent

### DIFF
--- a/prisma/migrations/20260228120000_snapshots_upsert_and_retention/migration.sql
+++ b/prisma/migrations/20260228120000_snapshots_upsert_and_retention/migration.sql
@@ -16,6 +16,5 @@ WHERE "id" IN (
 );
 
 -- Enforce one SUCCESS row and one ERROR row per key.
-CREATE UNIQUE INDEX "AnalyticsSnapshot_userId_providerKey_contextKey_rangePreset_toDate_status_key"
+CREATE UNIQUE INDEX IF NOT EXISTS "AnalyticsSnapshot_userId_providerKey_contextKey_rangePreset_toDate_status_key"
 ON "AnalyticsSnapshot"("userId", "providerKey", "contextKey", "rangePreset", "toDate", "status");
-


### PR DESCRIPTION
Railway production deploys have been failing on startup migrations with:\n\n- "relation ... already exists" when creating the AnalyticsSnapshot unique index (name is long and gets truncated)\n\nThis makes the index creation idempotent via `CREATE UNIQUE INDEX IF NOT EXISTS` so the migration succeeds even if the index already exists from a prior partial apply.