### PR TITLE
feat(logbook): add CSV/JSON export for filtered log entries

### DIFF
--- a/src/app/(dashboard)/logbook/page.tsx
+++ b/src/app/(dashboard)/logbook/page.tsx
@@ -89,7 +89,7 @@ export default function LogbookPage() {
       const rows = entries.map((entry) =>
         columns.map((col) => escapeCsvField(entry[col])).join(","),
       );
-      const csv = [header, ...rows].join("\n");
+      const csv = "\uFEFF" + [header, ...rows].join("\n");
       downloadBlob(csv, exportFilename("csv"), "text/csv");
     },
     [entries, downloadBlob, escapeCsvField, exportFilename],
@@ -217,14 +217,16 @@ export default function LogbookPage() {
                 <ChevronDown className="h-3 w-3" />
               </button>
               {exportOpen && (
-                <div className="absolute right-0 top-full z-10 mt-1 w-36 rounded-md border border-border bg-card py-1 shadow-lg">
+                <div role="menu" className="absolute right-0 top-full z-10 mt-1 w-36 rounded-md border border-border bg-card py-1 shadow-lg">
                   <button
+                    role="menuitem"
                     onClick={() => handleExport("csv")}
                     className="flex w-full items-center px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
                   >
                     Export as CSV
                   </button>
                   <button
+                    role="menuitem"
                     onClick={() => handleExport("json")}
                     className="flex w-full items-center px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
                   >


### PR DESCRIPTION
## Summary
- Add export dropdown button (CSV / JSON) in the logbook header next to date range inputs
- CSV generation with proper field escaping (commas, quotes, newlines)
- JSON export via pretty-printed `JSON.stringify`
- Smart filename includes date range: `logbook-2026-01-01-to-2026-02-28.csv`
- Blob + createObjectURL download mechanism with cleanup
- Outside-click handler to dismiss dropdown
- Button disabled when no entries to export

Closes #180

## Test plan
- [ ] Export button visible in logbook header
- [ ] CSV download works with correct columns and escaped values
- [ ] JSON download works with pretty-printed output
- [ ] Filename reflects current date filter
- [ ] Button disabled when entries list is empty
- [ ] Dropdown closes on outside click
- [ ] Zero TS/lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)