### PR TITLE
feat(analytics): add overview KPI deltas

### DIFF
--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -48,6 +48,8 @@ import {
   storeAnalyticsSnapshotFailure,
 } from "@/lib/analytics/snapshots";
 import { buildAnalyticsRouteMeta } from "@/lib/analytics/route-meta";
+import { computeAnalyticsKpis } from "@/lib/analytics/kpis";
+import { computeKpiDelta } from "@/lib/analytics/kpi-deltas";
 import type {
   AnalyticsDashboardData,
   AnalyticsRecommendation,
@@ -940,6 +942,7 @@ export async function GET(request: Request) {
   const DEFAULT_TIMEOUT = 12000;
 
   const snapshotExpiresAt = snapshotExpiryFromNow(1);
+  const capturedAtByDomain: Partial<Record<DomainKey, string | null>> = {};
 
   const settled = await Promise.allSettled(
     fetchers.map(async (entry): Promise<FetchOutcome> => {
@@ -1058,6 +1061,7 @@ export async function GET(request: Request) {
 
     const { key, payload, stale, capturedAt, fallbackError } = outcome.value;
     (result as unknown as Record<string, unknown>)[key] = payload;
+    capturedAtByDomain[key] = capturedAt;
 
     if (stale) {
       result.staleDomains.push(key);
@@ -1117,6 +1121,84 @@ export async function GET(request: Request) {
     } catch (error) {
       console.error("Failed to build financial planning data:", error);
       // Non-fatal — leave as null
+    }
+  }
+
+  if (section === "overview") {
+    try {
+      const prevToDate = new Date(fromDate.getTime() - 1);
+      const prevFromDate = new Date(
+        prevToDate.getTime() - (Math.max(1, range.days) - 1) * 24 * 60 * 60 * 1000,
+      );
+      prevFromDate.setUTCHours(0, 0, 0, 0);
+
+      const [prevStripe, prevGa] = await Promise.all([
+        readLatestSuccessfulSnapshot<StripeData>({
+          userId,
+          providerKey: "stripe",
+          contextKey: "default",
+          rangePreset: range.preset,
+          fromDate: prevFromDate,
+          toDate: prevToDate,
+        }),
+        readLatestSuccessfulSnapshot<AnalyticsDashboardData["googleAnalytics"]>({
+          userId,
+          providerKey: "googleAnalytics",
+          contextKey: "default",
+          rangePreset: range.preset,
+          fromDate: prevFromDate,
+          toDate: prevToDate,
+        }),
+      ]);
+
+      const currentTraffic =
+        result.googleAnalytics || result.ga ? computeAnalyticsKpis(result).traffic : null;
+      const currentFinance = result.stripe ? computeAnalyticsKpis(result).finance : null;
+
+      const prevTraffic = prevGa.payload
+        ? computeAnalyticsKpis(
+            { googleAnalytics: prevGa.payload } as unknown as AnalyticsDashboardData,
+          ).traffic
+        : null;
+      const prevFinance = prevStripe.payload
+        ? computeAnalyticsKpis(
+            { stripe: prevStripe.payload } as unknown as AnalyticsDashboardData,
+          ).finance
+        : null;
+
+      result.deltas = {
+        traffic: {
+          bounceRatePct: computeKpiDelta({
+            current: currentTraffic?.bounceRatePct ?? null,
+            previous: prevTraffic?.bounceRatePct ?? null,
+            currentCapturedAt: capturedAtByDomain.googleAnalytics ?? null,
+            previousCapturedAt: prevGa.capturedAt,
+          }),
+          pagesPerSession: computeKpiDelta({
+            current: currentTraffic?.pagesPerSession ?? null,
+            previous: prevTraffic?.pagesPerSession ?? null,
+            currentCapturedAt: capturedAtByDomain.googleAnalytics ?? null,
+            previousCapturedAt: prevGa.capturedAt,
+          }),
+        },
+        finance: {
+          mrr: computeKpiDelta({
+            current: currentFinance?.mrr ?? null,
+            previous: prevFinance?.mrr ?? null,
+            currentCapturedAt: capturedAtByDomain.stripe ?? null,
+            previousCapturedAt: prevStripe.capturedAt,
+          }),
+          paymentSuccessPct: computeKpiDelta({
+            current: currentFinance?.paymentSuccessPct ?? null,
+            previous: prevFinance?.paymentSuccessPct ?? null,
+            currentCapturedAt: capturedAtByDomain.stripe ?? null,
+            previousCapturedAt: prevStripe.capturedAt,
+          }),
+        },
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      result.errors.push({ source: "deltas", message });
     }
   }
 

--- a/src/lib/__tests__/analytics-kpi-deltas.test.ts
+++ b/src/lib/__tests__/analytics-kpi-deltas.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { computeKpiDelta } from "@/lib/analytics/kpi-deltas";
+
+describe("computeKpiDelta", () => {
+  it("computes absolute + percent delta and direction", () => {
+    const delta = computeKpiDelta({ current: 100, previous: 80 });
+    expect(delta).toEqual(
+      expect.objectContaining({
+        current: 100,
+        previous: 80,
+        delta: 20,
+        deltaPct: 25,
+        direction: "up",
+      }),
+    );
+  });
+
+  it("handles decreases", () => {
+    const delta = computeKpiDelta({ current: 80, previous: 100 });
+    expect(delta.delta).toBe(-20);
+    expect(delta.deltaPct).toBe(-20);
+    expect(delta.direction).toBe("down");
+  });
+
+  it("returns null deltas when current or previous is missing", () => {
+    expect(computeKpiDelta({ current: null, previous: 10 }).delta).toBeNull();
+    expect(computeKpiDelta({ current: 10, previous: null }).deltaPct).toBeNull();
+  });
+
+  it("returns null percent delta when previous is zero but current is non-zero", () => {
+    const delta = computeKpiDelta({ current: 10, previous: 0 });
+    expect(delta.delta).toBe(10);
+    expect(delta.deltaPct).toBeNull();
+    expect(delta.direction).toBe("up");
+  });
+
+  it("returns 0 percent delta when both values are zero", () => {
+    const delta = computeKpiDelta({ current: 0, previous: 0 });
+    expect(delta.delta).toBe(0);
+    expect(delta.deltaPct).toBe(0);
+    expect(delta.direction).toBe("flat");
+  });
+});
+

--- a/src/lib/analytics/kpi-deltas.ts
+++ b/src/lib/analytics/kpi-deltas.ts
@@ -1,0 +1,51 @@
+import type { KpiDelta } from "@/lib/analytics/types";
+
+export function computeKpiDelta(input: {
+  current: number | null;
+  previous: number | null;
+  currentCapturedAt?: string | null;
+  previousCapturedAt?: string | null;
+  epsilon?: number;
+}): KpiDelta {
+  const epsilon = input.epsilon ?? 1e-9;
+  const current = input.current;
+  const previous = input.previous;
+
+  if (current == null || previous == null) {
+    return {
+      current,
+      previous,
+      delta: null,
+      deltaPct: null,
+      direction: "flat",
+      dataRecency: {
+        currentCapturedAt: input.currentCapturedAt ?? null,
+        previousCapturedAt: input.previousCapturedAt ?? null,
+      },
+    };
+  }
+
+  const delta = current - previous;
+  const direction =
+    Math.abs(delta) <= epsilon ? "flat" : delta > 0 ? "up" : "down";
+
+  let deltaPct: number | null = null;
+  if (previous !== 0) {
+    deltaPct = (delta / previous) * 100;
+  } else if (current === 0) {
+    deltaPct = 0;
+  }
+
+  return {
+    current,
+    previous,
+    delta,
+    deltaPct,
+    direction,
+    dataRecency: {
+      currentCapturedAt: input.currentCapturedAt ?? null,
+      previousCapturedAt: input.previousCapturedAt ?? null,
+    },
+  };
+}
+

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -122,6 +122,9 @@ export interface HubSpotData {
   funnel: FunnelMetrics;
   contacts: ContactMetrics;
   repScoreboard?: HubSpotRepScoreboardRow[];
+  pipelineDetected?: { pipelineId: string; dealCount: number };
+  pipelineStageLabelsSource?: "api" | "fallback";
+  pipelineStages?: Array<{ stageId: string; label: string }>;
   deals?: Array<{
     dealId: string;
     dealName: string;
@@ -135,6 +138,26 @@ export interface HubSpotData {
     createdAt: string | null;
     closedAt?: string | null;
     stripeCustomerId?: string | null;
+    pipelineId: string | null;
+    contactIds: string[];
+    primaryContactId: string | null;
+    primaryContactEmail: string | null;
+    primaryContactAnalytics?: {
+      createdAt?: string | null;
+      source: string | null;
+      sourceData1: string | null;
+      sourceData2: string | null;
+      firstSeenAt: string | null;
+      lastSeenAt: string | null;
+      firstUrl: string | null;
+      lastUrl: string | null;
+      numVisits: number | null;
+      numPageViews: number | null;
+      utmSource: string | null;
+      utmMedium: string | null;
+      utmCampaign: string | null;
+    };
+    stageHistory?: Array<{ occurredAt: string; stageId: string; stageLabel: string }>;
   }>;
   _meta: AnalyticsTimestamp;
 }
@@ -933,7 +956,16 @@ export type TouchpointChannel =
   | "meta-ads"
   | "reddit-ads"
   | "pylon"
-  | "mercury";
+  | "mercury"
+  // Synthetic channels derived from HubSpot contact analytics (pre-HubSpot).
+  | "paid-search"
+  | "paid-social"
+  | "organic-search"
+  | "referral"
+  | "direct"
+  | "email"
+  | "partner"
+  | "outbound";
 
 export type TouchpointType =
   | "first-touch"
@@ -942,8 +974,16 @@ export type TouchpointType =
   | "support"
   | "expansion";
 
+export type BuyerJourneyPhase =
+  | "awareness"
+  | "website"
+  | "crm"
+  | "revenue"
+  | "retention";
+
 export interface Touchpoint {
   timestamp: string;
+  phase: BuyerJourneyPhase;
   channel: TouchpointChannel;
   type: TouchpointType;
   detail: string;
@@ -957,6 +997,7 @@ export interface CustomerJourneyRecord {
   currentStage: string;
   value: number;
   touchpoints: Touchpoint[];
+  stageHistory?: Array<{ occurredAt: string; stageId: string; stageLabel: string }>;
   firstTouch: string;
   lastTouch: string;
   daysInPipeline: number;
@@ -971,7 +1012,7 @@ export interface TouchpointSummary {
 }
 
 export interface JourneyPath {
-  sequence: TouchpointChannel[];
+  segments: Array<{ phase: BuyerJourneyPhase; channels: TouchpointChannel[] }>;
   count: number;
   kanbanCards: number;
   freeTrials: number;
@@ -1002,6 +1043,8 @@ export interface CustomerJourneyData {
   medianDaysToClose: number;
   topPaths: JourneyPath[];
   attribution: ChannelAttribution[];
+  stageOrder: string[];
+  stageOrderSource: "pipeline" | "fallback";
 }
 
 // ══════════════════════════════════════════════════════════
@@ -1255,6 +1298,31 @@ export interface FinancialPlanningData {
 // COMBINED DASHBOARD
 // ══════════════════════════════════════════════════════════
 
+export type KpiDeltaDirection = "up" | "down" | "flat";
+
+export interface KpiDelta {
+  current: number | null;
+  previous: number | null;
+  delta: number | null;
+  deltaPct: number | null;
+  direction: KpiDeltaDirection;
+  dataRecency: {
+    currentCapturedAt: string | null;
+    previousCapturedAt: string | null;
+  };
+}
+
+export interface AnalyticsKpiDeltas {
+  traffic: {
+    bounceRatePct: KpiDelta;
+    pagesPerSession: KpiDelta;
+  };
+  finance: {
+    mrr: KpiDelta;
+    paymentSuccessPct: KpiDelta;
+  };
+}
+
 export interface AnalyticsDashboardData {
   hubspot: HubSpotData | null;
   salesPerformance: SalesPerformancePack | null;
@@ -1317,6 +1385,7 @@ export interface AnalyticsDashboardData {
       paymentSuccessPct: number;
     };
   };
+  deltas?: AnalyticsKpiDeltas;
   errors: { source: string; message: string }[];
 }
 


### PR DESCRIPTION
Closes #297.

Adds a small `deltas` object to the `section=overview` analytics response, comparing current KPIs to the previous equal-length period using cached snapshots when available.

Includes unit coverage for the delta helper.
