### PR TITLE
feat(analytics): interactive drilldowns, charts, filters & CSV export

### DIFF
--- a/src/components/analytics/analytics-summary-page.tsx
+++ b/src/components/analytics/analytics-summary-page.tsx
@@ -17,6 +17,7 @@ import { CheckCircle, AlertTriangle, XCircle } from "lucide-react";
 import { DashboardEmptyState } from "@/components/dashboard/dashboard-empty-state";
 import { useDashboardResource } from "@/components/dashboard/use-dashboard-resource";
 import { Download } from "lucide-react";
+import { downloadCsv } from "@/lib/analytics/csv-export";
 
 interface SummaryPayload {
   generatedAt: string;
@@ -72,23 +73,6 @@ const STATUS_ICON: Record<string, React.ComponentType<{ className?: string }>> =
 };
 
 const SUMMARY_CACHE_PREFIX = "analytics:summary:v1:";
-
-function downloadCsv(filename: string, headers: string[], rows: string[][]): void {
-  const escape = (value: string) =>
-    value.includes(",") || value.includes('"') || value.includes("\n")
-      ? `"${value.replace(/"/g, '""')}"`
-      : value;
-  const lines = [headers.map(escape).join(","), ...rows.map((row) => row.map(escape).join(","))];
-  const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8;" });
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement("a");
-  anchor.href = url;
-  anchor.download = filename;
-  document.body.appendChild(anchor);
-  anchor.click();
-  document.body.removeChild(anchor);
-  URL.revokeObjectURL(url);
-}
 
 interface SummaryViewModel {
   summary: SummaryPayload;

--- a/src/components/analytics/customer-journey-drill-down.tsx
+++ b/src/components/analytics/customer-journey-drill-down.tsx
@@ -2,10 +2,11 @@
 
 import { useState, useMemo } from "react";
 import {
-  Route, Search, ChevronDown, ChevronRight, ArrowRight,
+  Route, Search, ChevronDown, ChevronRight,
   Filter, Calendar, DollarSign,
 } from "lucide-react";
 import type { AnalyticsDashboardData, TouchpointChannel } from "@/lib/analytics/types";
+import { DrilldownPanel } from "./drilldown-panel";
 
 const CHANNEL_LABELS: Record<TouchpointChannel, string> = {
   hubspot: "HubSpot",
@@ -20,6 +21,14 @@ const CHANNEL_LABELS: Record<TouchpointChannel, string> = {
   "reddit-ads": "Reddit Ads",
   pylon: "Pylon",
   mercury: "Mercury",
+  "paid-search": "Paid Search",
+  "paid-social": "Paid Social",
+  "organic-search": "Organic Search",
+  referral: "Referral",
+  direct: "Direct",
+  email: "Email",
+  partner: "Partner",
+  outbound: "Outbound",
 };
 
 const CHANNEL_COLORS: Record<TouchpointChannel, string> = {
@@ -35,6 +44,14 @@ const CHANNEL_COLORS: Record<TouchpointChannel, string> = {
   "reddit-ads": "#ff4500",
   pylon: "#6366f1",
   mercury: "#1c1c1e",
+  "paid-search": "#4285f4",
+  "paid-social": "#0081fb",
+  "organic-search": "#22c55e",
+  referral: "#8b5cf6",
+  direct: "#6b7280",
+  email: "#f59e0b",
+  partner: "#06b6d4",
+  outbound: "#ec4899",
 };
 
 function fmt$(n: number) {
@@ -86,48 +103,61 @@ export function CustomerJourneyDrillDown({ data }: { data: AnalyticsDashboardDat
   if (!journey || journey.journeys.length === 0) return <EmptyState />;
 
   return (
-    <div className="space-y-4">
-      {/* Filters */}
-      <div className="flex flex-wrap items-center gap-3">
-        <div className="relative flex-1">
-          <Search className="absolute left-2.5 top-2 h-3.5 w-3.5 text-muted-foreground" />
-          <input
-            type="text"
-            placeholder="Search deal or contact…"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="w-full rounded-md border border-border bg-card py-1.5 pl-8 pr-3 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
-          />
+    <DrilldownPanel
+      title="Customer Journey Records"
+      subtitle="Expandable deal records with touchpoint timelines"
+      statusLine={`${filtered.length} of ${journey.journeys.length} journeys`}
+      csvExport={{
+        filename: `customer-journeys-${new Date().toISOString().slice(0, 10)}.csv`,
+        headers: ["Deal Name", "Contact Email", "Stage", "Touches", "Days in Pipeline", "Value"],
+        rows: () =>
+          filtered.map((j) => [
+            j.dealName,
+            j.contactEmail ?? "",
+            j.currentStage,
+            String(j.touchpoints.length),
+            String(j.daysInPipeline),
+            String(j.value),
+          ]),
+      }}
+      filters={
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="relative flex-1">
+            <Search className="absolute left-2.5 top-2 h-3.5 w-3.5 text-muted-foreground" />
+            <input
+              type="text"
+              placeholder="Search deal or contact\u2026"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full rounded-md border border-border bg-card py-1.5 pl-8 pr-3 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+          <div className="flex items-center gap-1">
+            <Filter className="h-3.5 w-3.5 text-muted-foreground" />
+            <select
+              value={channelFilter}
+              onChange={(e) => setChannelFilter(e.target.value)}
+              className="rounded-md border border-border bg-card px-2 py-1.5 text-xs text-foreground focus:outline-none"
+            >
+              <option value="all">All Channels</option>
+              {allChannels.map((ch) => (
+                <option key={ch} value={ch}>{CHANNEL_LABELS[ch]}</option>
+              ))}
+            </select>
+            <select
+              value={stageFilter}
+              onChange={(e) => setStageFilter(e.target.value)}
+              className="rounded-md border border-border bg-card px-2 py-1.5 text-xs text-foreground focus:outline-none"
+            >
+              <option value="all">All Stages</option>
+              {allStages.map((s) => (
+                <option key={s} value={s}>{s}</option>
+              ))}
+            </select>
+          </div>
         </div>
-        <div className="flex items-center gap-1">
-          <Filter className="h-3.5 w-3.5 text-muted-foreground" />
-          <select
-            value={channelFilter}
-            onChange={(e) => setChannelFilter(e.target.value)}
-            className="rounded-md border border-border bg-card px-2 py-1.5 text-xs text-foreground focus:outline-none"
-          >
-            <option value="all">All Channels</option>
-            {allChannels.map((ch) => (
-              <option key={ch} value={ch}>{CHANNEL_LABELS[ch]}</option>
-            ))}
-          </select>
-          <select
-            value={stageFilter}
-            onChange={(e) => setStageFilter(e.target.value)}
-            className="rounded-md border border-border bg-card px-2 py-1.5 text-xs text-foreground focus:outline-none"
-          >
-            <option value="all">All Stages</option>
-            {allStages.map((s) => (
-              <option key={s} value={s}>{s}</option>
-            ))}
-          </select>
-        </div>
-      </div>
-
-      <p className="text-xs text-muted-foreground">
-        {filtered.length} of {journey.journeys.length} journeys
-      </p>
-
+      }
+    >
       {/* Journey Records */}
       <div className="space-y-2">
         {filtered.slice(0, 50).map((j) => {
@@ -213,7 +243,7 @@ export function CustomerJourneyDrillDown({ data }: { data: AnalyticsDashboardDat
           </p>
         )}
       </div>
-    </div>
+    </DrilldownPanel>
   );
 }
 

--- a/src/components/analytics/demo-attribution-view.tsx
+++ b/src/components/analytics/demo-attribution-view.tsx
@@ -3,7 +3,7 @@
 import { TrendingUp, BarChart3, ArrowRight } from "lucide-react";
 import type { AnalyticsDashboardData, DemoOutcome } from "@/lib/analytics/types";
 import { StatCard } from "./stat-card";
-import { RingStat } from "./bar-display";
+import { AreaTrend } from "@/components/charts/area-trend";
 
 const OUTCOME_COLORS: Record<DemoOutcome, string> = {
   completed: "#22c55e",
@@ -66,6 +66,42 @@ export function DemoAttributionView({ data }: { data: AnalyticsDashboardData | n
           icon={TrendingUp}
         />
       </div>
+
+      {/* Weekly Demo Volume Trend */}
+      {demo.weeklyTrend && demo.weeklyTrend.length > 1 && (
+        <div className="rounded-xl border border-border bg-card p-5">
+          <h3 className="mb-1 text-sm font-semibold text-foreground">Demo Volume by Week</h3>
+          <p className="mb-4 text-xs text-muted-foreground">
+            Scheduled, completed, and no-show trends over time
+          </p>
+          <AreaTrend
+            data={demo.weeklyTrend as unknown as Array<Record<string, unknown>>}
+            xKey="week"
+            yKeys={["scheduled", "completed", "noShows"]}
+            colors={["#3b82f6", "#22c55e", "#ef4444"]}
+            height={240}
+            yFormatter={(v) => String(v)}
+            xFormatter={(w) => {
+              const d = new Date(w);
+              return isNaN(d.getTime()) ? w : d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+            }}
+          />
+          <div className="mt-3 flex gap-4 text-[10px] text-muted-foreground">
+            <span className="flex items-center gap-1">
+              <div className="h-2 w-2 rounded-full" style={{ backgroundColor: "#3b82f6" }} />
+              Scheduled
+            </span>
+            <span className="flex items-center gap-1">
+              <div className="h-2 w-2 rounded-full" style={{ backgroundColor: "#22c55e" }} />
+              Completed
+            </span>
+            <span className="flex items-center gap-1">
+              <div className="h-2 w-2 rounded-full" style={{ backgroundColor: "#ef4444" }} />
+              No-Shows
+            </span>
+          </div>
+        </div>
+      )}
 
       {/* Source → Outcome Conversion Matrix */}
       <div className="rounded-xl border border-border bg-card p-5">

--- a/src/components/analytics/drilldown-panel.tsx
+++ b/src/components/analytics/drilldown-panel.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { ChevronDown, ChevronRight, Download, X } from "lucide-react";
+import { downloadCsv } from "@/lib/analytics/csv-export";
+
+// ---------------------------------------------------------------------------
+// DrilldownPanel — standardized wrapper for analytics drill-down sections
+// ---------------------------------------------------------------------------
+
+export interface DrilldownPanelProps {
+  /** Panel heading displayed in the header bar. */
+  title: string;
+  /** Optional subtitle below the title. */
+  subtitle?: string;
+  /** If provided, renders an "Export CSV" button that calls `downloadCsv`. */
+  csvExport?: {
+    filename: string;
+    headers: string[];
+    rows: () => string[][];
+  };
+  /** Optional filter controls rendered between the header and body. */
+  filters?: ReactNode;
+  /** Summary line below filters (e.g. "12 of 48 journeys"). */
+  statusLine?: string;
+  /** Body content — table, chart, etc. */
+  children: ReactNode;
+  /** Optional empty state message when there is no data. */
+  emptyMessage?: string;
+  /** Whether the panel body is empty (triggers empty state). */
+  isEmpty?: boolean;
+  /** Start collapsed (default false). */
+  defaultCollapsed?: boolean;
+}
+
+export function DrilldownPanel({
+  title,
+  subtitle,
+  csvExport,
+  filters,
+  statusLine,
+  children,
+  emptyMessage = "No data available.",
+  isEmpty = false,
+  defaultCollapsed = false,
+}: DrilldownPanelProps) {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
+
+  const handleExport = () => {
+    if (!csvExport) return;
+    downloadCsv(csvExport.filename, csvExport.headers, csvExport.rows());
+  };
+
+  return (
+    <section className="rounded-xl border border-border bg-card" aria-label={title}>
+      {/* Header */}
+      <button
+        type="button"
+        onClick={() => setCollapsed((prev) => !prev)}
+        className="flex w-full items-center justify-between gap-2 px-5 py-4 text-left"
+        aria-expanded={!collapsed}
+      >
+        <div className="flex items-center gap-2">
+          {collapsed ? (
+            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          )}
+          <div>
+            <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+            {subtitle && <p className="mt-0.5 text-xs text-muted-foreground">{subtitle}</p>}
+          </div>
+        </div>
+
+        {csvExport && !collapsed && (
+          <span
+            role="button"
+            tabIndex={0}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleExport();
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                e.stopPropagation();
+                handleExport();
+              }
+            }}
+            className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-muted"
+          >
+            <Download className="h-3 w-3" aria-hidden="true" />
+            Export CSV
+          </span>
+        )}
+      </button>
+
+      {/* Body */}
+      {!collapsed && (
+        <div className="border-t border-border px-5 pb-5 pt-4">
+          {filters && <div className="mb-3">{filters}</div>}
+
+          {statusLine && (
+            <p className="mb-3 text-xs text-muted-foreground">{statusLine}</p>
+          )}
+
+          {isEmpty ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">{emptyMessage}</p>
+          ) : (
+            children
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DrilldownDrawer — slide-over drawer for row-level detail
+// ---------------------------------------------------------------------------
+
+export interface DrilldownDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+}
+
+export function DrilldownDrawer({
+  open,
+  onClose,
+  title,
+  subtitle,
+  children,
+}: DrilldownDrawerProps) {
+  if (!open) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-40 bg-black/30"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Drawer */}
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className="fixed inset-y-0 right-0 z-50 flex w-full max-w-lg flex-col border-l border-border bg-card shadow-xl"
+      >
+        <div className="flex items-center justify-between border-b border-border px-5 py-4">
+          <div>
+            <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+            {subtitle && <p className="mt-0.5 text-xs text-muted-foreground">{subtitle}</p>}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close drawer"
+            className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4">{children}</div>
+      </aside>
+    </>
+  );
+}

--- a/src/components/analytics/sales-funnel-tab.tsx
+++ b/src/components/analytics/sales-funnel-tab.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import {
   Target, AlertTriangle, TrendingDown, CheckCircle,
-  Clock, ArrowRight, Zap,
+  Clock, ArrowRight, Zap, Filter,
 } from "lucide-react";
 import type { AnalyticsDashboardData, DealStage } from "@/lib/analytics/types";
 import { StatCard } from "./stat-card";
@@ -20,6 +21,8 @@ const FUNNEL_ORDER = [
   "Demo Follow-Up", "Budgetary Quote Sent", "Payment Link Sent",
   "Free Trial", "Freemium", "Subscription", "Closed Won",
 ];
+
+const TERMINAL_LABELS = ["Closed Won", "Closed Lost", "Unlikely", "Churn", "Ping Later", "On Hold"];
 
 const STAGE_COLORS: Record<string, string> = {
   "Prospect": "#4379f0",
@@ -40,10 +43,182 @@ const STAGE_COLORS: Record<string, string> = {
   "On Hold": "#9ca3af",
 };
 
-export function SalesFunnelTab({ data }: { data: AnalyticsDashboardData | null }) {
-  if (!data?.hubspot) return <EmptyState />;
+type DatePreset = "all" | "7d" | "30d" | "90d";
 
-  const { funnel } = data.hubspot;
+const DATE_PRESETS: { value: DatePreset; label: string }[] = [
+  { value: "all", label: "All Time" },
+  { value: "7d", label: "7 Days" },
+  { value: "30d", label: "30 Days" },
+  { value: "90d", label: "90 Days" },
+];
+
+function daysAgo(n: number): number {
+  return Date.now() - n * 24 * 60 * 60 * 1000;
+}
+
+interface Deal {
+  dealId: string;
+  dealName: string;
+  stageId: string;
+  stageLabel: string;
+  amount: number;
+  source: string;
+  ownerId: string | null;
+  repName?: string;
+  updatedAt: string | null;
+  createdAt: string | null;
+  closedAt?: string | null;
+}
+
+/** Recompute funnel-like metrics from a filtered set of deals. */
+function computeFunnelFromDeals(deals: Deal[]) {
+  const totalDeals = deals.length;
+  const stageMap = new Map<string, { count: number; value: number }>();
+  const sourceMap = new Map<string, { count: number; value: number }>();
+  const repMap = new Map<string, { count: number; value: number; closedWon: number; closedWonValue: number }>();
+
+  let closedWon = 0;
+  let closedLost = 0;
+  let unlikely = 0;
+  let churn = 0;
+  let noShows = 0;
+  let demoFollowUp = 0;
+  let totalAmount = 0;
+
+  for (const deal of deals) {
+    const label = deal.stageLabel;
+    const amt = deal.amount || 0;
+    totalAmount += amt;
+
+    // Stage counts
+    const existing = stageMap.get(label) ?? { count: 0, value: 0 };
+    existing.count += 1;
+    existing.value += amt;
+    stageMap.set(label, existing);
+
+    // Source counts
+    const srcKey = deal.source || "Unknown";
+    const srcEntry = sourceMap.get(srcKey) ?? { count: 0, value: 0 };
+    srcEntry.count += 1;
+    srcEntry.value += amt;
+    sourceMap.set(srcKey, srcEntry);
+
+    // Rep counts
+    const repKey = deal.repName || "Unassigned";
+    const repEntry = repMap.get(repKey) ?? { count: 0, value: 0, closedWon: 0, closedWonValue: 0 };
+    repEntry.count += 1;
+    repEntry.value += amt;
+    if (label === "Closed Won") {
+      repEntry.closedWon += 1;
+      repEntry.closedWonValue += amt;
+    }
+    repMap.set(repKey, repEntry);
+
+    // Tally terminal categories
+    if (label === "Closed Won") closedWon += 1;
+    if (label === "Closed Lost") closedLost += 1;
+    if (label === "Unlikely") unlikely += 1;
+    if (label === "Churn") churn += 1;
+    if (label === "No-Show/Reschedule") noShows += 1;
+    if (label === "Demo Follow-Up") demoFollowUp += 1;
+  }
+
+  const decided = closedWon + closedLost;
+  const winRate = decided > 0 ? (closedWon / decided) * 100 : 0;
+  const effectiveDenom = closedWon + closedLost + unlikely + churn;
+  const effectiveWinRate = effectiveDenom > 0 ? (closedWon / effectiveDenom) * 100 : 0;
+  const demoStage = stageMap.get("Demo Scheduled");
+  const noShowRate = demoStage && demoStage.count > 0
+    ? (noShows / (demoStage.count + noShows)) * 100
+    : (totalDeals > 0 ? (noShows / totalDeals) * 100 : 0);
+  const avgDealSize = totalDeals > 0 ? totalAmount / totalDeals : 0;
+
+  const stages: DealStage[] = Array.from(stageMap.entries()).map(([label, { count, value }]) => ({
+    stageId: label.toLowerCase().replace(/\s+/g, "-"),
+    label,
+    count,
+    value,
+  }));
+
+  const dealsBySource = Array.from(sourceMap.entries()).map(([source, { count, value }]) => ({
+    source,
+    count,
+    value,
+  }));
+
+  const dealsByRep = Array.from(repMap.entries()).map(([repName, stats]) => ({
+    repName,
+    count: stats.count,
+    value: stats.value,
+    closedWon: stats.closedWon,
+    closedWonValue: stats.closedWonValue,
+  }));
+
+  return {
+    totalDeals,
+    closedWon,
+    closedLost,
+    unlikely,
+    churn,
+    noShows,
+    demoFollowUp,
+    winRate,
+    effectiveWinRate,
+    noShowRate,
+    avgDealSize,
+    stages,
+    dealsBySource,
+    dealsByRep,
+    activeSubscriptions: 0,
+    demoScheduled: demoStage?.count ?? 0,
+  };
+}
+
+export function SalesFunnelTab({ data }: { data: AnalyticsDashboardData | null }) {
+  const [datePreset, setDatePreset] = useState<DatePreset>("all");
+  const [repFilter, setRepFilter] = useState<string>("all");
+
+  const deals = useMemo(() => data?.hubspot?.deals ?? [], [data?.hubspot?.deals]);
+  const originalFunnel = data?.hubspot?.funnel;
+
+  // Unique rep names for the filter dropdown
+  const repNames = useMemo(() => {
+    const set = new Set<string>();
+    for (const deal of deals) {
+      const name = (deal as Deal).repName;
+      if (name) set.add(name);
+    }
+    return Array.from(set).sort();
+  }, [deals]);
+
+  // Filter deals by date + rep
+  const filteredDeals = useMemo(() => {
+    let result = deals as Deal[];
+
+    if (datePreset !== "all") {
+      const cutoff = daysAgo(datePreset === "7d" ? 7 : datePreset === "30d" ? 30 : 90);
+      result = result.filter((d) => {
+        const ts = d.createdAt ? new Date(d.createdAt).getTime() : 0;
+        return ts >= cutoff;
+      });
+    }
+
+    if (repFilter !== "all") {
+      result = result.filter((d) => d.repName === repFilter);
+    }
+
+    return result;
+  }, [deals, datePreset, repFilter]);
+
+  const isFiltered = datePreset !== "all" || repFilter !== "all";
+
+  // Use recomputed metrics when filtered, original metrics when unfiltered
+  const funnel = useMemo(() => {
+    if (!isFiltered && originalFunnel) return originalFunnel;
+    return computeFunnelFromDeals(filteredDeals);
+  }, [isFiltered, originalFunnel, filteredDeals]);
+
+  if (!data?.hubspot) return <EmptyState />;
 
   // Build ordered funnel stages
   const orderedStages = FUNNEL_ORDER
@@ -52,13 +227,71 @@ export function SalesFunnelTab({ data }: { data: AnalyticsDashboardData | null }
 
   // Terminal stages
   const terminalStages = funnel.stages.filter(
-    (s) => ["Closed Won", "Closed Lost", "Unlikely", "Churn", "Ping Later", "On Hold"].includes(s.label)
+    (s) => TERMINAL_LABELS.includes(s.label)
   );
 
   const maxStageCount = Math.max(...orderedStages.map((s) => s.count), 1);
 
   return (
     <div className="space-y-6">
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3" role="toolbar" aria-label="Sales funnel filters">
+        <div className="flex items-center gap-1.5">
+          <Filter className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="text-xs text-muted-foreground">Date:</span>
+          <div className="flex gap-0.5 rounded-lg bg-secondary/50 p-0.5">
+            {DATE_PRESETS.map((preset) => (
+              <button
+                key={preset.value}
+                type="button"
+                onClick={() => setDatePreset(preset.value)}
+                className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                  datePreset === preset.value
+                    ? "bg-card text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+                aria-pressed={datePreset === preset.value}
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {repNames.length > 0 && (
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs text-muted-foreground">Rep:</span>
+            <select
+              value={repFilter}
+              onChange={(e) => setRepFilter(e.target.value)}
+              aria-label="Filter by rep"
+              className="rounded-md border border-border bg-card px-2 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+            >
+              <option value="all">All Reps</option>
+              {repNames.map((name) => (
+                <option key={name} value={name}>{name}</option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {isFiltered && (
+          <button
+            type="button"
+            onClick={() => { setDatePreset("all"); setRepFilter("all"); }}
+            className="text-xs text-muted-foreground underline-offset-4 hover:underline hover:text-foreground"
+          >
+            Clear filters
+          </button>
+        )}
+
+        {isFiltered && (
+          <span className="text-[11px] text-muted-foreground">
+            Showing {filteredDeals.length} of {deals.length} deals
+          </span>
+        )}
+      </div>
+
       {/* Top KPI Row */}
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
         <StatCard
@@ -132,7 +365,7 @@ export function SalesFunnelTab({ data }: { data: AnalyticsDashboardData | null }
 
       <RepScoreboardCard
         rows={funnel.dealsByRep ?? []}
-        deals={data.hubspot.deals ?? []}
+        deals={filteredDeals as typeof data.hubspot.deals}
         stripeChurnEvents={data.stripe?.subscriptions?.recentChurnEvents ?? []}
       />
 
@@ -244,7 +477,7 @@ export function SalesFunnelTab({ data }: { data: AnalyticsDashboardData | null }
                         <td className="py-2.5 text-right tabular-nums">{s.count}</td>
                         <td className="py-2.5 text-right tabular-nums font-medium">{fmt$(s.value)}</td>
                         <td className="py-2.5 text-right tabular-nums text-muted-foreground">
-                          {s.count > 0 ? fmt$(s.value / s.count) : "—"}
+                          {s.count > 0 ? fmt$(s.value / s.count) : "\u2014"}
                         </td>
                         <td className="py-2.5 text-right">
                           <div className="inline-flex items-center gap-2">

--- a/src/components/analytics/sub-dashboards/google-analytics-dashboard.tsx
+++ b/src/components/analytics/sub-dashboards/google-analytics-dashboard.tsx
@@ -129,7 +129,7 @@ export function GoogleAnalyticsDashboard({ data }: GoogleAnalyticsDashboardProps
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
           {data?.customerJourney?.topPaths && (
             <div className="col-span-1 lg:col-span-2">
-              <PathExploration paths={data.customerJourney.topPaths} />
+              <PathExploration paths={data.customerJourney.topPaths} journeys={data.customerJourney.journeys} />
             </div>
           )}
           {data?.customerJourney?.attribution && (

--- a/src/components/analytics/sub-dashboards/path-exploration.tsx
+++ b/src/components/analytics/sub-dashboards/path-exploration.tsx
@@ -1,29 +1,33 @@
 "use client";
 
-import { useMemo } from "react";
-import type { JourneyPath } from "@/lib/analytics/types";
-import { DashboardSectionCard } from "../dashboard-section-card";
-import { 
-  Megaphone, 
-  Search, 
-  Users, 
-  CreditCard, 
-  LayoutDashboard, 
-  MessageCircle, 
-  Headset, 
+import { useMemo, useState } from "react";
+import type { JourneyPath, CustomerJourneyRecord } from "@/lib/analytics/types";
+import { DrilldownPanel, DrilldownDrawer } from "../drilldown-panel";
+import {
+  Megaphone,
+  Search,
+  Users,
+  CreditCard,
+  LayoutDashboard,
+  MessageCircle,
+  Headset,
   ArrowRight,
-  MousePointerClick
+  MousePointerClick,
+  Route,
+  Calendar,
+  DollarSign,
 } from "lucide-react";
 
 interface PathExplorationProps {
   paths: JourneyPath[];
+  /** Optional: journey records for drill-down matching. */
+  journeys?: CustomerJourneyRecord[];
 }
 
 // Helper to get styling and icons for different traffic sources/steps
 function getStepFormat(stepName: string) {
-  // Normalize string for safety
   const normalized = stepName.toLowerCase();
-  
+
   if (normalized.includes("google ads")) {
     return { icon: Megaphone, colorClass: "bg-blue-500/15 text-blue-600 dark:text-blue-400 border-blue-500/20" };
   }
@@ -48,29 +52,40 @@ function getStepFormat(stepName: string) {
   if (normalized.includes("support")) {
     return { icon: Headset, colorClass: "bg-cyan-500/15 text-cyan-600 dark:text-cyan-400 border-cyan-500/20" };
   }
-  
-  // Default
+
   return { icon: ArrowRight, colorClass: "bg-secondary text-secondary-foreground border-border/40" };
 }
 
-export function PathExploration({ paths }: PathExplorationProps) {
+function formatChannelName(ch: string): string {
+  if (ch === "google-ads") return "Google Ads";
+  if (ch === "meta-ads") return "Meta Ads";
+  if (ch === "reddit-ads") return "Reddit Ads";
+  if (ch === "google-analytics") return "Organic Traffic";
+  if (ch === "hubspot") return "Sales Pipeline";
+  if (ch === "stripe") return "Billing/Trial";
+  if (ch === "coda") return "Kanban App";
+  if (ch === "pylon") return "Support (Pylon)";
+  return ch;
+}
+
+function fmt$(n: number) {
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
+  return `$${n.toFixed(0)}`;
+}
+
+export function PathExploration({ paths, journeys }: PathExplorationProps) {
+  const [selectedPathIdx, setSelectedPathIdx] = useState<number | null>(null);
+
   const chartData = useMemo(() => {
     return paths.slice(0, 10).map((path, idx) => {
-      const sequenceNames = path.sequence.map((ch) => {
-        // format names nicely
-        if (ch === "google-ads") return "Google Ads";
-        if (ch === "meta-ads") return "Meta Ads";
-        if (ch === "reddit-ads") return "Reddit Ads";
-        if (ch === "google-analytics") return "Organic Traffic";
-        if (ch === "hubspot") return "Sales Pipeline";
-        if (ch === "stripe") return "Billing/Trial";
-        if (ch === "coda") return "Kanban App";
-        if (ch === "pylon") return "Support (Pylon)";
-        return ch;
-      });
+      // path.sequence is the runtime field (array of channel IDs)
+      const rawSequence: string[] = (path as unknown as { sequence: string[] }).sequence ?? [];
+      const sequenceNames = rawSequence.map(formatChannelName);
       return {
         id: `path-${idx}`,
-        sequenceStr: sequenceNames.join(" → "),
+        rawSequence,
+        sequenceStr: sequenceNames.join(" \u2192 "),
         sequenceArray: sequenceNames,
         count: path.count,
         kanbanCards: path.kanbanCards,
@@ -82,92 +97,217 @@ export function PathExploration({ paths }: PathExplorationProps) {
     });
   }, [paths]);
 
+  // Match journeys to the selected path
+  const matchingJourneys = useMemo(() => {
+    if (selectedPathIdx == null || !journeys) return [];
+    const row = chartData[selectedPathIdx];
+    if (!row) return [];
+    const pathKey = row.rawSequence.join(" \u2192 ");
+    return journeys.filter((j) => {
+      const channels = [...new Set(j.touchpoints.map((tp) => tp.channel))];
+      return channels.join(" \u2192 ") === pathKey;
+    });
+  }, [selectedPathIdx, journeys, chartData]);
+
+  const selectedRow = selectedPathIdx != null ? chartData[selectedPathIdx] : null;
+
   if (!chartData || chartData.length === 0) {
     return (
-      <DashboardSectionCard title="Path Exploration">
-        <div className="flex items-center justify-center py-16 text-sm text-muted-foreground">
-          No journey path data available.
-        </div>
-      </DashboardSectionCard>
+      <DrilldownPanel
+        title="Path Exploration"
+        subtitle="Top conversion paths by customer journey"
+        isEmpty
+        emptyMessage="No journey path data available."
+      >
+        <span />
+      </DrilldownPanel>
     );
   }
 
   return (
-    <DashboardSectionCard title="Path Exploration">
-      <div className="overflow-x-auto pb-4">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-border text-left text-xs font-semibold tracking-wider text-muted-foreground uppercase">
-              <th className="pb-3 pl-4">Top Conversion Paths</th>
-              <th className="pb-3 text-right">Accounts</th>
-              <th className="pb-3 text-right">Kanban Actions</th>
-              <th className="pb-3 text-right">Free Trials</th>
-              <th className="pb-3 text-right">Demos</th>
-              <th className="pb-3 pr-4 text-right">Average Value</th>
-            </tr>
-          </thead>
-          <tbody>
-            {chartData.map((row) => (
-              <tr 
-                key={row.id} 
-                className="group border-b border-border/40 transition-all hover:bg-gradient-to-r hover:from-muted/40 hover:to-transparent"
-              >
-                <td className="py-4 pl-4">
-                  <div className="flex flex-wrap items-center gap-x-1.5 gap-y-2 font-medium">
-                    {row.sequenceStr.split(" → ").map((step, idx, arr) => {
-                      const { icon: Icon, colorClass } = getStepFormat(step);
-                      return (
-                        <span key={`${row.id}-${idx}`} className="flex items-center gap-1.5 shrink-0">
-                          <span className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs shadow-sm transition-transform group-hover:scale-[1.02] ${colorClass}`}>
-                            <Icon className="h-3 w-3" />
-                            {step}
-                          </span>
-                          {idx < arr.length - 1 && (
-                            <ArrowRight className="h-3 w-3 text-muted-foreground/50 mx-0.5" />
-                          )}
-                        </span>
-                      );
-                    })}
-                  </div>
-                  <div className="mt-2 text-xs text-muted-foreground font-medium flex items-center gap-1">
-                    <span className="inline-block w-1.5 h-1.5 rounded-full bg-emerald-500/50" />
-                    Avg. {row.avgDays} days to close
-                  </div>
-                </td>
-                <td className="py-4 text-right tabular-nums text-foreground font-medium">
-                  {row.count}
-                </td>
-                <td className="py-4 text-right tabular-nums text-muted-foreground">
-                  {row.kanbanCards > 0 ? (
-                    <span className="inline-flex items-center justify-center min-w-[2rem] rounded-md bg-muted px-2 py-0.5 font-medium text-foreground">
-                      {row.kanbanCards}
-                    </span>
-                  ) : "-"}
-                </td>
-                <td className="py-4 text-right tabular-nums text-muted-foreground">
-                  {row.freeTrials > 0 ? (
-                    <span className="inline-flex items-center justify-center min-w-[2rem] rounded-md bg-muted px-2 py-0.5 font-medium text-foreground">
-                      {row.freeTrials}
-                    </span>
-                  ) : "-"}
-                </td>
-                <td className="py-4 text-right tabular-nums text-muted-foreground">
-                  {row.demos > 0 ? (
-                    <span className="inline-flex items-center justify-center min-w-[2rem] rounded-md bg-muted px-2 py-0.5 font-medium text-foreground">
-                      {row.demos}
-                    </span>
-                  ) : "-"}
-                </td>
-                <td className="py-4 pr-4 pl-4 text-right tabular-nums text-foreground">
-                  <span className="inline-flex items-center justify-center rounded-md bg-emerald-500/10 px-2.5 py-1 font-semibold text-emerald-600 dark:text-emerald-400">
-                    ${row.value.toLocaleString()}
-                  </span>
-                </td>
+    <>
+      <DrilldownPanel
+        title="Path Exploration"
+        subtitle="Top conversion paths by customer journey"
+        csvExport={{
+          filename: `path-exploration-${new Date().toISOString().slice(0, 10)}.csv`,
+          headers: ["Path", "Accounts", "Kanban Actions", "Free Trials", "Demos", "Avg Days to Close", "Average Value"],
+          rows: () =>
+            chartData.map((row) => [
+              row.sequenceStr,
+              String(row.count),
+              String(row.kanbanCards),
+              String(row.freeTrials),
+              String(row.demos),
+              String(row.avgDays),
+              String(row.value),
+            ]),
+        }}
+      >
+        <div className="overflow-x-auto pb-4">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                <th className="pb-3 pl-4">Top Conversion Paths</th>
+                <th className="pb-3 text-right">Accounts</th>
+                <th className="pb-3 text-right">Kanban Actions</th>
+                <th className="pb-3 text-right">Free Trials</th>
+                <th className="pb-3 text-right">Demos</th>
+                <th className="pb-3 pr-4 text-right">Average Value</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </DashboardSectionCard>
+            </thead>
+            <tbody>
+              {chartData.map((row, idx) => (
+                <tr
+                  key={row.id}
+                  role={journeys ? "button" : undefined}
+                  tabIndex={journeys ? 0 : undefined}
+                  onClick={journeys ? () => setSelectedPathIdx(idx) : undefined}
+                  onKeyDown={
+                    journeys
+                      ? (e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            setSelectedPathIdx(idx);
+                          }
+                        }
+                      : undefined
+                  }
+                  className={`group border-b border-border/40 transition-all hover:bg-gradient-to-r hover:from-muted/40 hover:to-transparent${
+                    journeys ? " cursor-pointer" : ""
+                  }`}
+                >
+                  <td className="py-4 pl-4">
+                    <div className="flex flex-wrap items-center gap-x-1.5 gap-y-2 font-medium">
+                      {row.sequenceArray.map((step, stepIdx, arr) => {
+                        const { icon: Icon, colorClass } = getStepFormat(step);
+                        return (
+                          <span key={`${row.id}-${stepIdx}`} className="flex items-center gap-1.5 shrink-0">
+                            <span className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs shadow-sm transition-transform group-hover:scale-[1.02] ${colorClass}`}>
+                              <Icon className="h-3 w-3" />
+                              {step}
+                            </span>
+                            {stepIdx < arr.length - 1 && (
+                              <ArrowRight className="h-3 w-3 text-muted-foreground/50 mx-0.5" />
+                            )}
+                          </span>
+                        );
+                      })}
+                    </div>
+                    <div className="mt-2 text-xs text-muted-foreground font-medium flex items-center gap-1">
+                      <span className="inline-block w-1.5 h-1.5 rounded-full bg-emerald-500/50" />
+                      Avg. {row.avgDays} days to close
+                    </div>
+                  </td>
+                  <td className="py-4 text-right tabular-nums text-foreground font-medium">
+                    {row.count}
+                  </td>
+                  <td className="py-4 text-right tabular-nums text-muted-foreground">
+                    {row.kanbanCards > 0 ? (
+                      <span className="inline-flex items-center justify-center min-w-[2rem] rounded-md bg-muted px-2 py-0.5 font-medium text-foreground">
+                        {row.kanbanCards}
+                      </span>
+                    ) : "-"}
+                  </td>
+                  <td className="py-4 text-right tabular-nums text-muted-foreground">
+                    {row.freeTrials > 0 ? (
+                      <span className="inline-flex items-center justify-center min-w-[2rem] rounded-md bg-muted px-2 py-0.5 font-medium text-foreground">
+                        {row.freeTrials}
+                      </span>
+                    ) : "-"}
+                  </td>
+                  <td className="py-4 text-right tabular-nums text-muted-foreground">
+                    {row.demos > 0 ? (
+                      <span className="inline-flex items-center justify-center min-w-[2rem] rounded-md bg-muted px-2 py-0.5 font-medium text-foreground">
+                        {row.demos}
+                      </span>
+                    ) : "-"}
+                  </td>
+                  <td className="py-4 pr-4 pl-4 text-right tabular-nums text-foreground">
+                    <span className="inline-flex items-center justify-center rounded-md bg-emerald-500/10 px-2.5 py-1 font-semibold text-emerald-600 dark:text-emerald-400">
+                      ${row.value.toLocaleString()}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </DrilldownPanel>
+
+      {/* Path detail drawer */}
+      <DrilldownDrawer
+        open={selectedPathIdx != null}
+        onClose={() => setSelectedPathIdx(null)}
+        title="Path Detail"
+        subtitle={selectedRow ? `${selectedRow.sequenceStr} \u2014 ${selectedRow.count} accounts` : ""}
+      >
+        {selectedRow && (
+          <div className="space-y-4">
+            {/* Path summary stats */}
+            <div className="grid grid-cols-2 gap-3">
+              <div className="rounded-lg border border-border/60 px-3 py-2">
+                <p className="text-[11px] text-muted-foreground">Accounts</p>
+                <p className="text-lg font-semibold text-foreground">{selectedRow.count}</p>
+              </div>
+              <div className="rounded-lg border border-border/60 px-3 py-2">
+                <p className="text-[11px] text-muted-foreground">Avg Value</p>
+                <p className="text-lg font-semibold text-foreground">${selectedRow.value.toLocaleString()}</p>
+              </div>
+              <div className="rounded-lg border border-border/60 px-3 py-2">
+                <p className="text-[11px] text-muted-foreground">Avg Days to Close</p>
+                <p className="text-lg font-semibold text-foreground">{selectedRow.avgDays}d</p>
+              </div>
+              <div className="rounded-lg border border-border/60 px-3 py-2">
+                <p className="text-[11px] text-muted-foreground">Demos</p>
+                <p className="text-lg font-semibold text-foreground">{selectedRow.demos}</p>
+              </div>
+            </div>
+
+            {/* Matching journeys list */}
+            <div>
+              <h4 className="mb-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                Matching Journeys ({matchingJourneys.length})
+              </h4>
+              {matchingJourneys.length === 0 ? (
+                <p className="py-4 text-center text-xs text-muted-foreground">
+                  {journeys ? "No matching journeys found for this path." : "Journey data not available for drill-down."}
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {matchingJourneys.slice(0, 30).map((j) => (
+                    <div key={j.dealId} className="rounded-lg border border-border/60 px-3 py-2.5">
+                      <p className="text-sm font-medium text-foreground">{j.dealName}</p>
+                      <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                        <span className="flex items-center gap-1">
+                          <Route className="h-3 w-3" />
+                          {j.touchpoints.length} touches
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <Calendar className="h-3 w-3" />
+                          {j.daysInPipeline}d in pipeline
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <DollarSign className="h-3 w-3" />
+                          {fmt$(j.value)}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-[11px] text-muted-foreground">
+                        {j.currentStage} · {j.contactEmail ?? "No contact"}
+                      </p>
+                    </div>
+                  ))}
+                  {matchingJourneys.length > 30 && (
+                    <p className="text-center text-xs text-muted-foreground">
+                      Showing 30 of {matchingJourneys.length} journeys.
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </DrilldownDrawer>
+    </>
   );
 }

--- a/src/lib/analytics/csv-export.ts
+++ b/src/lib/analytics/csv-export.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared CSV export utility for analytics drilldown panels.
+ */
+
+function escapeCsvValue(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/** Build a CSV string from headers and row data. */
+export function buildCsvString(headers: string[], rows: string[][]): string {
+  const lines = [
+    headers.map(escapeCsvValue).join(","),
+    ...rows.map((row) => row.map(escapeCsvValue).join(",")),
+  ];
+  return lines.join("\n");
+}
+
+/** Trigger a browser file download for the given CSV content. */
+export function downloadCsv(
+  filename: string,
+  headers: string[],
+  rows: string[][],
+): void {
+  const csv = buildCsvString(headers, rows);
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- **#305**: Standardized drilldown panels — new `DrilldownPanel` (collapsible, filterable) and `DrilldownDrawer` (slide-over detail) components, plus shared `csv-export.ts` utility used across all analytics views
- **#146**: Interactive path drill-downs — clickable path-exploration rows open a drawer showing matched customer journeys with deal details and summary stats
- **#147**: Visual time-series `AreaTrend` chart for weekly demo volume (scheduled/completed/no-shows) in the demo attribution view
- **#145**: Global date preset (All/7d/30d/90d) and rep filters for the sales funnel tab with client-side funnel metric recomputation from filtered deals

Closes #305, closes #146, closes #147, closes #145

## Files changed
| File | Change |
|------|--------|
| `src/lib/analytics/csv-export.ts` | **New** — shared CSV export utility |
| `src/components/analytics/drilldown-panel.tsx` | **New** — DrilldownPanel + DrilldownDrawer |
| `src/components/analytics/analytics-summary-page.tsx` | Use shared csv-export |
| `src/components/analytics/customer-journey-drill-down.tsx` | Wrap in DrilldownPanel + CSV export |
| `src/components/analytics/sub-dashboards/path-exploration.tsx` | DrilldownPanel + clickable rows + drawer |
| `src/components/analytics/sub-dashboards/google-analytics-dashboard.tsx` | Pass journeys prop to PathExploration |
| `src/components/analytics/demo-attribution-view.tsx` | Add AreaTrend chart |
| `src/components/analytics/sales-funnel-tab.tsx` | Date/rep filters + funnel recomputation |

## Test plan
- [x] TypeScript type check passes (no errors in modified files)
- [x] ESLint passes on all 8 modified/new files
- [x] 22 component test suites (126 tests) pass including analytics-summary-page and personalized-dashboard
- [ ] Manual: verify path drill-down drawer opens with matching journeys
- [ ] Manual: verify demo AreaTrend chart renders with weekly data
- [ ] Manual: verify sales funnel filters recompute metrics correctly
- [ ] Manual: verify CSV export downloads from drilldown panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)