### PR TITLE
feat(#303): Add funnel analytics (submissions → created → completed)

### DIFF
--- a/.ralph-team/agents/backend.md
+++ b/.ralph-team/agents/backend.md
@@ -50,3 +50,16 @@ patterns, gotchas, and conventions.
 - **vitest config**: `@/` alias mapped via `resolve.alias` in `vitest.config.ts`
 - **Package scripts**: `npm test` runs `vitest run`, `npm run test:watch` for dev mode
 - **Prisma in worktrees**: Need to run `npx prisma generate` in worktrees before tests will pass (the generated client is gitignored)
+- **pretest hook**: `npm test` automatically runs `prisma generate` before vitest (via `pretest` in `package.json`) — no need to run it manually
+- **TaskStatus enum values**: BACKLOG | QUEUED | WORKING_ON_TODAY | ACTIVE | NOT_DONE | DONE — only DONE is a terminal status
+
+## Funnel Analytics Patterns (Issue #303)
+
+- **Separation of concerns**: Pure computation in `src/lib/funnel-analytics.ts` (no DB imports), data access in `src/lib/funnel-data.ts` — keeps unit tests dependency-free
+- **Conversion rate rounding**: `Math.round((n/d) * 10000) / 10000` for 4-decimal determinism across environments
+- **NaN/negative guard**: `Math.max(0, value || 0)` handles NaN, undefined, null, and negative inputs
+- **SubmissionEvent model**: New Prisma model in funnel analytics section at bottom of schema; relation on User added as `submissionEvents SubmissionEvent[]`
+- **Terminal statuses**: Hardcoded to `["DONE"]` in `funnel-data.ts` — matches `TaskStatus` enum; not configurable in MVP
+- **Funnel endpoint**: `GET /api/analytics/funnel?from=ISO&to=ISO&projectId=optional`
+- **Submission endpoint**: `POST /api/analytics/funnel/submissions` with body `{ type, referenceId?, metadata? }`
+- **Pre-existing test failures**: `analytics-fetchers-coda.test.ts` (8 fails) and `analytics-fetchers-hubspot.test.ts` (2 fails) are pre-existing, unrelated to funnel changes

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,6 +68,8 @@ model User {
   conferenceTeamMemberships ConferenceTeamMember[] @relation("ConferenceTeamMemberUser")
   ownedConferenceInventoryItems ConferenceInventoryItem[] @relation("ConferenceInventoryItemOwner")
 
+  submissionEvents SubmissionEvent[]
+
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
 }
@@ -1583,4 +1585,22 @@ model ForecastScenario {
   updatedAt   DateTime @updatedAt
 
   @@index([userId])
+}
+
+// ============================================================
+// FUNNEL ANALYTICS
+// ============================================================
+
+model SubmissionEvent {
+  id          String   @id @default(cuid())
+  type        String                        // e.g. "download_request", "form_submission"
+  referenceId String?                       // optional external reference
+  metadata    Json     @default("{}")
+  userId      String
+  user        User     @relation(fields: [userId], references: [id])
+  createdAt   DateTime @default(now())
+
+  @@index([createdAt])
+  @@index([userId])
+  @@index([type, createdAt])
 }

--- a/src/app/api/analytics/funnel/route.ts
+++ b/src/app/api/analytics/funnel/route.ts
@@ -1,0 +1,62 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { fetchFunnelInput } from "@/lib/funnel-data";
+import { computeFunnel } from "@/lib/funnel-analytics";
+import type { FunnelResult } from "@/lib/funnel-analytics";
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = req.nextUrl;
+  const fromParam = searchParams.get("from");
+  const toParam = searchParams.get("to");
+  const projectId = searchParams.get("projectId") ?? undefined;
+
+  if (!fromParam || !toParam) {
+    return NextResponse.json(
+      { error: "Missing required query parameters: from, to" },
+      { status: 400 },
+    );
+  }
+
+  const from = new Date(fromParam);
+  const to = new Date(toParam);
+
+  if (isNaN(from.getTime()) || isNaN(to.getTime())) {
+    return NextResponse.json(
+      { error: "Invalid date format. Use ISO 8601." },
+      { status: 400 },
+    );
+  }
+
+  if (from > to) {
+    return NextResponse.json(
+      { error: '"from" must be before or equal to "to"' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const input = await fetchFunnelInput(prisma, { from, to, projectId });
+    const funnel = computeFunnel(input);
+
+    const result: FunnelResult = {
+      ...funnel,
+      dateRange: { from: from.toISOString(), to: to.toISOString() },
+    };
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Funnel analytics error:", error);
+    return NextResponse.json(
+      { error: "Failed to compute funnel analytics" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/analytics/funnel/submissions/route.ts
+++ b/src/app/api/analytics/funnel/submissions/route.ts
@@ -1,0 +1,50 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userId = (session.user as { id?: string }).id;
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = await req.json();
+    const { type, referenceId, metadata } = body as {
+      type?: string;
+      referenceId?: string;
+      metadata?: Record<string, unknown>;
+    };
+
+    if (!type) {
+      return NextResponse.json(
+        { error: "Missing required field: type" },
+        { status: 400 },
+      );
+    }
+
+    const event = await prisma.submissionEvent.create({
+      data: {
+        type,
+        referenceId: referenceId ?? null,
+        metadata: metadata ?? {},
+        userId,
+      },
+    });
+
+    return NextResponse.json(event, { status: 201 });
+  } catch (error) {
+    console.error("Submission event error:", error);
+    return NextResponse.json(
+      { error: "Failed to record submission event" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/__tests__/funnel-analytics.test.ts
+++ b/src/lib/__tests__/funnel-analytics.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeConversionRate,
+  computeDropOffReasons,
+  computeFunnel,
+  type FunnelInput,
+} from "@/lib/funnel-analytics";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// computeConversionRate
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("computeConversionRate", () => {
+  it("returns 0 when denominator is 0", () => {
+    expect(computeConversionRate(50, 0)).toBe(0);
+  });
+
+  it("returns 0 when denominator is negative", () => {
+    expect(computeConversionRate(50, -10)).toBe(0);
+  });
+
+  it("returns correct rate with normal values", () => {
+    expect(computeConversionRate(50, 100)).toBe(0.5);
+  });
+
+  it("returns 1 when numerator equals denominator", () => {
+    expect(computeConversionRate(100, 100)).toBe(1);
+  });
+
+  it("handles numerator > denominator (value > 1)", () => {
+    const rate = computeConversionRate(120, 100);
+    expect(rate).toBe(1.2);
+  });
+
+  it("rounds to 4 decimal places for determinism", () => {
+    // 1/3 = 0.333333... → rounds to 0.3333
+    expect(computeConversionRate(1, 3)).toBe(0.3333);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// computeFunnel
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeInput(overrides: Partial<FunnelInput> = {}): FunnelInput {
+  return {
+    submissions: 100,
+    created: 60,
+    completed: 30,
+    statusBreakdown: { BACKLOG: 10, ACTIVE: 20, DONE: 30 },
+    terminalStatuses: ["DONE"],
+    ...overrides,
+  };
+}
+
+describe("computeFunnel", () => {
+  it("computes full funnel with normal data", () => {
+    const result = computeFunnel(makeInput());
+
+    expect(result.totalSubmissions).toBe(100);
+    expect(result.totalCreated).toBe(60);
+    expect(result.totalCompleted).toBe(30);
+
+    const [sub, created, completed] = result.stages;
+
+    // submissions stage
+    expect(sub.name).toBe("submissions");
+    expect(sub.count).toBe(100);
+    expect(sub.conversionFromPrevious).toBeNull();
+    expect(sub.conversionFromTop).toBe(1);
+    expect(sub.dropOffCount).toBe(40);
+    expect(sub.dropOffRate).toBe(0.4);
+
+    // created stage
+    expect(created.name).toBe("created");
+    expect(created.count).toBe(60);
+    expect(created.conversionFromPrevious).toBe(0.6);
+    expect(created.conversionFromTop).toBe(0.6);
+    expect(created.dropOffCount).toBe(30);
+    expect(created.dropOffRate).toBe(0.5);
+
+    // completed stage
+    expect(completed.name).toBe("completed");
+    expect(completed.count).toBe(30);
+    expect(completed.conversionFromPrevious).toBe(0.5);
+    expect(completed.conversionFromTop).toBe(0.3);
+    expect(completed.dropOffCount).toBeNull();
+    expect(completed.dropOffRate).toBeNull();
+
+    expect(result.overallConversionRate).toBe(0.3);
+  });
+
+  it("handles zero submissions gracefully", () => {
+    const result = computeFunnel(makeInput({ submissions: 0, created: 0, completed: 0 }));
+
+    expect(result.totalSubmissions).toBe(0);
+    expect(result.stages[0].count).toBe(0);
+    expect(result.stages[0].dropOffCount).toBe(0);
+    expect(result.stages[0].dropOffRate).toBe(0);
+    expect(result.stages[1].conversionFromPrevious).toBe(0);
+    expect(result.overallConversionRate).toBe(0);
+  });
+
+  it("handles zero created with nonzero submissions", () => {
+    const result = computeFunnel(makeInput({ submissions: 50, created: 0, completed: 0 }));
+
+    expect(result.totalSubmissions).toBe(50);
+    expect(result.totalCreated).toBe(0);
+    // all submissions dropped off before creation
+    expect(result.stages[0].dropOffCount).toBe(50);
+    expect(result.stages[1].conversionFromPrevious).toBe(0);
+    expect(result.stages[1].dropOffRate).toBe(0);
+    expect(result.overallConversionRate).toBe(0);
+  });
+
+  it("handles zero completed", () => {
+    const result = computeFunnel(makeInput({ completed: 0 }));
+
+    expect(result.totalCompleted).toBe(0);
+    expect(result.stages[2].count).toBe(0);
+    expect(result.stages[2].conversionFromPrevious).toBe(0);
+    expect(result.stages[2].conversionFromTop).toBe(0);
+    expect(result.overallConversionRate).toBe(0);
+  });
+
+  it("handles all zeros", () => {
+    const result = computeFunnel(
+      makeInput({ submissions: 0, created: 0, completed: 0, statusBreakdown: {} }),
+    );
+
+    expect(result.stages).toHaveLength(3);
+    for (const stage of result.stages) {
+      expect(stage.count).toBe(0);
+    }
+    expect(result.overallConversionRate).toBe(0);
+  });
+
+  it("treats NaN input as 0", () => {
+    const result = computeFunnel(
+      makeInput({ submissions: NaN, created: NaN, completed: NaN }),
+    );
+
+    expect(result.totalSubmissions).toBe(0);
+    expect(result.totalCreated).toBe(0);
+    expect(result.totalCompleted).toBe(0);
+    expect(result.stages).toHaveLength(3);
+  });
+
+  it("treats negative input as 0", () => {
+    const result = computeFunnel(
+      makeInput({ submissions: -10, created: -5, completed: -1 }),
+    );
+
+    expect(result.totalSubmissions).toBe(0);
+    expect(result.totalCreated).toBe(0);
+    expect(result.totalCompleted).toBe(0);
+  });
+
+  it("produces deterministic output for identical input", () => {
+    const input = makeInput();
+    const a = computeFunnel(input);
+    const b = computeFunnel(input);
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it("first stage conversionFromPrevious is null", () => {
+    const result = computeFunnel(makeInput());
+    expect(result.stages[0].conversionFromPrevious).toBeNull();
+  });
+
+  it("last stage dropOff fields are null", () => {
+    const result = computeFunnel(makeInput());
+    const last = result.stages[result.stages.length - 1];
+    expect(last.dropOffCount).toBeNull();
+    expect(last.dropOffRate).toBeNull();
+  });
+
+  it("overallConversionRate is completed / submissions", () => {
+    const result = computeFunnel(makeInput({ submissions: 200, created: 150, completed: 75 }));
+    expect(result.overallConversionRate).toBe(computeConversionRate(75, 200));
+  });
+
+  it("stages array always has exactly 3 entries", () => {
+    const result = computeFunnel(makeInput());
+    expect(result.stages).toHaveLength(3);
+  });
+
+  it("handles large numbers without overflow", () => {
+    const result = computeFunnel(
+      makeInput({ submissions: 1_000_000, created: 750_000, completed: 500_000 }),
+    );
+
+    expect(result.totalSubmissions).toBe(1_000_000);
+    expect(result.totalCreated).toBe(750_000);
+    expect(result.totalCompleted).toBe(500_000);
+    expect(result.overallConversionRate).toBe(0.5);
+    expect(result.stages[1].conversionFromTop).toBe(0.75);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// computeDropOffReasons
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("computeDropOffReasons", () => {
+  it("excludes terminal statuses from drop-off list", () => {
+    const breakdown = { BACKLOG: 10, ACTIVE: 20, DONE: 30 };
+    const reasons = computeDropOffReasons(breakdown, ["DONE"], 60);
+    const statuses = reasons.map((r) => r.status);
+    expect(statuses).not.toContain("DONE");
+    expect(statuses).toContain("ACTIVE");
+    expect(statuses).toContain("BACKLOG");
+  });
+
+  it("sorts by count descending", () => {
+    const breakdown = { BACKLOG: 5, QUEUED: 25, ACTIVE: 15, NOT_DONE: 10 };
+    const reasons = computeDropOffReasons(breakdown, ["DONE"], 100);
+    expect(reasons[0].status).toBe("QUEUED");
+    expect(reasons[1].status).toBe("ACTIVE");
+    expect(reasons[2].status).toBe("NOT_DONE");
+    expect(reasons[3].status).toBe("BACKLOG");
+  });
+
+  it("limits to default topN of 5 results", () => {
+    const breakdown = {
+      A: 10, B: 9, C: 8, D: 7, E: 6, F: 5, G: 4,
+    };
+    const reasons = computeDropOffReasons(breakdown, [], 100);
+    expect(reasons).toHaveLength(5);
+  });
+
+  it("respects a custom topN", () => {
+    const breakdown = { A: 10, B: 9, C: 8, D: 7, E: 6 };
+    const reasons = computeDropOffReasons(breakdown, [], 100, 3);
+    expect(reasons).toHaveLength(3);
+  });
+
+  it("returns empty array for empty statusBreakdown", () => {
+    const reasons = computeDropOffReasons({}, ["DONE"], 100);
+    expect(reasons).toEqual([]);
+  });
+
+  it("returns empty array when all statuses are terminal", () => {
+    const breakdown = { DONE: 50, CLOSED: 20 };
+    const reasons = computeDropOffReasons(breakdown, ["DONE", "CLOSED"], 70);
+    expect(reasons).toEqual([]);
+  });
+
+  it("computes percentage relative to totalCreated", () => {
+    const breakdown = { ACTIVE: 20, BACKLOG: 10 };
+    const reasons = computeDropOffReasons(breakdown, ["DONE"], 100);
+    const active = reasons.find((r) => r.status === "ACTIVE")!;
+    const backlog = reasons.find((r) => r.status === "BACKLOG")!;
+    expect(active.percentage).toBe(computeConversionRate(20, 100));
+    expect(backlog.percentage).toBe(computeConversionRate(10, 100));
+  });
+
+  it("returns empty array when totalCreated is 0", () => {
+    const breakdown = { ACTIVE: 5 };
+    // With 0 totalCreated, percentages are all 0 but we still return the breakdown
+    // The key check: function does not crash
+    const reasons = computeDropOffReasons(breakdown, [], 0);
+    expect(reasons).toHaveLength(1);
+    expect(reasons[0].percentage).toBe(0);
+  });
+});

--- a/src/lib/funnel-analytics.ts
+++ b/src/lib/funnel-analytics.ts
@@ -1,0 +1,133 @@
+// ─── Funnel Analytics — Pure Computation Engine ───────────────────────────────
+// No DB access. Takes pre-fetched counts/data as input, returns deterministic
+// results for a given input state. Safe to test without mocking.
+
+export interface FunnelStage {
+  name: string;
+  count: number;
+  conversionFromPrevious: number | null; // null for first stage
+  conversionFromTop: number;             // always relative to submissions
+  dropOffCount: number | null;           // null for last stage
+  dropOffRate: number | null;            // null for last stage
+}
+
+export interface DropOffReason {
+  status: string;
+  count: number;
+  percentage: number;
+}
+
+export interface FunnelResult {
+  dateRange: { from: string; to: string };
+  stages: FunnelStage[];
+  topDropOffStatuses: DropOffReason[];
+  totalSubmissions: number;
+  totalCreated: number;
+  totalCompleted: number;
+  overallConversionRate: number;
+}
+
+export interface FunnelInput {
+  submissions: number;
+  created: number;
+  completed: number;
+  statusBreakdown: Record<string, number>; // status -> count of tasks with that status
+  terminalStatuses: string[];              // which statuses count as "completed"
+}
+
+/**
+ * Compute a conversion rate, rounded to 4 decimal places for determinism.
+ * Returns 0 when denominator is <= 0.
+ */
+export function computeConversionRate(numerator: number, denominator: number): number {
+  if (denominator <= 0) return 0;
+  return Math.round((numerator / denominator) * 10000) / 10000;
+}
+
+/**
+ * Compute drop-off reasons from a status breakdown, excluding terminal statuses.
+ * Results are sorted by count descending and limited to topN entries.
+ * Percentage is relative to totalCreated.
+ */
+export function computeDropOffReasons(
+  statusBreakdown: Record<string, number>,
+  terminalStatuses: string[],
+  totalCreated: number,
+  topN = 5,
+): DropOffReason[] {
+  const terminalSet = new Set(terminalStatuses);
+
+  return Object.entries(statusBreakdown)
+    .filter(([status]) => !terminalSet.has(status))
+    .map(([status, count]) => ({
+      status,
+      count,
+      percentage: computeConversionRate(count, totalCreated),
+    }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, topN);
+}
+
+/**
+ * Compute the full funnel from pre-fetched counts.
+ * All inputs are sanitized (NaN/undefined/negative → 0).
+ */
+export function computeFunnel(
+  input: FunnelInput,
+): Omit<FunnelResult, "dateRange"> {
+  const { statusBreakdown, terminalStatuses } = input;
+
+  // Guard: treat negatives/NaN/undefined as 0
+  const safeSubmissions = Math.max(0, input.submissions || 0);
+  const safeCreated = Math.max(0, input.created || 0);
+  const safeCompleted = Math.max(0, input.completed || 0);
+
+  const stages: FunnelStage[] = [
+    {
+      name: "submissions",
+      count: safeSubmissions,
+      conversionFromPrevious: null,
+      conversionFromTop: 1,
+      dropOffCount: safeSubmissions - safeCreated,
+      dropOffRate: computeConversionRate(
+        safeSubmissions - safeCreated,
+        safeSubmissions,
+      ),
+    },
+    {
+      name: "created",
+      count: safeCreated,
+      conversionFromPrevious: computeConversionRate(safeCreated, safeSubmissions),
+      conversionFromTop: computeConversionRate(safeCreated, safeSubmissions),
+      dropOffCount: safeCreated - safeCompleted,
+      dropOffRate: computeConversionRate(
+        safeCreated - safeCompleted,
+        safeCreated,
+      ),
+    },
+    {
+      name: "completed",
+      count: safeCompleted,
+      conversionFromPrevious: computeConversionRate(safeCompleted, safeCreated),
+      conversionFromTop: computeConversionRate(safeCompleted, safeSubmissions),
+      dropOffCount: null,
+      dropOffRate: null,
+    },
+  ];
+
+  const topDropOffStatuses = computeDropOffReasons(
+    statusBreakdown,
+    terminalStatuses,
+    safeCreated,
+    5,
+  );
+
+  return {
+    stages,
+    topDropOffStatuses,
+    totalSubmissions: safeSubmissions,
+    totalCreated: safeCreated,
+    totalCompleted: safeCompleted,
+    overallConversionRate: computeConversionRate(safeCompleted, safeSubmissions),
+  };
+}

--- a/src/lib/funnel-data.ts
+++ b/src/lib/funnel-data.ts
@@ -1,0 +1,69 @@
+// ─── Funnel Data Access Layer ──────────────────────────────────────────────────
+// Queries Prisma for the raw counts needed by the pure funnel engine.
+// Separating this from funnel-analytics.ts enables clean unit testing of the
+// computation without DB access.
+
+import { PrismaClient } from "@/generated/prisma/client";
+import type { FunnelInput } from "./funnel-analytics";
+
+// TaskStatus enum values from prisma/schema.prisma
+// BACKLOG | QUEUED | WORKING_ON_TODAY | ACTIVE | NOT_DONE | DONE
+const TERMINAL_STATUSES = ["DONE"] as const;
+
+export interface FunnelQueryParams {
+  from: Date;
+  to: Date;
+  projectId?: string;
+}
+
+export async function fetchFunnelInput(
+  prisma: PrismaClient,
+  params: FunnelQueryParams,
+): Promise<FunnelInput> {
+  const { from, to, projectId } = params;
+  const dateFilter = { gte: from, lte: to };
+
+  // 1. Count submission events in range
+  const submissions = await prisma.submissionEvent.count({
+    where: {
+      createdAt: dateFilter,
+      ...(projectId
+        ? { metadata: { path: ["projectId"], equals: projectId } }
+        : {}),
+    },
+  });
+
+  // 2. Count tasks created in range
+  const taskWhere: Record<string, unknown> = { createdAt: dateFilter };
+  if (projectId) taskWhere.projectId = projectId;
+
+  const created = await prisma.task.count({ where: taskWhere });
+
+  // 3. Count completed tasks (those with a terminal status, created in range)
+  const completed = await prisma.task.count({
+    where: {
+      ...taskWhere,
+      status: { in: TERMINAL_STATUSES as unknown as string[] },
+    },
+  });
+
+  // 4. Get status breakdown for all tasks created in range
+  const statusGroups = await prisma.task.groupBy({
+    by: ["status"],
+    where: taskWhere,
+    _count: { status: true },
+  });
+
+  const statusBreakdown: Record<string, number> = {};
+  for (const group of statusGroups) {
+    statusBreakdown[group.status] = group._count.status;
+  }
+
+  return {
+    submissions,
+    created,
+    completed,
+    statusBreakdown,
+    terminalStatuses: [...TERMINAL_STATUSES],
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `SubmissionEvent` Prisma model to track the top of the funnel (download/submission requests)
- Implements a pure funnel computation engine (`src/lib/funnel-analytics.ts`) — deterministic, no DB dependency
- Adds Prisma data access layer (`src/lib/funnel-data.ts`) that queries task counts and status breakdowns
- New `GET /api/analytics/funnel` endpoint with `from`, `to`, `projectId` query params
- New `POST /api/analytics/funnel/submissions` endpoint to record submission events

## New Endpoints

### `GET /api/analytics/funnel?from=ISO&to=ISO&projectId=optional`
Returns:
```json
{
  "dateRange": { "from": "...", "to": "..." },
  "stages": [
    { "name": "submissions", "count": N, "conversionFromPrevious": null, ... },
    { "name": "created", "count": N, ... },
    { "name": "completed", "count": N, "dropOffCount": null, ... }
  ],
  "topDropOffStatuses": [{ "status": "ACTIVE", "count": 12, "percentage": 0.2 }, ...],
  "totalSubmissions": N,
  "totalCreated": N,
  "totalCompleted": N,
  "overallConversionRate": 0.3
}
```

### `POST /api/analytics/funnel/submissions`
Body: `{ "type": "download_request", "referenceId"?: "...", "metadata"?: {} }`

## Test plan
- [x] 27 unit tests in `src/lib/__tests__/funnel-analytics.test.ts` covering:
  - `computeConversionRate`: zero denom, negative denom, normal, 4-decimal determinism
  - `computeFunnel`: normal data, all zeros, NaN/negative inputs, determinism, edge cases
  - `computeDropOffReasons`: terminal status filtering, sort order, topN limiting, empty inputs
- [x] All 27 new tests pass
- [x] Pre-existing test suite: 1489 passed / 10 failed (failures are pre-existing in unrelated fetcher tests)

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)