### PR TITLE
feat(insights): add pagination for AI insight results

### DIFF
--- a/src/components/analytics/ai-insights-page.tsx
+++ b/src/components/analytics/ai-insights-page.tsx
@@ -78,6 +78,10 @@ export function AiInsightsPage() {
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
 
+  useEffect(() => {
+    if (page > totalPages) setPage(totalPages);
+  }, [page, totalPages]);
+
   const paginatedInsights = useMemo(() => {
     const start = (page - 1) * pageSize;
     return filtered.slice(start, start + pageSize);
@@ -192,12 +196,13 @@ export function AiInsightsPage() {
       </div>
 
       {filtered.length > 0 && (
-        <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border bg-card px-4 py-3">
+        <nav aria-label="Pagination" className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border bg-card px-4 py-3">
           <div className="flex items-center gap-2">
             <span className="text-xs text-muted-foreground">
               Showing {(page - 1) * pageSize + 1}&ndash;{Math.min(page * pageSize, filtered.length)} of {filtered.length}
             </span>
             <select
+              aria-label="Results per page"
               value={pageSize}
               onChange={(e) => {
                 setPageSize(Number(e.target.value));
@@ -232,7 +237,7 @@ export function AiInsightsPage() {
               Next
             </button>
           </div>
-        </div>
+        </nav>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Add pagination with configurable page size (10/25/50, default 25)
- Show "Showing X–Y of Z" indicator with Previous/Next buttons
- Page resets to 1 when severity, section, or sort filter changes
- StatCard counts still reflect full filtered dataset (not paginated subset)
- Significant render performance improvement for large insight sets

Closes #175

## Test plan
- [ ] Default page size is 25; only 25 cards render at a time
- [ ] Previous/Next buttons navigate pages correctly
- [ ] Buttons disabled at first/last page boundaries
- [ ] Page size dropdown works (10, 25, 50)
- [ ] Page resets to 1 when changing any filter or sort
- [ ] Stat cards show counts for ALL filtered insights
- [ ] "No insights match" empty state still works
- [ ] Zero TS/lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)