### PR TITLE
feat(conferences): add summary stat cards with correct banner ordering

### DIFF
--- a/.ralph-team/agents/frontend.md
+++ b/.ralph-team/agents/frontend.md
@@ -5,13 +5,25 @@ Future iterations read this file to benefit from previously discovered
 patterns, gotchas, and conventions.
 
 ## Discovered Patterns
-
+- Dashboard pages are thin wrappers around `*Dashboard` client components (e.g. `ConferenceDashboard`)
+- `useDashboardResource` hook handles fetch/cache/stale/error state uniformly across all dashboards
+- Stat cards pattern: compute stats via `useMemo` in dashboard component, pass as props to presentational component
+- ARIA: wrap stat grid in `<section aria-label="...">`, each card uses `role="region" aria-label="{label}: {value}"`
+- Icon library: lucide-react (already installed); no heroicons
 
 ## Gotchas
-
+- `ConferenceListItem` has NO `attendeeCount` field — use `_count.leads` for lead count stats
+- Pre-existing TypeScript errors throughout repo (missing Prisma client); not introduced by frontend work
+- `resource.lastUpdatedAt` is safe as `now` ref for filtering, but use `new Date()` in pure utility functions for testability
 
 ## Conventions
-
+- File naming: kebab-case for all component and utility files (`conference-stat-cards.tsx`, `compute-conference-stats.ts`)
+- Exports: named exports for components used across files; default export avoided
+- Tests live in `__tests__/` subdirectory co-located with the source file
+- `src/lib/conferences/` — pure utility functions (no React); `src/components/conferences/` — React components
 
 ## Stack-Specific Notes
+- Vitest: jsdom environment, `@/` alias via `resolve.alias`, no global setup file
+- Testing library: `@testing-library/react` + `vitest`; use `screen.getByRole` for ARIA-based queries
+- Tailwind responsive grid: `grid-cols-2 sm:grid-cols-3 lg:grid-cols-5` works well for 5 stat cards
 

--- a/.ralph-team/progress.txt
+++ b/.ralph-team/progress.txt
@@ -3,6 +3,33 @@
 # It serves as cumulative memory across fresh-context Ralph iterations.
 # =====================================================================
 
+--- Frontend Agent Iteration 1 | Issue #307 ---
+Timestamp: 2026-03-02T01:45:00Z
+Branch: agent/frontend/issue-307
+Status: completed
+
+## Changes
+- src/lib/conferences/compute-conference-stats.ts — NEW: pure function computing total/upcoming/inProgress/past/totalLeads from ConferenceListItem[]
+- src/components/conferences/conference-stat-cards.tsx — NEW: ConferenceStatCards component with responsive grid and proper ARIA labels
+- src/components/conferences/conference-dashboard.tsx — MODIFIED: removed inline stat card code, now uses ConferenceStatCards + computeConferenceStats
+- src/lib/conferences/__tests__/compute-conference-stats.test.ts — NEW: 8 unit tests
+- src/components/conferences/__tests__/conference-stat-cards.test.tsx — NEW: 4 component tests
+
+## Key Decisions
+- Stat cards render AFTER DashboardStaleBanner and DashboardErrorBanner — ordering is correct
+- Added "In Progress" as a third timing category (started but not ended); uses startDate < now < endDate
+- Added "Total Leads" using _count.leads from ConferenceListItem (no attendeeCount field exists)
+- Responsive grid: grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 (5 cards total)
+- Filename convention: kebab-case (conference-stat-cards.tsx, compute-conference-stats.ts)
+- Project uses lucide-react for icons; no separate icon library needed
+
+## Learnings
+- ConferenceListItem has _count.{deadlines,leads,expenses,tasks,projects} — use leads for total leads stat
+- No attendeeCount field on ConferenceListItem — plan assumption was wrong
+- Vitest config uses jsdom environment and @/ alias via resolve.alias
+- Tests use @testing-library/react + vitest; no global setup file needed
+- Pre-existing TS errors (missing Prisma client) throughout repo; new files have zero TS errors
+
 --- Architect Iteration 1 ---
 Timestamp: 2026-02-15T14:30:00Z
 

--- a/src/components/conferences/__tests__/conference-stat-cards.test.tsx
+++ b/src/components/conferences/__tests__/conference-stat-cards.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ConferenceStatCards } from "../conference-stat-cards";
+import type { ConferenceStats } from "@/lib/conferences/compute-conference-stats";
+
+const baseStats: ConferenceStats = {
+  total: 10,
+  upcoming: 3,
+  inProgress: 2,
+  past: 5,
+  totalLeads: 42,
+};
+
+describe("ConferenceStatCards", () => {
+  it("renders all five stat cards", () => {
+    render(<ConferenceStatCards stats={baseStats} />);
+    expect(screen.getByRole("region", { name: /Total:/i })).toBeTruthy();
+    expect(screen.getByRole("region", { name: /Upcoming:/i })).toBeTruthy();
+    expect(screen.getByRole("region", { name: /In Progress:/i })).toBeTruthy();
+    expect(screen.getByRole("region", { name: /Past:/i })).toBeTruthy();
+    expect(screen.getByRole("region", { name: /Total Leads:/i })).toBeTruthy();
+  });
+
+  it("displays correct values from stats", () => {
+    render(<ConferenceStatCards stats={baseStats} />);
+    expect(screen.getByRole("region", { name: "Total: 10" })).toBeTruthy();
+    expect(screen.getByRole("region", { name: "Upcoming: 3" })).toBeTruthy();
+    expect(screen.getByRole("region", { name: "In Progress: 2" })).toBeTruthy();
+    expect(screen.getByRole("region", { name: "Past: 5" })).toBeTruthy();
+    expect(screen.getByRole("region", { name: "Total Leads: 42" })).toBeTruthy();
+  });
+
+  it("wraps cards in a section with accessible label", () => {
+    render(<ConferenceStatCards stats={baseStats} />);
+    expect(
+      screen.getByRole("region", { name: "Conference summary statistics" })
+    ).toBeTruthy();
+  });
+
+  it("renders zero values without error", () => {
+    const zeroStats: ConferenceStats = {
+      total: 0,
+      upcoming: 0,
+      inProgress: 0,
+      past: 0,
+      totalLeads: 0,
+    };
+    render(<ConferenceStatCards stats={zeroStats} />);
+    expect(screen.getByRole("region", { name: "Total: 0" })).toBeTruthy();
+  });
+});

--- a/src/components/conferences/conference-dashboard.tsx
+++ b/src/components/conferences/conference-dashboard.tsx
@@ -2,14 +2,16 @@
 
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Plus, CalendarDays, CalendarCheck, CalendarClock } from "lucide-react";
+import { Plus } from "lucide-react";
 import { ConferenceCard } from "@/components/conferences/conference-card";
 import { ConferenceCreateModal } from "@/components/conferences/conference-create-modal";
+import { ConferenceStatCards } from "@/components/conferences/conference-stat-cards";
 import { DashboardEmptyState } from "@/components/dashboard/dashboard-empty-state";
 import { DashboardErrorBanner } from "@/components/dashboard/dashboard-error-banner";
 import { DashboardLoadingState } from "@/components/dashboard/dashboard-loading-state";
 import { DashboardStaleBanner } from "@/components/dashboard/dashboard-stale-banner";
 import { useDashboardResource } from "@/components/dashboard/use-dashboard-resource";
+import { computeConferenceStats } from "@/lib/conferences/compute-conference-stats";
 import {
   CONFERENCE_STATUS_LABELS,
   type ConferenceListItem,
@@ -82,20 +84,10 @@ export function ConferenceDashboard() {
     });
   }, [conferences, query, resource.lastUpdatedAt, statusFilter, timingFilter]);
 
-  const stats = useMemo(() => {
-    const now = resource.lastUpdatedAt ? Date.parse(resource.lastUpdatedAt) : null;
-    let upcoming = 0;
-    let past = 0;
-    for (const conf of conferences) {
-      const end = Date.parse(conf.endDate);
-      if (now === null || Number.isNaN(end) || end >= now) {
-        upcoming++;
-      } else {
-        past++;
-      }
-    }
-    return { total: conferences.length, upcoming, past };
-  }, [conferences, resource.lastUpdatedAt]);
+  const stats = useMemo(
+    () => computeConferenceStats(conferences),
+    [conferences]
+  );
 
   const onCreated = async (created: { id: string }, opts: { seedPlaybook: boolean }) => {
     setCreateOpen(false);
@@ -171,29 +163,7 @@ export function ConferenceDashboard() {
         <DashboardErrorBanner message={resource.error} onRetry={resource.refresh} />
       ) : null}
 
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-        {[
-          { label: "Total", value: stats.total, icon: CalendarDays, color: "var(--primary)" },
-          { label: "Upcoming", value: stats.upcoming, icon: CalendarClock, color: "#22c55e" },
-          { label: "Past", value: stats.past, icon: CalendarCheck, color: "#3b82f6" },
-        ].map((stat) => (
-          <div
-            key={stat.label}
-            className="flex items-center gap-3 rounded-xl border border-border bg-card px-4 py-3"
-          >
-            <div
-              className="flex h-9 w-9 items-center justify-center rounded-lg"
-              style={{ backgroundColor: `${stat.color}18` }}
-            >
-              <stat.icon className="h-4 w-4" style={{ color: stat.color }} />
-            </div>
-            <div>
-              <p className="text-lg font-bold text-foreground">{stat.value}</p>
-              <p className="text-xs text-muted-foreground">{stat.label}</p>
-            </div>
-          </div>
-        ))}
-      </div>
+      <ConferenceStatCards stats={stats} />
 
       <div className="flex flex-wrap items-center gap-3">
         <select

--- a/src/components/conferences/conference-stat-cards.tsx
+++ b/src/components/conferences/conference-stat-cards.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { CalendarCheck, CalendarClock, CalendarDays, Users } from "lucide-react";
+import type { ConferenceStats } from "@/lib/conferences/compute-conference-stats";
+
+interface ConferenceStatCardsProps {
+  stats: ConferenceStats;
+}
+
+interface StatCardDef {
+  label: string;
+  value: number;
+  icon: React.ReactNode;
+  color: string;
+}
+
+function StatCard({ label, value, icon, color }: StatCardDef) {
+  return (
+    <div
+      role="region"
+      aria-label={`${label}: ${value}`}
+      className="flex items-center gap-3 rounded-xl border border-border bg-card px-4 py-3"
+    >
+      <div
+        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg"
+        style={{ backgroundColor: `${color}18` }}
+        aria-hidden="true"
+      >
+        <span style={{ color }}>{icon}</span>
+      </div>
+      <div>
+        <p className="text-lg font-bold text-foreground">{value}</p>
+        <p className="text-xs text-muted-foreground">{label}</p>
+      </div>
+    </div>
+  );
+}
+
+export function ConferenceStatCards({ stats }: ConferenceStatCardsProps) {
+  const cards: StatCardDef[] = [
+    {
+      label: "Total",
+      value: stats.total,
+      icon: <CalendarDays className="h-4 w-4" />,
+      color: "var(--primary)",
+    },
+    {
+      label: "Upcoming",
+      value: stats.upcoming,
+      icon: <CalendarClock className="h-4 w-4" />,
+      color: "#22c55e",
+    },
+    {
+      label: "In Progress",
+      value: stats.inProgress,
+      icon: <CalendarClock className="h-4 w-4" />,
+      color: "#f59e0b",
+    },
+    {
+      label: "Past",
+      value: stats.past,
+      icon: <CalendarCheck className="h-4 w-4" />,
+      color: "#3b82f6",
+    },
+    {
+      label: "Total Leads",
+      value: stats.totalLeads,
+      icon: <Users className="h-4 w-4" />,
+      color: "#8b5cf6",
+    },
+  ];
+
+  return (
+    <section aria-label="Conference summary statistics">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        {cards.map((card) => (
+          <StatCard key={card.label} {...card} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/conferences/__tests__/compute-conference-stats.test.ts
+++ b/src/lib/conferences/__tests__/compute-conference-stats.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { computeConferenceStats } from "../compute-conference-stats";
+import type { ConferenceListItem } from "@/types";
+
+// Minimal stub satisfying ConferenceListItem for testing
+function makeConf(
+  overrides: Partial<ConferenceListItem> & {
+    startDate: string;
+    endDate: string;
+    leads?: number;
+  }
+): ConferenceListItem {
+  return {
+    id: "c1",
+    slug: "test",
+    name: "Test Conf",
+    websiteUrl: null,
+    timezone: "UTC",
+    city: null,
+    region: null,
+    country: null,
+    venue: null,
+    status: "confirmed",
+    type: "conference",
+    ownerId: null,
+    owner: null,
+    primaryProjectId: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    _count: {
+      deadlines: 0,
+      leads: overrides.leads ?? 0,
+      expenses: 0,
+      tasks: 0,
+      projects: 0,
+    },
+    ...overrides,
+  } as ConferenceListItem;
+}
+
+const NOW = new Date("2026-06-15T00:00:00Z");
+
+describe("computeConferenceStats", () => {
+  it("returns zeroes for empty array", () => {
+    expect(computeConferenceStats([], NOW)).toEqual({
+      total: 0,
+      upcoming: 0,
+      inProgress: 0,
+      past: 0,
+      totalLeads: 0,
+    });
+  });
+
+  it("classifies a future conference as upcoming", () => {
+    const conf = makeConf({ startDate: "2026-07-01", endDate: "2026-07-03" });
+    const result = computeConferenceStats([conf], NOW);
+    expect(result.upcoming).toBe(1);
+    expect(result.inProgress).toBe(0);
+    expect(result.past).toBe(0);
+  });
+
+  it("classifies a past conference correctly", () => {
+    const conf = makeConf({ startDate: "2026-01-01", endDate: "2026-01-05" });
+    const result = computeConferenceStats([conf], NOW);
+    expect(result.past).toBe(1);
+    expect(result.upcoming).toBe(0);
+    expect(result.inProgress).toBe(0);
+  });
+
+  it("classifies a conference in progress (started, not ended)", () => {
+    const conf = makeConf({ startDate: "2026-06-10", endDate: "2026-06-20" });
+    const result = computeConferenceStats([conf], NOW);
+    expect(result.inProgress).toBe(1);
+    expect(result.upcoming).toBe(0);
+    expect(result.past).toBe(0);
+  });
+
+  it("handles mixed states correctly", () => {
+    const conferences = [
+      makeConf({ id: "a", startDate: "2026-07-01", endDate: "2026-07-03" }), // upcoming
+      makeConf({ id: "b", startDate: "2026-01-01", endDate: "2026-01-05" }), // past
+      makeConf({ id: "c", startDate: "2026-06-10", endDate: "2026-06-20" }), // inProgress
+    ];
+    const result = computeConferenceStats(conferences, NOW);
+    expect(result).toEqual({ total: 3, upcoming: 1, inProgress: 1, past: 1, totalLeads: 0 });
+  });
+
+  it("sums leads across all conferences", () => {
+    const conferences = [
+      makeConf({ id: "a", startDate: "2026-07-01", endDate: "2026-07-03", leads: 5 }),
+      makeConf({ id: "b", startDate: "2026-01-01", endDate: "2026-01-05", leads: 10 }),
+    ];
+    expect(computeConferenceStats(conferences, NOW).totalLeads).toBe(15);
+  });
+
+  it("counts total correctly", () => {
+    const conferences = Array.from({ length: 4 }, (_, i) =>
+      makeConf({ id: String(i), startDate: "2026-07-01", endDate: "2026-07-03" })
+    );
+    expect(computeConferenceStats(conferences, NOW).total).toBe(4);
+  });
+
+  it("classifies conference with past start and no valid end as inProgress", () => {
+    const conf = makeConf({ startDate: "2026-06-01", endDate: "invalid" });
+    const result = computeConferenceStats([conf], NOW);
+    expect(result.inProgress).toBe(1);
+  });
+});

--- a/src/lib/conferences/compute-conference-stats.ts
+++ b/src/lib/conferences/compute-conference-stats.ts
@@ -1,0 +1,46 @@
+import type { ConferenceListItem } from "@/types";
+
+export interface ConferenceStats {
+  /** Total number of conferences */
+  total: number;
+  /** Conferences with start date in the future */
+  upcoming: number;
+  /** Conferences currently running (started but not ended) */
+  inProgress: number;
+  /** Conferences that have already ended */
+  past: number;
+  /** Sum of leads across all conferences */
+  totalLeads: number;
+}
+
+/**
+ * Derive summary statistics from a list of conferences.
+ * The `now` parameter is injectable for deterministic tests.
+ */
+export function computeConferenceStats(
+  conferences: ConferenceListItem[],
+  now: Date = new Date()
+): ConferenceStats {
+  const nowMs = now.getTime();
+  let upcoming = 0;
+  let inProgress = 0;
+  let past = 0;
+  let totalLeads = 0;
+
+  for (const conf of conferences) {
+    const startMs = Date.parse(conf.startDate);
+    const endMs = Date.parse(conf.endDate);
+
+    if (!Number.isNaN(startMs) && startMs > nowMs) {
+      upcoming++;
+    } else if (!Number.isNaN(endMs) && endMs < nowMs) {
+      past++;
+    } else {
+      inProgress++;
+    }
+
+    totalLeads += conf._count?.leads ?? 0;
+  }
+
+  return { total: conferences.length, upcoming, inProgress, past, totalLeads };
+}


### PR DESCRIPTION
## Summary
- Extracts the inline stat card grid from `ConferenceDashboard` into a dedicated `ConferenceStatCards` component with proper ARIA labels (`role="region"` per card, `aria-label` on the section)
- Adds `computeConferenceStats` pure utility that classifies conferences into **Upcoming / In Progress / Past** and sums `_count.leads` for a Total Leads stat
- Stat cards render **after** `DashboardStaleBanner` and `DashboardErrorBanner` — warnings remain visible first
- Responsive grid: `grid-cols-2 sm:grid-cols-3 lg:grid-cols-5`

## Files
| File | Change |
|---|---|
| `src/lib/conferences/compute-conference-stats.ts` | New — pure stats function |
| `src/components/conferences/conference-stat-cards.tsx` | New — accessible stat card grid |
| `src/components/conferences/conference-dashboard.tsx` | Modified — uses new component |
| `src/lib/conferences/__tests__/compute-conference-stats.test.ts` | New — 8 unit tests |
| `src/components/conferences/__tests__/conference-stat-cards.test.tsx` | New — 4 component tests |

## Test plan
- [ ] All 12 new tests pass (`npx vitest run src/lib/conferences/__tests__ src/components/conferences/__tests__`)
- [ ] Conferences page renders stat cards below any stale/error banners
- [ ] Cards stack on mobile (< 640px), 3-col on tablet, 5-col on desktop
- [ ] Each card has an accessible label readable by screen readers

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)