### PR TITLE
feat(logbook): export entries to CSV/JSON with a11y dropdown (#304)

### DIFF
--- a/src/app/(dashboard)/logbook/page.tsx
+++ b/src/app/(dashboard)/logbook/page.tsx
@@ -1,22 +1,10 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { AlertTriangle, BookOpen, Calendar, ChevronDown, ChevronLeft, ChevronRight, Download } from "lucide-react";
+import { AlertTriangle, BookOpen, Calendar, ChevronLeft, ChevronRight } from "lucide-react";
 import { readSessionCache, writeSessionCache } from "@/lib/client/session-cache";
-
-interface LogbookEntry {
-  id: string;
-  taskTitle: string;
-  taskNotes: string | null;
-  projectName: string | null;
-  sprintName: string | null;
-  priority: string;
-  status: string;
-  responsible: string | null;
-  accountable: string | null;
-  completedOn: string;
-  archivedAt: string;
-}
+import LogbookExportDropdown from "@/components/logbook/LogbookExportDropdown";
+import type { LogbookEntry } from "@/lib/export/logbook-export";
 
 export default function LogbookPage() {
   const [entries, setEntries] = useState<LogbookEntry[]>([]);
@@ -25,88 +13,13 @@ export default function LogbookPage() {
   const [page, setPage] = useState(1);
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
-  const [exportOpen, setExportOpen] = useState(false);
-  const exportRef = useRef<HTMLDivElement>(null);
   const fetchIdRef = useRef(0);
   const cacheKey = `dashboard:logbook:v1:${page}:${startDate || "all"}:${endDate || "all"}`;
 
-  const exportFilename = useCallback(
-    (ext: string) => {
-      if (startDate && endDate) return `logbook-${startDate}-to-${endDate}.${ext}`;
-      if (startDate) return `logbook-from-${startDate}.${ext}`;
-      if (endDate) return `logbook-to-${endDate}.${ext}`;
-      return `logbook-all.${ext}`;
-    },
-    [startDate, endDate],
-  );
-
-  const escapeCsvField = useCallback((value: string | null): string => {
-    if (value === null || value === undefined) return "";
-    const str = String(value);
-    if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")) {
-      return `"${str.replace(/"/g, '""')}"`;
-    }
-    return str;
-  }, []);
-
-  const downloadBlob = useCallback((content: string, filename: string, mimeType: string) => {
-    const blob = new Blob([content], { type: mimeType });
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = filename;
-    document.body.appendChild(anchor);
-    anchor.click();
-    document.body.removeChild(anchor);
-    URL.revokeObjectURL(url);
-  }, []);
-
-  const handleExport = useCallback(
-    (format: "csv" | "json") => {
-      setExportOpen(false);
-      if (entries.length === 0) return;
-
-      if (format === "json") {
-        const json = JSON.stringify(entries, null, 2);
-        downloadBlob(json, exportFilename("json"), "application/json");
-        return;
-      }
-
-      const columns: (keyof LogbookEntry)[] = [
-        "id",
-        "taskTitle",
-        "taskNotes",
-        "projectName",
-        "sprintName",
-        "priority",
-        "status",
-        "responsible",
-        "accountable",
-        "completedOn",
-        "archivedAt",
-      ];
-      const header = columns.join(",");
-      const rows = entries.map((entry) =>
-        columns.map((col) => escapeCsvField(entry[col])).join(","),
-      );
-      const csv = "\uFEFF" + [header, ...rows].join("\n");
-      downloadBlob(csv, exportFilename("csv"), "text/csv");
-    },
-    [entries, downloadBlob, escapeCsvField, exportFilename],
-  );
-
-  /* Close export dropdown on outside click */
-  useEffect(() => {
-    function onClickOutside(e: MouseEvent) {
-      if (exportRef.current && !exportRef.current.contains(e.target as Node)) {
-        setExportOpen(false);
-      }
-    }
-    if (exportOpen) {
-      document.addEventListener("mousedown", onClickOutside);
-      return () => document.removeEventListener("mousedown", onClickOutside);
-    }
-  }, [exportOpen]);
+  const dateRange =
+    startDate && endDate
+      ? { from: new Date(startDate), to: new Date(endDate) }
+      : null;
 
   useEffect(() => {
     let active = true;
@@ -167,6 +80,40 @@ export default function LogbookPage() {
     };
   }, [cacheKey, endDate, page, startDate]);
 
+  const handleRetry = useCallback(() => {
+    setError(null);
+    setLoading(true);
+    fetchIdRef.current++;
+    const retryParams = new URLSearchParams({
+      page: page.toString(),
+      limit: "25",
+    });
+    if (startDate) retryParams.set("startDate", startDate);
+    if (endDate) retryParams.set("endDate", endDate);
+    const retryId = fetchIdRef.current;
+    fetch(`/api/logbook?${retryParams}`)
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed to fetch");
+        return r.json();
+      })
+      .then((data) => {
+        if (retryId === fetchIdRef.current) {
+          const nextEntries = (data?.entries ?? (Array.isArray(data) ? data : [])) as LogbookEntry[];
+          setEntries(nextEntries);
+          setError(null);
+          writeSessionCache<LogbookEntry[]>(cacheKey, nextEntries);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (retryId === fetchIdRef.current) {
+          setError("Failed to load log entries");
+          console.error("Logbook fetch failed:", err);
+          setLoading(false);
+        }
+      });
+  }, [cacheKey, endDate, page, startDate]);
+
   return (
     <div className="flex h-full flex-col">
       <div className="border-b border-border px-6 py-3">
@@ -203,38 +150,7 @@ export default function LogbookPage() {
               }}
               className="rounded-md border border-border bg-secondary px-2 py-1 text-xs text-foreground"
             />
-            <div ref={exportRef} className="relative ml-2">
-              <button
-                aria-label="Export entries"
-                aria-expanded={exportOpen}
-                aria-haspopup="true"
-                onClick={() => setExportOpen((prev) => !prev)}
-                disabled={entries.length === 0}
-                className="inline-flex items-center gap-1 rounded-md border border-border bg-secondary px-2.5 py-1 text-xs text-foreground hover:bg-secondary/80 disabled:opacity-40 disabled:cursor-not-allowed"
-              >
-                <Download className="h-3.5 w-3.5" />
-                Export
-                <ChevronDown className="h-3 w-3" />
-              </button>
-              {exportOpen && (
-                <div role="menu" className="absolute right-0 top-full z-10 mt-1 w-36 rounded-md border border-border bg-card py-1 shadow-lg">
-                  <button
-                    role="menuitem"
-                    onClick={() => handleExport("csv")}
-                    className="flex w-full items-center px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
-                  >
-                    Export as CSV
-                  </button>
-                  <button
-                    role="menuitem"
-                    onClick={() => handleExport("json")}
-                    className="flex w-full items-center px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
-                  >
-                    Export as JSON
-                  </button>
-                </div>
-              )}
-            </div>
+            <LogbookExportDropdown entries={entries} dateRange={dateRange} />
           </div>
         </div>
       </div>
@@ -249,39 +165,7 @@ export default function LogbookPage() {
             <AlertTriangle className="h-8 w-8 text-yellow-500" />
             <p className="text-sm text-muted-foreground">{error}</p>
             <button
-              onClick={() => {
-                setError(null);
-                setLoading(true);
-                fetchIdRef.current++;
-                const retryParams = new URLSearchParams({
-                  page: page.toString(),
-                  limit: "25",
-                });
-                if (startDate) retryParams.set("startDate", startDate);
-                if (endDate) retryParams.set("endDate", endDate);
-                const retryId = fetchIdRef.current;
-                fetch(`/api/logbook?${retryParams}`)
-                  .then((r) => {
-                    if (!r.ok) throw new Error("Failed to fetch");
-                    return r.json();
-                  })
-                  .then((data) => {
-                    if (retryId === fetchIdRef.current) {
-                      const nextEntries = (data?.entries ?? (Array.isArray(data) ? data : [])) as LogbookEntry[];
-                      setEntries(nextEntries);
-                      setError(null);
-                      writeSessionCache<LogbookEntry[]>(cacheKey, nextEntries);
-                      setLoading(false);
-                    }
-                  })
-                  .catch((err) => {
-                    if (retryId === fetchIdRef.current) {
-                      setError("Failed to load log entries");
-                      console.error("Logbook fetch failed:", err);
-                      setLoading(false);
-                    }
-                  });
-              }}
+              onClick={handleRetry}
               className="rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground hover:bg-primary/90"
             >
               Retry

--- a/src/components/logbook/LogbookExportDropdown.tsx
+++ b/src/components/logbook/LogbookExportDropdown.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState, useRef, useCallback, useEffect } from "react";
+import { ChevronDown, Download } from "lucide-react";
+import { downloadCSV, downloadJSON } from "@/lib/export/logbook-export";
+import type { LogbookEntry } from "@/lib/export/logbook-export";
+
+export interface LogbookExportDropdownProps {
+  entries: LogbookEntry[];
+  dateRange?: { from: Date; to: Date } | null;
+  disabled?: boolean;
+}
+
+const MENU_ITEMS = [
+  { label: "Export as CSV", format: "csv" as const },
+  { label: "Export as JSON", format: "json" as const },
+] as const;
+
+export default function LogbookExportDropdown({
+  entries,
+  dateRange,
+  disabled = false,
+}: LogbookExportDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const [focusIndex, setFocusIndex] = useState(-1);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLUListElement>(null);
+
+  const isDisabled = disabled || entries.length === 0;
+
+  const handleExport = useCallback(
+    (format: "csv" | "json") => {
+      if (format === "csv") {
+        downloadCSV(entries, dateRange);
+      } else {
+        downloadJSON(entries, dateRange);
+      }
+      setOpen(false);
+      setFocusIndex(-1);
+      triggerRef.current?.focus();
+    },
+    [entries, dateRange]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          if (!open) {
+            setOpen(true);
+            setFocusIndex(0);
+          } else {
+            setFocusIndex((prev) => Math.min(prev + 1, MENU_ITEMS.length - 1));
+          }
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          if (open) {
+            setFocusIndex((prev) => Math.max(prev - 1, 0));
+          }
+          break;
+        case "Enter":
+        case " ":
+          e.preventDefault();
+          if (open && focusIndex >= 0) {
+            handleExport(MENU_ITEMS[focusIndex].format);
+          } else if (!open) {
+            setOpen(true);
+            setFocusIndex(0);
+          }
+          break;
+        case "Escape":
+          e.preventDefault();
+          setOpen(false);
+          setFocusIndex(-1);
+          triggerRef.current?.focus();
+          break;
+        case "Tab":
+          setOpen(false);
+          setFocusIndex(-1);
+          break;
+      }
+    },
+    [open, focusIndex, handleExport]
+  );
+
+  // Move focus to the active menu item when focusIndex changes
+  useEffect(() => {
+    if (open && focusIndex >= 0 && menuRef.current) {
+      const items = menuRef.current.querySelectorAll<HTMLElement>('[role="menuitem"]');
+      items[focusIndex]?.focus();
+    }
+  }, [open, focusIndex]);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    function onMouseDown(e: MouseEvent) {
+      if (
+        !triggerRef.current?.contains(e.target as Node) &&
+        !menuRef.current?.contains(e.target as Node)
+      ) {
+        setOpen(false);
+        setFocusIndex(-1);
+      }
+    }
+    document.addEventListener("mousedown", onMouseDown);
+    return () => document.removeEventListener("mousedown", onMouseDown);
+  }, [open]);
+
+  return (
+    <div className="relative inline-block">
+      <button
+        ref={triggerRef}
+        id="logbook-export-trigger"
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-controls="logbook-export-menu"
+        aria-label={`Export ${entries.length} logbook entries`}
+        disabled={isDisabled}
+        onClick={() => {
+          if (!isDisabled) setOpen((prev) => !prev);
+        }}
+        onKeyDown={handleKeyDown}
+        className="inline-flex items-center gap-1 rounded-md border border-border bg-secondary px-2.5 py-1 text-xs text-foreground hover:bg-secondary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        <Download className="h-3.5 w-3.5" />
+        Export
+        <ChevronDown className="h-3 w-3" />
+      </button>
+
+      {open && (
+        <ul
+          ref={menuRef}
+          id="logbook-export-menu"
+          role="menu"
+          aria-labelledby="logbook-export-trigger"
+          className="absolute right-0 top-full z-10 mt-1 w-40 rounded-md border border-border bg-card py-1 shadow-lg"
+        >
+          {MENU_ITEMS.map((item, i) => (
+            <li
+              key={item.format}
+              role="menuitem"
+              tabIndex={focusIndex === i ? 0 : -1}
+              onClick={() => handleExport(item.format)}
+              onKeyDown={handleKeyDown}
+              className="flex w-full cursor-pointer items-center px-3 py-1.5 text-xs text-foreground hover:bg-secondary focus:bg-secondary focus:outline-none"
+            >
+              {item.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/logbook/__tests__/LogbookExportDropdown.test.tsx
+++ b/src/components/logbook/__tests__/LogbookExportDropdown.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import LogbookExportDropdown from "../LogbookExportDropdown";
+
+vi.mock("@/lib/export/logbook-export", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/export/logbook-export")>();
+  return {
+    ...actual,
+    downloadCSV: vi.fn(),
+    downloadJSON: vi.fn(),
+  };
+});
+
+import { downloadCSV, downloadJSON } from "@/lib/export/logbook-export";
+
+const mockEntries = [
+  {
+    id: "1",
+    taskTitle: "Test Task",
+    taskNotes: null,
+    projectName: "Project A",
+    sprintName: null,
+    priority: "P1",
+    status: "DONE",
+    responsible: "Alice",
+    accountable: null,
+    completedOn: "2026-01-01T00:00:00Z",
+    archivedAt: "2026-01-01T01:00:00Z",
+  },
+];
+
+describe("LogbookExportDropdown", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders a button with correct aria attributes when closed", () => {
+    render(<LogbookExportDropdown entries={mockEntries} />);
+    const btn = screen.getByRole("button", { name: /export/i });
+    expect(btn.getAttribute("aria-haspopup")).toBe("true");
+    expect(btn.getAttribute("aria-expanded")).toBe("false");
+    expect(btn.getAttribute("aria-controls")).toBe("logbook-export-menu");
+  });
+
+  it("aria-label includes entry count", () => {
+    render(<LogbookExportDropdown entries={mockEntries} />);
+    const btn = screen.getByRole("button");
+    expect(btn.getAttribute("aria-label")).toBe("Export 1 logbook entries");
+  });
+
+  it("is disabled when entries is empty", () => {
+    render(<LogbookExportDropdown entries={[]} />);
+    const btn = screen.getByRole("button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("opens menu on click and sets aria-expanded to true", async () => {
+    render(<LogbookExportDropdown entries={mockEntries} />);
+    const btn = screen.getByRole("button", { name: /export/i });
+    await userEvent.click(btn);
+    expect(btn.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByRole("menu")).toBeTruthy();
+    expect(screen.getAllByRole("menuitem")).toHaveLength(2);
+  });
+
+  it("menu has aria-labelledby pointing to trigger", async () => {
+    render(<LogbookExportDropdown entries={mockEntries} />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    const menu = screen.getByRole("menu");
+    expect(menu.getAttribute("aria-labelledby")).toBe("logbook-export-trigger");
+  });
+
+  it("closes menu on Escape and returns focus to trigger", async () => {
+    render(<LogbookExportDropdown entries={mockEntries} />);
+    const btn = screen.getByRole("button", { name: /export/i });
+    await userEvent.click(btn);
+    expect(screen.getByRole("menu")).toBeTruthy();
+    await userEvent.keyboard("{Escape}");
+    expect(btn.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(document.activeElement).toBe(btn);
+  });
+
+  it("opens menu and focuses first item on ArrowDown from trigger", async () => {
+    render(<LogbookExportDropdown entries={mockEntries} />);
+    const btn = screen.getByRole("button", { name: /export/i });
+    btn.focus();
+    await userEvent.keyboard("{ArrowDown}");
+    const items = screen.getAllByRole("menuitem");
+    expect(document.activeElement).toBe(items[0]);
+  });
+
+  it("navigates between menu items with ArrowDown/ArrowUp", async () => {
+    render(<LogbookExportDropdown entries={mockEntries} />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.keyboard("{ArrowDown}");
+    const items = screen.getAllByRole("menuitem");
+    expect(document.activeElement).toBe(items[0]);
+    await userEvent.keyboard("{ArrowDown}");
+    expect(document.activeElement).toBe(items[1]);
+    await userEvent.keyboard("{ArrowUp}");
+    expect(document.activeElement).toBe(items[0]);
+  });
+
+  it("triggers CSV download on CSV menuitem click", async () => {
+    render(<LogbookExportDropdown entries={mockEntries} />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(screen.getByText(/csv/i));
+    expect(downloadCSV).toHaveBeenCalledWith(mockEntries, undefined);
+  });
+
+  it("triggers JSON download on JSON menuitem click", async () => {
+    render(<LogbookExportDropdown entries={mockEntries} />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(screen.getByText(/json/i));
+    expect(downloadJSON).toHaveBeenCalledWith(mockEntries, undefined);
+  });
+
+  it("closes menu after export selection", async () => {
+    render(<LogbookExportDropdown entries={mockEntries} />);
+    const btn = screen.getByRole("button", { name: /export/i });
+    await userEvent.click(btn);
+    await userEvent.click(screen.getByText(/csv/i));
+    expect(btn.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("passes dateRange through to download function", async () => {
+    const range = { from: new Date("2026-01-01"), to: new Date("2026-01-31") };
+    render(<LogbookExportDropdown entries={mockEntries} dateRange={range} />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(screen.getByText(/json/i));
+    expect(downloadJSON).toHaveBeenCalledWith(mockEntries, range);
+  });
+
+  it("does not open menu when disabled prop is true", async () => {
+    render(<LogbookExportDropdown entries={mockEntries} disabled />);
+    const btn = screen.getByRole("button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    await userEvent.click(btn);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});

--- a/src/lib/export/__tests__/logbook-export.test.ts
+++ b/src/lib/export/__tests__/logbook-export.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import {
+  serializeToCSV,
+  serializeToJSON,
+  CSV_COLUMNS,
+} from "../logbook-export";
+import type { LogbookEntry } from "../logbook-export";
+
+const mockEntries: LogbookEntry[] = [
+  {
+    id: "entry-1",
+    taskTitle: "Implement feature X",
+    taskNotes: "Some notes here",
+    projectName: "Alpha Project",
+    sprintName: "Sprint 1",
+    priority: "P1",
+    status: "DONE",
+    responsible: "Alice",
+    accountable: "Bob",
+    completedOn: "2026-01-15T10:30:00Z",
+    archivedAt: "2026-01-15T11:00:00Z",
+  },
+  {
+    id: "entry-2",
+    taskTitle: "Fix bug with, commas",
+    taskNotes: null,
+    projectName: null,
+    sprintName: null,
+    priority: "P2",
+    status: "DONE",
+    responsible: null,
+    accountable: null,
+    completedOn: "2026-01-16T14:00:00Z",
+    archivedAt: "2026-01-16T14:30:00Z",
+  },
+  {
+    id: "entry-3",
+    taskTitle: 'He said "hello, world"',
+    taskNotes: "Notes with\nnewline",
+    projectName: "Beta",
+    sprintName: null,
+    priority: "P0",
+    status: "DONE",
+    responsible: "Carol",
+    accountable: null,
+    completedOn: "2026-01-17T09:00:00Z",
+    archivedAt: "2026-01-17T09:15:00Z",
+  },
+];
+
+describe("serializeToCSV", () => {
+  it("starts with UTF-8 BOM", () => {
+    const csv = serializeToCSV(mockEntries);
+    expect(csv.charCodeAt(0)).toBe(0xfeff);
+  });
+
+  it("has correct header row matching CSV_COLUMNS", () => {
+    const csv = serializeToCSV(mockEntries);
+    const firstLine = csv.split("\r\n")[0].replace("\uFEFF", "");
+    expect(firstLine).toBe(CSV_COLUMNS.map((c) => c.header).join(","));
+  });
+
+  it("uses CRLF line endings", () => {
+    const csv = serializeToCSV(mockEntries);
+    expect(csv).toContain("\r\n");
+  });
+
+  it("has correct number of lines (header + rows)", () => {
+    const csv = serializeToCSV(mockEntries);
+    const lines = csv.split("\r\n");
+    expect(lines).toHaveLength(mockEntries.length + 1);
+  });
+
+  it("escapes cells containing commas by wrapping in double quotes", () => {
+    const csv = serializeToCSV(mockEntries);
+    expect(csv).toContain('"Fix bug with, commas"');
+  });
+
+  it("escapes cells containing double quotes by doubling them", () => {
+    const csv = serializeToCSV(mockEntries);
+    expect(csv).toContain('"He said ""hello, world"""');
+  });
+
+  it("escapes cells containing newlines", () => {
+    const csv = serializeToCSV(mockEntries);
+    expect(csv).toContain('"Notes with\nnewline"');
+  });
+
+  it("returns BOM + header only for empty entries", () => {
+    const csv = serializeToCSV([]);
+    const expected = "\uFEFF" + CSV_COLUMNS.map((c) => c.header).join(",");
+    expect(csv).toBe(expected);
+  });
+
+  it("handles null fields gracefully with empty string", () => {
+    const sparse: LogbookEntry[] = [
+      {
+        id: "x",
+        taskTitle: "Test",
+        taskNotes: null,
+        projectName: null,
+        sprintName: null,
+        priority: "P3",
+        status: "DONE",
+        responsible: null,
+        accountable: null,
+        completedOn: "2026-01-01T00:00:00Z",
+        archivedAt: "2026-01-01T00:01:00Z",
+      },
+    ];
+    const csv = serializeToCSV(sparse);
+    expect(csv).toContain("x");
+    expect(csv).not.toContain("undefined");
+    expect(csv).not.toContain("null");
+  });
+
+  it("formats completedOn and archivedAt as ISO strings", () => {
+    const csv = serializeToCSV(mockEntries);
+    expect(csv).toContain("2026-01-15T10:30:00.000Z");
+    expect(csv).toContain("2026-01-15T11:00:00.000Z");
+  });
+});
+
+describe("serializeToJSON", () => {
+  it("returns valid JSON array", () => {
+    const json = serializeToJSON(mockEntries);
+    const parsed = JSON.parse(json);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(3);
+  });
+
+  it("uses column headers as object keys", () => {
+    const json = serializeToJSON(mockEntries);
+    const parsed = JSON.parse(json);
+    CSV_COLUMNS.forEach((col) => {
+      expect(parsed[0]).toHaveProperty(col.header);
+    });
+  });
+
+  it("returns empty JSON array for no entries", () => {
+    const result = JSON.parse(serializeToJSON([]));
+    expect(result).toEqual([]);
+  });
+
+  it("maps task title correctly", () => {
+    const json = serializeToJSON(mockEntries);
+    const parsed = JSON.parse(json);
+    expect(parsed[0]["Task"]).toBe("Implement feature X");
+  });
+
+  it("converts null fields to empty string", () => {
+    const json = serializeToJSON(mockEntries);
+    const parsed = JSON.parse(json);
+    expect(parsed[1]["Project"]).toBe("");
+    expect(parsed[1]["Sprint"]).toBe("");
+  });
+});

--- a/src/lib/export/logbook-export.ts
+++ b/src/lib/export/logbook-export.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure utility functions for serializing logbook entries to CSV/JSON.
+ * No DOM dependency in serialization functions — only downloadCSV/downloadJSON touch the DOM.
+ */
+
+export interface LogbookEntry {
+  id: string;
+  taskTitle: string;
+  taskNotes: string | null;
+  projectName: string | null;
+  sprintName: string | null;
+  priority: string;
+  status: string;
+  responsible: string | null;
+  accountable: string | null;
+  completedOn: string;
+  archivedAt: string;
+}
+
+export const CSV_COLUMNS: {
+  header: string;
+  accessor: (e: LogbookEntry) => string;
+}[] = [
+  { header: "ID", accessor: (e) => e.id },
+  { header: "Task", accessor: (e) => e.taskTitle },
+  { header: "Notes", accessor: (e) => e.taskNotes ?? "" },
+  { header: "Project", accessor: (e) => e.projectName ?? "" },
+  { header: "Sprint", accessor: (e) => e.sprintName ?? "" },
+  { header: "Priority", accessor: (e) => e.priority },
+  { header: "Status", accessor: (e) => e.status },
+  { header: "Responsible", accessor: (e) => e.responsible ?? "" },
+  { header: "Accountable", accessor: (e) => e.accountable ?? "" },
+  { header: "Completed On", accessor: (e) => e.completedOn ? new Date(e.completedOn).toISOString() : "" },
+  { header: "Archived At", accessor: (e) => e.archivedAt ? new Date(e.archivedAt).toISOString() : "" },
+];
+
+function escapeCSVCell(value: string): string {
+  if (/[",\r\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/**
+ * Serialize entries to CSV with UTF-8 BOM (\uFEFF) prepended.
+ * BOM ensures Excel on Windows auto-detects UTF-8 encoding.
+ * Uses CRLF (\r\n) line endings per RFC 4180.
+ */
+export function serializeToCSV(entries: LogbookEntry[]): string {
+  const BOM = "\uFEFF";
+  const header = CSV_COLUMNS.map((c) => c.header).join(",");
+  const rows = entries.map((entry) =>
+    CSV_COLUMNS.map((col) => escapeCSVCell(String(col.accessor(entry)))).join(",")
+  );
+  return BOM + [header, ...rows].join("\r\n");
+}
+
+export function serializeToJSON(entries: LogbookEntry[]): string {
+  const data = entries.map((entry) => {
+    const obj: Record<string, string> = {};
+    CSV_COLUMNS.forEach((col) => {
+      obj[col.header] = String(col.accessor(entry));
+    });
+    return obj;
+  });
+  return JSON.stringify(data, null, 2);
+}
+
+function buildFilename(ext: string, dateRange?: { from: Date; to: Date } | null): string {
+  const base = "wipguard-logbook";
+  if (dateRange) {
+    const from = dateRange.from.toISOString().slice(0, 10);
+    const to = dateRange.to.toISOString().slice(0, 10);
+    return `${base}_${from}_${to}.${ext}`;
+  }
+  return `${base}_${new Date().toISOString().slice(0, 10)}.${ext}`;
+}
+
+function triggerDownload(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export function downloadCSV(
+  entries: LogbookEntry[],
+  dateRange?: { from: Date; to: Date } | null
+): void {
+  const content = serializeToCSV(entries);
+  triggerDownload(content, buildFilename("csv", dateRange), "text/csv;charset=utf-8;");
+}
+
+export function downloadJSON(
+  entries: LogbookEntry[],
+  dateRange?: { from: Date; to: Date } | null
+): void {
+  const content = serializeToJSON(entries);
+  triggerDownload(content, buildFilename("json", dateRange), "application/json;charset=utf-8;");
+}


### PR DESCRIPTION
## Summary

Adds CSV and JSON export to the Logbook page, extracted into a reusable accessible dropdown component.

- **`src/lib/export/logbook-export.ts`** — Pure serialization utilities (no DOM dependency in serialize functions):
  - `serializeToCSV`: UTF-8 BOM (`\uFEFF`) + CRLF (`\r\n`) line endings + RFC 4180 escaping → opens correctly in Excel/Numbers on all platforms
  - `serializeToJSON`: column-keyed JSON array
  - `downloadCSV` / `downloadJSON`: Blob trigger with date-range filename (e.g. `wipguard-logbook_2026-01-01_2026-01-31.csv`)

- **`src/components/logbook/LogbookExportDropdown.tsx`** — WAI-ARIA menu button:
  - Trigger: `aria-haspopup="true"`, `aria-expanded`, `aria-controls`, dynamic `aria-label` with entry count
  - Menu: `role="menu"` + `aria-labelledby`; items: `role="menuitem"` + roving `tabIndex`
  - Keyboard: `ArrowDown`/`Up` navigate, `Escape` closes + returns focus to trigger, `Enter`/`Space` activates, `Tab` closes
  - Disabled when `entries.length === 0`

- **`src/app/(dashboard)/logbook/page.tsx`** — Replaced inline export logic with `<LogbookExportDropdown>` component; extracted retry handler into `useCallback`

## Test plan

- [x] 15 unit tests for serialization: UTF-8 BOM presence, CRLF endings, header correctness, comma/quote/newline escaping, empty entries, null fields, ISO date formatting
- [x] 13 component tests: ARIA attributes, disabled state, open/close, keyboard navigation (ArrowDown/Up/Escape), CSV/JSON download called with correct args, dateRange passthrough, focus returns to trigger after close
- [x] ESLint: clean on new files
- [x] TypeScript: no new errors (pre-existing errors unrelated to this ticket)

## Encoding details

| Detail | Value |
|--------|-------|
| BOM | `\uFEFF` prepended to CSV string before Blob creation |
| Line endings | `\r\n` (CRLF) per RFC 4180 |
| Cell escaping | Wrap in `"..."` if contains `,`, `"`, `\r`, or `\n`; internal `"` doubled |
| ARIA pattern | WAI-ARIA Menu Button |

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)