### PR TITLE
feat(webflow): replace placeholder metrics with real content analytics

### DIFF
--- a/src/components/analytics/ads-webflow-tab.tsx
+++ b/src/components/analytics/ads-webflow-tab.tsx
@@ -2,13 +2,19 @@
 
 import {
   FileText, Database, Calendar,
-  FormInput, Link2,
+  FormInput, Link2, Search, RefreshCw,
 } from "lucide-react";
-import type { AnalyticsDashboardData, WebflowFormEntry } from "@/lib/analytics/types";
+import type {
+  AnalyticsDashboardData,
+  WebflowFormEntry,
+  WebflowPageDetail,
+} from "@/lib/analytics/types";
 import { FinanceDataEmptyState } from "@/components/analytics/finance-empty-state";
 import { StatCard } from "@/components/analytics/stat-card";
+import { BarDisplay, RingStat } from "@/components/analytics/bar-display";
+import { AreaTrend } from "@/components/charts/area-trend";
 import {
-  timeAgo,
+  fmtN, fmtPct, timeAgo,
   AlertBanner, DataTable, InsightCard,
   SectionCard, type DataTableColumn,
 } from "./dashboard-primitives";
@@ -42,8 +48,27 @@ export function AdsWebflowTab({ data }: AdsWebflowTabProps) {
     formSubmissions, customDomains,
   } = webflow;
 
+  // Safe defaults for new fields (backward compat with old snapshots)
+  const publishedPages = webflow.publishedPages ?? totalPages;
+  const draftPages = webflow.draftPages ?? 0;
+  const archivedPages = webflow.archivedPages ?? 0;
+  const seoAudit = webflow.seoAudit ?? {
+    totalPages: 0, pagesWithSeoTitle: 0, pagesWithSeoDescription: 0,
+    pagesWithOgImage: 0, seoScore: 0,
+  };
+  const contentFreshness = webflow.contentFreshness ?? {
+    updatedLast7d: 0, updatedLast30d: 0, updatedLast90d: 0, staleOver90d: 0,
+  };
+  const recentlyUpdatedPages = webflow.recentlyUpdatedPages ?? [];
+  const collections = webflow.collections ?? [];
+  const totalCmsItems = webflow.totalCmsItems ?? 0;
+  const emptyCollections = webflow.emptyCollections ?? 0;
+  const formTrend = webflow.formTrend ?? [];
+  const totalFormSubmissions = webflow.totalFormSubmissions
+    ?? formSubmissions.reduce((sum, f) => sum + f.count, 0);
+  const pages = webflow.pages ?? [];
+
   // ── Derived metrics ──
-  const totalFormSubmissions = formSubmissions.reduce((sum, f) => sum + f.count, 0);
   const referenceTimestamp = data?.meta?.servedAt
     ? new Date(data.meta.servedAt).getTime()
     : null;
@@ -52,20 +77,32 @@ export function AdsWebflowTab({ data }: AdsWebflowTabProps) {
     ? Math.floor((referenceTimestamp - lastPublishedTimestamp) / (1000 * 60 * 60 * 24))
     : null;
 
+  // Freshness exclusive buckets for display
+  const fresh7d = contentFreshness.updatedLast7d;
+  const fresh8to30d = contentFreshness.updatedLast30d - contentFreshness.updatedLast7d;
+  const fresh31to90d = contentFreshness.updatedLast90d - contentFreshness.updatedLast30d;
+  const stale90d = contentFreshness.staleOver90d;
+
   // ── Alerts ──
   const alerts: { severity: "critical" | "warning" | "info"; title: string; description: string }[] = [];
-  if (daysSincePublish !== null && daysSincePublish > 30) {
+  if (daysSincePublish !== null && daysSincePublish > 90) {
+    alerts.push({
+      severity: "critical",
+      title: `Site is ${daysSincePublish} days stale`,
+      description: "The site hasn't been published in over 3 months. Unpublished changes may be accumulating. Review and publish immediately.",
+    });
+  } else if (daysSincePublish !== null && daysSincePublish > 30) {
     alerts.push({
       severity: "warning",
       title: `Site hasn't been published in ${daysSincePublish} days`,
       description: "Stale content may impact SEO and user experience. Review pending changes and publish.",
     });
   }
-  if (daysSincePublish !== null && daysSincePublish > 90) {
+  if (seoAudit.seoScore > 0 && seoAudit.seoScore < 50) {
     alerts.push({
-      severity: "critical",
-      title: `Site is ${daysSincePublish} days stale`,
-      description: "The site hasn't been published in over 3 months. Unpublished changes may be accumulating. Review and publish immediately.",
+      severity: "warning",
+      title: `SEO coverage is low — ${seoAudit.seoScore}%`,
+      description: "Many pages are missing SEO titles, meta descriptions, or Open Graph images. Improve coverage to boost search visibility.",
     });
   }
   if (customDomains.length === 0) {
@@ -73,6 +110,13 @@ export function AdsWebflowTab({ data }: AdsWebflowTabProps) {
       severity: "info",
       title: "No custom domains configured",
       description: "Site is only accessible via Webflow subdomain. Add a custom domain for a professional presence.",
+    });
+  }
+  if (emptyCollections > 0) {
+    alerts.push({
+      severity: "info",
+      title: `${emptyCollections} empty CMS collection${emptyCollections !== 1 ? "s" : ""}`,
+      description: "Some collections have no items. Consider removing unused collections to keep the CMS clean.",
     });
   }
 
@@ -85,12 +129,34 @@ export function AdsWebflowTab({ data }: AdsWebflowTabProps) {
       severity: "success",
     });
   }
+  if (seoAudit.seoScore >= 80) {
+    insights.push({
+      title: "Strong SEO Coverage",
+      insight: `${seoAudit.seoScore}% SEO score — most pages have proper titles, descriptions, and OG images.`,
+      severity: "success",
+    });
+  }
   if (totalFormSubmissions > 0) {
     const topForm = [...formSubmissions].sort((a, b) => b.count - a.count)[0];
     insights.push({
       title: "Form Activity",
       insight: `${totalFormSubmissions} total form submission${totalFormSubmissions !== 1 ? "s" : ""}. "${topForm.formName}" leads with ${topForm.count} submission${topForm.count !== 1 ? "s" : ""}.`,
       severity: "success",
+    });
+  }
+  if (stale90d > totalPages * 0.5 && totalPages > 0) {
+    insights.push({
+      title: "Content Going Stale",
+      insight: `${stale90d} of ${totalPages} pages haven't been updated in over 90 days. Outdated content can hurt SEO.`,
+      action: "Audit stale pages and update or archive those no longer relevant.",
+      severity: "warning",
+    });
+  }
+  if (draftPages > totalPages * 0.3 && totalPages > 0) {
+    insights.push({
+      title: "Many Draft Pages",
+      insight: `${draftPages} pages are still in draft. Review and publish or discard drafts that are no longer needed.`,
+      severity: "info",
     });
   }
   if (totalPages > 50) {
@@ -116,11 +182,51 @@ export function AdsWebflowTab({ data }: AdsWebflowTabProps) {
     });
   }
 
-  // ── Form submissions table ──
+  // ── Table columns ──
   const formColumns: DataTableColumn<WebflowFormEntry>[] = [
     { key: "formName", header: "Form Name", render: (r) => <span className="font-medium text-foreground">{r.formName}</span> },
     { key: "count", header: "Submissions", align: "right", render: (r) => <span className="tabular-nums font-medium">{r.count}</span> },
   ];
+
+  const recentPageColumns: DataTableColumn<WebflowPageDetail>[] = [
+    { key: "title", header: "Page", render: (r) => <span className="font-medium text-foreground truncate max-w-[200px] block">{r.title || r.slug}</span> },
+    { key: "slug", header: "Slug", render: (r) => <span className="text-muted-foreground truncate max-w-[160px] block">/{r.slug}</span> },
+    { key: "updatedOn", header: "Updated", render: (r) => <span className="text-muted-foreground text-xs">{r.updatedOn ? timeAgo(r.updatedOn) : "—"}</span> },
+    {
+      key: "status", header: "Status", render: (r) => (
+        <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+          r.archived
+            ? "bg-muted text-muted-foreground"
+            : r.draft
+              ? "bg-yellow-500/10 text-yellow-600"
+              : "bg-emerald-500/10 text-emerald-600"
+        }`}>
+          {r.archived ? "Archived" : r.draft ? "Draft" : "Published"}
+        </span>
+      ),
+    },
+  ];
+
+  const seoMissingPages = pages.filter((p) => !p.seoTitle || !p.seoDescription).slice(0, 10);
+  const seoMissingColumns: DataTableColumn<WebflowPageDetail>[] = [
+    { key: "title", header: "Page", render: (r) => <span className="font-medium text-foreground truncate max-w-[180px] block">{r.title || r.slug}</span> },
+    {
+      key: "missing", header: "Missing", render: (r) => {
+        const missing: string[] = [];
+        if (!r.seoTitle) missing.push("Title");
+        if (!r.seoDescription) missing.push("Description");
+        if (!r.openGraphImageUrl) missing.push("OG Image");
+        return <span className="text-xs text-yellow-600">{missing.join(", ")}</span>;
+      },
+    },
+  ];
+
+  // SEO ring color
+  const seoColor = seoAudit.seoScore >= 80
+    ? "#22c55e"
+    : seoAudit.seoScore >= 50
+      ? "#eab308"
+      : "#ef4444";
 
   return (
     <div className="space-y-6">
@@ -133,23 +239,38 @@ export function AdsWebflowTab({ data }: AdsWebflowTabProps) {
         </div>
       )}
 
-      {/* Site Header */}
+      {/* KPI Stat Cards */}
       <SectionCard title={siteName || "Webflow Site"} subtitle="Site overview and health">
-        <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
           <StatCard
-            label="Total Pages"
-            value={totalPages.toString()}
+            label="Published Pages"
+            value={publishedPages.toString()}
+            subtitle={`${draftPages} draft, ${archivedPages} archived`}
             icon={FileText}
           />
           <StatCard
-            label="CMS Collections"
-            value={totalCollections.toString()}
+            label="CMS Items"
+            value={fmtN(totalCmsItems)}
+            subtitle={`${totalCollections} collection${totalCollections !== 1 ? "s" : ""}`}
             icon={Database}
           />
           <StatCard
             label="Form Submissions"
-            value={totalFormSubmissions.toString()}
+            value={fmtN(totalFormSubmissions)}
+            subtitle={`${formSubmissions.length} active form${formSubmissions.length !== 1 ? "s" : ""}`}
             icon={FormInput}
+          />
+          <StatCard
+            label="SEO Health"
+            value={`${seoAudit.seoScore}%`}
+            icon={Search}
+            iconColor={seoAudit.seoScore >= 80 ? "text-emerald-500" : seoAudit.seoScore >= 50 ? "text-yellow-500" : "text-red-500"}
+          />
+          <StatCard
+            label="Fresh Content"
+            value={contentFreshness.updatedLast30d.toString()}
+            subtitle="pages updated in last 30 days"
+            icon={RefreshCw}
           />
           <StatCard
             label="Last Published"
@@ -160,7 +281,133 @@ export function AdsWebflowTab({ data }: AdsWebflowTabProps) {
         </div>
       </SectionCard>
 
-      {/* Domains + Publishing */}
+      {/* Form Submission Trend */}
+      {formTrend.length > 1 && (
+        <SectionCard title="Form Submission Trend" subtitle="Daily submissions over the selected period">
+          <AreaTrend
+            data={formTrend.map((e) => ({ ...e }) as Record<string, unknown>)}
+            xKey="date"
+            yKeys={["submissions"]}
+            colors={["hsl(var(--primary))"]}
+            height={220}
+            xFormatter={(v) => {
+              const d = new Date(v);
+              return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+            }}
+          />
+        </SectionCard>
+      )}
+
+      {/* SEO Audit + CMS Collections */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        {/* SEO Audit */}
+        <SectionCard title="SEO Audit" subtitle={`${seoAudit.seoScore}% coverage score`}>
+          <div className="space-y-4">
+            <div className="flex justify-center">
+              <RingStat value={seoAudit.seoScore} max={100} label="SEO Score" color={seoColor} />
+            </div>
+            <div className="space-y-2">
+              {[
+                { label: "SEO Title", count: seoAudit.pagesWithSeoTitle },
+                { label: "Meta Description", count: seoAudit.pagesWithSeoDescription },
+                { label: "OG Image", count: seoAudit.pagesWithOgImage },
+              ].map((item) => {
+                const pct = seoAudit.totalPages > 0 ? (item.count / seoAudit.totalPages) * 100 : 0;
+                return (
+                  <div key={item.label} className="flex items-center gap-3">
+                    <span className="w-32 text-right text-sm text-muted-foreground">{item.label}</span>
+                    <div className="flex-1">
+                      <div className="relative h-5 overflow-hidden rounded bg-secondary/60">
+                        <div
+                          className="h-full rounded bg-primary/80 transition-all duration-500"
+                          style={{ width: `${Math.max(pct, 2)}%` }}
+                        />
+                      </div>
+                    </div>
+                    <span className="w-20 text-right text-xs tabular-nums text-muted-foreground">
+                      {item.count}/{seoAudit.totalPages} ({fmtPct(pct)})
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+            {seoMissingPages.length > 0 && (
+              <div className="pt-2">
+                <p className="text-xs font-medium text-muted-foreground mb-2">Pages Missing SEO</p>
+                <DataTable columns={seoMissingColumns} rows={seoMissingPages} emptyMessage="All pages have SEO metadata" />
+              </div>
+            )}
+          </div>
+        </SectionCard>
+
+        {/* CMS Collections */}
+        <SectionCard title="CMS Collections" subtitle={`${fmtN(totalCmsItems)} items across ${totalCollections} collections`}>
+          {collections.length > 0 ? (
+            <div className="space-y-4">
+              <BarDisplay
+                items={[...collections]
+                  .sort((a, b) => b.itemCount - a.itemCount)
+                  .map((c) => ({
+                    label: c.displayName,
+                    value: c.itemCount,
+                    color: c.itemCount === 0 ? "hsl(var(--muted-foreground))" : undefined,
+                  }))}
+              />
+              {emptyCollections > 0 && (
+                <p className="text-xs text-muted-foreground">
+                  {emptyCollections} empty collection{emptyCollections !== 1 ? "s" : ""} — consider removing unused collections.
+                </p>
+              )}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No CMS collections on this site.</p>
+          )}
+        </SectionCard>
+      </div>
+
+      {/* Content Freshness + Recently Updated */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        {/* Freshness Distribution */}
+        <SectionCard title="Content Freshness" subtitle="When pages were last updated">
+          <div className="space-y-3">
+            {[
+              { label: "Last 7 days", count: fresh7d, color: "#22c55e" },
+              { label: "8–30 days", count: fresh8to30d, color: "#818cf8" },
+              { label: "31–90 days", count: fresh31to90d, color: "#eab308" },
+              { label: "Over 90 days", count: stale90d, color: "#ef4444" },
+            ].map((bucket) => {
+              const pct = totalPages > 0 ? (bucket.count / totalPages) * 100 : 0;
+              return (
+                <div key={bucket.label} className="flex items-center gap-3">
+                  <span className="w-28 text-right text-sm text-muted-foreground">{bucket.label}</span>
+                  <div className="flex-1">
+                    <div className="relative h-6 overflow-hidden rounded bg-secondary/60">
+                      <div
+                        className="h-full rounded transition-all duration-500"
+                        style={{ width: `${Math.max(pct, 2)}%`, backgroundColor: bucket.color }}
+                      />
+                    </div>
+                  </div>
+                  <span className="w-16 text-right text-xs tabular-nums text-muted-foreground">
+                    {bucket.count} page{bucket.count !== 1 ? "s" : ""}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </SectionCard>
+
+        {/* Recently Updated Pages */}
+        <SectionCard title="Recently Updated Pages" subtitle="Last 10 modified pages">
+          {recentlyUpdatedPages.length > 0 ? (
+            <DataTable columns={recentPageColumns} rows={recentlyUpdatedPages} emptyMessage="No page update data" />
+          ) : (
+            <p className="text-sm text-muted-foreground">No page update timestamps available.</p>
+          )}
+        </SectionCard>
+      </div>
+
+      {/* Custom Domains + Form Breakdown */}
       <div className="grid gap-4 lg:grid-cols-2">
         {/* Custom Domains */}
         <SectionCard title="Custom Domains" subtitle={`${customDomains.length} domain${customDomains.length !== 1 ? "s" : ""} configured`}>
@@ -178,87 +425,54 @@ export function AdsWebflowTab({ data }: AdsWebflowTabProps) {
           )}
         </SectionCard>
 
-        {/* Publishing Status */}
-        <SectionCard title="Publishing Status" subtitle="Deployment and content freshness">
-          <div className="space-y-3">
-            <div className="flex items-center justify-between rounded-lg bg-secondary/40 px-3 py-2">
-              <span className="text-sm text-foreground">Last Published</span>
-              <span className={`text-sm font-bold ${
-                daysSincePublish !== null && daysSincePublish > 30
-                  ? "text-yellow-500"
-                  : daysSincePublish !== null && daysSincePublish > 90
-                    ? "text-red-500"
-                    : "text-emerald-500"
-              }`}>
-                {lastPublished ? timeAgo(lastPublished) : "Never published"}
-              </span>
-            </div>
-            <div className="flex items-center justify-between rounded-lg bg-secondary/40 px-3 py-2">
-              <span className="text-sm text-foreground">Site Name</span>
-              <span className="text-sm font-bold text-foreground">{siteName || "—"}</span>
-            </div>
-            <div className="flex items-center justify-between rounded-lg bg-secondary/40 px-3 py-2">
-              <span className="text-sm text-foreground">Pages</span>
-              <span className="text-sm font-bold tabular-nums text-foreground">{totalPages}</span>
-            </div>
-            <div className="flex items-center justify-between rounded-lg bg-secondary/40 px-3 py-2">
-              <span className="text-sm text-foreground">CMS Collections</span>
-              <span className="text-sm font-bold tabular-nums text-foreground">{totalCollections}</span>
-            </div>
-          </div>
-        </SectionCard>
-      </div>
-
-      {/* Form Submissions */}
-      {formSubmissions.length > 0 && (
-        <SectionCard title="Form Submissions" subtitle="Submissions by form">
-          <div className="space-y-4">
-            {/* Form distribution bars */}
-            <div className="space-y-2">
-              {[...formSubmissions]
-                .sort((a, b) => b.count - a.count)
-                .map((form) => {
-                  const maxCount = Math.max(...formSubmissions.map((f) => f.count), 1);
-                  const share = totalFormSubmissions > 0
-                    ? (form.count / totalFormSubmissions) * 100
-                    : 0;
-                  return (
-                    <div key={form.formName} className="flex items-center gap-3">
-                      <span className="w-40 truncate text-right text-sm text-muted-foreground" title={form.formName}>
-                        {form.formName}
-                      </span>
-                      <div className="flex-1">
-                        <div className="relative h-7 overflow-hidden rounded-md">
-                          <div
-                            className="flex h-full items-center rounded-md bg-primary px-3 transition-all duration-500"
-                            style={{
-                              width: `${Math.max((form.count / maxCount) * 100, 10)}%`,
-                              minWidth: "50px",
-                            }}
-                          >
-                            <span className="text-[10px] font-bold text-white drop-shadow">
-                              {form.count}
-                            </span>
+        {/* Form Submissions Breakdown */}
+        {formSubmissions.length > 0 && (
+          <SectionCard title="Form Submissions" subtitle="Submissions by form">
+            <div className="space-y-4">
+              <div className="space-y-2">
+                {[...formSubmissions]
+                  .sort((a, b) => b.count - a.count)
+                  .map((form) => {
+                    const maxCount = Math.max(...formSubmissions.map((f) => f.count), 1);
+                    const share = totalFormSubmissions > 0
+                      ? (form.count / totalFormSubmissions) * 100
+                      : 0;
+                    return (
+                      <div key={form.formName} className="flex items-center gap-3">
+                        <span className="w-40 truncate text-right text-sm text-muted-foreground" title={form.formName}>
+                          {form.formName}
+                        </span>
+                        <div className="flex-1">
+                          <div className="relative h-7 overflow-hidden rounded-md">
+                            <div
+                              className="flex h-full items-center rounded-md bg-primary px-3 transition-all duration-500"
+                              style={{
+                                width: `${Math.max((form.count / maxCount) * 100, 10)}%`,
+                                minWidth: "50px",
+                              }}
+                            >
+                              <span className="text-[10px] font-bold text-white drop-shadow">
+                                {form.count}
+                              </span>
+                            </div>
                           </div>
                         </div>
+                        <span className="w-12 text-right text-xs tabular-nums text-muted-foreground">
+                          {share.toFixed(0)}%
+                        </span>
                       </div>
-                      <span className="w-12 text-right text-xs tabular-nums text-muted-foreground">
-                        {share.toFixed(0)}%
-                      </span>
-                    </div>
-                  );
-                })}
+                    );
+                  })}
+              </div>
+              <DataTable
+                columns={formColumns}
+                rows={[...formSubmissions].sort((a, b) => b.count - a.count)}
+                emptyMessage="No form submissions"
+              />
             </div>
-
-            {/* Table view */}
-            <DataTable
-              columns={formColumns}
-              rows={[...formSubmissions].sort((a, b) => b.count - a.count)}
-              emptyMessage="No form submissions"
-            />
-          </div>
-        </SectionCard>
-      )}
+          </SectionCard>
+        )}
+      </div>
 
       {/* Insights & Recommendations */}
       {insights.length > 0 && (

--- a/src/components/analytics/marketing-tab-new.tsx
+++ b/src/components/analytics/marketing-tab-new.tsx
@@ -924,20 +924,20 @@ export function MarketingTabNew({ data }: MarketingTabNewProps) {
 
               <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
                 <div className="bg-secondary/40 rounded-lg p-3">
-                  <p className="text-xs text-muted-foreground mb-1">Traffic / Visits</p>
-                  <p className="text-lg font-semibold text-foreground">{fmtNum(webflow.traffic)}</p>
+                  <p className="text-xs text-muted-foreground mb-1">Published Pages</p>
+                  <p className="text-lg font-semibold text-foreground">{fmtNum(webflow.publishedPages ?? webflow.totalPages)}</p>
                 </div>
                 <div className="bg-secondary/40 rounded-lg p-3">
-                  <p className="text-xs text-muted-foreground mb-1">Bounce Rate</p>
-                  <p className="text-lg font-semibold text-foreground">{fmtPct(webflow.bounceRate)}</p>
+                  <p className="text-xs text-muted-foreground mb-1">SEO Health</p>
+                  <p className="text-lg font-semibold text-foreground">{(webflow.seoAudit?.seoScore ?? 0)}%</p>
                 </div>
                 <div className="bg-secondary/40 rounded-lg p-3">
-                  <p className="text-xs text-muted-foreground mb-1">Clicks</p>
-                  <p className="text-lg font-semibold text-foreground">{fmtNum(webflow.clicks)}</p>
+                  <p className="text-xs text-muted-foreground mb-1">CMS Items</p>
+                  <p className="text-lg font-semibold text-foreground">{fmtNum(webflow.totalCmsItems ?? 0)}</p>
                 </div>
                 <div className="bg-secondary/40 rounded-lg p-3">
-                  <p className="text-xs text-muted-foreground mb-1">Repeat Visitors</p>
-                  <p className="text-lg font-semibold text-foreground">{fmtNum(webflow.returningVisitors)}</p>
+                  <p className="text-xs text-muted-foreground mb-1">Form Submissions</p>
+                  <p className="text-lg font-semibold text-foreground">{fmtNum(webflow.totalFormSubmissions ?? 0)}</p>
                 </div>
                 <div className="bg-secondary/40 rounded-lg p-3">
                   <p className="text-xs text-muted-foreground mb-1">Pages</p>

--- a/src/lib/__tests__/analytics-fetchers-webflow.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-webflow.test.ts
@@ -31,7 +31,7 @@ describe("webflow fetcher", () => {
     );
   });
 
-  it("parses pages/collections/form submissions from v2 response variants", async () => {
+  it("parses pages/collections/form submissions with enriched data", async () => {
     const fetchMock = vi.fn();
     fetchMock
       .mockResolvedValueOnce(
@@ -43,19 +43,46 @@ describe("webflow fetcher", () => {
       )
       .mockResolvedValueOnce(
         jsonResponse({
-          pages: [{ id: "p1" }, { id: "p2" }],
+          pages: [
+            {
+              id: "p1",
+              title: "Home",
+              slug: "home",
+              createdOn: "2025-01-01T00:00:00.000Z",
+              updatedOn: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+              draft: false,
+              archived: false,
+              seo: { title: "Home | Arda", description: "Welcome to Arda" },
+              openGraph: { imageUrl: "https://example.com/og.png" },
+            },
+            {
+              id: "p2",
+              title: "About",
+              slug: "about",
+              createdOn: "2025-01-02T00:00:00.000Z",
+              updatedOn: new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString(),
+              draft: true,
+              archived: false,
+              seo: {},
+              openGraph: {},
+            },
+          ],
         })
       )
       .mockResolvedValueOnce(
         jsonResponse({
-          collections: [{ id: "c1" }],
+          collections: [
+            { id: "c1", displayName: "Blog Posts", slug: "blog-posts", itemCount: 15 },
+            { id: "c2", displayName: "Team", slug: "team", itemCount: 0 },
+          ],
         })
       )
       .mockResolvedValueOnce(
         jsonResponse({
           formSubmissions: [
-            { formId: "f1", formName: "Contact" },
-            { formId: "f1", formName: "Contact" },
+            { formId: "f1", formName: "Contact", createdOn: "2026-02-15T10:00:00.000Z" },
+            { formId: "f1", formName: "Contact", createdOn: "2026-02-15T14:00:00.000Z" },
+            { formId: "f2", formName: "Newsletter", createdOn: "2026-02-16T09:00:00.000Z" },
           ],
         })
       );
@@ -64,10 +91,186 @@ describe("webflow fetcher", () => {
 
     const data = await fetchWebflowData("token", "site-id");
 
+    // Basic fields still work
     expect(data.siteName).toBe("Arda Site");
     expect(data.totalPages).toBe(2);
-    expect(data.totalCollections).toBe(1);
+    expect(data.totalCollections).toBe(2);
     expect(data.customDomains).toEqual(["arda.cards"]);
-    expect(data.formSubmissions).toEqual([{ formName: "Contact", count: 2 }]);
+
+    // Removed fields should NOT exist
+    expect(data).not.toHaveProperty("traffic");
+    expect(data).not.toHaveProperty("bounceRate");
+    expect(data).not.toHaveProperty("clicks");
+    expect(data).not.toHaveProperty("returningVisitors");
+
+    // Page details
+    expect(data.pages).toHaveLength(2);
+    expect(data.pages[0].title).toBe("Home");
+    expect(data.pages[0].seoTitle).toBe("Home | Arda");
+    expect(data.pages[0].seoDescription).toBe("Welcome to Arda");
+    expect(data.pages[0].openGraphImageUrl).toBe("https://example.com/og.png");
+    expect(data.pages[1].title).toBe("About");
+    expect(data.pages[1].draft).toBe(true);
+    expect(data.pages[1].seoTitle).toBeNull();
+
+    // Page counts
+    expect(data.publishedPages).toBe(1);
+    expect(data.draftPages).toBe(1);
+    expect(data.archivedPages).toBe(0);
+
+    // Collection details
+    expect(data.collections).toHaveLength(2);
+    expect(data.collections[0].displayName).toBe("Blog Posts");
+    expect(data.collections[0].itemCount).toBe(15);
+    expect(data.totalCmsItems).toBe(15);
+    expect(data.emptyCollections).toBe(1);
+
+    // Form data
+    expect(data.formSubmissions).toEqual(
+      expect.arrayContaining([
+        { formName: "Contact", count: 2 },
+        { formName: "Newsletter", count: 1 },
+      ])
+    );
+    expect(data.totalFormSubmissions).toBe(3);
+
+    // Form trend (bucketed by day)
+    expect(data.formTrend).toEqual([
+      { date: "2026-02-15", submissions: 2 },
+      { date: "2026-02-16", submissions: 1 },
+    ]);
+  });
+
+  it("computes SEO audit score correctly", async () => {
+    const fetchMock = vi.fn();
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          displayName: "SEO Test",
+          lastPublishedOn: "2026-01-01T00:00:00.000Z",
+          customDomains: [],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          pages: [
+            // Full SEO
+            {
+              id: "p1", title: "Page 1", slug: "p1",
+              seo: { title: "P1 Title", description: "P1 Desc" },
+              openGraph: { imageUrl: "https://example.com/og1.png" },
+            },
+            // Partial SEO (title only)
+            {
+              id: "p2", title: "Page 2", slug: "p2",
+              seo: { title: "P2 Title" },
+              openGraph: {},
+            },
+            // No SEO
+            {
+              id: "p3", title: "Page 3", slug: "p3",
+              seo: {},
+              openGraph: {},
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ collections: [] }))
+      .mockResolvedValueOnce(jsonResponse({ formSubmissions: [] }));
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const data = await fetchWebflowData("token", "site-id");
+
+    expect(data.seoAudit.totalPages).toBe(3);
+    expect(data.seoAudit.pagesWithSeoTitle).toBe(2);
+    expect(data.seoAudit.pagesWithSeoDescription).toBe(1);
+    expect(data.seoAudit.pagesWithOgImage).toBe(1);
+    // Score: round(40*(2/3) + 40*(1/3) + 20*(1/3)) = round(26.67 + 13.33 + 6.67) = 47
+    expect(data.seoAudit.seoScore).toBe(47);
+  });
+
+  it("buckets content freshness by updatedOn date", async () => {
+    const now = Date.now();
+    const dayMs = 24 * 60 * 60 * 1000;
+
+    const fetchMock = vi.fn();
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          displayName: "Freshness Test",
+          lastPublishedOn: "2026-01-01T00:00:00.000Z",
+          customDomains: [],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          pages: [
+            { id: "p1", title: "Fresh", slug: "fresh", updatedOn: new Date(now - 3 * dayMs).toISOString() },
+            { id: "p2", title: "Recent", slug: "recent", updatedOn: new Date(now - 20 * dayMs).toISOString() },
+            { id: "p3", title: "Aging", slug: "aging", updatedOn: new Date(now - 60 * dayMs).toISOString() },
+            { id: "p4", title: "Stale", slug: "stale", updatedOn: new Date(now - 120 * dayMs).toISOString() },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ collections: [] }))
+      .mockResolvedValueOnce(jsonResponse({ formSubmissions: [] }));
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const data = await fetchWebflowData("token", "site-id");
+
+    expect(data.contentFreshness.updatedLast7d).toBe(1);
+    expect(data.contentFreshness.updatedLast30d).toBe(2);
+    expect(data.contentFreshness.updatedLast90d).toBe(3);
+    expect(data.contentFreshness.staleOver90d).toBe(1);
+  });
+
+  it("handles pages with missing optional fields gracefully", async () => {
+    const fetchMock = vi.fn();
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          name: "Bare Site",
+          customDomains: [],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          pages: [
+            { id: "p1", name: "Minimal Page" },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          collections: [
+            { id: "c1", name: "Bare Collection" },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ formSubmissions: [] }));
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const data = await fetchWebflowData("token", "site-id");
+
+    expect(data.siteName).toBe("Bare Site");
+    expect(data.pages[0].title).toBe("Minimal Page");
+    expect(data.pages[0].slug).toBe("");
+    expect(data.pages[0].createdOn).toBeNull();
+    expect(data.pages[0].updatedOn).toBeNull();
+    expect(data.pages[0].seoTitle).toBeNull();
+    expect(data.pages[0].seoDescription).toBeNull();
+    expect(data.pages[0].openGraphImageUrl).toBeNull();
+    expect(data.pages[0].draft).toBe(false);
+    expect(data.pages[0].archived).toBe(false);
+
+    // Page with no updatedOn goes into stale bucket
+    expect(data.contentFreshness.staleOver90d).toBe(1);
+
+    // Collection with no itemCount defaults to 0
+    expect(data.collections[0].itemCount).toBe(0);
+    expect(data.collections[0].displayName).toBe("Bare Collection");
   });
 });

--- a/src/lib/analytics/fetchers-ga-webflow.ts
+++ b/src/lib/analytics/fetchers-ga-webflow.ts
@@ -5,6 +5,11 @@ import {
   GATopPage,
   WebflowData,
   WebflowFormEntry,
+  WebflowPageDetail,
+  WebflowCollectionDetail,
+  WebflowFormTrendEntry,
+  WebflowSeoAudit,
+  WebflowContentFreshness,
   AnalyticsTimestamp,
 } from "./types";
 
@@ -396,14 +401,100 @@ export async function fetchWebflowData(
     return "";
   }).filter(Boolean);
 
-  const pages = asArray(pagesResponse.items).length
+  const rawPages = asArray(pagesResponse.items).length
     ? asArray(pagesResponse.items)
     : asArray(pagesResponse.pages);
-  const collections = asArray(collectionsResponse.items).length
+  const rawCollections = asArray(collectionsResponse.items).length
     ? asArray(collectionsResponse.items)
     : asArray(collectionsResponse.collections);
 
+  // ── Parse page details ──
+  const now = Date.now();
+  const dayMs = 24 * 60 * 60 * 1000;
+  const daysSince = (dateStr: string | null): number => {
+    if (!dateStr) return Infinity;
+    const d = new Date(dateStr);
+    if (isNaN(d.getTime())) return Infinity;
+    return Math.floor((now - d.getTime()) / dayMs);
+  };
+  const strOrNull = (v: unknown): string | null =>
+    typeof v === "string" && v.length > 0 ? v : null;
+
+  const pageDetails: WebflowPageDetail[] = rawPages.map((entry) => {
+    const p = requireObject(entry);
+    const seo = requireObject(p.seo);
+    const og = requireObject(p.openGraph);
+    return {
+      id: String(p.id || p._id || ""),
+      title: String(p.title || p.name || ""),
+      slug: String(p.slug || ""),
+      createdOn: strOrNull(p.createdOn),
+      updatedOn: strOrNull(p.updatedOn || p.lastUpdated),
+      draft: p.draft === true,
+      archived: p.archived === true,
+      seoTitle: strOrNull(seo.title || p.seoTitle),
+      seoDescription: strOrNull(seo.description || p.seoDescription),
+      openGraphImageUrl: strOrNull(og.imageUrl || og.image),
+    };
+  });
+
+  // ── SEO audit ──
+  const totalPageCount = pageDetails.length;
+  const pagesWithSeoTitle = pageDetails.filter((p) => p.seoTitle !== null).length;
+  const pagesWithSeoDescription = pageDetails.filter((p) => p.seoDescription !== null).length;
+  const pagesWithOgImage = pageDetails.filter((p) => p.openGraphImageUrl !== null).length;
+  const seoScore =
+    totalPageCount > 0
+      ? Math.round(
+          40 * (pagesWithSeoTitle / totalPageCount) +
+          40 * (pagesWithSeoDescription / totalPageCount) +
+          20 * (pagesWithOgImage / totalPageCount)
+        )
+      : 0;
+  const seoAudit: WebflowSeoAudit = {
+    totalPages: totalPageCount,
+    pagesWithSeoTitle,
+    pagesWithSeoDescription,
+    pagesWithOgImage,
+    seoScore,
+  };
+
+  // ── Content freshness ──
+  const contentFreshness: WebflowContentFreshness = {
+    updatedLast7d: pageDetails.filter((p) => daysSince(p.updatedOn) <= 7).length,
+    updatedLast30d: pageDetails.filter((p) => daysSince(p.updatedOn) <= 30).length,
+    updatedLast90d: pageDetails.filter((p) => daysSince(p.updatedOn) <= 90).length,
+    staleOver90d: pageDetails.filter((p) => daysSince(p.updatedOn) > 90).length,
+  };
+
+  // ── Recently updated pages (top 10) ──
+  const recentlyUpdatedPages = [...pageDetails]
+    .filter((p) => p.updatedOn !== null)
+    .sort((a, b) => new Date(b.updatedOn!).getTime() - new Date(a.updatedOn!).getTime())
+    .slice(0, 10);
+
+  // ── Draft / published / archived counts ──
+  const archivedPages = pageDetails.filter((p) => p.archived).length;
+  const draftPages = pageDetails.filter((p) => p.draft && !p.archived).length;
+  const publishedPages = totalPageCount - draftPages - archivedPages;
+
+  // ── Parse collection details ──
+  const collectionDetails: WebflowCollectionDetail[] = rawCollections.map((entry) => {
+    const c = requireObject(entry);
+    return {
+      id: String(c.id || c._id || ""),
+      displayName: String(c.displayName || c.name || c.slug || ""),
+      slug: String(c.slug || ""),
+      itemCount: typeof c.itemCount === "number" ? c.itemCount : 0,
+      createdOn: strOrNull(c.createdOn),
+    };
+  });
+  const totalCmsItems = collectionDetails.reduce((sum, c) => sum + c.itemCount, 0);
+  const emptyCollections = collectionDetails.filter((c) => c.itemCount === 0).length;
+
+  // ── Form submissions + trend ──
   let formSubmissions: WebflowFormEntry[] = [];
+  let formTrend: WebflowFormTrendEntry[] = [];
   try {
     const formsRes = await fetch(`${baseUrl}/sites/${siteId}/form_submissions`, {
       headers,
@@ -415,43 +506,70 @@ export async function fetchWebflowData(
         : asArray(formsResponse.formSubmissions);
 
       const formMap: Record<string, number> = {};
+      const trendMap: Record<string, number> = {};
       items.forEach((submission) => {
         const row = requireObject(submission);
-        
+
         // Filter by date if createdOn is available and bounds exist
-        if (from && to && row.createdOn) {
-          const createdOnStr = String(row.createdOn);
-          const createdDate = new Date(createdOnStr);
-          if (!isNaN(createdDate.getTime())) {
-            if (createdDate < from || createdDate > to) {
-              return; // Skip submission outside range
-            }
+        let createdDate: Date | null = null;
+        if (row.createdOn) {
+          const d = new Date(String(row.createdOn));
+          if (!isNaN(d.getTime())) createdDate = d;
+        }
+
+        if (from && to && createdDate) {
+          if (createdDate < from || createdDate > to) {
+            return; // Skip submission outside range
           }
         }
-        
+
         const formName = String(row.formName || row.formId || "Unknown");
         formMap[formName] = (formMap[formName] || 0) + 1;
+
+        // Bucket by day for trend
+        if (createdDate) {
+          const dayKey = createdDate.toISOString().split("T")[0];
+          trendMap[dayKey] = (trendMap[dayKey] || 0) + 1;
+        }
       });
       formSubmissions = Object.entries(formMap).map(([formName, count]) => ({
         formName,
         count,
       }));
+      formTrend = Object.entries(trendMap)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([date, submissions]) => ({ date, submissions }));
     }
   } catch {
     formSubmissions = [];
+    formTrend = [];
   }
+
+  const totalFormSubmissions = formSubmissions.reduce((sum, f) => sum + f.count, 0);
 
   return {
     siteName,
     lastPublished,
-    totalPages: pages.length,
-    totalCollections: collections.length,
+    totalPages: totalPageCount,
+    totalCollections: rawCollections.length,
     formSubmissions,
     customDomains,
-    traffic: 0,
-    bounceRate: 0,
-    clicks: 0,
-    returningVisitors: 0,
+
+    publishedPages,
+    draftPages,
+    archivedPages,
+    pages: pageDetails,
+    seoAudit,
+    contentFreshness,
+    recentlyUpdatedPages,
+
+    collections: collectionDetails,
+    totalCmsItems,
+    emptyCollections,
+
+    formTrend,
+    totalFormSubmissions,
+
     _meta: makeMeta("live"),
   };
 }

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -417,6 +417,47 @@ export interface WebflowFormEntry {
   count: number;
 }
 
+export interface WebflowPageDetail {
+  id: string;
+  title: string;
+  slug: string;
+  createdOn: string | null;
+  updatedOn: string | null;
+  draft: boolean;
+  archived: boolean;
+  seoTitle: string | null;
+  seoDescription: string | null;
+  openGraphImageUrl: string | null;
+}
+
+export interface WebflowCollectionDetail {
+  id: string;
+  displayName: string;
+  slug: string;
+  itemCount: number;
+  createdOn: string | null;
+}
+
+export interface WebflowFormTrendEntry {
+  date: string;
+  submissions: number;
+}
+
+export interface WebflowSeoAudit {
+  totalPages: number;
+  pagesWithSeoTitle: number;
+  pagesWithSeoDescription: number;
+  pagesWithOgImage: number;
+  seoScore: number;
+}
+
+export interface WebflowContentFreshness {
+  updatedLast7d: number;
+  updatedLast30d: number;
+  updatedLast90d: number;
+  staleOver90d: number;
+}
+
 export interface WebflowData {
   siteName: string;
   lastPublished: string;
@@ -424,10 +465,22 @@ export interface WebflowData {
   totalCollections: number;
   formSubmissions: WebflowFormEntry[];
   customDomains: string[];
-  traffic: number;
-  bounceRate: number;
-  clicks: number;
-  returningVisitors: number;
+
+  publishedPages: number;
+  draftPages: number;
+  archivedPages: number;
+  pages: WebflowPageDetail[];
+  seoAudit: WebflowSeoAudit;
+  contentFreshness: WebflowContentFreshness;
+  recentlyUpdatedPages: WebflowPageDetail[];
+
+  collections: WebflowCollectionDetail[];
+  totalCmsItems: number;
+  emptyCollections: number;
+
+  formTrend: WebflowFormTrendEntry[];
+  totalFormSubmissions: number;
+
   _meta: AnalyticsTimestamp;
 }
 


### PR DESCRIPTION
## Summary
- Replaced four always-zero placeholder fields (`traffic`, `bounceRate`, `clicks`, `returningVisitors`) with real derived metrics from the Webflow API v2 pages, collections, and form submissions endpoints
- Added SEO audit scoring (weighted title/description/OG image coverage), content freshness analysis (7d/30d/90d/stale buckets), CMS utilization (item counts, empty collection detection), and form submission daily trends
- Rewrote the Webflow tab UI with 7 rich sections: KPI stat cards, form trend chart, SEO audit with RingStat, CMS collection breakdown, content freshness distribution, recently updated pages table, and enhanced insights
- Fixed the marketing tab to reference real metrics instead of the removed placeholder fields

## Test plan
- [x] TypeScript type-check passes (`npx tsc --noEmit` — no errors in modified files)
- [x] ESLint passes with zero warnings on all modified files
- [x] All 5 Webflow fetcher tests pass (1 existing updated + 4 new: SEO scoring, freshness bucketing, missing fields handling, form trend bucketing)
- [ ] Visual verification of the Webflow tab with a connected Webflow site
- [ ] Verify old cached snapshots render gracefully with safe defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)