### PR TITLE
feat(integrations): add provider health and retry endpoints

### DIFF
--- a/src/app/api/integrations/[provider]/health/route.ts
+++ b/src/app/api/integrations/[provider]/health/route.ts
@@ -1,0 +1,110 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { enforcePermission } from "@/lib/permissions";
+import { prisma } from "@/lib/prisma";
+import { getIntegrationBySlug } from "@/lib/integrations/catalog";
+import { resolveIntegrationOwnerUserId } from "@/lib/integrations/ownership";
+import { getCircuitSnapshot } from "@/lib/integrations/circuit-breaker";
+import {
+  assembleProviderHealth,
+  type ConnectionHealth,
+  type RuleHealth,
+} from "@/lib/integrations/provider-health";
+
+interface RouteParams {
+  params: Promise<{ provider: string }>;
+}
+
+export async function GET(
+  request: NextRequest,
+  context: RouteParams,
+): Promise<NextResponse> {
+  try {
+    const { provider: slug } = await context.params;
+    const definition = getIntegrationBySlug(slug);
+    if (!definition) {
+      return NextResponse.json({ error: "Provider not found" }, { status: 404 });
+    }
+
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "integration.read",
+      request,
+      targetType: "integration",
+      targetId: definition.provider,
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
+    }
+
+    const ownerUserId = resolveIntegrationOwnerUserId(session.user.id);
+
+    const [connectionRow, ruleRows, circuit] = await Promise.all([
+      prisma.integrationConnection.findUnique({
+        where: {
+          userId_provider: { userId: ownerUserId, provider: definition.provider },
+        },
+        select: {
+          provider: true,
+          status: true,
+          lastSyncedAt: true,
+          lastError: true,
+          connectedAt: true,
+        },
+      }),
+      prisma.integrationRule.findMany({
+        where: { userId: ownerUserId, provider: definition.provider },
+        select: {
+          key: true,
+          enabled: true,
+          lastRunAt: true,
+          lastError: true,
+          lastObservedAt: true,
+        },
+        orderBy: { updatedAt: "desc" },
+      }),
+      getCircuitSnapshot(definition.provider, ownerUserId),
+    ]);
+
+    const connection: ConnectionHealth = connectionRow
+      ? {
+          provider: connectionRow.provider,
+          status: connectionRow.status,
+          lastSyncedAt: connectionRow.lastSyncedAt,
+          lastError: connectionRow.lastError,
+          connectedAt: connectionRow.connectedAt,
+        }
+      : {
+          provider: definition.provider,
+          status: "DISCONNECTED",
+          lastSyncedAt: null,
+          lastError: null,
+          connectedAt: null,
+        };
+
+    const rules: RuleHealth[] = ruleRows.map((r) => ({
+      key: r.key,
+      enabled: r.enabled,
+      lastRunAt: r.lastRunAt,
+      lastError: r.lastError,
+      lastObservedAt: r.lastObservedAt,
+    }));
+
+    const health = assembleProviderHealth({ connection, rules, circuit });
+
+    return NextResponse.json(health);
+  } catch (error) {
+    console.error("GET /api/integrations/[provider]/health error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch provider health" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/integrations/[provider]/retry/route.ts
+++ b/src/app/api/integrations/[provider]/retry/route.ts
@@ -1,0 +1,117 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { enforcePermission } from "@/lib/permissions";
+import { prisma } from "@/lib/prisma";
+import { getIntegrationBySlug } from "@/lib/integrations/catalog";
+import { resolveIntegrationOwnerUserId } from "@/lib/integrations/ownership";
+import { getCircuitSnapshot } from "@/lib/integrations/circuit-breaker";
+import { runRules } from "@/lib/integrations/orchestrator";
+
+interface RouteParams {
+  params: Promise<{ provider: string }>;
+}
+
+export async function POST(
+  request: NextRequest,
+  context: RouteParams,
+): Promise<NextResponse> {
+  try {
+    const { provider: slug } = await context.params;
+    const definition = getIntegrationBySlug(slug);
+    if (!definition) {
+      return NextResponse.json({ error: "Provider not found" }, { status: 404 });
+    }
+
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const permission = await enforcePermission({
+      userId: session.user.id,
+      action: "integration.manage",
+      request,
+      targetType: "integration",
+      targetId: definition.provider,
+    });
+    if (permission.deniedResponse) {
+      return permission.deniedResponse;
+    }
+
+    const ownerUserId = resolveIntegrationOwnerUserId(session.user.id);
+
+    // Verify the provider is connected
+    const connection = await prisma.integrationConnection.findUnique({
+      where: {
+        userId_provider: { userId: ownerUserId, provider: definition.provider },
+      },
+      select: { status: true },
+    });
+
+    if (!connection || connection.status === "DISCONNECTED") {
+      return NextResponse.json(
+        { error: "Integration is not connected" },
+        { status: 409 },
+      );
+    }
+
+    // Check circuit breaker — reject if still in cooldown
+    const circuit = await getCircuitSnapshot(definition.provider, ownerUserId);
+    if (circuit.state === "OPEN" && circuit.nextRetryAt) {
+      return NextResponse.json(
+        {
+          error: "Circuit breaker is open — retry not allowed yet",
+          nextRetryAt: circuit.nextRetryAt.toISOString(),
+          backoff: {
+            circuitState: circuit.state,
+            consecutiveFailures: circuit.consecutiveFailures,
+            currentCooldownMs: circuit.currentCooldownMs,
+            openCount: circuit.openCount,
+          },
+        },
+        { status: 429 },
+      );
+    }
+
+    // Verify there are enabled rules to run
+    const enabledRuleCount = await prisma.integrationRule.count({
+      where: {
+        userId: ownerUserId,
+        provider: definition.provider,
+        enabled: true,
+      },
+    });
+
+    if (enabledRuleCount === 0) {
+      return NextResponse.json(
+        { error: "No enabled sync rules for this provider" },
+        { status: 409 },
+      );
+    }
+
+    // Trigger sync through the existing orchestrator (respects circuit breaker internally)
+    const result = await runRules({
+      mode: "incremental",
+      providers: [definition.provider],
+      userIds: [ownerUserId],
+      dryRun: false,
+      startedAt: new Date().toISOString(),
+    });
+
+    return NextResponse.json({
+      ok: true,
+      provider: definition.provider,
+      executedRules: result.executedRules,
+      startedAt: result.startedAt,
+      finishedAt: result.finishedAt,
+    });
+  } catch (error) {
+    console.error("POST /api/integrations/[provider]/retry error:", error);
+    return NextResponse.json(
+      { error: "Failed to trigger retry" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/integrations/circuit-breaker.ts
+++ b/src/lib/integrations/circuit-breaker.ts
@@ -258,6 +258,44 @@ export function getCircuitState(provider: string, userId: string): CircuitState 
   return "CLOSED";
 }
 
+export interface CircuitSnapshot {
+  state: CircuitState;
+  consecutiveFailures: number;
+  currentCooldownMs: number;
+  openCount: number;
+  openedAt: number | null;
+  /** When the circuit will transition to HALF_OPEN (null if CLOSED or already past cooldown). */
+  nextRetryAt: Date | null;
+}
+
+/**
+ * Async read of the full circuit entry for observability endpoints.
+ * Reads from DB to ensure accuracy (in-memory cache may be cold).
+ */
+export async function getCircuitSnapshot(
+  provider: string,
+  userId: string,
+): Promise<CircuitSnapshot> {
+  const entry = await loadEntry(provider, userId);
+
+  let nextRetryAt: Date | null = null;
+  if (entry.state === "OPEN" && entry.openedAt !== null) {
+    const retryAtMs = entry.openedAt + entry.currentCooldownMs;
+    if (retryAtMs > Date.now()) {
+      nextRetryAt = new Date(retryAtMs);
+    }
+  }
+
+  return {
+    state: entry.state,
+    consecutiveFailures: entry.consecutiveFailures,
+    currentCooldownMs: entry.currentCooldownMs,
+    openCount: entry.openCount,
+    openedAt: entry.openedAt,
+    nextRetryAt,
+  };
+}
+
 /**
  * Error thrown when the circuit is open and the request is rejected.
  */

--- a/src/lib/integrations/provider-health.ts
+++ b/src/lib/integrations/provider-health.ts
@@ -1,0 +1,180 @@
+/**
+ * Provider Health Assembly
+ *
+ * Pure functions that assemble per-provider health/sync state from
+ * IntegrationConnection, IntegrationRule, and IntegrationCircuitState data.
+ * Used by GET /api/integrations/[provider]/health.
+ */
+
+import type { CircuitSnapshot } from "@/lib/integrations/circuit-breaker";
+
+// ---------------------------------------------------------------------------
+// Input types (matching Prisma select shapes)
+// ---------------------------------------------------------------------------
+
+export interface ConnectionHealth {
+  provider: string;
+  status: string;
+  lastSyncedAt: Date | null;
+  lastError: string | null;
+  connectedAt: Date | null;
+}
+
+export interface RuleHealth {
+  key: string;
+  enabled: boolean;
+  lastRunAt: Date | null;
+  lastError: string | null;
+  lastObservedAt: Date | null;
+}
+
+// ---------------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------------
+
+export interface ProviderHealthError {
+  message: string;
+  code: string;
+}
+
+export interface ProviderHealthResponse {
+  provider: string;
+  status: string;
+  lastSuccessfulSyncAt: string | null;
+  lastAttemptAt: string | null;
+  lastError: ProviderHealthError | null;
+  nextRetryAt: string | null;
+  backoff: {
+    circuitState: string;
+    consecutiveFailures: number;
+    currentCooldownMs: number;
+    openCount: number;
+  } | null;
+  rules: Array<{
+    key: string;
+    enabled: boolean;
+    lastRunAt: string | null;
+    lastError: string | null;
+    lastObservedAt: string | null;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+const ERROR_PATTERNS: Array<{ pattern: RegExp; code: string }> = [
+  { pattern: /\bauth\b|unauthorized|403|401|token.*expired|invalid.*token/i, code: "AUTH_FAILED" },
+  { pattern: /rate.?limit|429|too many requests|throttl/i, code: "RATE_LIMITED" },
+  { pattern: /timeout|timed?\s*out|ETIMEDOUT|ESOCKETTIMEDOUT/i, code: "TIMEOUT" },
+  { pattern: /5\d{2}\b|internal server|bad gateway|service unavailable|upstream/i, code: "UPSTREAM_ERROR" },
+  { pattern: /network|ECONNREFUSED|ENOTFOUND|ECONNRESET|fetch failed/i, code: "NETWORK_ERROR" },
+  { pattern: /circuit.?breaker|circuit.*open/i, code: "CIRCUIT_OPEN" },
+];
+
+export function classifyError(message: string): string {
+  for (const { pattern, code } of ERROR_PATTERNS) {
+    if (pattern.test(message)) {
+      return code;
+    }
+  }
+  return "UNKNOWN";
+}
+
+// ---------------------------------------------------------------------------
+// Assembly
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive `lastAttemptAt` from the most recent rule execution across all
+ * rules for a provider. Returns null if no rules have run.
+ */
+export function deriveLastAttemptAt(rules: RuleHealth[]): Date | null {
+  let latest: Date | null = null;
+  for (const rule of rules) {
+    if (rule.lastRunAt && (!latest || rule.lastRunAt > latest)) {
+      latest = rule.lastRunAt;
+    }
+  }
+  return latest;
+}
+
+/**
+ * Derive the most relevant error from connection + rules.
+ * Prefers the most recent error (by associated timestamp), falling back
+ * to the connection-level error.
+ */
+export function deriveLastError(
+  connection: ConnectionHealth,
+  rules: RuleHealth[],
+): ProviderHealthError | null {
+  // Collect all errors with their associated timestamps
+  const candidates: Array<{ message: string; at: Date | null }> = [];
+
+  if (connection.lastError) {
+    candidates.push({ message: connection.lastError, at: connection.lastSyncedAt });
+  }
+
+  for (const rule of rules) {
+    if (rule.lastError) {
+      candidates.push({ message: rule.lastError, at: rule.lastRunAt });
+    }
+  }
+
+  if (candidates.length === 0) return null;
+
+  // Sort by timestamp descending (nulls last)
+  candidates.sort((a, b) => {
+    if (!a.at && !b.at) return 0;
+    if (!a.at) return 1;
+    if (!b.at) return -1;
+    return b.at.getTime() - a.at.getTime();
+  });
+
+  const best = candidates[0]!;
+  return {
+    message: best.message,
+    code: classifyError(best.message),
+  };
+}
+
+/**
+ * Assemble a complete health response for a single provider.
+ */
+export function assembleProviderHealth(input: {
+  connection: ConnectionHealth;
+  rules: RuleHealth[];
+  circuit: CircuitSnapshot;
+}): ProviderHealthResponse {
+  const { connection, rules, circuit } = input;
+
+  const lastAttemptAt = deriveLastAttemptAt(rules);
+  const lastError = deriveLastError(connection, rules);
+
+  const hasBackoff =
+    circuit.state !== "CLOSED" || circuit.consecutiveFailures > 0;
+
+  return {
+    provider: connection.provider,
+    status: connection.status,
+    lastSuccessfulSyncAt: connection.lastSyncedAt?.toISOString() ?? null,
+    lastAttemptAt: lastAttemptAt?.toISOString() ?? null,
+    lastError,
+    nextRetryAt: circuit.nextRetryAt?.toISOString() ?? null,
+    backoff: hasBackoff
+      ? {
+          circuitState: circuit.state,
+          consecutiveFailures: circuit.consecutiveFailures,
+          currentCooldownMs: circuit.currentCooldownMs,
+          openCount: circuit.openCount,
+        }
+      : null,
+    rules: rules.map((rule) => ({
+      key: rule.key,
+      enabled: rule.enabled,
+      lastRunAt: rule.lastRunAt?.toISOString() ?? null,
+      lastError: rule.lastError ?? null,
+      lastObservedAt: rule.lastObservedAt?.toISOString() ?? null,
+    })),
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/integrations/[provider]/health` endpoint that assembles connection status, rule execution state, and circuit-breaker backoff into a single health response with classified error codes
- Adds `POST /api/integrations/[provider]/retry` endpoint to manually trigger sync retry with circuit-breaker guard (rejects while cooldown is active)
- Exports `getCircuitSnapshot()` from the circuit-breaker module for async DB reads (observability)
- Introduces `provider-health.ts` with error classification patterns (AUTH_FAILED, RATE_LIMITED, TIMEOUT, etc.)

## Test plan
- [ ] Verify health endpoint returns correct status for connected/disconnected providers
- [ ] Verify retry endpoint respects circuit breaker open state (returns 429)
- [ ] Verify retry endpoint triggers orchestrator sync for eligible providers
- [ ] Verify error classification matches expected patterns


Made with [Cursor](https://cursor.com)