### PR TITLE
feat(#299): add pin/dismiss + create-task actions on insight cards

### DIFF
--- a/src/components/analytics/__tests__/dismiss-undo-toast.test.tsx
+++ b/src/components/analytics/__tests__/dismiss-undo-toast.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DismissUndoToast } from "../dismiss-undo-toast";
+
+describe("DismissUndoToast", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the insight title in the message", () => {
+    render(
+      <DismissUndoToast
+        insightTitle="Pipeline conversion risk"
+        onUndo={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Pipeline conversion risk/)).toBeTruthy();
+  });
+
+  it("has role=alert for screen reader announcement", () => {
+    const { container } = render(
+      <DismissUndoToast insightTitle="Test" onUndo={vi.fn()} onClose={vi.fn()} />
+    );
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).toBeTruthy();
+  });
+
+  it("undo button calls onUndo and onClose", () => {
+    const onUndo = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <DismissUndoToast insightTitle="Test" onUndo={onUndo} onClose={onClose} />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Undo" }));
+    expect(onUndo).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("auto-closes after durationMs", () => {
+    const onClose = vi.fn();
+    render(
+      <DismissUndoToast
+        insightTitle="Test"
+        onUndo={vi.fn()}
+        onClose={onClose}
+        durationMs={3000}
+      />
+    );
+    expect(onClose).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(3000);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not auto-close before durationMs elapses", () => {
+    const onClose = vi.fn();
+    render(
+      <DismissUndoToast
+        insightTitle="Test"
+        onUndo={vi.fn()}
+        onClose={onClose}
+        durationMs={5000}
+      />
+    );
+    vi.advanceTimersByTime(4999);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/analytics/__tests__/insight-card-actions.test.tsx
+++ b/src/components/analytics/__tests__/insight-card-actions.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { InsightCardActions } from "../insight-card-actions";
+
+const baseProps = {
+  insightId: "test-insight",
+  isPinned: false,
+  onTogglePin: vi.fn(),
+  onDismiss: vi.fn(),
+  onCreateTask: vi.fn(),
+  isCreatingTask: false,
+};
+
+describe("InsightCardActions", () => {
+  it("renders three action buttons", () => {
+    render(<InsightCardActions {...baseProps} />);
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.length).toBe(3);
+  });
+
+  it("pin button has correct aria-label when unpinned", () => {
+    render(<InsightCardActions {...baseProps} isPinned={false} />);
+    const pinBtn = screen.getByRole("button", { name: "Pin insight" });
+    expect(pinBtn).toBeTruthy();
+    expect(pinBtn.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("pin button has correct aria-label when pinned", () => {
+    render(<InsightCardActions {...baseProps} isPinned={true} />);
+    const pinBtn = screen.getByRole("button", { name: "Unpin insight" });
+    expect(pinBtn).toBeTruthy();
+    expect(pinBtn.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("pin button calls onTogglePin on click", () => {
+    const onTogglePin = vi.fn();
+    render(<InsightCardActions {...baseProps} onTogglePin={onTogglePin} />);
+    fireEvent.click(screen.getByRole("button", { name: "Pin insight" }));
+    expect(onTogglePin).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismiss button calls onDismiss on click", () => {
+    const onDismiss = vi.fn();
+    render(<InsightCardActions {...baseProps} onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss insight" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("create task button calls onCreateTask on click", () => {
+    const onCreateTask = vi.fn();
+    render(<InsightCardActions {...baseProps} onCreateTask={onCreateTask} />);
+    fireEvent.click(screen.getByRole("button", { name: "Create task from this insight" }));
+    expect(onCreateTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("create task button is disabled when isCreatingTask is true", () => {
+    render(<InsightCardActions {...baseProps} isCreatingTask={true} />);
+    const btn = screen.getByRole("button", { name: "Create task from this insight" });
+    expect(btn.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("create task button shows spinner when isCreatingTask is true", () => {
+    const { container } = render(<InsightCardActions {...baseProps} isCreatingTask={true} />);
+    // Loader2 renders with animate-spin class
+    const spinner = container.querySelector(".animate-spin");
+    expect(spinner).toBeTruthy();
+  });
+
+  it("all buttons are keyboard-accessible (have button role)", () => {
+    render(<InsightCardActions {...baseProps} />);
+    const buttons = screen.getAllByRole("button");
+    buttons.forEach((btn) => {
+      expect(btn.tagName).toBe("BUTTON");
+    });
+  });
+
+  it("group wrapper has aria-label for screen reader context", () => {
+    const { container } = render(<InsightCardActions {...baseProps} />);
+    const group = container.querySelector('[role="group"]');
+    expect(group).toBeTruthy();
+    expect(group?.getAttribute("aria-label")).toBe("Insight actions");
+  });
+});

--- a/src/components/analytics/ai-insights-page.tsx
+++ b/src/components/analytics/ai-insights-page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
 import { InsightCardFull } from "./insight-card-full";
 import { StatCard } from "./stat-card";
-import type { AnalyticsDashboardData, AnalyticsSectionId } from "@/lib/analytics/types";
+import { DismissUndoToast } from "./dismiss-undo-toast";
+import type { AnalyticsDashboardData, AnalyticsSectionId, AiInsight } from "@/lib/analytics/types";
 import { AlertTriangle, AlertCircle, Info, BarChart3 } from "lucide-react";
 import { populateConnectionStatus } from "@/hooks/use-connection-status";
 import { useDashboardResource } from "@/components/dashboard/use-dashboard-resource";
+import { useInsightPreferences } from "@/lib/hooks/use-insight-preferences";
 
 type SeverityFilter = "all" | "critical" | "warning" | "info";
 type SectionFilter = "all" | AnalyticsSectionId;
@@ -46,6 +48,21 @@ export function AiInsightsPage() {
   const [sortMode, setSortMode] = useState<SortMode>("severity");
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState<(typeof PAGE_SIZES)[number]>(25);
+  const [showDismissed, setShowDismissed] = useState(false);
+  const [recentlyDismissed, setRecentlyDismissed] = useState<{ id: string; title: string } | null>(null);
+  const [taskError, setTaskError] = useState<string | null>(null);
+
+  const {
+    isPinned,
+    isDismissed,
+    togglePin,
+    dismiss,
+    undoDismiss,
+    createTaskFromInsight,
+    creatingTaskForId,
+    sortAndFilter,
+    dismissedIds,
+  } = useInsightPreferences();
 
   useEffect(() => {
     if (!data) return;
@@ -54,21 +71,34 @@ export function AiInsightsPage() {
 
   const allInsights = data?.aiInsights?.global ?? [];
 
+  const dismissedCount = useMemo(
+    () => allInsights.filter((i) => isDismissed(i.id)).length,
+    [allInsights, isDismissed, dismissedIds]
+  );
+
   const filtered = useMemo(() => {
-    let result = allInsights;
+    // First apply sortAndFilter (handles pin order + dismissed filtering)
+    let result = sortAndFilter(allInsights, showDismissed);
+
+    // Then apply severity/section filters
     if (severityFilter !== "all") {
       result = result.filter((i) => i.severity === severityFilter);
     }
     if (sectionFilter !== "all") {
       result = result.filter((i) => i.section === sectionFilter);
     }
-    if (sortMode === "severity") {
-      result = [...result].sort((a, b) => (SEVERITY_ORDER[a.severity] ?? 9) - (SEVERITY_ORDER[b.severity] ?? 9));
-    } else {
-      result = [...result].sort((a, b) => b.confidence - a.confidence);
-    }
-    return result;
-  }, [allInsights, severityFilter, sectionFilter, sortMode]);
+
+    // Sort within unpinned group (pinned always stay on top from sortAndFilter)
+    const pinned = result.filter((i) => isPinned(i.id));
+    const unpinned = result.filter((i) => !isPinned(i.id));
+
+    const sortFn = (a: AiInsight, b: AiInsight) =>
+      sortMode === "severity"
+        ? (SEVERITY_ORDER[a.severity] ?? 9) - (SEVERITY_ORDER[b.severity] ?? 9)
+        : b.confidence - a.confidence;
+
+    return [...pinned, ...unpinned.sort(sortFn)];
+  }, [allInsights, severityFilter, sectionFilter, sortMode, sortAndFilter, showDismissed, isPinned, dismissedIds]);
 
   const totalInsights = filtered.length;
   const pageCount = Math.max(1, Math.ceil(totalInsights / pageSize));
@@ -95,6 +125,27 @@ export function AiInsightsPage() {
   const avgConfidence = allInsights.length > 0
     ? allInsights.reduce((sum, i) => sum + i.confidence, 0) / allInsights.length
     : 0;
+
+  const handleDismiss = useCallback((insight: AiInsight) => {
+    void dismiss(insight.id);
+    setRecentlyDismissed({ id: insight.id, title: insight.title });
+  }, [dismiss]);
+
+  const handleUndoDismiss = useCallback(() => {
+    if (recentlyDismissed) {
+      void undoDismiss(recentlyDismissed.id);
+      setRecentlyDismissed(null);
+    }
+  }, [recentlyDismissed, undoDismiss]);
+
+  const handleCreateTask = useCallback(async (insight: AiInsight) => {
+    setTaskError(null);
+    try {
+      await createTaskFromInsight(insight);
+    } catch {
+      setTaskError(`Failed to create task for "${insight.title}". Please try again.`);
+    }
+  }, [createTaskFromInsight]);
 
   if (loading) {
     return (
@@ -124,6 +175,12 @@ export function AiInsightsPage() {
       {error && (
         <div className="rounded-xl border border-border bg-card p-4">
           <p className="text-sm text-muted-foreground">{error}</p>
+        </div>
+      )}
+
+      {taskError && (
+        <div className="rounded-xl border border-red-200 bg-red-50 p-4 dark:border-red-900/50 dark:bg-red-900/10">
+          <p className="text-sm text-red-600 dark:text-red-400">{taskError}</p>
         </div>
       )}
 
@@ -190,9 +247,31 @@ export function AiInsightsPage() {
             <p className="text-sm text-muted-foreground">No insights match current filters</p>
           </div>
         ) : (
-          pagedInsights.map((insight) => <InsightCardFull key={insight.id} insight={insight} />)
+          pagedInsights.map((insight) => (
+            <InsightCardFull
+              key={insight.id}
+              insight={insight}
+              isPinned={isPinned(insight.id)}
+              onTogglePin={() => void togglePin(insight.id)}
+              onDismiss={() => handleDismiss(insight)}
+              onCreateTask={() => void handleCreateTask(insight)}
+              isCreatingTask={creatingTaskForId === insight.id}
+            />
+          ))
         )}
       </div>
+
+      {dismissedCount > 0 && (
+        <button
+          type="button"
+          onClick={() => setShowDismissed((prev) => !prev)}
+          className="text-xs text-muted-foreground underline hover:text-foreground"
+        >
+          {showDismissed
+            ? "Hide dismissed insights"
+            : `Show ${dismissedCount} dismissed insight${dismissedCount !== 1 ? "s" : ""}`}
+        </button>
+      )}
 
       {totalInsights > 0 && (
         <div className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 sm:flex-row sm:items-center sm:justify-between">
@@ -286,6 +365,14 @@ export function AiInsightsPage() {
             )}
           </div>
         </div>
+      )}
+
+      {recentlyDismissed && (
+        <DismissUndoToast
+          insightTitle={recentlyDismissed.title}
+          onUndo={handleUndoDismiss}
+          onClose={() => setRecentlyDismissed(null)}
+        />
       )}
     </div>
   );

--- a/src/components/analytics/dismiss-undo-toast.tsx
+++ b/src/components/analytics/dismiss-undo-toast.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+interface DismissUndoToastProps {
+  insightTitle: string;
+  onUndo: () => void;
+  onClose: () => void;
+  durationMs?: number;
+}
+
+export function DismissUndoToast({
+  insightTitle,
+  onUndo,
+  onClose,
+  durationMs = 5000,
+}: DismissUndoToastProps) {
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onCloseRef.current();
+    }, durationMs);
+    return () => clearTimeout(timer);
+  }, [durationMs]);
+
+  function handleUndo() {
+    onUndo();
+    onClose();
+  }
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="fixed bottom-4 left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-lg bg-gray-900 px-4 py-3 text-sm text-white shadow-lg dark:bg-gray-100 dark:text-gray-900"
+    >
+      <span className="max-w-[240px] truncate">
+        Dismissed &ldquo;{insightTitle}&rdquo;
+      </span>
+      <button
+        type="button"
+        onClick={handleUndo}
+        className="shrink-0 font-semibold underline text-blue-300 hover:text-blue-200 dark:text-blue-600 dark:hover:text-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
+      >
+        Undo
+      </button>
+    </div>
+  );
+}

--- a/src/components/analytics/insight-card-actions.tsx
+++ b/src/components/analytics/insight-card-actions.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Pin, X, ListPlus, Loader2 } from "lucide-react";
+
+interface InsightCardActionsProps {
+  insightId: string;
+  isPinned: boolean;
+  onTogglePin: () => void;
+  onDismiss: () => void;
+  onCreateTask: () => void;
+  isCreatingTask: boolean;
+}
+
+export function InsightCardActions({
+  isPinned,
+  onTogglePin,
+  onDismiss,
+  onCreateTask,
+  isCreatingTask,
+}: InsightCardActionsProps) {
+  return (
+    <div className="flex items-center gap-0.5" role="group" aria-label="Insight actions">
+      <button
+        type="button"
+        onClick={onTogglePin}
+        className={`rounded-md p-1.5 transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 ${
+          isPinned
+            ? "text-amber-500 hover:bg-amber-50 dark:hover:bg-amber-900/20"
+            : "text-muted-foreground hover:bg-secondary hover:text-foreground"
+        }`}
+        aria-label={isPinned ? "Unpin insight" : "Pin insight"}
+        aria-pressed={isPinned}
+        title={isPinned ? "Unpin" : "Pin to top"}
+      >
+        <Pin
+          className={`h-3.5 w-3.5 ${isPinned ? "fill-current" : ""}`}
+          aria-hidden="true"
+        />
+      </button>
+
+      <button
+        type="button"
+        onClick={onCreateTask}
+        disabled={isCreatingTask}
+        className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50"
+        aria-label="Create task from this insight"
+        title="Create task"
+      >
+        {isCreatingTask ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+        ) : (
+          <ListPlus className="h-3.5 w-3.5" aria-hidden="true" />
+        )}
+      </button>
+
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-red-50 hover:text-red-500 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 dark:hover:bg-red-900/20"
+        aria-label="Dismiss insight"
+        title="Dismiss"
+      >
+        <X className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/analytics/insight-card-full.tsx
+++ b/src/components/analytics/insight-card-full.tsx
@@ -2,6 +2,7 @@
 
 import type { AiInsight } from "@/lib/analytics/types";
 import { AlertTriangle, AlertCircle, Info, ExternalLink } from "lucide-react";
+import { InsightCardActions } from "./insight-card-actions";
 
 const SEVERITY_CONFIG = {
   critical: { border: "border-red-500/20", bg: "bg-red-500/5", icon: AlertTriangle, color: "text-red-500", badge: "bg-red-500/10 text-red-500" },
@@ -9,27 +10,68 @@ const SEVERITY_CONFIG = {
   info: { border: "border-blue-500/20", bg: "bg-blue-500/5", icon: Info, color: "text-blue-500", badge: "bg-blue-500/10 text-blue-500" },
 } as const;
 
-export function InsightCardFull({ insight }: { insight: AiInsight }) {
+interface InsightCardFullProps {
+  insight: AiInsight;
+  isPinned?: boolean;
+  onTogglePin?: () => void;
+  onDismiss?: () => void;
+  onCreateTask?: () => void;
+  isCreatingTask?: boolean;
+}
+
+export function InsightCardFull({
+  insight,
+  isPinned = false,
+  onTogglePin,
+  onDismiss,
+  onCreateTask,
+  isCreatingTask = false,
+}: InsightCardFullProps) {
   const cfg = SEVERITY_CONFIG[insight.severity];
   const Icon = cfg.icon;
 
+  const showActions = onTogglePin != null && onDismiss != null && onCreateTask != null;
+
   return (
-    <div className={`rounded-xl border ${cfg.border} ${cfg.bg} p-5`}>
+    <div
+      className={`rounded-xl border p-5 transition-colors ${cfg.border} ${cfg.bg} ${
+        isPinned ? "ring-1 ring-amber-400/50" : ""
+      }`}
+    >
       <div className="flex items-start gap-3">
-        <Icon className={`mt-0.5 h-5 w-5 ${cfg.color}`} />
-        <div className="flex-1">
-          <div className="flex items-center gap-2 flex-wrap">
-            <h3 className="text-sm font-semibold text-foreground">{insight.title}</h3>
-            <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${cfg.badge}`}>
-              {insight.severity}
-            </span>
-            <span className="rounded-full bg-secondary px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
-              {insight.section}
-            </span>
-            {insight.stale && (
-              <span className="rounded-full bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-500">
-                stale data
+        <Icon className={`mt-0.5 h-5 w-5 shrink-0 ${cfg.color}`} aria-hidden="true" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex flex-wrap items-center gap-2 min-w-0">
+              <h3 className="text-sm font-semibold text-foreground">{insight.title}</h3>
+              <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${cfg.badge}`}>
+                {insight.severity}
               </span>
+              <span className="rounded-full bg-secondary px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                {insight.section}
+              </span>
+              {isPinned && (
+                <span className="rounded-full bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400">
+                  pinned
+                </span>
+              )}
+              {insight.stale && (
+                <span className="rounded-full bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-500">
+                  stale data
+                </span>
+              )}
+            </div>
+            {showActions && (
+              <div className="shrink-0">
+                <InsightCardActions
+                  insightId={insight.id}
+                  isPinned={isPinned}
+                  onTogglePin={onTogglePin!}
+                  onDismiss={onDismiss!}
+                  onCreateTask={onCreateTask!}
+                  isCreatingTask={isCreatingTask}
+                />
+              </div>
             )}
           </div>
           <p className="mt-1 text-sm text-muted-foreground">{insight.why}</p>
@@ -84,10 +126,11 @@ export function InsightCardFull({ insight }: { insight: AiInsight }) {
           {insight.actions.map((action, i) => (
             <button
               key={i}
+              type="button"
               className="flex items-center gap-1.5 rounded-lg border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-secondary"
             >
               {action.label}
-              <ExternalLink className="h-3 w-3 text-muted-foreground" />
+              <ExternalLink className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
             </button>
           ))}
         </div>

--- a/src/lib/hooks/__tests__/use-insight-preferences.test.ts
+++ b/src/lib/hooks/__tests__/use-insight-preferences.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useInsightPreferences } from "../use-insight-preferences";
+import type { AiInsight } from "@/lib/analytics/types";
+
+function makeInsight(overrides: Partial<AiInsight> = {}): AiInsight {
+  return {
+    id: "insight-1",
+    section: "sales-pipeline",
+    severity: "warning",
+    title: "Pipeline risk",
+    why: "Conversion dropped",
+    confidence: 0.8,
+    expectedImpact: "Recover demos",
+    stale: false,
+    evidence: [],
+    actions: [],
+    ...overrides,
+  };
+}
+
+// Helper to build a fetch mock that returns preferences
+function mockFetch(preferences: Array<{ insightId: string; status: string }> = []) {
+  return vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+    const method = opts?.method ?? "GET";
+    if (method === "GET") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ preferences }),
+      } as Response);
+    }
+    // POST
+    const body = JSON.parse(opts?.body as string ?? "{}");
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ preference: body }),
+    } as Response);
+  });
+}
+
+describe("useInsightPreferences", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loads pinned/dismissed preferences from API on mount", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch([
+        { insightId: "abc", status: "pinned" },
+        { insightId: "def", status: "dismissed" },
+      ])
+    );
+
+    const { result } = renderHook(() => useInsightPreferences());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.isPinned("abc")).toBe(true);
+    expect(result.current.isDismissed("def")).toBe(true);
+    expect(result.current.isPinned("def")).toBe(false);
+    expect(result.current.isDismissed("abc")).toBe(false);
+  });
+
+  it("togglePin adds id to pinnedIds (optimistic)", async () => {
+    const { result } = renderHook(() => useInsightPreferences());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.isPinned("xyz")).toBe(false);
+
+    await act(async () => {
+      await result.current.togglePin("xyz");
+    });
+
+    expect(result.current.isPinned("xyz")).toBe(true);
+  });
+
+  it("togglePin removes id from pinnedIds when already pinned", async () => {
+    vi.stubGlobal("fetch", mockFetch([{ insightId: "xyz", status: "pinned" }]));
+    const { result } = renderHook(() => useInsightPreferences());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.isPinned("xyz")).toBe(true);
+
+    await act(async () => {
+      await result.current.togglePin("xyz");
+    });
+
+    expect(result.current.isPinned("xyz")).toBe(false);
+  });
+
+  it("dismiss adds id to dismissedIds (optimistic)", async () => {
+    const { result } = renderHook(() => useInsightPreferences());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.isDismissed("aaa")).toBe(false);
+
+    await act(async () => {
+      await result.current.dismiss("aaa");
+    });
+
+    expect(result.current.isDismissed("aaa")).toBe(true);
+  });
+
+  it("undoDismiss removes id from dismissedIds", async () => {
+    vi.stubGlobal("fetch", mockFetch([{ insightId: "aaa", status: "dismissed" }]));
+    const { result } = renderHook(() => useInsightPreferences());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.isDismissed("aaa")).toBe(true);
+
+    await act(async () => {
+      await result.current.undoDismiss("aaa");
+    });
+
+    expect(result.current.isDismissed("aaa")).toBe(false);
+  });
+
+  it("sortAndFilter puts pinned insights first", async () => {
+    vi.stubGlobal("fetch", mockFetch([{ insightId: "b", status: "pinned" }]));
+    const { result } = renderHook(() => useInsightPreferences());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const insights = [
+      makeInsight({ id: "a", title: "A" }),
+      makeInsight({ id: "b", title: "B" }),
+      makeInsight({ id: "c", title: "C" }),
+    ];
+
+    const sorted = result.current.sortAndFilter(insights);
+    expect(sorted[0].id).toBe("b");
+  });
+
+  it("sortAndFilter hides dismissed insights by default", async () => {
+    vi.stubGlobal("fetch", mockFetch([{ insightId: "dismissed-one", status: "dismissed" }]));
+    const { result } = renderHook(() => useInsightPreferences());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const insights = [
+      makeInsight({ id: "dismissed-one" }),
+      makeInsight({ id: "visible" }),
+    ];
+
+    const sorted = result.current.sortAndFilter(insights);
+    expect(sorted.some((i) => i.id === "dismissed-one")).toBe(false);
+    expect(sorted.some((i) => i.id === "visible")).toBe(true);
+  });
+
+  it("sortAndFilter includes dismissed when showDismissed=true", async () => {
+    vi.stubGlobal("fetch", mockFetch([{ insightId: "dismissed-one", status: "dismissed" }]));
+    const { result } = renderHook(() => useInsightPreferences());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const insights = [
+      makeInsight({ id: "dismissed-one" }),
+      makeInsight({ id: "visible" }),
+    ];
+
+    const sorted = result.current.sortAndFilter(insights, true);
+    expect(sorted.some((i) => i.id === "dismissed-one")).toBe(true);
+  });
+
+  it("createTaskFromInsight calls POST /api/tasks with correct payload", async () => {
+    const fetchMock = mockFetch();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useInsightPreferences());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const insight = makeInsight({ id: "ins-1", title: "Fix pipeline", severity: "critical" });
+
+    await act(async () => {
+      await result.current.createTaskFromInsight(insight);
+    });
+
+    // Find the POST /api/tasks call (the first call was GET /api/insights/preferences)
+    const taskCall = fetchMock.mock.calls.find(
+      ([url, opts]) => url === "/api/tasks" && (opts as RequestInit)?.method === "POST"
+    );
+    expect(taskCall).toBeTruthy();
+
+    const body = JSON.parse((taskCall![1] as RequestInit).body as string);
+    expect(body.title).toBe("[Insight] Fix pipeline");
+    expect(body.status).toBe("BACKLOG");
+    expect(body.priority).toBe("P1"); // critical → P1
+  });
+
+  it("createTaskFromInsight sets creatingTaskForId during fetch, resets after", async () => {
+    let resolveTask!: (v: Response) => void;
+    const taskPromise = new Promise<Response>((r) => { resolveTask = r; });
+
+    const fetchMock = vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+      if ((opts?.method ?? "GET") === "GET") {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ preferences: [] }) } as Response);
+      }
+      return taskPromise;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useInsightPreferences());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const insight = makeInsight({ id: "ins-2" });
+    let createDone = false;
+
+    act(() => {
+      result.current.createTaskFromInsight(insight).then(() => { createDone = true; });
+    });
+
+    // After kicking off createTask, creatingTaskForId should be set
+    await waitFor(() => expect(result.current.creatingTaskForId).toBe("ins-2"));
+
+    // Resolve the task API call
+    resolveTask({ ok: true, json: () => Promise.resolve({ id: "task-1", title: "[Insight] Test" }) } as Response);
+
+    await waitFor(() => expect(createDone).toBe(true));
+    expect(result.current.creatingTaskForId).toBeNull();
+  });
+
+  it("sortAndFilter preserves relative order within each group", async () => {
+    vi.stubGlobal("fetch", mockFetch([{ insightId: "b", status: "pinned" }]));
+    const { result } = renderHook(() => useInsightPreferences());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const insights = [
+      makeInsight({ id: "a" }),
+      makeInsight({ id: "b" }), // pinned
+      makeInsight({ id: "c" }),
+    ];
+
+    const sorted = result.current.sortAndFilter(insights);
+    expect(sorted[0].id).toBe("b");
+    // a and c preserve order among unpinned
+    expect(sorted[1].id).toBe("a");
+    expect(sorted[2].id).toBe("c");
+  });
+});

--- a/src/lib/hooks/use-insight-preferences.ts
+++ b/src/lib/hooks/use-insight-preferences.ts
@@ -1,0 +1,196 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import type { AiInsight } from "@/lib/analytics/types";
+
+export type InsightStatus = "pinned" | "dismissed" | "default";
+
+interface InsightPreference {
+  insightId: string;
+  status: InsightStatus;
+}
+
+interface UseInsightPreferencesReturn {
+  pinnedIds: Set<string>;
+  dismissedIds: Set<string>;
+  isPinned: (id: string) => boolean;
+  isDismissed: (id: string) => boolean;
+  togglePin: (id: string) => Promise<void>;
+  dismiss: (id: string) => Promise<void>;
+  undoDismiss: (id: string) => Promise<void>;
+  createTaskFromInsight: (insight: AiInsight) => Promise<void>;
+  creatingTaskForId: string | null;
+  sortAndFilter: (insights: AiInsight[], showDismissed?: boolean) => AiInsight[];
+  loading: boolean;
+}
+
+async function setPreference(insightId: string, status: InsightStatus): Promise<void> {
+  const res = await fetch("/api/insights/preferences", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ insightId, status }),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to save preference: ${res.status}`);
+  }
+}
+
+function buildTaskDescription(insight: AiInsight): string {
+  const lines: string[] = [
+    insight.why,
+    "",
+    insight.expectedImpact ? `**Expected impact:** ${insight.expectedImpact}` : "",
+    "",
+    "---",
+    `*Auto-created from AI insight: ${insight.id}*`,
+    `*Section: ${insight.section}*`,
+    `*Severity: ${insight.severity}*`,
+  ].filter((line, idx, arr) => {
+    // Remove consecutive empty lines
+    if (line === "" && arr[idx - 1] === "") return false;
+    return true;
+  });
+  return lines.join("\n").trim();
+}
+
+export function useInsightPreferences(): UseInsightPreferencesReturn {
+  const [pinnedIds, setPinnedIds] = useState<Set<string>>(new Set());
+  const [dismissedIds, setDismissedIds] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
+  const [creatingTaskForId, setCreatingTaskForId] = useState<string | null>(null);
+
+  // Load preferences from API on mount
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch("/api/insights/preferences");
+        if (!res.ok) return;
+        const data = (await res.json()) as { preferences: InsightPreference[] };
+        if (cancelled) return;
+        const pinned = new Set<string>();
+        const dismissed = new Set<string>();
+        for (const pref of data.preferences) {
+          if (pref.status === "pinned") pinned.add(pref.insightId);
+          else if (pref.status === "dismissed") dismissed.add(pref.insightId);
+        }
+        setPinnedIds(pinned);
+        setDismissedIds(dismissed);
+      } catch {
+        // Silently fail — preferences are non-critical
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    void load();
+    return () => { cancelled = true; };
+  }, []);
+
+  const isPinned = useCallback((id: string) => pinnedIds.has(id), [pinnedIds]);
+  const isDismissed = useCallback((id: string) => dismissedIds.has(id), [dismissedIds]);
+
+  const togglePin = useCallback(async (id: string) => {
+    const wasPin = pinnedIds.has(id);
+    const newStatus: InsightStatus = wasPin ? "default" : "pinned";
+
+    // Optimistic update
+    setPinnedIds((prev) => {
+      const next = new Set(prev);
+      if (wasPin) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+    try {
+      await setPreference(id, newStatus);
+    } catch {
+      // Rollback on failure
+      setPinnedIds((prev) => {
+        const next = new Set(prev);
+        if (wasPin) next.add(id);
+        else next.delete(id);
+        return next;
+      });
+    }
+  }, [pinnedIds]);
+
+  const dismiss = useCallback(async (id: string) => {
+    // Optimistic update
+    setDismissedIds((prev) => new Set([...prev, id]));
+
+    try {
+      await setPreference(id, "dismissed");
+    } catch {
+      // Rollback
+      setDismissedIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+  }, []);
+
+  const undoDismiss = useCallback(async (id: string) => {
+    // Optimistic update
+    setDismissedIds((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+
+    try {
+      await setPreference(id, "default");
+    } catch {
+      // Rollback
+      setDismissedIds((prev) => new Set([...prev, id]));
+    }
+  }, []);
+
+  const createTaskFromInsight = useCallback(async (insight: AiInsight): Promise<void> => {
+    setCreatingTaskForId(insight.id);
+    try {
+      const res = await fetch("/api/tasks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: `[Insight] ${insight.title}`,
+          notes: buildTaskDescription(insight),
+          status: "BACKLOG",
+          priority: insight.severity === "critical" ? "P1" : insight.severity === "warning" ? "P2" : "P3",
+        }),
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to create task: ${res.status}`);
+      }
+    } finally {
+      setCreatingTaskForId(null);
+    }
+  }, []);
+
+  const sortAndFilter = useCallback(
+    (insights: AiInsight[], showDismissed = false): AiInsight[] => {
+      const filtered = showDismissed
+        ? insights
+        : insights.filter((i) => !dismissedIds.has(i.id));
+
+      const pinned = filtered.filter((i) => pinnedIds.has(i.id));
+      const unpinned = filtered.filter((i) => !pinnedIds.has(i.id));
+      return [...pinned, ...unpinned];
+    },
+    [pinnedIds, dismissedIds]
+  );
+
+  return {
+    pinnedIds,
+    dismissedIds,
+    isPinned,
+    isDismissed,
+    togglePin,
+    dismiss,
+    undoDismiss,
+    createTaskFromInsight,
+    creatingTaskForId,
+    sortAndFilter,
+    loading,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds three interactive affordances to AI Insight cards on the `/analytics/ai-insights` page:
  - **Pin/unpin** — keeps important insights at the top of the list; highlighted with an amber ring
  - **Dismiss with undo** — hides irrelevant insights; a toast appears with a 5-second Undo window
  - **Create task** — creates a real task via `POST /api/tasks` with title/notes prefilled from the insight

## Architecture

- **`useInsightPreferences` hook** (`src/lib/hooks/use-insight-preferences.ts`): loads pin/dismissed state from the server-side `/api/insights/preferences` endpoint (built by backend in #300), uses optimistic updates so the UI responds instantly, rolls back on API failure
- **`InsightCardActions`** (`src/components/analytics/insight-card-actions.tsx`): accessible action bar with ARIA labels, `aria-pressed` for the pin toggle, and `focus-visible` rings
- **`DismissUndoToast`** (`src/components/analytics/dismiss-undo-toast.tsx`): `role="alert"` toast with auto-close timer and Undo button
- **`InsightCardFull`** updated: action props are optional — existing callers continue to work unchanged
- **`AiInsightsPage`** updated: integrates hook, filters dismissed, sorts pinned to top, shows dismiss undo toast and task-error banner

## Acceptance Criteria

- ✅ Pins/dismissals remembered across reloads (server-side via `/api/insights/preferences`)
- ✅ "Create task" produces a real task (`POST /api/tasks`) with insight title/description prefilled
- ✅ Task includes insight context (severity→priority mapping: critical→P1, warning→P2, info→P3)

## Test plan

- [ ] Run `npm test` — 26 new tests across 3 files, all passing
- [ ] Navigate to `/analytics/ai-insights`, pin an insight, reload — verify it's still pinned and at the top
- [ ] Dismiss an insight — verify it disappears — click Undo in the toast — verify it reappears
- [ ] Click "Create task" on an insight — verify task is created in the board/tasks list

🤖 Generated with [Claude Code](https://claude.com/claude-code)