### PR TITLE
feat(integrations): add cold-start env diagnostic log

### DIFF
--- a/src/app/api/integrations/route.test.ts
+++ b/src/app/api/integrations/route.test.ts
@@ -53,6 +53,10 @@ vi.mock("@/lib/analytics/provider-health", () => ({
   })),
 }));
 
+vi.mock("@/lib/integrations/env-diagnostic", () => ({
+  logIntegrationEnvDiagnostic: vi.fn(),
+}));
+
 vi.mock("@/lib/integrations/catalog", () => ({
   listIntegrationDefinitions: vi.fn(() => [
     {

--- a/src/app/api/integrations/route.ts
+++ b/src/app/api/integrations/route.ts
@@ -20,6 +20,7 @@ import {
   isIntegrationConfigured,
   listIntegrationDefinitions,
 } from "@/lib/integrations/catalog";
+import { logIntegrationEnvDiagnostic } from "@/lib/integrations/env-diagnostic";
 import { normalizeCodaDocId } from "@/lib/integrations/coda-config";
 import {
   bestEffortMigrateConnectionsToOwner,
@@ -82,6 +83,8 @@ function hasCredentialForProvider(
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
+  logIntegrationEnvDiagnostic();
+
   try {
     const session = await auth();
     if (!session?.user) {

--- a/src/lib/integrations/env-diagnostic.ts
+++ b/src/lib/integrations/env-diagnostic.ts
@@ -1,0 +1,72 @@
+/**
+ * Integration Environment Diagnostic
+ *
+ * Logs a one-time summary of which integration providers have their required
+ * environment variables set. Runs on the first API request (cold start) so
+ * operators can immediately see what's missing in Railway / production logs
+ * without visiting the settings UI.
+ */
+
+import {
+  listIntegrationDefinitions,
+  isOAuthIntegration,
+  getMissingIntegrationEnv,
+} from "@/lib/integrations/catalog";
+
+let logged = false;
+
+export function logIntegrationEnvDiagnostic(): void {
+  if (logged) return;
+  logged = true;
+
+  const definitions = listIntegrationDefinitions();
+  const lines: string[] = [];
+  let missingCount = 0;
+
+  for (const def of definitions) {
+    if (!isOAuthIntegration(def)) {
+      lines.push(`  ${def.slug}: OK (token-based, no OAuth env required)`);
+      continue;
+    }
+
+    const missing = getMissingIntegrationEnv(def);
+    if (missing.length === 0) {
+      lines.push(`  ${def.slug}: OK`);
+    } else {
+      lines.push(`  ${def.slug}: MISSING (${missing.join(", ")})`);
+      missingCount += 1;
+    }
+  }
+
+  const coreVars = [
+    "DATABASE_URL",
+    "NEXTAUTH_SECRET",
+    "NEXTAUTH_URL",
+    "INTEGRATION_TOKEN_SECRET",
+    "INTEGRATION_OWNER_USER_ID",
+  ];
+
+  const coreLines: string[] = [];
+  for (const key of coreVars) {
+    const set = Boolean(process.env[key]?.trim());
+    coreLines.push(`  ${key}: ${set ? "SET" : "NOT SET"}`);
+  }
+
+  const level = missingCount > 0 ? "warn" : "info";
+  const summary =
+    missingCount > 0
+      ? `${missingCount} OAuth provider(s) missing env vars`
+      : "All OAuth providers configured";
+
+  console[level](
+    [
+      `[integrations] Environment diagnostic (${summary}):`,
+      "",
+      "Core variables:",
+      ...coreLines,
+      "",
+      "Provider OAuth credentials:",
+      ...lines,
+    ].join("\n")
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a one-time cold-start diagnostic log to `/api/integrations` that reports which OAuth providers have their required env vars (`CLIENT_ID`/`CLIENT_SECRET`) set vs missing
- Surfaces misconfigured deployments in Railway logs immediately, instead of requiring someone to visit the settings UI to discover the issue
- New file: `src/lib/integrations/env-diagnostic.ts`

## Test plan
- [x] All 1361 tests pass (115 test files)
- [ ] Deploy to Railway and check logs for `[integrations] Environment diagnostic` output
- [ ] Verify integrations page still loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)