### PR TITLE
feat(#300): Persist insight pin/dismiss preferences per user

### DIFF
--- a/.ralph-team/agents/backend.md
+++ b/.ralph-team/agents/backend.md
@@ -63,3 +63,13 @@ patterns, gotchas, and conventions.
 - **Funnel endpoint**: `GET /api/analytics/funnel?from=ISO&to=ISO&projectId=optional`
 - **Submission endpoint**: `POST /api/analytics/funnel/submissions` with body `{ type, referenceId?, metadata? }`
 - **Pre-existing test failures**: `analytics-fetchers-coda.test.ts` (8 fails) and `analytics-fetchers-hubspot.test.ts` (2 fails) are pre-existing, unrelated to funnel changes
+
+## InsightPreference Patterns (Issue #300)
+
+- **insightId is opaque**: String slug/hash, NOT a FK to a DB table — insights are computed artifacts. Use VarChar(256) to prevent abuse.
+- **status as VARCHAR**: Avoids Prisma enum migration overhead; validation at API layer allows adding statuses (e.g., "snoozed") without a migration.
+- **"default" status = delete**: Rather than storing a "default" row, delete the preference row entirely to reset. Keeps the table small and queries simple.
+- **Compound unique for upsert**: `@@unique([userId, insightId], name: "userId_insightId")` maps to Prisma upsert key `{ userId_insightId: { userId, insightId } }`.
+- **User isolation**: Every query includes `userId: session.user.id` from session — never accepted as a client parameter.
+- **URL parsing in routes**: Use `new URL(req.url)` instead of `req.nextUrl` for compatibility with test environments that use standard `Request` objects.
+- **Manual migration**: When DATABASE_URL is unavailable in worktree, write migration SQL manually following the existing migration style; Prisma generate still works without DB access.

--- a/prisma/migrations/20260302000000_add_insight_preference/migration.sql
+++ b/prisma/migrations/20260302000000_add_insight_preference/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "insight_preferences" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "insightId" VARCHAR(256) NOT NULL,
+    "status" VARCHAR(20) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "insight_preferences_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "insight_preferences_userId_insightId_key" ON "insight_preferences"("userId", "insightId");
+
+-- CreateIndex
+CREATE INDEX "insight_preferences_userId_idx" ON "insight_preferences"("userId");
+
+-- AddForeignKey
+ALTER TABLE "insight_preferences" ADD CONSTRAINT "insight_preferences_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,7 @@ model User {
   ownedConferenceInventoryItems ConferenceInventoryItem[] @relation("ConferenceInventoryItemOwner")
 
   submissionEvents SubmissionEvent[]
+  insightPreferences InsightPreference[]
 
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
@@ -1603,4 +1604,23 @@ model SubmissionEvent {
   @@index([createdAt])
   @@index([userId])
   @@index([type, createdAt])
+}
+
+// ============================================================
+// INSIGHT PREFERENCES
+// ============================================================
+
+model InsightPreference {
+  id        String   @id @default(cuid())
+  userId    String
+  insightId String   @db.VarChar(256)
+  status    String   @db.VarChar(20)  // "pinned" | "dismissed"
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, insightId], name: "userId_insightId")
+  @@index([userId])
+  @@map("insight_preferences")
 }

--- a/src/app/api/insights/preferences/__tests__/route.test.ts
+++ b/src/app/api/insights/preferences/__tests__/route.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    insightPreference: {
+      findMany: vi.fn(),
+      upsert: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  },
+}));
+
+function makeGetRequest(url: string) {
+  return new Request(url, { method: "GET" }) as never;
+}
+
+function makePostRequest(url: string, body: unknown) {
+  return new Request(url, {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  }) as never;
+}
+
+describe("GET /api/insights/preferences", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    const { auth } = await import("@/lib/auth");
+    vi.mocked(auth).mockResolvedValue(null as never);
+
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest("http://localhost/api/insights/preferences"));
+
+    expect(res.status).toBe(401);
+    const json = await res.json() as { error: string };
+    expect(json.error).toBe("Unauthorized");
+  });
+
+  it("returns 401 when session exists but has no user id", async () => {
+    const { auth } = await import("@/lib/auth");
+    vi.mocked(auth).mockResolvedValue({ user: {} } as never);
+
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest("http://localhost/api/insights/preferences"));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns all preferences for the authenticated user", async () => {
+    const { auth } = await import("@/lib/auth");
+    const { prisma } = await import("@/lib/prisma");
+
+    vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(prisma.insightPreference.findMany).mockResolvedValue([
+      { id: "p1", userId: "user-1", insightId: "ins-a", status: "pinned", createdAt: new Date(), updatedAt: new Date() },
+    ] as never);
+
+    const { GET } = await import("../route");
+    const res = await GET(makeGetRequest("http://localhost/api/insights/preferences"));
+    const json = await res.json() as { preferences: unknown[] };
+
+    expect(res.status).toBe(200);
+    expect(json.preferences).toHaveLength(1);
+    expect(vi.mocked(prisma.insightPreference.findMany)).toHaveBeenCalledWith({
+      where: { userId: "user-1" },
+    });
+  });
+
+  it("filters by insightId when query param is present", async () => {
+    const { auth } = await import("@/lib/auth");
+    const { prisma } = await import("@/lib/prisma");
+
+    vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(prisma.insightPreference.findMany).mockResolvedValue([] as never);
+
+    const { GET } = await import("../route");
+    await GET(makeGetRequest("http://localhost/api/insights/preferences?insightId=ins-a"));
+
+    expect(vi.mocked(prisma.insightPreference.findMany)).toHaveBeenCalledWith({
+      where: { userId: "user-1", insightId: "ins-a" },
+    });
+  });
+
+  it("never leaks other users' preferences (WHERE always includes userId)", async () => {
+    const { auth } = await import("@/lib/auth");
+    const { prisma } = await import("@/lib/prisma");
+
+    vi.mocked(auth).mockResolvedValue({ user: { id: "user-2" } } as never);
+    vi.mocked(prisma.insightPreference.findMany).mockResolvedValue([] as never);
+
+    const { GET } = await import("../route");
+    await GET(makeGetRequest("http://localhost/api/insights/preferences"));
+
+    const call = vi.mocked(prisma.insightPreference.findMany).mock.calls[0][0];
+    expect((call.where as { userId: string }).userId).toBe("user-2");
+  });
+});
+
+describe("POST /api/insights/preferences", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    const { auth } = await import("@/lib/auth");
+    vi.mocked(auth).mockResolvedValue(null as never);
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest("http://localhost/api/insights/preferences", { insightId: "abc", status: "pinned" }));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("creates a pinned preference via upsert", async () => {
+    const { auth } = await import("@/lib/auth");
+    const { prisma } = await import("@/lib/prisma");
+
+    vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as never);
+    const fakePreference = { id: "pref-1", userId: "user-1", insightId: "ins-a", status: "pinned" };
+    vi.mocked(prisma.insightPreference.upsert).mockResolvedValue(fakePreference as never);
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest("http://localhost/api/insights/preferences", { insightId: "ins-a", status: "pinned" }));
+    const json = await res.json() as { preference: typeof fakePreference };
+
+    expect(res.status).toBe(200);
+    expect(json.preference.status).toBe("pinned");
+    expect(vi.mocked(prisma.insightPreference.upsert)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId_insightId: { userId: "user-1", insightId: "ins-a" } },
+      })
+    );
+  });
+
+  it("updates a dismissed preference via upsert", async () => {
+    const { auth } = await import("@/lib/auth");
+    const { prisma } = await import("@/lib/prisma");
+
+    vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(prisma.insightPreference.upsert).mockResolvedValue({ id: "pref-1", status: "dismissed" } as never);
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest("http://localhost/api/insights/preferences", { insightId: "ins-b", status: "dismissed" }));
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(prisma.insightPreference.upsert)).toHaveBeenCalled();
+  });
+
+  it("deletes the row when status is 'default'", async () => {
+    const { auth } = await import("@/lib/auth");
+    const { prisma } = await import("@/lib/prisma");
+
+    vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(prisma.insightPreference.deleteMany).mockResolvedValue({ count: 1 } as never);
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest("http://localhost/api/insights/preferences", { insightId: "ins-a", status: "default" }));
+    const json = await res.json() as { preference: null };
+
+    expect(res.status).toBe(200);
+    expect(json.preference).toBeNull();
+    expect(vi.mocked(prisma.insightPreference.deleteMany)).toHaveBeenCalledWith({
+      where: { userId: "user-1", insightId: "ins-a" },
+    });
+    expect(vi.mocked(prisma.insightPreference.upsert)).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid status", async () => {
+    const { auth } = await import("@/lib/auth");
+    vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as never);
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest("http://localhost/api/insights/preferences", { insightId: "abc", status: "archived" }));
+
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: string };
+    expect(json.error).toContain("status");
+  });
+
+  it("returns 400 when insightId is missing", async () => {
+    const { auth } = await import("@/lib/auth");
+    vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as never);
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest("http://localhost/api/insights/preferences", { status: "pinned" }));
+
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: string };
+    expect(json.error).toContain("insightId");
+  });
+
+  it("returns 400 when insightId exceeds 256 chars", async () => {
+    const { auth } = await import("@/lib/auth");
+    vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as never);
+
+    const { POST } = await import("../route");
+    const res = await POST(makePostRequest("http://localhost/api/insights/preferences", { insightId: "x".repeat(257), status: "pinned" }));
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/insights/preferences/route.ts
+++ b/src/app/api/insights/preferences/route.ts
@@ -1,0 +1,76 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { validateUpsertInput } from "@/lib/validators/insight-preference";
+
+// GET /api/insights/preferences
+// Optional query: ?insightId=<id>  (filter to one)
+// Returns: { preferences: InsightPreference[] }
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const insightId = searchParams.get("insightId");
+
+  const where: { userId: string; insightId?: string } = {
+    userId: session.user.id,
+  };
+  if (insightId) {
+    where.insightId = insightId;
+  }
+
+  const preferences = await prisma.insightPreference.findMany({ where });
+
+  return NextResponse.json({ preferences });
+}
+
+// POST /api/insights/preferences
+// Body: { insightId: string, status: "pinned" | "dismissed" | "default" }
+// "default" removes the record (soft-reset).
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const result = validateUpsertInput(body);
+
+  if (!result.valid) {
+    return NextResponse.json({ error: result.error }, { status: 400 });
+  }
+
+  const { insightId, status } = result.data!;
+  const userId = session.user.id;
+
+  // "default" means the user is resetting — delete the row
+  if (status === "default") {
+    await prisma.insightPreference.deleteMany({
+      where: { userId, insightId },
+    });
+    return NextResponse.json({ preference: null });
+  }
+
+  // Upsert for pinned/dismissed
+  const preference = await prisma.insightPreference.upsert({
+    where: {
+      userId_insightId: { userId, insightId },
+    },
+    create: {
+      userId,
+      insightId,
+      status,
+    },
+    update: {
+      status,
+      updatedAt: new Date(),
+    },
+  });
+
+  return NextResponse.json({ preference });
+}

--- a/src/lib/__tests__/insight-preference-validation.test.ts
+++ b/src/lib/__tests__/insight-preference-validation.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { validateUpsertInput } from "@/lib/validators/insight-preference";
+
+describe("validateUpsertInput", () => {
+  it("accepts valid pinned input", () => {
+    const res = validateUpsertInput({ insightId: "wip-bottleneck-col3", status: "pinned" });
+    expect(res.valid).toBe(true);
+    expect(res.data).toEqual({ insightId: "wip-bottleneck-col3", status: "pinned" });
+  });
+
+  it("accepts valid dismissed input", () => {
+    const res = validateUpsertInput({ insightId: "cycle-time-spike", status: "dismissed" });
+    expect(res.valid).toBe(true);
+    expect(res.data).toEqual({ insightId: "cycle-time-spike", status: "dismissed" });
+  });
+
+  it("accepts default (reset) status", () => {
+    const res = validateUpsertInput({ insightId: "some-insight", status: "default" });
+    expect(res.valid).toBe(true);
+    expect(res.data).toEqual({ insightId: "some-insight", status: "default" });
+  });
+
+  it("rejects missing insightId", () => {
+    const res = validateUpsertInput({ status: "pinned" });
+    expect(res.valid).toBe(false);
+    expect(res.error).toContain("insightId");
+  });
+
+  it("rejects empty insightId", () => {
+    const res = validateUpsertInput({ insightId: "", status: "pinned" });
+    expect(res.valid).toBe(false);
+    expect(res.error).toContain("insightId");
+  });
+
+  it("rejects insightId exceeding 256 chars", () => {
+    const res = validateUpsertInput({ insightId: "x".repeat(257), status: "pinned" });
+    expect(res.valid).toBe(false);
+    expect(res.error).toContain("insightId");
+  });
+
+  it("accepts insightId of exactly 256 chars", () => {
+    const res = validateUpsertInput({ insightId: "x".repeat(256), status: "pinned" });
+    expect(res.valid).toBe(true);
+  });
+
+  it("rejects invalid status", () => {
+    const res = validateUpsertInput({ insightId: "abc", status: "archived" });
+    expect(res.valid).toBe(false);
+    expect(res.error).toContain("status");
+  });
+
+  it("rejects null body", () => {
+    const res = validateUpsertInput(null);
+    expect(res.valid).toBe(false);
+    expect(res.error).toContain("JSON object");
+  });
+
+  it("rejects non-object body", () => {
+    const res = validateUpsertInput("string");
+    expect(res.valid).toBe(false);
+    expect(res.error).toContain("JSON object");
+  });
+
+  it("rejects numeric body", () => {
+    const res = validateUpsertInput(42);
+    expect(res.valid).toBe(false);
+  });
+});

--- a/src/lib/validators/insight-preference.ts
+++ b/src/lib/validators/insight-preference.ts
@@ -1,0 +1,35 @@
+export const INSIGHT_PREFERENCE_STATUSES = ["pinned", "dismissed", "default"] as const;
+export type InsightPreferenceStatus = (typeof INSIGHT_PREFERENCE_STATUSES)[number];
+
+export interface UpsertInsightPreferenceInput {
+  insightId: string;
+  status: InsightPreferenceStatus;
+}
+
+export function validateUpsertInput(body: unknown): {
+  valid: boolean;
+  data?: UpsertInsightPreferenceInput;
+  error?: string;
+} {
+  if (!body || typeof body !== "object") {
+    return { valid: false, error: "Body must be a JSON object" };
+  }
+
+  const { insightId, status } = body as Record<string, unknown>;
+
+  if (typeof insightId !== "string" || insightId.length === 0 || insightId.length > 256) {
+    return { valid: false, error: "insightId is required (string, max 256 chars)" };
+  }
+
+  if (
+    typeof status !== "string" ||
+    !INSIGHT_PREFERENCE_STATUSES.includes(status as InsightPreferenceStatus)
+  ) {
+    return {
+      valid: false,
+      error: `status must be one of: ${INSIGHT_PREFERENCE_STATUSES.join(", ")}`,
+    };
+  }
+
+  return { valid: true, data: { insightId, status: status as InsightPreferenceStatus } };
+}


### PR DESCRIPTION
## Summary

Closes #300.

Adds server-side persistence for user insight feedback (pinned/dismissed) so preferences sync across devices.

- **New Prisma model** `InsightPreference` keyed on `(userId, insightId)` with cascade delete and a `@@unique` composite index enabling efficient upsert
- **Migration** `20260302000000_add_insight_preference` — additive only, no destructive changes
- **GET `/api/insights/preferences`** — returns all preferences for the authed user; accepts optional `?insightId=` filter; `userId` always derived from session (never from client)
- **POST `/api/insights/preferences`** — upserts `pinned`/`dismissed`; deletes the row on `"default"` (reset to no preference)
- **Shared validator** `src/lib/validators/insight-preference.ts` — pure function, reusable if a bulk endpoint is added later
- **Frontend opt-in**: local fallback still works; frontend can call these endpoints to sync preferences across devices

## Design decisions

- `insightId` is an opaque `VARCHAR(256)` string (not a FK) — insights are computed artifacts identified by stable hash/slug
- `status` stored as `VARCHAR(20)` string rather than a Prisma enum — avoids a new migration if statuses evolve (e.g., "snoozed")
- `"default"` status on POST deletes the row instead of storing a "reset" marker, keeping the table compact

## Test plan

- [x] 11 validator unit tests — valid inputs, edge cases (empty string, 257-char id, wrong type, null/non-object body)
- [x] 12 route integration tests — auth guard, user isolation verified via mock call assertions, upsert, delete-on-default, all 400 error paths
- [x] All 23 new tests passing, no regressions in existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)