### PR TITLE
feat(#148): Add entry animations and time-in-stage tooltips to VisualFunnel

### DIFF
--- a/.ralph-team/progress.txt
+++ b/.ralph-team/progress.txt
@@ -136,3 +136,21 @@ Gotchas:
   - Pre-existing TS errors in deals/ and analytics customer-journey files — not related to dashboard.
   - recharts mock needs to cover ALL exports used by all chart components (LineChart, AreaChart, BarChart,
     PieChart, ComposedChart, Bar, Line, Area, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend).
+
+--- Frontend Agent Iteration | Issue #148 ---
+Timestamp: 2026-03-02T02:50:00Z
+Branch: agent/frontend/issue-148
+Status: completed
+Changes:
+  - src/app/globals.css — Added funnel animation keyframes (funnel-enter, funnel-badge-enter, tooltip-fade-in) via @keyframes + @theme (Tailwind v4 syntax). motion-safe: variant in Tailwind v4 handles prefers-reduced-motion automatically.
+  - src/components/analytics/funnel-tooltip.tsx — NEW: Accessible tooltip component (role="tooltip", conditional render, dark mode aware, motion-safe:animate-tooltip-fade-in)
+  - src/components/analytics/visual-funnel.tsx — Extended FunnelStageData with optional avgDays; added staggered entry animations (motion-safe:animate-funnel-enter) on stage rows + badge; converted conversion badge div → button with onFocus/onBlur/onMouseEnter/onMouseLeave + aria-describedby; integrated FunnelTooltip; time formatting helper (days/hours/minutes)
+  - src/components/analytics/visual-funnel.test.tsx — NEW: 11 component tests covering tooltip on focus/hover, hours format, blur hides, no tooltip when avgDays absent, aria-describedby wiring, empty state, onStageClick
+Tests: 11 passed, 0 failed
+Learnings:
+  - Tailwind v4 custom animations: define @keyframes + register in @theme { --animate-<name>: ... } in globals.css; use animate-<name> and motion-safe:animate-<name> in JSX
+  - Tailwind v4 has no tailwind.config.ts — all theme extensions go in globals.css @theme block
+  - Tests co-located with components (not in __tests__ subdir) in this project
+  - fireEvent.focus() in jsdom correctly triggers onFocus handlers; no need for userEvent.tab() for tooltip trigger tests
+  - avgDays on conversion badge: tooltips show the time spent in the *previous* stage (prevStage.avgDays)
+  - VisualFunnel only renders stages whose label is in MAIN_PATH array — test data must use those labels

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -484,3 +484,43 @@ body {
   border-color: var(--ring);
   outline: none;
 }
+
+/* ─── Funnel Animation Keyframes ─── */
+@keyframes funnel-enter {
+  from {
+    opacity: 0;
+    transform: scaleX(0.85) translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: scaleX(1) translateY(0);
+  }
+}
+
+@keyframes funnel-badge-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes tooltip-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(3px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@theme {
+  --animate-funnel-enter: funnel-enter 0.4s ease-out both;
+  --animate-funnel-badge-enter: funnel-badge-enter 0.3s ease-out both;
+  --animate-tooltip-fade-in: tooltip-fade-in 0.15s ease-out both;
+}

--- a/src/components/analytics/funnel-tooltip.tsx
+++ b/src/components/analytics/funnel-tooltip.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+interface FunnelTooltipProps {
+  id: string;
+  content: string;
+  visible: boolean;
+  className?: string;
+}
+
+export function FunnelTooltip({ id, content, visible, className }: FunnelTooltipProps) {
+  if (!visible) return null;
+
+  return (
+    <div
+      id={id}
+      role="tooltip"
+      className={`absolute z-50 whitespace-nowrap rounded-md bg-gray-900 px-3 py-1.5 text-xs font-medium text-white shadow-lg pointer-events-none motion-safe:animate-tooltip-fade-in dark:bg-gray-700 ${className ?? ""}`}
+    >
+      {content}
+      <div className="absolute -bottom-1 left-1/2 h-2 w-2 -translate-x-1/2 rotate-45 bg-gray-900 dark:bg-gray-700" />
+    </div>
+  );
+}

--- a/src/components/analytics/visual-funnel.test.tsx
+++ b/src/components/analytics/visual-funnel.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { VisualFunnel, type FunnelStageData } from "@/components/analytics/visual-funnel";
+
+// Only stages in MAIN_PATH are rendered by VisualFunnel.
+// MAIN_PATH = ["Prospect","Lead","Demo Scheduled","Demo Follow-Up","Budgetary Quote Sent","Payment Link Sent","Subscription"]
+
+const baseStages: FunnelStageData[] = [
+  { id: "prospect", label: "Prospect", count: 100, value: 50000, avgDays: 3.2 },
+  { id: "lead", label: "Lead", count: 80, value: 40000, avgDays: 0.5 },
+  { id: "demo", label: "Demo Scheduled", count: 40, value: 20000 },
+];
+
+describe("VisualFunnel", () => {
+  it("renders stage labels", () => {
+    render(<VisualFunnel stages={baseStages} />);
+    expect(screen.getByText("Prospect")).toBeTruthy();
+    expect(screen.getByText("Lead")).toBeTruthy();
+    expect(screen.getByText("Demo Scheduled")).toBeTruthy();
+  });
+
+  it("renders conversion badges between stages", () => {
+    render(<VisualFunnel stages={baseStages} />);
+    // Lead/Prospect → 80/100 = 80%
+    expect(screen.getByText("80% conversion")).toBeTruthy();
+    // Demo Scheduled/Lead → 40/80 = 50%
+    expect(screen.getByText("50% conversion")).toBeTruthy();
+  });
+
+  it("shows tooltip with avgDays in days format on focus", () => {
+    render(<VisualFunnel stages={baseStages} />);
+    // Badge between Prospect→Lead shows Prospect's avgDays (3.2)
+    const badge = screen.getByRole("button", { name: /80% conversion/ });
+    fireEvent.focus(badge);
+    expect(screen.getByRole("tooltip")).toBeTruthy();
+    expect(screen.getByRole("tooltip").textContent).toContain("Avg: 3.2 days in stage");
+  });
+
+  it("shows tooltip with avgDays in hours format on focus", () => {
+    render(<VisualFunnel stages={baseStages} />);
+    // Badge between Lead→Demo Scheduled shows Lead's avgDays (0.5 → 12 hours)
+    const badge = screen.getByRole("button", { name: /50% conversion/ });
+    fireEvent.focus(badge);
+    expect(screen.getByRole("tooltip")).toBeTruthy();
+    expect(screen.getByRole("tooltip").textContent).toContain("Avg: 12 hours in stage");
+  });
+
+  it("hides tooltip after blur", () => {
+    render(<VisualFunnel stages={baseStages} />);
+    const badge = screen.getByRole("button", { name: /80% conversion/ });
+    fireEvent.focus(badge);
+    expect(screen.getByRole("tooltip")).toBeTruthy();
+    fireEvent.blur(badge);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("shows tooltip on mouse enter and hides on mouse leave", () => {
+    render(<VisualFunnel stages={baseStages} />);
+    const badge = screen.getByRole("button", { name: /80% conversion/ });
+    fireEvent.mouseEnter(badge);
+    expect(screen.getByRole("tooltip")).toBeTruthy();
+    fireEvent.mouseLeave(badge);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("does not render tooltip when avgDays is undefined", () => {
+    const stagesWithoutAvg: FunnelStageData[] = [
+      { id: "prospect", label: "Prospect", count: 100, value: 50000 },
+      { id: "lead", label: "Lead", count: 50, value: 25000 },
+    ];
+    render(<VisualFunnel stages={stagesWithoutAvg} />);
+    const badge = screen.getByRole("button", { name: /50% conversion/ });
+    fireEvent.focus(badge);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("has aria-describedby linking badge to tooltip id when avgDays present", () => {
+    render(<VisualFunnel stages={baseStages} />);
+    const badge = screen.getByRole("button", { name: /80% conversion/ });
+    expect(badge.getAttribute("aria-describedby")).toBeTruthy();
+  });
+
+  it("does not have aria-describedby when avgDays is absent", () => {
+    const stagesWithoutAvg: FunnelStageData[] = [
+      { id: "prospect", label: "Prospect", count: 100, value: 50000 },
+      { id: "lead", label: "Lead", count: 50, value: 25000 },
+    ];
+    render(<VisualFunnel stages={stagesWithoutAvg} />);
+    const badge = screen.getByRole("button", { name: /50% conversion/ });
+    expect(badge.getAttribute("aria-describedby")).toBeNull();
+  });
+
+  it("shows empty state when no matching MAIN_PATH stages provided", () => {
+    render(<VisualFunnel stages={[{ id: "x", label: "Unknown Stage", count: 5, value: 0 }]} />);
+    expect(screen.getByText("No pipeline stages available")).toBeTruthy();
+  });
+
+  it("calls onStageClick when a stage card is clicked", () => {
+    let clicked: FunnelStageData | null = null;
+    render(<VisualFunnel stages={baseStages} onStageClick={(s) => { clicked = s; }} />);
+    // The stage card is a div with onClick — find by role or by clicking the stage label area
+    fireEvent.click(screen.getByText("Prospect").closest("div[class*='cursor-pointer']")!);
+    expect(clicked).not.toBeNull();
+    expect((clicked as FunnelStageData | null)?.label).toBe("Prospect");
+  });
+});

--- a/src/components/analytics/visual-funnel.tsx
+++ b/src/components/analytics/visual-funnel.tsx
@@ -1,24 +1,26 @@
 "use client";
 
-import { useMemo } from "react";
-import { 
-  ArrowDown, 
-  Eye, 
-  Target, 
-  Calendar, 
-  MessageSquare, 
-  FileText, 
-  Link as LinkIcon, 
+import { useMemo, useState, useId } from "react";
+import {
+  ArrowDown,
+  Eye,
+  Target,
+  Calendar,
+  MessageSquare,
+  FileText,
+  Link as LinkIcon,
   CheckCircle2,
   TrendingUp,
   XCircle
 } from "lucide-react";
+import { FunnelTooltip } from "./funnel-tooltip";
 
 export interface FunnelStageData {
   id: string;
   label: string;
   count: number;
   value: number;
+  avgDays?: number;
 }
 
 interface VisualFunnelProps {
@@ -59,7 +61,24 @@ function getStageStyle(label: string, pct: number) {
   }
 }
 
+function formatTimeInStage(avgDays: number): string {
+  if (avgDays < 1 / 24) {
+    const minutes = Math.round(avgDays * 24 * 60);
+    return `Avg: ${minutes} min in stage`;
+  }
+  if (avgDays < 1) {
+    const hours = Math.round(avgDays * 24);
+    return `Avg: ${hours} hour${hours !== 1 ? "s" : ""} in stage`;
+  }
+  const days = parseFloat(avgDays.toFixed(1));
+  return `Avg: ${days} day${days === 1 ? "" : "s"} in stage`;
+}
+
 export function VisualFunnel({ stages, onStageClick }: VisualFunnelProps) {
+  const [hoveredBadgeIndex, setHoveredBadgeIndex] = useState<number | null>(null);
+  const [focusedBadgeIndex, setFocusedBadgeIndex] = useState<number | null>(null);
+  const tooltipIdPrefix = useId();
+
   const stageMap = useMemo(() => {
     const map = new Map<string, FunnelStageData>();
     stages.forEach((s) => map.set(s.label, s));
@@ -86,33 +105,64 @@ export function VisualFunnel({ stages, onStageClick }: VisualFunnelProps) {
     <div className="flex w-full flex-col items-center py-8">
       {/* Container for the connected line and nodes */}
       <div className="relative flex w-full max-w-2xl flex-col items-center">
-        
+
         {mainStages.map((stage, idx) => {
           const pct = Math.max((stage.count / maxCount) * 100, 15);
-          const hasNext = idx < mainStages.length - 1 || closedWon || closedLost;
           const prevCount = idx > 0 ? mainStages[idx - 1].count : null;
           const conversion = prevCount ? Math.round((stage.count / prevCount) * 100) : null;
-          
+          // avgDays lives on the *previous* stage (time to get from prev → current)
+          const prevStage = idx > 0 ? mainStages[idx - 1] : null;
+          const badgeAvgDays = prevStage?.avgDays;
+          const tooltipId = `${tooltipIdPrefix}-tooltip-${idx}`;
+          const isTooltipVisible =
+            (hoveredBadgeIndex === idx || focusedBadgeIndex === idx) &&
+            badgeAvgDays != null;
+
           const { icon: StageIcon, color, bg, border, gradient } = getStageStyle(stage.label, pct);
 
           return (
-            <div key={stage.id} className="relative flex w-full flex-col items-center group/stage">
+            <div
+              key={stage.id}
+              className="relative flex w-full flex-col items-center group/stage motion-safe:animate-funnel-enter"
+              style={{ animationDelay: `${idx * 80}ms` }}
+            >
               {/* Vertical connector line from previous stage */}
               {idx > 0 && (
                 <div className="relative flex h-12 w-full items-center justify-center">
                   <div className="absolute top-0 bottom-0 w-px bg-gradient-to-b from-border/80 to-border/30" />
-                  
+
                   {/* Conversion Badge */}
                   {conversion !== null && (
-                    <div className="relative z-10 rounded-full border border-border/50 bg-background/95 px-3 py-1 text-[11px] font-medium text-muted-foreground shadow-sm backdrop-blur-sm transition-colors group-hover/stage:border-border group-hover/stage:text-foreground">
-                      {conversion}% conversion
+                    <div className="relative flex justify-center">
+                      <button
+                        type="button"
+                        className="relative z-10 rounded-full border border-border/50 bg-background/95 px-3 py-1 text-[11px] font-medium text-muted-foreground shadow-sm backdrop-blur-sm transition-colors group-hover/stage:border-border group-hover/stage:text-foreground hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary cursor-default motion-safe:animate-funnel-badge-enter"
+                        style={{ animationDelay: `${idx * 80 + 40}ms` }}
+                        aria-label={`${conversion}% conversion${badgeAvgDays != null ? `. ${formatTimeInStage(badgeAvgDays)}` : ""}`}
+                        aria-describedby={badgeAvgDays != null ? tooltipId : undefined}
+                        onMouseEnter={() => setHoveredBadgeIndex(idx)}
+                        onMouseLeave={() => setHoveredBadgeIndex(null)}
+                        onFocus={() => setFocusedBadgeIndex(idx)}
+                        onBlur={() => setFocusedBadgeIndex(null)}
+                      >
+                        {conversion}% conversion
+                      </button>
+
+                      {badgeAvgDays != null && (
+                        <FunnelTooltip
+                          id={tooltipId}
+                          content={formatTimeInStage(badgeAvgDays)}
+                          visible={isTooltipVisible}
+                          className="absolute -top-9 left-1/2 -translate-x-1/2"
+                        />
+                      )}
                     </div>
                   )}
                 </div>
               )}
 
               {/* Stage Card */}
-              <div 
+              <div
                 className={`relative flex w-full cursor-pointer items-center overflow-hidden rounded-xl border bg-card p-4 shadow-sm transition-all duration-300 hover:-translate-y-0.5 hover:shadow-md ${border}`}
                 onClick={() => onStageClick?.(stage)}
               >
@@ -120,10 +170,10 @@ export function VisualFunnel({ stages, onStageClick }: VisualFunnelProps) {
                 <div className="absolute inset-x-0 bottom-0 top-0 opacity-0 transition-opacity duration-300 group-hover/stage:opacity-100">
                   <div className={`absolute inset-0 bg-gradient-to-r from-transparent via-transparent ${gradient}`} />
                 </div>
-                
+
                 {/* Subtle percentage indicator on the left edge */}
-                <div 
-                  className={`absolute left-0 top-0 bottom-0 w-1 ${bg} opacity-50`} 
+                <div
+                  className={`absolute left-0 top-0 bottom-0 w-1 ${bg} opacity-50`}
                   style={{ height: `${pct}%`, top: 'auto', bottom: 0 }}
                 />
 
@@ -138,12 +188,12 @@ export function VisualFunnel({ stages, onStageClick }: VisualFunnelProps) {
                   <div className="flex flex-1 flex-col">
                     <h4 className="text-base font-semibold tracking-tight text-foreground">{stage.label}</h4>
                     <div className="mt-1 flex items-center gap-3">
-                      
+
                       {/* Completion bar mini */}
                       <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-secondary/50">
-                        <div 
-                          className={`h-full rounded-full bg-current ${color}`} 
-                          style={{ width: `${pct}%` }} 
+                        <div
+                          className={`h-full rounded-full bg-current ${color}`}
+                          style={{ width: `${pct}%` }}
                         />
                       </div>
                       <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
@@ -175,7 +225,7 @@ export function VisualFunnel({ stages, onStageClick }: VisualFunnelProps) {
             <div className="absolute -top-2 left-1/4 right-1/4 h-8 border-t border-l border-r border-border/50 rounded-t-xl" />
             <div className="absolute top-6 left-1/4 h-6 w-px bg-border/50" />
             <div className="absolute top-6 right-1/4 h-6 w-px bg-border/50" />
-            
+
             {/* Closed Won Branch */}
             <div className="flex w-1/2 flex-col items-center px-3 pt-12">
               <div className="group flex w-full flex-col items-center justify-center rounded-xl border border-emerald-500/20 bg-gradient-to-b from-emerald-500/5 to-transparent p-5 text-center shadow-sm transition-all hover:-translate-y-0.5 hover:border-emerald-500/40 hover:shadow-md">


### PR DESCRIPTION
## Summary

- **Entry animations**: Staggered CSS keyframe animations on funnel stage cards and conversion badges via `motion-safe:animate-funnel-enter` — automatically respects `prefers-reduced-motion` using Tailwind v4's built-in `motion-safe:` variant
- **Accessible tooltips**: Conversion badges between stages are now `<button>` elements with `onFocus`/`onBlur`/`onMouseEnter`/`onMouseLeave` handlers; `FunnelTooltip` component shows avg time-in-stage (days/hours/minutes) with `role="tooltip"` and `aria-describedby` linkage
- **Graceful degradation**: Tooltips only render when `avgDays` is provided on `FunnelStageData`; existing consumers without `avgDays` work unchanged
- **New `FunnelTooltip` component**: Reusable, dark-mode aware tooltip with `role="tooltip"` ARIA semantics

## Files Changed

| File | Change |
|---|---|
| `src/components/analytics/visual-funnel.tsx` | Extended `FunnelStageData` with optional `avgDays`; converted badge div→button; added animations + tooltip integration |
| `src/components/analytics/funnel-tooltip.tsx` | **New**: Accessible tooltip component |
| `src/app/globals.css` | Added `@keyframes` + `@theme` registrations for funnel animations (Tailwind v4) |
| `src/components/analytics/visual-funnel.test.tsx` | **New**: 11 component tests |

## Test plan

- [x] 11 vitest component tests pass (`npm test -- visual-funnel`)
- [x] Tooltip appears on keyboard focus (button element, `onFocus` handler)
- [x] Tooltip appears on hover (`onMouseEnter`)
- [x] Tooltip hides on blur/mouse leave
- [x] Correct format: days (3.2 → "3.2 days"), hours (0.5 → "12 hours")
- [x] No tooltip when `avgDays` is absent — `aria-describedby` also absent
- [x] `aria-describedby` links badge to tooltip `id`
- [x] Empty state renders when no MAIN_PATH stages present
- [x] Animations use `motion-safe:` — reduced-motion users unaffected

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)