### PR TITLE
chore: track Railway cron sync + SEMRUSH migration

### DIFF
--- a/prisma/migrations/20260301100000_add_semrush_integration_provider/migration.sql
+++ b/prisma/migrations/20260301100000_add_semrush_integration_provider/migration.sql
@@ -1,0 +1,2 @@
+ALTER TYPE "IntegrationProvider" ADD VALUE IF NOT EXISTS 'SEMRUSH';
+

--- a/railway/cron-sync/Dockerfile
+++ b/railway/cron-sync/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.20
+
+RUN apk add --no-cache curl ca-certificates
+
+COPY run.sh /run.sh
+RUN chmod +x /run.sh
+
+CMD ["/run.sh"]
+

--- a/railway/cron-sync/railway.json
+++ b/railway/cron-sync/railway.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "cronSchedule": "*/10 * * * *",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}
+

--- a/railway/cron-sync/run.sh
+++ b/railway/cron-sync/run.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+: "${TARGET_URL:?TARGET_URL is required}"
+
+HEADER_NAME="${CRON_HEADER_NAME:-x-cron-secret}"
+SECRET="${CRON_SYNC_SECRET:-${INTEGRATION_SYNC_SECRET:-}}"
+
+if [ -z "${SECRET}" ]; then
+  echo "Missing CRON_SYNC_SECRET or INTEGRATION_SYNC_SECRET"
+  exit 1
+fi
+
+echo "POST ${TARGET_URL}"
+curl -fsS -X POST "${TARGET_URL}" \
+  -H "${HEADER_NAME}: ${SECRET}" \
+  -H "content-type: application/json" \
+  --data '{}'
+echo "ok"
+


### PR DESCRIPTION
## Summary
- Add `railway/cron-sync` so the deployed Railway cron service is tracked in git.
- Add a Prisma migration to ensure Postgres has the `IntegrationProvider` enum value `SEMRUSH` (matches current `schema.prisma` + avoids prod drift).

## Test plan
- [ ] Confirm Railway cron-sync service still calls `/api/cron/sync` successfully in the target environment.
- [ ] Run `npx prisma migrate deploy` in a fresh environment to confirm the enum migration applies cleanly.

Made with [Cursor](https://cursor.com)