### PR TITLE
feat(dashboard): land visual + interactive refresh + chart tests (#296)

### DIFF
--- a/.ralph-team/agents/frontend.md
+++ b/.ralph-team/agents/frontend.md
@@ -10,20 +10,33 @@ patterns, gotchas, and conventions.
 - Stat cards pattern: compute stats via `useMemo` in dashboard component, pass as props to presentational component
 - ARIA: wrap stat grid in `<section aria-label="...">`, each card uses `role="region" aria-label="{label}: {value}"`
 - Icon library: lucide-react (already installed); no heroicons
+- Dashboard visual refresh (DonutChart + StackedBarChart + SparkLine) landed in PR #276 (commit ed0f418 on main)
+- PersonalizedDashboard uses `focusKey` state to drive interactive focus list (blocked/overdue/dueSoon/active)
+- `completedByDay` sparkline is sliced to `.slice(-7)` to match "Completed (7d)" label
+- teamStatusKeys legend humanizes WORKING_ON_TODAY → Working On Today via `.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase())`
+- Recharts mock pattern: `vi.mock("recharts", async () => import("@/lib/__mocks__/recharts"))` — reusable shared mock at `src/lib/__mocks__/recharts.tsx`
+- Chart components live in `src/components/charts/`: SparkLine, DonutChart, StackedBarChart, AreaTrend, ComposedMetric, HorizontalFunnel
+- SparkLine returns null for data.length < 2 to avoid rendering a degenerate single-point line
 
 ## Gotchas
 - `ConferenceListItem` has NO `attendeeCount` field — use `_count.leads` for lead count stats
 - Pre-existing TypeScript errors throughout repo (missing Prisma client); not introduced by frontend work
 - `resource.lastUpdatedAt` is safe as `now` ref for filtering, but use `new Date()` in pure utility functions for testability
+- Recharts mock must cover ALL exports used across chart components: LineChart, AreaChart, BarChart, PieChart, ComposedChart, Bar, Line, Area, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend
+- Pre-existing TS errors in `src/app/api/deals/` and `src/components/analytics/customer-journey-*` — NOT introduced by dashboard work
+- DonutChart center overlay uses `pointer-events-none absolute inset-0` so it doesn't block chart interaction
 
 ## Conventions
 - File naming: kebab-case for all component and utility files (`conference-stat-cards.tsx`, `compute-conference-stats.ts`)
 - Exports: named exports for components used across files; default export avoided
 - Tests live in `__tests__/` subdirectory co-located with the source file
 - `src/lib/conferences/` — pure utility functions (no React); `src/components/conferences/` — React components
+- Chart tests: use `vi.mock("recharts", async () => import("@/lib/__mocks__/recharts"))` at the top of each test file
+- Chart __tests__ directory: `src/components/charts/__tests__/`
 
 ## Stack-Specific Notes
 - Vitest: jsdom environment, `@/` alias via `resolve.alias`, no global setup file
 - Testing library: `@testing-library/react` + `vitest`; use `screen.getByRole` for ARIA-based queries
 - Tailwind responsive grid: `grid-cols-2 sm:grid-cols-3 lg:grid-cols-5` works well for 5 stat cards
-
+- recharts mock shared module: `src/lib/__mocks__/recharts.tsx`
+- vitest config has no global setup file — mocks must be registered per test file

--- a/.ralph-team/progress.txt
+++ b/.ralph-team/progress.txt
@@ -87,3 +87,29 @@ Learnings:
   - Hierarchy endpoint needs flat mode for table consumers (board uses tree, table uses flat)
   - vitest config uses @/ alias via resolve.alias in vitest.config.ts
 
+
+--- Frontend Agent | Issue #296 ---
+Timestamp: 2026-03-02T02:50:00Z
+Branch: agent/frontend/issue-296
+Status: completed
+Changes:
+  - src/lib/__mocks__/recharts.tsx — NEW: Shared recharts mock for vitest/jsdom
+    (ResponsiveContainer, LineChart, AreaChart, BarChart, PieChart, ComposedChart, etc.)
+  - src/components/charts/__tests__/spark-line.test.tsx — NEW: 5 tests (dimensions, null for <2 pts, custom color)
+  - src/components/charts/__tests__/donut-chart.test.tsx — NEW: 4 tests (center label/value, size, single segment)
+Tests: 19 passed (5 test files: dashboard-trends, spark-line, donut-chart, use-dashboard-resource, personalized-dashboard)
+Key patterns:
+  - Dashboard visual refresh (DonutChart workload, StackedBarChart team status, SparkLine completed trend)
+    was already merged to main via PR #276 (squash commit ed0f418). The 3 unshipped commits
+    (e9d953f, 9ad5703, 76217b2) were squash-merged.
+  - Recharts mock pattern: vi.mock("recharts", async () => import("@/lib/__mocks__/recharts"))
+    Works without a global vitest setup file.
+  - SparkLine returns null for data.length < 2 — guards against single-point render.
+  - DonutChart accepts centerLabel + centerValue for inside-ring text overlay.
+  - focusKey state in PersonalizedDashboard drives interactive focus list (blocked/overdue/dueSoon/active).
+  - completedByDay sparkline is sliced to last 7 days (.slice(-7)) to match "Completed (7d)" label.
+  - teamStatusKeys legend humanizes WORKING_ON_TODAY → Working On Today via .replace() chain.
+Gotchas:
+  - Pre-existing TS errors in deals/ and analytics customer-journey files — not related to dashboard.
+  - recharts mock needs to cover ALL exports used by all chart components (LineChart, AreaChart, BarChart,
+    PieChart, ComposedChart, Bar, Line, Area, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend).

--- a/src/components/charts/__tests__/donut-chart.test.tsx
+++ b/src/components/charts/__tests__/donut-chart.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DonutChart } from "@/components/charts/donut-chart";
+
+vi.mock("recharts", async () => import("@/lib/__mocks__/recharts"));
+
+const segments = [
+  { name: "Blocked", value: 3, color: "#FC5A29" },
+  { name: "Active", value: 7, color: "#3b82f6" },
+];
+
+describe("DonutChart", () => {
+  it("renders center label and value when provided", () => {
+    render(
+      <DonutChart segments={segments} centerLabel="Total" centerValue="10" />
+    );
+    expect(screen.getByText("Total")).toBeTruthy();
+    expect(screen.getByText("10")).toBeTruthy();
+  });
+
+  it("renders without center overlay when neither prop is provided", () => {
+    const { queryByText } = render(<DonutChart segments={segments} />);
+    expect(queryByText("Total")).toBeNull();
+  });
+
+  it("uses the given size for the container", () => {
+    const { container } = render(<DonutChart segments={segments} size={120} />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.style.width).toBe("120px");
+    expect(wrapper.style.height).toBe("120px");
+  });
+
+  it("renders with a single segment without crashing", () => {
+    render(
+      <DonutChart
+        segments={[{ name: "All", value: 10 }]}
+        centerLabel="Tasks"
+        centerValue="10"
+      />
+    );
+    expect(screen.getByText("Tasks")).toBeTruthy();
+  });
+});

--- a/src/components/charts/__tests__/spark-line.test.tsx
+++ b/src/components/charts/__tests__/spark-line.test.tsx
@@ -1,0 +1,35 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SparkLine } from "@/components/charts/spark-line";
+
+vi.mock("recharts", async () => import("@/lib/__mocks__/recharts"));
+
+describe("SparkLine", () => {
+  it("renders a container element with the given dimensions", () => {
+    const { container } = render(<SparkLine data={[1, 3, 2, 5, 4]} width={56} height={20} />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper.style.width).toBe("56px");
+    expect(wrapper.style.height).toBe("20px");
+  });
+
+  it("returns null when data has fewer than 2 points", () => {
+    const { container } = render(<SparkLine data={[5]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null for empty data", () => {
+    const { container } = render(<SparkLine data={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders when given exactly 2 data points", () => {
+    const { container } = render(<SparkLine data={[1, 2]} />);
+    expect(container.firstChild).not.toBeNull();
+  });
+
+  it("accepts a custom color prop without crashing", () => {
+    const { container } = render(<SparkLine data={[1, 2, 3]} color="#FF0000" />);
+    expect(container.firstChild).not.toBeNull();
+  });
+});

--- a/src/lib/__mocks__/recharts.tsx
+++ b/src/lib/__mocks__/recharts.tsx
@@ -1,0 +1,60 @@
+/**
+ * Minimal recharts mock for vitest / jsdom.
+ *
+ * jsdom does not implement SVGElement layout, so Recharts' ResponsiveContainer
+ * cannot measure its container and often throws or renders nothing useful.
+ * This mock replaces every Recharts component with a lightweight passthrough so
+ * tests can assert on the data-driven output (aria labels, rendered text) rather
+ * than on chart internals.
+ *
+ * Usage in a test file:
+ *   vi.mock("recharts", async () => import("@/lib/__mocks__/recharts"));
+ */
+
+import type { ReactNode } from "react";
+
+function Passthrough({ children }: { children?: ReactNode }) {
+  return <div>{children}</div>;
+}
+
+function SvgPassthrough({ children }: { children?: ReactNode }) {
+  return <svg>{children}</svg>;
+}
+
+export const ResponsiveContainer = Passthrough;
+export const LineChart = SvgPassthrough;
+export const AreaChart = SvgPassthrough;
+export const BarChart = SvgPassthrough;
+export const PieChart = SvgPassthrough;
+export const ComposedChart = SvgPassthrough;
+
+export function Line() {
+  return <line />;
+}
+export function Area() {
+  return <path />;
+}
+export function Bar() {
+  return <rect />;
+}
+export function Pie() {
+  return <g />;
+}
+export function Cell() {
+  return null;
+}
+export function XAxis() {
+  return <g />;
+}
+export function YAxis() {
+  return <g />;
+}
+export function CartesianGrid() {
+  return <g />;
+}
+export function Tooltip() {
+  return null;
+}
+export function Legend() {
+  return null;
+}


### PR DESCRIPTION
## Summary

Closes #296.

The dashboard visual + interactive refresh (`/dashboard` page) was delivered in PR #276, which squash-merged the three reference commits (`e9d953f`, `9ad5703`, `76217b2`) from the unshipped `codex/dashboard-visual-interactive` branch. This PR adds the remaining test coverage for the chart primitives introduced by that refresh.

### What landed in PR #276 (already on `main`):
- **Interactive focus list**: `focusKey` state lets the workload donut legend drive a dynamic task list (Blocked / Overdue / Due Soon / Active); keyboard-accessible via Enter/Space
- **DonutChart workload ring**: visual breakdown of personal task load with color-coded segments
- **StackedBarChart team status**: humanized legend (e.g. `WORKING_ON_TODAY` → `Working On Today`)
- **SparkLine completed trend**: inline 7-day sparkline on the Completed (7d) metric card; `isAnimationActive={false}` for performance
- **`buildDailyCountSeriesUtc`**: utility that fills zero-counts for days with no completions

### What this PR adds on top:
- **`src/lib/__mocks__/recharts.tsx`** — Shared recharts mock for vitest/jsdom; covers all exports used by the chart suite (LineChart, AreaChart, BarChart, PieChart, ComposedChart, Bar, Line, Area, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend). Usage: `vi.mock("recharts", async () => import("@/lib/__mocks__/recharts"))`
- **`src/components/charts/__tests__/spark-line.test.tsx`** — 5 tests: dimensions, null guard for <2 data points, custom color
- **`src/components/charts/__tests__/donut-chart.test.tsx`** — 4 tests: center label/value overlay, size prop, single-segment edge case

## Test plan
- [x] `npx vitest run src/components/charts/__tests__/` — 9 tests pass
- [x] `npx vitest run src/components/dashboard/` — 8 tests pass (personalized dashboard + hook)
- [x] `npx vitest run src/lib/__tests__/dashboard-trends.test.ts` — 2 tests pass
- [x] `npx tsc --noEmit` — no errors in dashboard/chart files (pre-existing errors in deals/ and analytics/customer-journey/ are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)