### PR TITLE
feat(a11y): WIP pressure heatmap keyboard navigation + ARIA (#306)

### DIFF
--- a/.ralph-team/agents/frontend.md
+++ b/.ralph-team/agents/frontend.md
@@ -17,6 +17,9 @@ patterns, gotchas, and conventions.
 - Recharts mock pattern: `vi.mock("recharts", async () => import("@/lib/__mocks__/recharts"))` — reusable shared mock at `src/lib/__mocks__/recharts.tsx`
 - Chart components live in `src/components/charts/`: SparkLine, DonutChart, StackedBarChart, AreaTrend, ComposedMetric, HorizontalFunnel
 - SparkLine returns null for data.length < 2 to avoid rendering a degenerate single-point line
+- ARIA grid pattern: role=grid → role=row (display:contents) → role=gridcell with aria-rowindex + aria-colindex
+- Roving tabindex: only focused cell has tabIndex=0, all others -1; implement via hook `useRovingTabindex`
+- Responsive grid columns tracked via matchMedia listeners (lg:4 / sm:3 / default:2 breakpoints)
 
 ## Gotchas
 - `ConferenceListItem` has NO `attendeeCount` field — use `_count.leads` for lead count stats
@@ -25,18 +28,23 @@ patterns, gotchas, and conventions.
 - Recharts mock must cover ALL exports used across chart components: LineChart, AreaChart, BarChart, PieChart, ComposedChart, Bar, Line, Area, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend
 - Pre-existing TS errors in `src/app/api/deals/` and `src/components/analytics/customer-journey-*` — NOT introduced by dashboard work
 - DonutChart center overlay uses `pointer-events-none absolute inset-0` so it doesn't block chart interaction
+- jsdom sets `window.innerWidth` to 1024 by default — override in tests when breakpoint-sensitive behavior matters
+- jsdom has no `window.matchMedia` — mock it in tests for components using responsive breakpoints
 
 ## Conventions
-- File naming: kebab-case for all component and utility files (`conference-stat-cards.tsx`, `compute-conference-stats.ts`)
+- File naming: kebab-case for all component and utility files (`conference-stat-cards.tsx`, `compute-conference-stats.ts`, `wip-pressure-heatmap.tsx`)
 - Exports: named exports for components used across files; default export avoided
-- Tests live in `__tests__/` subdirectory co-located with the source file
+- Tests live in `__tests__/` subdirectory co-located with the source file (or `src/hooks/__tests__/`)
 - `src/lib/conferences/` — pure utility functions (no React); `src/components/conferences/` — React components
+- Focus rings: use `focus-visible:*` (not `focus:*`) to avoid mouse visual noise
+- WIP heatmap lives at `src/components/whip/wip-pressure-heatmap.tsx` (note: "whip" directory, not "heatmap")
 - Chart tests: use `vi.mock("recharts", async () => import("@/lib/__mocks__/recharts"))` at the top of each test file
 - Chart __tests__ directory: `src/components/charts/__tests__/`
 
 ## Stack-Specific Notes
 - Vitest: jsdom environment, `@/` alias via `resolve.alias`, no global setup file
-- Testing library: `@testing-library/react` + `vitest`; use `screen.getByRole` for ARIA-based queries
-- Tailwind responsive grid: `grid-cols-2 sm:grid-cols-3 lg:grid-cols-5` works well for 5 stat cards
+- Testing library: `@testing-library/react` + `vitest` (+ `@testing-library/user-event` when needed); use `screen.getByRole` for ARIA-based queries
+- Tailwind responsive grid: `grid-cols-2 sm:grid-cols-3 lg:grid-cols-4` works well for 4-wide grids
 - recharts mock shared module: `src/lib/__mocks__/recharts.tsx`
 - vitest config has no global setup file — mocks must be registered per test file
+- `display: contents` on ARIA row wrappers: keeps CSS grid layout while adding semantic row structure; some ATs may not expose role=row, but aria-rowindex on gridcells provides fallback

--- a/.ralph-team/progress.txt
+++ b/.ralph-team/progress.txt
@@ -68,6 +68,29 @@ Timestamp: 2026-02-15T14:30:00Z
 - WGX-004 was split into subtasks #27-31; all closed — concurrency foundation is solid
 - Integration framework already scaffolded (IntegrationConnection model, /api/integrations routes)
 
+--- Frontend Agent Iteration 1 | Issue #306 ---
+Timestamp: 2026-03-02T01:51:00Z
+Branch: agent/frontend/issue-306
+Status: completed
+Changes:
+  - src/hooks/useRovingTabindex.ts — NEW: reusable hook for 2D keyboard navigation in flat arrays
+  - src/components/whip/wip-pressure-heatmap.tsx — Updated with proper ARIA grid pattern
+  - src/hooks/__tests__/useRovingTabindex.test.ts — NEW: 16 unit tests
+  - src/components/whip/__tests__/wip-pressure-heatmap.a11y.test.tsx — NEW: 17 a11y tests
+Tests: 33 passed (2 test files), 0 failed
+Key patterns:
+  - ARIA grid: role=grid → role=row (display:contents) → role=gridcell
+  - Responsive column tracking via matchMedia (lg:4, sm:3, default:2)
+  - Roving tabindex: only focused cell gets tabIndex=0, all others -1
+  - Arrow keys, Home/End, Ctrl+Home/Ctrl+End supported
+  - focus-visible:ring-2 for keyboard focus ring (not focus: to avoid mouse visual noise)
+Gotchas:
+  - jsdom sets window.innerWidth to 1024 by default — must mock to 0 in tests for 2-col layout
+  - window.matchMedia must also be mocked in jsdom tests
+  - display:contents on row wrappers may not expose role=row to all screen readers,
+    but aria-rowindex/aria-colindex on each gridcell ensures AT gets correct position info
+  - The act() warning from React on Ctrl+Home test is benign (userEvent handles it)
+
 --- Backend Agent Iteration 1 | Issue #5 ---
 Timestamp: 2026-02-15T15:10:00Z
 Status: completed

--- a/src/components/whip/__tests__/wip-pressure-heatmap.a11y.test.tsx
+++ b/src/components/whip/__tests__/wip-pressure-heatmap.a11y.test.tsx
@@ -1,0 +1,239 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WipPressureHeatmap } from "../wip-pressure-heatmap";
+import type { FlowRiskIntelligenceReport, PersonWipPressure } from "../types";
+
+// jsdom doesn't implement matchMedia; mock it returning no matches.
+// Also pin innerWidth to 0 so getResponsiveCols() consistently returns 2
+// (the smallest breakpoint), ensuring all tests use a 2-column layout.
+beforeEach(() => {
+  Object.defineProperty(window, "innerWidth", {
+    writable: true,
+    configurable: true,
+    value: 0,
+  });
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+function makePerson(
+  userId: string,
+  name: string,
+  activeTaskCount: number,
+  wipLimit: number,
+  pressureScore: number
+): PersonWipPressure {
+  return {
+    userId,
+    name,
+    email: `${userId}@example.com`,
+    activeTaskCount,
+    wipLimit,
+    pressureScore,
+    pressureRatio: activeTaskCount / wipLimit,
+    overloaded: activeTaskCount > wipLimit,
+    topTaskIds: [],
+  };
+}
+
+const mockPeople: PersonWipPressure[] = [
+  makePerson("u1", "Alice", 2, 4, 50),
+  makePerson("u2", "Bob", 3, 4, 75),
+  makePerson("u3", "Carol", 4, 3, 133),
+  makePerson("u4", "Dave", 1, 4, 25),
+  makePerson("u5", "Eve", 5, 3, 166),
+  makePerson("u6", "Frank", 2, 4, 50),
+];
+
+function makeReport(people: PersonWipPressure[]): FlowRiskIntelligenceReport {
+  return {
+    generatedAt: "2026-01-01T00:00:00Z",
+    asOf: "2026-01-01T00:00:00Z",
+    config: {} as FlowRiskIntelligenceReport["config"],
+    wipPressure: { people, columns: [] },
+    chronicBlockers: [],
+    staleDependencyChains: [],
+    fixedDateAlerts: [],
+    recommendations: [],
+    slippageCorrelation: {} as FlowRiskIntelligenceReport["slippageCorrelation"],
+    traceability: {
+      source:
+        "Task + Task.dependsOn + Task.responsible + StatusHistory + BoardSettings",
+      taskCount: 0,
+      blockerEventCount: 0,
+      boardSettingCount: 0,
+      taskSampleIds: [],
+    },
+  };
+}
+
+describe("WipPressureHeatmap a11y", () => {
+  it("renders with role=grid and aria-label", () => {
+    render(<WipPressureHeatmap riskReport={makeReport(mockPeople)} />);
+    const grid = screen.getByRole("grid");
+    expect(grid).toBeTruthy();
+    expect(grid.getAttribute("aria-label")).toBe("WIP pressure by team member");
+  });
+
+  it("renders all people as gridcells", () => {
+    render(<WipPressureHeatmap riskReport={makeReport(mockPeople)} />);
+    const cells = screen.getAllByRole("gridcell");
+    expect(cells).toHaveLength(6);
+  });
+
+  it("each cell has a descriptive aria-label", () => {
+    render(<WipPressureHeatmap riskReport={makeReport(mockPeople)} />);
+    const cells = screen.getAllByRole("gridcell");
+    // Alice: 50% = Moderate pressure
+    expect(cells[0].getAttribute("aria-label")).toContain("Alice");
+    expect(cells[0].getAttribute("aria-label")).toContain("Moderate pressure");
+    expect(cells[0].getAttribute("aria-label")).toContain("2 active tasks out of 4 WIP limit");
+    // Carol: 133% = Over limit pressure
+    expect(cells[2].getAttribute("aria-label")).toContain("Carol");
+    expect(cells[2].getAttribute("aria-label")).toContain("Over limit pressure");
+    // Eve: 166% = Critical pressure
+    expect(cells[4].getAttribute("aria-label")).toContain("Eve");
+    expect(cells[4].getAttribute("aria-label")).toContain("Critical pressure");
+  });
+
+  it("first cell has tabIndex=0, others have tabIndex=-1 initially", () => {
+    render(<WipPressureHeatmap riskReport={makeReport(mockPeople)} />);
+    const cells = screen.getAllByRole("gridcell");
+    expect(cells[0].getAttribute("tabindex")).toBe("0");
+    cells.slice(1).forEach((cell) => {
+      expect(cell.getAttribute("tabindex")).toBe("-1");
+    });
+  });
+
+  it("cells have aria-colindex attributes", () => {
+    render(<WipPressureHeatmap riskReport={makeReport(mockPeople)} />);
+    const cells = screen.getAllByRole("gridcell");
+    // Default is 2 cols; first row cells are colindex 1 and 2
+    expect(cells[0].getAttribute("aria-colindex")).toBe("1");
+    expect(cells[1].getAttribute("aria-colindex")).toBe("2");
+    // Second row resets to col 1
+    expect(cells[2].getAttribute("aria-colindex")).toBe("1");
+  });
+
+  it("cells have aria-rowindex attributes", () => {
+    render(<WipPressureHeatmap riskReport={makeReport(mockPeople)} />);
+    const cells = screen.getAllByRole("gridcell");
+    // Row 1
+    expect(cells[0].getAttribute("aria-rowindex")).toBe("1");
+    expect(cells[1].getAttribute("aria-rowindex")).toBe("1");
+    // Row 2
+    expect(cells[2].getAttribute("aria-rowindex")).toBe("2");
+    expect(cells[3].getAttribute("aria-rowindex")).toBe("2");
+    // Row 3
+    expect(cells[4].getAttribute("aria-rowindex")).toBe("3");
+    expect(cells[5].getAttribute("aria-rowindex")).toBe("3");
+  });
+
+  it("navigates right with ArrowRight", async () => {
+    const user = userEvent.setup();
+    render(<WipPressureHeatmap riskReport={makeReport(mockPeople)} />);
+    const cells = screen.getAllByRole("gridcell");
+    cells[0].focus();
+    await user.keyboard("{ArrowRight}");
+    expect(cells[1]).toBe(document.activeElement);
+    expect(cells[1].getAttribute("tabindex")).toBe("0");
+    expect(cells[0].getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("navigates down with ArrowDown (using 2-col default layout)", async () => {
+    const user = userEvent.setup();
+    render(<WipPressureHeatmap riskReport={makeReport(mockPeople)} />);
+    const cells = screen.getAllByRole("gridcell");
+    cells[0].focus();
+    await user.keyboard("{ArrowDown}");
+    // 2 cols: index 0 → row 0, index 2 → row 1
+    expect(cells[2]).toBe(document.activeElement);
+  });
+
+  it("does not move past grid boundaries", async () => {
+    const user = userEvent.setup();
+    render(<WipPressureHeatmap riskReport={makeReport(mockPeople)} />);
+    const cells = screen.getAllByRole("gridcell");
+    cells[0].focus();
+    await user.keyboard("{ArrowLeft}");
+    expect(cells[0]).toBe(document.activeElement);
+    await user.keyboard("{ArrowUp}");
+    expect(cells[0]).toBe(document.activeElement);
+  });
+
+  it("Home moves to first cell in row", async () => {
+    const user = userEvent.setup();
+    render(<WipPressureHeatmap riskReport={makeReport(mockPeople)} />);
+    const cells = screen.getAllByRole("gridcell");
+    // Navigate to index 3 (row 1, col 1 in 2-col layout)
+    cells[0].focus();
+    await user.keyboard("{ArrowDown}{ArrowRight}");
+    expect(cells[3]).toBe(document.activeElement);
+    // Home should go to index 2 (row 1, col 0)
+    await user.keyboard("{Home}");
+    expect(cells[2]).toBe(document.activeElement);
+  });
+
+  it("Ctrl+Home moves to first cell overall", async () => {
+    const user = userEvent.setup();
+    render(<WipPressureHeatmap riskReport={makeReport(mockPeople)} />);
+    const cells = screen.getAllByRole("gridcell");
+    cells[5].focus();
+    await user.keyboard("{Control>}{Home}{/Control}");
+    expect(cells[0]).toBe(document.activeElement);
+  });
+
+  it("Ctrl+End moves to last cell overall", async () => {
+    const user = userEvent.setup();
+    render(<WipPressureHeatmap riskReport={makeReport(mockPeople)} />);
+    const cells = screen.getAllByRole("gridcell");
+    cells[0].focus();
+    await user.keyboard("{Control>}{End}{/Control}");
+    expect(cells[5]).toBe(document.activeElement);
+  });
+
+  it("renders row wrappers with role=row", () => {
+    render(<WipPressureHeatmap riskReport={makeReport(mockPeople)} />);
+    const rows = screen.getAllByRole("row");
+    // 6 cells in 2-col grid = 3 rows
+    expect(rows).toHaveLength(3);
+  });
+
+  it("shows loading skeleton when riskReport is null", () => {
+    render(<WipPressureHeatmap riskReport={null} />);
+    expect(screen.queryByRole("grid")).toBeNull();
+  });
+
+  it("shows empty state when no people", () => {
+    render(<WipPressureHeatmap riskReport={makeReport([])} />);
+    expect(screen.queryByRole("grid")).toBeNull();
+    expect(screen.getByText("No active task assignments found.")).toBeTruthy();
+  });
+
+  it("marks overloaded cells with an Overloaded badge", () => {
+    render(<WipPressureHeatmap riskReport={makeReport(mockPeople)} />);
+    // Carol (u3) has 4 tasks with WIP limit 3 = overloaded
+    const overloadedBadges = screen.getAllByRole("img", { name: "Overloaded" });
+    expect(overloadedBadges.length).toBeGreaterThan(0);
+  });
+
+  it("focus ring classes are present on gridcells", () => {
+    render(<WipPressureHeatmap riskReport={makeReport(mockPeople)} />);
+    const cells = screen.getAllByRole("gridcell");
+    cells.forEach((cell) => {
+      expect(cell.className).toContain("focus-visible:ring-2");
+    });
+  });
+});

--- a/src/components/whip/wip-pressure-heatmap.tsx
+++ b/src/components/whip/wip-pressure-heatmap.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import type { FlowRiskIntelligenceReport, PersonWipPressure } from "./types";
+import { useRovingTabindex } from "@/hooks/useRovingTabindex";
 
 interface WipPressureHeatmapProps {
   riskReport: FlowRiskIntelligenceReport | null;
@@ -33,11 +34,23 @@ function severityIndicator(score: number): string {
 
 interface PressureCellProps {
   person: PersonWipPressure;
-  cellRef: React.Ref<HTMLDivElement>;
-  isFocused: boolean;
+  cellRef: (el: HTMLElement | null) => void;
+  tabIndex: number;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  onFocus: () => void;
+  ariaColIndex: number;
+  ariaRowIndex: number;
 }
 
-function PressureCell({ person, cellRef, isFocused }: PressureCellProps) {
+function PressureCell({
+  person,
+  cellRef,
+  tabIndex,
+  onKeyDown,
+  onFocus,
+  ariaColIndex,
+  ariaRowIndex,
+}: PressureCellProps) {
   const color = pressureColor(person.pressureScore);
   const label = pressureLabel(person.pressureScore);
   const displayName = person.name ?? person.email ?? "Unassigned";
@@ -48,9 +61,13 @@ function PressureCell({ person, cellRef, isFocused }: PressureCellProps) {
     <div
       ref={cellRef}
       role="gridcell"
-      tabIndex={isFocused ? 0 : -1}
+      aria-rowindex={ariaRowIndex}
+      aria-colindex={ariaColIndex}
+      tabIndex={tabIndex}
       aria-label={ariaLabel}
-      className={`rounded-lg border-2 ${color} px-3 py-2.5 transition-all duration-200 outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1`}
+      onKeyDown={onKeyDown}
+      onFocus={onFocus}
+      className={`rounded-lg border-2 ${color} px-3 py-2.5 transition-all duration-200 outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 cursor-pointer`}
       title={`${displayName}: ${person.activeTaskCount} active / ${person.wipLimit} limit`}
     >
       <div className="flex items-center justify-between gap-2">
@@ -101,59 +118,39 @@ function PressureCell({ person, cellRef, isFocused }: PressureCellProps) {
   );
 }
 
-export function WipPressureHeatmap({ riskReport }: WipPressureHeatmapProps) {
-  const [focusedIndex, setFocusedIndex] = useState(0);
-  const focusedIndexRef = useRef(0);
-  const cellRefs = useRef<(HTMLDivElement | null)[]>([]);
+/**
+ * Returns the current responsive column count matching Tailwind breakpoints:
+ * grid-cols-2 (default) | sm:grid-cols-3 (>=640) | lg:grid-cols-4 (>=1024)
+ */
+function getResponsiveCols(): number {
+  if (typeof window === "undefined") return 2;
+  if (window.innerWidth >= 1024) return 4;
+  if (window.innerWidth >= 640) return 3;
+  return 2;
+}
 
-  // getColumnCount reads window.innerWidth on each call, so it always returns
-  // the current value even without a resize listener. This is acceptable
-  // because it is only invoked during keydown events, not during render.
-  const getColumnCount = useCallback((): number => {
-    // Match the responsive grid breakpoints: grid-cols-2 sm:grid-cols-3 lg:grid-cols-4
-    if (typeof window === "undefined") return 2;
-    const width = window.innerWidth;
-    if (width >= 1024) return 4; // lg
-    if (width >= 640) return 3;  // sm
-    return 2;                     // default
+function useGridCols(): number {
+  const [cols, setCols] = useState(getResponsiveCols);
+
+  useEffect(() => {
+    const queries = [
+      { mq: window.matchMedia("(min-width: 1024px)"), cols: 4 },
+      { mq: window.matchMedia("(min-width: 640px)"), cols: 3 },
+    ];
+
+    function update() {
+      setCols(getResponsiveCols());
+    }
+
+    queries.forEach(({ mq }) => mq.addEventListener("change", update));
+    return () => queries.forEach(({ mq }) => mq.removeEventListener("change", update));
   }, []);
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>, totalCells: number) => {
-      const cols = getColumnCount();
-      const current = focusedIndexRef.current;
-      let nextIndex = current;
+  return cols;
+}
 
-      switch (e.key) {
-        case "ArrowRight":
-          nextIndex = Math.min(current + 1, totalCells - 1);
-          break;
-        case "ArrowLeft":
-          nextIndex = Math.max(current - 1, 0);
-          break;
-        case "ArrowDown":
-          nextIndex = Math.min(current + cols, totalCells - 1);
-          break;
-        case "ArrowUp":
-          nextIndex = Math.max(current - cols, 0);
-          break;
-        case "Home":
-          nextIndex = 0;
-          break;
-        case "End":
-          nextIndex = totalCells - 1;
-          break;
-        default:
-          return;
-      }
-
-      e.preventDefault();
-      focusedIndexRef.current = nextIndex;
-      setFocusedIndex(nextIndex);
-      cellRefs.current[nextIndex]?.focus();
-    },
-    [getColumnCount]
-  );
+export function WipPressureHeatmap({ riskReport }: WipPressureHeatmapProps) {
+  const cols = useGridCols();
 
   if (!riskReport) {
     return (
@@ -170,9 +167,6 @@ export function WipPressureHeatmap({ riskReport }: WipPressureHeatmapProps) {
       </div>
     );
   }
-
-  // Guard against focusedIndex exceeding bounds (e.g. if people list shrinks)
-  const safeFocusedIndex = Math.min(focusedIndex, people.length - 1);
 
   // Summary stats
   const overloaded = people.filter((p) => p.overloaded).length;
@@ -197,26 +191,63 @@ export function WipPressureHeatmap({ riskReport }: WipPressureHeatmapProps) {
         </div>
       </div>
 
-      <div
-        role="grid"
-        aria-label="WIP pressure by team member"
-        className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4"
-        onKeyDown={(e) => handleKeyDown(e, people.length)}
-      >
-        {/* Single ARIA row wrapper using display:contents to preserve CSS grid layout */}
-        <div role="row" style={{ display: "contents" }}>
-          {people.map((person, index) => (
-            <PressureCell
-              key={person.userId}
-              person={person}
-              isFocused={index === safeFocusedIndex}
-              cellRef={(el) => {
-                cellRefs.current[index] = el;
-              }}
-            />
-          ))}
-        </div>
-      </div>
+      <HeatmapGrid people={people} cols={cols} />
+    </div>
+  );
+}
+
+interface HeatmapGridProps {
+  people: PersonWipPressure[];
+  cols: number;
+}
+
+function HeatmapGrid({ people, cols }: HeatmapGridProps) {
+  const { getCellProps } = useRovingTabindex(people.length, cols);
+
+  const rowCount = Math.ceil(people.length / cols);
+
+  // Build grid-cols class based on cols value
+  const gridColsClass =
+    cols === 4 ? "grid-cols-4" : cols === 3 ? "grid-cols-3" : "grid-cols-2";
+
+  return (
+    <div
+      role="grid"
+      aria-label="WIP pressure by team member"
+      aria-rowcount={rowCount}
+      aria-colcount={cols}
+      className={`grid ${gridColsClass} gap-2`}
+    >
+      {Array.from({ length: rowCount }, (_, rowIdx) => {
+        const startIdx = rowIdx * cols;
+        const rowPeople = people.slice(startIdx, startIdx + cols);
+
+        return (
+          <div
+            key={rowIdx}
+            role="row"
+            aria-rowindex={rowIdx + 1}
+            style={{ display: "contents" }}
+          >
+            {rowPeople.map((person, colIdx) => {
+              const linearIndex = startIdx + colIdx;
+              const cellProps = getCellProps(linearIndex);
+              return (
+                <PressureCell
+                  key={person.userId}
+                  person={person}
+                  cellRef={cellProps.ref}
+                  tabIndex={cellProps.tabIndex}
+                  onKeyDown={cellProps.onKeyDown}
+                  onFocus={cellProps.onFocus}
+                  ariaColIndex={colIdx + 1}
+                  ariaRowIndex={rowIdx + 1}
+                />
+              );
+            })}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/hooks/__tests__/useRovingTabindex.test.ts
+++ b/src/hooks/__tests__/useRovingTabindex.test.ts
@@ -1,0 +1,208 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useRovingTabindex } from "../useRovingTabindex";
+
+describe("useRovingTabindex", () => {
+  it("initializes focused index to 0", () => {
+    const { result } = renderHook(() => useRovingTabindex(6, 3));
+    expect(result.current.focusedIndex).toBe(0);
+  });
+
+  it("returns tabIndex 0 for focused cell, -1 for others", () => {
+    const { result } = renderHook(() => useRovingTabindex(6, 3));
+    expect(result.current.getCellProps(0).tabIndex).toBe(0);
+    expect(result.current.getCellProps(1).tabIndex).toBe(-1);
+    expect(result.current.getCellProps(5).tabIndex).toBe(-1);
+  });
+
+  it("setFocusedIndex updates focused index", () => {
+    const { result } = renderHook(() => useRovingTabindex(6, 3));
+    act(() => result.current.setFocusedIndex(4));
+    expect(result.current.focusedIndex).toBe(4);
+    expect(result.current.getCellProps(4).tabIndex).toBe(0);
+    expect(result.current.getCellProps(0).tabIndex).toBe(-1);
+  });
+
+  it("clamps to bounds without wrap", () => {
+    const { result } = renderHook(() => useRovingTabindex(6, 3));
+    act(() => result.current.setFocusedIndex(-1));
+    expect(result.current.focusedIndex).toBe(0);
+    act(() => result.current.setFocusedIndex(100));
+    expect(result.current.focusedIndex).toBe(5);
+  });
+
+  it("wraps around with wrap option", () => {
+    const { result } = renderHook(() => useRovingTabindex(6, 3, { wrap: true }));
+    act(() => result.current.setFocusedIndex(-1));
+    expect(result.current.focusedIndex).toBe(5);
+    act(() => result.current.setFocusedIndex(6));
+    expect(result.current.focusedIndex).toBe(0);
+  });
+
+  it("fires onFocusChange callback", () => {
+    const cb = vi.fn();
+    const { result } = renderHook(() =>
+      useRovingTabindex(6, 3, { onFocusChange: cb })
+    );
+    act(() => result.current.setFocusedIndex(3));
+    expect(cb).toHaveBeenCalledWith(3);
+  });
+
+  it("ArrowRight moves forward by 1", () => {
+    const { result } = renderHook(() => useRovingTabindex(6, 3));
+    const mockEvent = {
+      key: "ArrowRight",
+      ctrlKey: false,
+      preventDefault: vi.fn(),
+    } as unknown as React.KeyboardEvent;
+    act(() => {
+      result.current.getCellProps(0).onKeyDown(mockEvent);
+    });
+    expect(result.current.focusedIndex).toBe(1);
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
+  });
+
+  it("ArrowLeft moves back by 1", () => {
+    const { result } = renderHook(() => useRovingTabindex(6, 3));
+    act(() => result.current.setFocusedIndex(2));
+    const mockEvent = {
+      key: "ArrowLeft",
+      ctrlKey: false,
+      preventDefault: vi.fn(),
+    } as unknown as React.KeyboardEvent;
+    act(() => {
+      result.current.getCellProps(2).onKeyDown(mockEvent);
+    });
+    expect(result.current.focusedIndex).toBe(1);
+  });
+
+  it("ArrowDown moves forward by cols", () => {
+    const { result } = renderHook(() => useRovingTabindex(6, 3));
+    // Index 1 is row 0, col 1. ArrowDown -> row 1, col 1 -> index 4
+    act(() => result.current.setFocusedIndex(1));
+    const mockEvent = {
+      key: "ArrowDown",
+      ctrlKey: false,
+      preventDefault: vi.fn(),
+    } as unknown as React.KeyboardEvent;
+    act(() => {
+      result.current.getCellProps(1).onKeyDown(mockEvent);
+    });
+    expect(result.current.focusedIndex).toBe(4);
+  });
+
+  it("ArrowUp moves back by cols", () => {
+    const { result } = renderHook(() => useRovingTabindex(6, 3));
+    act(() => result.current.setFocusedIndex(4));
+    const mockEvent = {
+      key: "ArrowUp",
+      ctrlKey: false,
+      preventDefault: vi.fn(),
+    } as unknown as React.KeyboardEvent;
+    act(() => {
+      result.current.getCellProps(4).onKeyDown(mockEvent);
+    });
+    expect(result.current.focusedIndex).toBe(1);
+  });
+
+  it("Home moves to first cell in current row", () => {
+    const { result } = renderHook(() => useRovingTabindex(6, 3));
+    // Index 4 is row 1, col 1. Home -> row 1, col 0 -> index 3
+    act(() => result.current.setFocusedIndex(4));
+    const mockEvent = {
+      key: "Home",
+      ctrlKey: false,
+      preventDefault: vi.fn(),
+    } as unknown as React.KeyboardEvent;
+    act(() => {
+      result.current.getCellProps(4).onKeyDown(mockEvent);
+    });
+    expect(result.current.focusedIndex).toBe(3);
+  });
+
+  it("End moves to last cell in current row", () => {
+    const { result } = renderHook(() => useRovingTabindex(6, 3));
+    // Index 3 is row 1, col 0. End -> row 1, col 2 -> index 5
+    act(() => result.current.setFocusedIndex(3));
+    const mockEvent = {
+      key: "End",
+      ctrlKey: false,
+      preventDefault: vi.fn(),
+    } as unknown as React.KeyboardEvent;
+    act(() => {
+      result.current.getCellProps(3).onKeyDown(mockEvent);
+    });
+    expect(result.current.focusedIndex).toBe(5);
+  });
+
+  it("Ctrl+Home moves to first cell overall", () => {
+    const { result } = renderHook(() => useRovingTabindex(6, 3));
+    act(() => result.current.setFocusedIndex(5));
+    const mockEvent = {
+      key: "Home",
+      ctrlKey: true,
+      preventDefault: vi.fn(),
+    } as unknown as React.KeyboardEvent;
+    act(() => {
+      result.current.getCellProps(5).onKeyDown(mockEvent);
+    });
+    expect(result.current.focusedIndex).toBe(0);
+  });
+
+  it("Ctrl+End moves to last cell overall", () => {
+    const { result } = renderHook(() => useRovingTabindex(6, 3));
+    const mockEvent = {
+      key: "End",
+      ctrlKey: true,
+      preventDefault: vi.fn(),
+    } as unknown as React.KeyboardEvent;
+    act(() => {
+      result.current.getCellProps(0).onKeyDown(mockEvent);
+    });
+    expect(result.current.focusedIndex).toBe(5);
+  });
+
+  it("does not move past grid boundaries without wrap", () => {
+    const { result } = renderHook(() => useRovingTabindex(6, 3));
+    // At index 0: ArrowLeft and ArrowUp should stay at 0
+    const leftEvent = {
+      key: "ArrowLeft",
+      ctrlKey: false,
+      preventDefault: vi.fn(),
+    } as unknown as React.KeyboardEvent;
+    act(() => {
+      result.current.getCellProps(0).onKeyDown(leftEvent);
+    });
+    expect(result.current.focusedIndex).toBe(0);
+
+    const upEvent = {
+      key: "ArrowUp",
+      ctrlKey: false,
+      preventDefault: vi.fn(),
+    } as unknown as React.KeyboardEvent;
+    act(() => {
+      result.current.getCellProps(0).onKeyDown(upEvent);
+    });
+    expect(result.current.focusedIndex).toBe(0);
+
+    // At last index: ArrowRight and ArrowDown should stay at last
+    act(() => result.current.setFocusedIndex(5));
+    const rightEvent = {
+      key: "ArrowRight",
+      ctrlKey: false,
+      preventDefault: vi.fn(),
+    } as unknown as React.KeyboardEvent;
+    act(() => {
+      result.current.getCellProps(5).onKeyDown(rightEvent);
+    });
+    expect(result.current.focusedIndex).toBe(5);
+  });
+
+  it("onFocus sets focus to that cell", () => {
+    const { result } = renderHook(() => useRovingTabindex(6, 3));
+    act(() => {
+      result.current.getCellProps(3).onFocus();
+    });
+    expect(result.current.focusedIndex).toBe(3);
+  });
+});

--- a/src/hooks/useRovingTabindex.ts
+++ b/src/hooks/useRovingTabindex.ts
@@ -1,0 +1,140 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface RovingOptions {
+  /** Wrap around at edges? Default false */
+  wrap?: boolean;
+  /** Callback when focused cell changes */
+  onFocusChange?: (index: number) => void;
+}
+
+interface CellProps {
+  tabIndex: number;
+  ref: (el: HTMLElement | null) => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  onFocus: () => void;
+}
+
+interface RovingTabindexReturn {
+  /** The currently focused linear index */
+  focusedIndex: number;
+  /** Get props for a cell at linear index */
+  getCellProps: (index: number) => CellProps;
+  /** Imperatively set focus by linear index */
+  setFocusedIndex: (index: number) => void;
+}
+
+/**
+ * Manages roving tabindex for a flat array displayed in a 2D grid.
+ *
+ * @param count - Total number of cells
+ * @param cols  - Number of columns in the grid layout
+ * @param options - Optional config (wrap, onFocusChange)
+ */
+export function useRovingTabindex(
+  count: number,
+  cols: number,
+  options: RovingOptions = {}
+): RovingTabindexReturn {
+  const { wrap = false, onFocusChange } = options;
+  const [focusedIndex, setFocusedIndexState] = useState(0);
+  const cellRefs = useRef<Map<number, HTMLElement>>(new Map());
+  // Track the latest count/cols without invalidating callbacks
+  const countRef = useRef(count);
+  const colsRef = useRef(cols);
+  countRef.current = count;
+  colsRef.current = cols;
+
+  const clamp = useCallback((index: number): number => {
+    const n = countRef.current;
+    if (n === 0) return 0;
+    if (wrap) return ((index % n) + n) % n;
+    return Math.max(0, Math.min(n - 1, index));
+  }, [wrap]);
+
+  const setFocusedIndex = useCallback(
+    (index: number) => {
+      const clamped = clamp(index);
+      setFocusedIndexState(clamped);
+      onFocusChange?.(clamped);
+    },
+    [clamp, onFocusChange]
+  );
+
+  // Focus the DOM element when focusedIndex changes
+  useEffect(() => {
+    const el = cellRefs.current.get(focusedIndex);
+    if (el && document.activeElement !== el) {
+      el.focus();
+    }
+  }, [focusedIndex]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent, index: number) => {
+      const cols = colsRef.current;
+      const count = countRef.current;
+      const row = Math.floor(index / cols);
+      const lastCol = cols - 1;
+
+      let nextIndex = index;
+      let handled = true;
+
+      switch (e.key) {
+        case "ArrowRight":
+          nextIndex = index + 1;
+          break;
+        case "ArrowLeft":
+          nextIndex = index - 1;
+          break;
+        case "ArrowDown":
+          nextIndex = index + cols;
+          break;
+        case "ArrowUp":
+          nextIndex = index - cols;
+          break;
+        case "Home":
+          if (e.ctrlKey) {
+            nextIndex = 0;
+          } else {
+            nextIndex = row * cols; // first cell in current row
+          }
+          break;
+        case "End":
+          if (e.ctrlKey) {
+            nextIndex = count - 1;
+          } else {
+            // Last cell in current row (clamped to count)
+            nextIndex = Math.min(row * cols + lastCol, count - 1);
+          }
+          break;
+        default:
+          handled = false;
+      }
+
+      if (handled) {
+        e.preventDefault();
+        setFocusedIndex(nextIndex);
+      }
+    },
+    [setFocusedIndex]
+  );
+
+  const getCellProps = useCallback(
+    (index: number): CellProps => ({
+      tabIndex: index === focusedIndex ? 0 : -1,
+      ref: (el: HTMLElement | null) => {
+        if (el) {
+          cellRefs.current.set(index, el);
+        } else {
+          cellRefs.current.delete(index);
+        }
+      },
+      onKeyDown: (e: React.KeyboardEvent) => handleKeyDown(e, index),
+      onFocus: () => setFocusedIndexState(index),
+    }),
+    [focusedIndex, handleKeyDown]
+  );
+
+  return { focusedIndex, getCellProps, setFocusedIndex };
+}


### PR DESCRIPTION
## Summary

- Implements `useRovingTabindex` hook for 2D keyboard navigation across a flat array displayed in a responsive CSS grid
- Refactors `WipPressureHeatmap` with proper ARIA grid pattern: `role=grid` → `role=row` (via `display:contents`) → `role=gridcell`
- Every cell gets `aria-rowindex` and `aria-colindex` for screen reader position announcements
- Responsive column count tracked live via `matchMedia` listeners (lg: 4 cols, sm: 3 cols, default: 2 cols)
- Replaces `focus:ring-ring` with `focus-visible:ring-2 focus-visible:ring-blue-500` to avoid mouse focus noise

## Keyboard support

| Key | Action |
|-----|--------|
| `ArrowRight/Left` | Move one cell horizontally |
| `ArrowDown/Up` | Move one row vertically |
| `Home` | First cell in current row |
| `End` | Last cell in current row |
| `Ctrl+Home` | First cell overall |
| `Ctrl+End` | Last cell overall |

## Test plan

- [x] 16 unit tests for `useRovingTabindex` hook (boundary clamping, wrap mode, all key bindings, onFocusChange callback)
- [x] 17 a11y integration tests for `WipPressureHeatmap` (role presence, aria-label content, tabindex management, keyboard navigation, row/col index attributes)
- [x] All 33 tests pass

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)