### PR TITLE
Harden Railway deploy migrations

### DIFF
--- a/migrate.cjs
+++ b/migrate.cjs
@@ -23,9 +23,47 @@ try {
 
 const MIGRATIONS_DIR = path.join(__dirname, "prisma", "migrations");
 
+const ADVISORY_LOCK_KEY_1 = 0x57495047; // "WIPG"
+const ADVISORY_LOCK_KEY_2 = 0x4d494752; // "MIGR"
+const LOCK_MAX_WAIT_MS = 300_000;
+const LOCK_RETRY_INTERVAL_MS = 1_000;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function acquireAdvisoryLock(client) {
+  const start = Date.now();
+  let attempts = 0;
+  while (Date.now() - start < LOCK_MAX_WAIT_MS) {
+    attempts++;
+    const result = await client.query(
+      "SELECT pg_try_advisory_lock($1, $2) AS locked",
+      [ADVISORY_LOCK_KEY_1, ADVISORY_LOCK_KEY_2],
+    );
+    if (result.rows?.[0]?.locked) {
+      return true;
+    }
+
+    const waitedMs = Date.now() - start;
+    if (attempts === 1 || waitedMs % 10_000 < LOCK_RETRY_INTERVAL_MS) {
+      console.log(
+        `  waiting for migration lock... (${Math.floor(waitedMs / 1000)}s)`,
+      );
+    }
+    await sleep(LOCK_RETRY_INTERVAL_MS);
+  }
+
+  return false;
+}
+
 async function run() {
   const connectionString = process.env.DATABASE_URL;
   if (!connectionString) {
+    if (process.env.NODE_ENV === "production") {
+      console.error("DATABASE_URL not set in production; refusing to start");
+      process.exit(1);
+    }
     console.error("DATABASE_URL not set, skipping migrations");
     process.exit(0);
   }
@@ -36,7 +74,16 @@ async function run() {
 
   // Append sslmode=no-verify for managed Postgres SSL connections if not already set.
   // Keep local/dev defaults non-SSL unless explicitly configured.
-  const url = new URL(connectionString);
+  let url;
+  try {
+    url = new URL(connectionString);
+  } catch (error) {
+    console.error(
+      "Invalid DATABASE_URL:",
+      error instanceof Error ? error.message : String(error),
+    );
+    process.exit(1);
+  }
   if (useSSL && !url.searchParams.has("sslmode")) {
     url.searchParams.set("sslmode", "no-verify");
   }
@@ -50,10 +97,20 @@ async function run() {
   }
 
   const pool = new Pool(poolOptions);
+  const client = await pool.connect();
+  let lockAcquired = false;
 
   try {
+    lockAcquired = await acquireAdvisoryLock(client);
+    if (!lockAcquired) {
+      console.error(
+        `Timed out waiting for migration lock after ${Math.floor(LOCK_MAX_WAIT_MS / 1000)}s`,
+      );
+      process.exit(1);
+    }
+
     // Ensure _prisma_migrations table exists
-    await pool.query(`
+    await client.query(`
       CREATE TABLE IF NOT EXISTS "_prisma_migrations" (
         "id" VARCHAR(36) NOT NULL PRIMARY KEY,
         "checksum" VARCHAR(64) NOT NULL,
@@ -67,7 +124,7 @@ async function run() {
     `);
 
     // Get already-applied migrations
-    const applied = await pool.query(
+    const applied = await client.query(
       'SELECT migration_name FROM "_prisma_migrations" WHERE rolled_back_at IS NULL',
     );
     const appliedSet = new Set(applied.rows.map((r) => r.migration_name));
@@ -93,6 +150,12 @@ async function run() {
 
       const sqlFile = path.join(MIGRATIONS_DIR, dir, "migration.sql");
       const sql = fs.readFileSync(sqlFile, "utf-8");
+      if (/\bCONCURRENTLY\b/i.test(sql)) {
+        console.error(
+          `Migration ${dir} contains CONCURRENTLY; refusing to run outside a transaction`,
+        );
+        process.exit(1);
+      }
       const checksum = crypto
         .createHash("sha256")
         .update(sql)
@@ -100,12 +163,23 @@ async function run() {
         .slice(0, 64);
 
       console.log("  apply: " + dir + "...");
-      await pool.query(sql);
+      await client.query("BEGIN");
+      try {
+        await client.query(sql);
 
-      await pool.query(
-        'INSERT INTO "_prisma_migrations" (id, checksum, finished_at, migration_name, applied_steps_count) VALUES (gen_random_uuid(), $1, now(), $2, 1)',
-        [checksum, dir],
-      );
+        const migrationId = crypto.randomUUID();
+        await client.query(
+          'INSERT INTO "_prisma_migrations" (id, checksum, finished_at, migration_name, applied_steps_count) VALUES ($1, $2, now(), $3, 1)',
+          [migrationId, checksum, dir],
+        );
+
+        await client.query("COMMIT");
+      } catch (error) {
+        await client.query("ROLLBACK");
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`Migration failed (${dir}):`, message);
+        process.exit(1);
+      }
 
       console.log("  done: " + dir);
       appliedCount++;
@@ -117,11 +191,21 @@ async function run() {
       console.log("  Applied " + appliedCount + " migration(s).");
     }
   } finally {
+    try {
+      if (lockAcquired) {
+        await client.query("SELECT pg_advisory_unlock($1, $2)", [
+          ADVISORY_LOCK_KEY_1,
+          ADVISORY_LOCK_KEY_2,
+        ]);
+      }
+    } catch {}
+    client.release();
     await pool.end();
   }
 }
 
 run().catch((e) => {
-  console.error("Migration failed:", e.message);
+  const message = e instanceof Error ? e.message : String(e);
+  console.error("Migration failed:", message);
   process.exit(1);
 });

--- a/railway.json
+++ b/railway.json
@@ -7,6 +7,6 @@
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10,
     "healthcheckPath": "/api/realtime/bootstrap",
-    "healthcheckTimeout": 30
+    "healthcheckTimeout": 120
   }
 }


### PR DESCRIPTION
Fixes recurring Railway deploy failures caused by partially-applied migrations and index name collisions.\n\nChanges:\n- Run each migration in a transaction (rollback on failure).\n- Use a Postgres advisory lock to prevent multi-replica races.\n- Generate migration IDs in Node (no gen_random_uuid dependency).\n- Fail fast in production if DATABASE_URL is missing.\n- Increase Railway healthcheck timeout to 120s to tolerate migration/lock time.\n