### PR TITLE
fix(analytics): normalise paymentSuccessPct to 0–100 range

### DIFF
--- a/src/lib/analytics/kpis.ts
+++ b/src/lib/analytics/kpis.ts
@@ -25,7 +25,9 @@ export function computeAnalyticsKpis(data: AnalyticsDashboardData) {
   // ── Finance KPIs ──
   const stripe = data.stripe;
   const mrr = stripe?.revenue.mrr ?? 0;
-  const paymentSuccessPct = stripe?.payments.successRate ?? 0;
+  // successRate is a 0–1 fraction; normalise to 0–100 like bounceRatePct.
+  const rawSuccess = stripe?.payments.successRate ?? 0;
+  const paymentSuccessPct = rawSuccess >= 0 && rawSuccess <= 1 ? rawSuccess * 100 : rawSuccess;
 
   return {
     traffic: { bounceRatePct, pagesPerSession, engagementScore, pageDepthScore },


### PR DESCRIPTION
## Summary
- Fixes `computeAnalyticsKpis()` to normalise `paymentSuccessPct` from a 0–1 fraction to 0–100, matching the convention used for `bounceRatePct`
- Without this, the Stripe sub-dashboard displays "0.95%" instead of "95%" and the positive/negative indicator is always negative
- Found during post-merge review of PR #270

## Test plan
- [x] `npx tsc --noEmit` passes (no new type errors)
- [x] All 30 analytics tests pass (`integration-child-dashboards`, `analytics-fetchers-coda`)
- [ ] Verify Stripe sub-dashboard renders correct payment success percentage with live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)