### PR TITLE
fix(analytics): Reddit Ads 400 error and Meta Page discovery

### DIFF
--- a/src/lib/__tests__/analytics-fetchers-ads.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-ads.test.ts
@@ -232,7 +232,7 @@ describe("analytics ads fetchers", () => {
       data?: { starts_at?: string; ends_at?: string };
     };
     expect(payload.data?.starts_at).toMatch(/^\d{4}-\d{2}-\d{2}T00:00:00Z$/);
-    expect(payload.data?.ends_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    expect(payload.data?.ends_at).toMatch(/^\d{4}-\d{2}-\d{2}T00:00:00Z$/);
 
     for (const [, init] of fetchMock.mock.calls as Array<[unknown, RequestInit]>) {
       const headers = (init?.headers || {}) as Record<string, string>;

--- a/src/lib/analytics/fetchers-ads.ts
+++ b/src/lib/analytics/fetchers-ads.ts
@@ -919,12 +919,27 @@ export async function fetchRedditAdsData(
     Boolean(rangeFrom && rangeTo && rangeFrom <= rangeTo);
 
   const now = rangeTo ? new Date(rangeTo) : new Date();
-  const startsAt = useRange ? new Date(rangeFrom!) : new Date(now);
+
+  const rawStartsAt = useRange ? new Date(rangeFrom!) : new Date(now);
   if (!useRange) {
-    startsAt.setUTCDate(startsAt.getUTCDate() - 29);
+    rawStartsAt.setUTCDate(rawStartsAt.getUTCDate() - 29);
   }
-  startsAt.setUTCHours(0, 0, 0, 0);
-  now.setUTCHours(23, 59, 59, 999);
+  rawStartsAt.setUTCHours(0, 0, 0, 0);
+
+  const rawEndsAt = new Date(now);
+  rawEndsAt.setUTCHours(23, 59, 59, 999);
+
+  // Reddit Ads API v3 requires day-boundary (midnight) timestamps.
+  const startsAtNorm = new Date(rawStartsAt);
+  startsAtNorm.setUTCHours(0, 0, 0, 0);
+  const endsAtNorm = new Date(rawEndsAt);
+  endsAtNorm.setUTCHours(0, 0, 0, 0);
+  if (endsAtNorm.getTime() < rawEndsAt.getTime()) {
+    endsAtNorm.setUTCDate(endsAtNorm.getUTCDate() + 1);
+  }
+
+  const startsAtIso = startsAtNorm.toISOString().replace(/\.\d{3}Z$/, "Z");
+  const endsAtIso = endsAtNorm.toISOString().replace(/\.\d{3}Z$/, "Z");
   const reportsResponse = await fetch(
     `https://ads-api.reddit.com/api/v3/ad_accounts/${cleanAccountId}/reports`,
     {

--- a/src/lib/integrations/meta-auth.ts
+++ b/src/lib/integrations/meta-auth.ts
@@ -222,6 +222,38 @@ export async function discoverMetaPageAndInstagram(input: {
     }
   }
 
+  // Fallback: if /me/accounts returned no pages, the token may be a Page
+  // Access Token. In that case, /me returns the page itself.
+  if (!pageId) {
+    try {
+      const meUrl = new URL(`https://graph.facebook.com/${graphVersion}/me`);
+      meUrl.searchParams.set("fields", "id,name,instagram_business_account{id}");
+
+      const meResponse = await fetchWithTimeout(
+        meUrl,
+        {
+          method: "GET",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        timeoutMs
+      );
+
+      if (meResponse.ok) {
+        const meBody = asRecord(await readJsonOrText(meResponse));
+        const meId = getString(meBody, "id");
+        if (meId) {
+          pageId = meId;
+          if (!instagramAccountId) {
+            const igBiz = asRecord(meBody?.instagram_business_account);
+            instagramAccountId = getString(igBiz, "id");
+          }
+        }
+      }
+    } catch {
+      // Best-effort fallback
+    }
+  }
+
   return { pageId, instagramAccountId };
 }
 


### PR DESCRIPTION
## Summary
- **Reddit Ads**: Normalize date params to midnight boundaries — the v3 reports endpoint rejects non-midnight timestamps like `T23:59:59Z`. `ends_at` now snaps forward to start-of-next-day for correct coverage.
- **Meta Page**: Add `/me` fallback in `discoverMetaPageAndInstagram` so Page Access Tokens (where `/me/accounts` returns empty) resolve the page ID via `/me` directly.

## Test plan
- [x] `analytics-fetchers-ads.test.ts` — all 9 tests pass, including tightened midnight boundary assertion
- [ ] Verify Reddit Ads card no longer shows 400 error on the dashboard
- [ ] Verify Meta Page card shows data (or a clear API error) instead of "Not configured"

🤖 Generated with [Claude Code](https://claude.com/claude-code)