### PR TITLE
feat(analytics): complete HubSpot contact attribution on customer journey

### DIFF
--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -228,6 +228,7 @@ const SECTION_DOMAINS: Record<string, DomainKey[]> = {
   ],
   "cj-overview": ["hubspot", "stripe", "googleWorkspace", "slack", "webflow", "googleAnalytics", "googleAds", "metaAds", "instagram", "redditAds", "pylon", "customerJourney"],
   "cj-touchpoints": ["hubspot", "stripe", "googleWorkspace", "slack", "webflow", "googleAnalytics", "googleAds", "metaAds", "instagram", "redditAds", "pylon", "customerJourney"],
+  "cj-conversion": ["hubspot", "stripe", "googleWorkspace", "slack", "webflow", "googleAnalytics", "googleAds", "metaAds", "instagram", "redditAds", "pylon", "customerJourney"],
 
   "demo-analytics": [
     "hubspot", "googleWorkspace", "demoAnalytics",
@@ -1103,9 +1104,6 @@ export async function GET(request: Request) {
   }
   if (domains.has("distilledInsights")) {
     result.distilledInsights = buildDistilledInsights(result);
-  }
-  if (domains.has("customerJourney")) {
-    result.customerJourney = buildCustomerJourneyData(result);
   }
   if (domains.has("demoAnalytics")) {
     result.demoAnalytics = buildDemoAnalyticsData(result);

--- a/src/components/analytics/customer-journey-drill-down.tsx
+++ b/src/components/analytics/customer-journey-drill-down.tsx
@@ -20,6 +20,14 @@ const CHANNEL_LABELS: Record<TouchpointChannel, string> = {
   "reddit-ads": "Reddit Ads",
   pylon: "Pylon",
   mercury: "Mercury",
+  "paid-search": "Paid Search",
+  "paid-social": "Paid Social",
+  "organic-search": "Organic Search",
+  referral: "Referral",
+  direct: "Direct",
+  email: "Email",
+  partner: "Partner",
+  outbound: "Outbound",
 };
 
 const CHANNEL_COLORS: Record<TouchpointChannel, string> = {
@@ -35,6 +43,14 @@ const CHANNEL_COLORS: Record<TouchpointChannel, string> = {
   "reddit-ads": "#ff4500",
   pylon: "#6366f1",
   mercury: "#1c1c1e",
+  "paid-search": "#34a853",
+  "paid-social": "#1877f2",
+  "organic-search": "#fbbc04",
+  referral: "#ea4335",
+  direct: "#9aa0a6",
+  email: "#f59e0b",
+  partner: "#8b5cf6",
+  outbound: "#10b981",
 };
 
 function fmt$(n: number) {

--- a/src/components/analytics/customer-journey-tab.tsx
+++ b/src/components/analytics/customer-journey-tab.tsx
@@ -27,6 +27,14 @@ const CHANNEL_LABELS: Record<TouchpointChannel, string> = {
   "reddit-ads": "Reddit Ads",
   pylon: "Pylon",
   mercury: "Mercury",
+  "paid-search": "Paid Search",
+  "paid-social": "Paid Social",
+  "organic-search": "Organic Search",
+  referral: "Referral",
+  direct: "Direct",
+  email: "Email",
+  partner: "Partner",
+  outbound: "Outbound",
 };
 
 const CHANNEL_COLORS: Record<TouchpointChannel, string> = {
@@ -42,6 +50,14 @@ const CHANNEL_COLORS: Record<TouchpointChannel, string> = {
   "reddit-ads": "#ff4500",
   pylon: "#6366f1",
   mercury: "#1c1c1e",
+  "paid-search": "#34a853",
+  "paid-social": "#1877f2",
+  "organic-search": "#fbbc04",
+  referral: "#ea4335",
+  direct: "#9aa0a6",
+  email: "#f59e0b",
+  partner: "#8b5cf6",
+  outbound: "#10b981",
 };
 
 export function CustomerJourneyTab({ data }: { data: AnalyticsDashboardData | null }) {

--- a/src/lib/__tests__/analytics-customer-journey.test.ts
+++ b/src/lib/__tests__/analytics-customer-journey.test.ts
@@ -1,9 +1,24 @@
 import { describe, expect, it } from "vitest";
 import { buildCustomerJourneyData } from "@/lib/analytics/customer-journey";
 import { createEmptyAnalyticsDashboardData } from "@/lib/analytics/response-shape";
-import type { AnalyticsDashboardData } from "@/lib/analytics/types";
+import type { AnalyticsDashboardData, HubSpotData } from "@/lib/analytics/types";
 
 const META = { fetchedAt: "2026-02-10T00:00:00.000Z", nextRefresh: "2026-02-10T01:00:00.000Z", source: "live" as const };
+
+type DealInput = NonNullable<HubSpotData["deals"]>[number];
+
+function deal(overrides: Partial<DealInput> & Pick<DealInput, "dealId" | "dealName" | "stageId" | "stageLabel" | "amount" | "source">): DealInput {
+  return {
+    ownerId: null,
+    createdAt: "2026-02-01T00:00:00.000Z",
+    updatedAt: "2026-02-10T00:00:00.000Z",
+    pipelineId: null,
+    contactIds: [],
+    primaryContactId: null,
+    primaryContactEmail: null,
+    ...overrides,
+  };
+}
 
 function baseData(): AnalyticsDashboardData {
   return createEmptyAnalyticsDashboardData({
@@ -18,99 +33,65 @@ function baseData(): AnalyticsDashboardData {
   });
 }
 
+const MINIMAL_FUNNEL = {
+  totalDeals: 1, closedWon: 0, closedLost: 0, unlikely: 0, churn: 0,
+  activeSubscriptions: 0, noShows: 0, demoScheduled: 0, demoFollowUp: 0,
+  avgDealSize: 0, winRate: 0, effectiveWinRate: 0, noShowRate: 0,
+  stages: [] as { stageId: string; label: string; count: number; value: number }[],
+  dealsBySource: [] as { source: string; count: number; value: number }[],
+};
+
+const MINIMAL_CONTACTS = { totalContacts: 0, recentContacts: 0, bySource: [] as { source: string; count: number }[] };
+
 describe("buildCustomerJourneyData", () => {
   it("builds journeys, touchpoint summary, and attribution from hubspot deals", () => {
     const data = baseData();
     data.hubspot = {
       funnel: {
+        ...MINIMAL_FUNNEL,
         totalDeals: 2,
         closedWon: 1,
-        closedLost: 0,
-        unlikely: 0,
-        churn: 0,
         activeSubscriptions: 1,
-        noShows: 0,
         demoScheduled: 1,
         demoFollowUp: 1,
         avgDealSize: 4000,
         winRate: 50,
         effectiveWinRate: 40,
-        noShowRate: 0,
         stages: [
           { stageId: "lead", label: "Lead", count: 1, value: 5000 },
           { stageId: "demo", label: "Demo Scheduled", count: 1, value: 3000 },
         ],
         dealsBySource: [{ source: "Organic", count: 2, value: 8000 }],
       },
-      contacts: {
-        totalContacts: 10,
-        recentContacts: 2,
-        bySource: [],
-      },
+      contacts: { totalContacts: 10, recentContacts: 2, bySource: [] },
       deals: [
-        {
-          dealId: "deal-1",
-          dealName: "Acme Corp",
-          stageId: "lead",
-          stageLabel: "Lead",
-          amount: 5000,
-          source: "Organic",
-          ownerId: "owner-1",
-          createdAt: "2026-02-01T00:00:00.000Z",
-          updatedAt: "2026-02-10T00:00:00.000Z",
-        },
-        {
-          dealId: "deal-2",
-          dealName: "Beta LLC",
-          stageId: "demo",
-          stageLabel: "Demo Scheduled",
-          amount: 3000,
-          source: "Paid",
-          ownerId: "owner-2",
-          createdAt: "2026-02-02T00:00:00.000Z",
-          updatedAt: "2026-02-11T00:00:00.000Z",
-        },
+        deal({
+          dealId: "deal-1", dealName: "Acme Corp", stageId: "lead", stageLabel: "Lead",
+          amount: 5000, source: "Organic", ownerId: "owner-1",
+        }),
+        deal({
+          dealId: "deal-2", dealName: "Beta LLC", stageId: "demo", stageLabel: "Demo Scheduled",
+          amount: 3000, source: "Paid", ownerId: "owner-2",
+          createdAt: "2026-02-02T00:00:00.000Z", updatedAt: "2026-02-11T00:00:00.000Z",
+        }),
       ],
       _meta: META,
     };
 
     data.stripe = {
       revenue: {
-        mrr: 12000,
-        mrrChange: 2,
-        totalRevenue30d: 15000,
-        totalRevenuePrev30d: 14000,
-        revenueGrowth: 7.1,
-        avgRevenuePerCustomer: 600,
+        mrr: 12000, mrrChange: 2, totalRevenue30d: 15000,
+        totalRevenuePrev30d: 14000, revenueGrowth: 7.1, avgRevenuePerCustomer: 600,
       },
-      subscriptions: {
-        active: 20,
-        pastDue: 1,
-        canceled: 0,
-        trialing: 2,
-        churnRate: 0.02,
-        recentChurnEvents: [],
-      },
-      payments: {
-        succeeded: 100,
-        failed: 2,
-        successRate: 0.98,
-      },
+      subscriptions: { active: 20, pastDue: 1, canceled: 0, trialing: 2, churnRate: 0.02, recentChurnEvents: [] },
+      payments: { succeeded: 100, failed: 2, successRate: 0.98 },
       revenueTrend: [],
       _meta: META,
     };
 
     data.googleAds = {
-      totalSpend30d: 1000,
-      totalImpressions: 10000,
-      totalClicks: 200,
-      totalConversions: 10,
-      ctr: 2,
-      cpc: 5,
-      cpa: 100,
-      roas: 1,
-      campaigns: [],
-      _meta: META,
+      totalSpend30d: 1000, totalImpressions: 10000, totalClicks: 200, totalConversions: 10,
+      ctr: 2, cpc: 5, cpa: 100, roas: 1, campaigns: [], _meta: META,
     };
 
     const journey = buildCustomerJourneyData(data);
@@ -120,5 +101,138 @@ describe("buildCustomerJourneyData", () => {
     expect(journey.topPaths.length).toBeGreaterThan(0);
     expect(journey.attribution.length).toBeGreaterThan(0);
     expect(journey.avgTouchpoints).toBeGreaterThan(0);
+  });
+
+  it("populates stageOrder from pipeline stages", () => {
+    const data = baseData();
+    data.hubspot = {
+      funnel: MINIMAL_FUNNEL,
+      contacts: MINIMAL_CONTACTS,
+      pipelineStages: [
+        { stageId: "s1", label: "Lead" },
+        { stageId: "s2", label: "Demo" },
+        { stageId: "s3", label: "Won" },
+      ],
+      deals: [
+        deal({ dealId: "deal-1", dealName: "Test", stageId: "s1", stageLabel: "Lead", amount: 1000, source: "Organic" }),
+      ],
+      _meta: META,
+    };
+
+    const journey = buildCustomerJourneyData(data);
+    expect(journey.stageOrder).toEqual(["Lead", "Demo", "Won"]);
+    expect(journey.stageOrderSource).toBe("pipeline");
+  });
+
+  it("falls back to canonical stage order when no pipeline stages", () => {
+    const data = baseData();
+    data.hubspot = {
+      funnel: MINIMAL_FUNNEL,
+      contacts: MINIMAL_CONTACTS,
+      deals: [
+        deal({ dealId: "deal-1", dealName: "Test", stageId: "s1", stageLabel: "Lead", amount: 1000, source: "Organic" }),
+      ],
+      _meta: META,
+    };
+
+    const journey = buildCustomerJourneyData(data);
+    expect(journey.stageOrderSource).toBe("fallback");
+    expect(journey.stageOrder!.length).toBeGreaterThan(0);
+    expect(journey.stageOrder).toContain("Lead");
+    expect(journey.stageOrder).toContain("Closed Won");
+  });
+
+  it("generates synthetic touchpoints from contact analytics", () => {
+    const data = baseData();
+    data.hubspot = {
+      funnel: MINIMAL_FUNNEL,
+      contacts: MINIMAL_CONTACTS,
+      deals: [
+        deal({
+          dealId: "deal-1",
+          dealName: "Organic Deal",
+          stageId: "lead",
+          stageLabel: "Lead",
+          amount: 5000,
+          source: "ORGANIC_SEARCH",
+          primaryContactAnalytics: {
+            source: "ORGANIC_SEARCH",
+            sourceData1: "google",
+            sourceData2: null,
+            firstSeenAt: "2026-01-15T10:00:00.000Z",
+            lastSeenAt: "2026-01-20T14:00:00.000Z",
+            firstUrl: "https://example.com/pricing",
+            lastUrl: "https://example.com/demo",
+            numVisits: 5,
+            numPageViews: 12,
+            utmSource: "google",
+            utmMedium: "organic",
+            utmCampaign: null,
+          },
+        }),
+      ],
+      _meta: META,
+    };
+
+    const journey = buildCustomerJourneyData(data);
+    expect(journey.journeys).toHaveLength(1);
+
+    const j = journey.journeys[0];
+    const organicTouchpoints = j.touchpoints.filter((tp) => tp.channel === "organic-search");
+    expect(organicTouchpoints.length).toBeGreaterThanOrEqual(1);
+
+    // First-seen touchpoint should have awareness phase
+    const firstSeen = organicTouchpoints.find((tp) => tp.type === "first-touch");
+    expect(firstSeen).toBeDefined();
+    expect(firstSeen!.phase).toBe("awareness");
+    expect(firstSeen!.timestamp).toBe("2026-01-15T10:00:00.000Z");
+
+    // Last-seen touchpoint should have website phase
+    const lastSeen = organicTouchpoints.find((tp) => tp.type === "engagement");
+    expect(lastSeen).toBeDefined();
+    expect(lastSeen!.phase).toBe("website");
+
+    // Attribution table should include organic-search
+    const organicAttribution = journey.attribution.find((a) => a.channel === "organic-search");
+    expect(organicAttribution).toBeDefined();
+  });
+
+  it("maps paid-search from CPC utm_medium", () => {
+    const data = baseData();
+    data.hubspot = {
+      funnel: MINIMAL_FUNNEL,
+      contacts: MINIMAL_CONTACTS,
+      deals: [
+        deal({
+          dealId: "deal-cpc",
+          dealName: "CPC Deal",
+          stageId: "lead",
+          stageLabel: "Lead",
+          amount: 2000,
+          source: "OTHER_CAMPAIGNS",
+          primaryContactAnalytics: {
+            source: "OTHER_CAMPAIGNS",
+            sourceData1: null,
+            sourceData2: null,
+            firstSeenAt: "2026-01-10T08:00:00.000Z",
+            lastSeenAt: null,
+            firstUrl: null,
+            lastUrl: null,
+            numVisits: 1,
+            numPageViews: 2,
+            utmSource: "google",
+            utmMedium: "cpc",
+            utmCampaign: "brand-q1",
+          },
+        }),
+      ],
+      _meta: META,
+    };
+
+    const journey = buildCustomerJourneyData(data);
+    const j = journey.journeys[0];
+    const paidSearch = j.touchpoints.filter((tp) => tp.channel === "paid-search");
+    expect(paidSearch.length).toBeGreaterThanOrEqual(1);
+    expect(paidSearch[0].detail).toContain("cpc");
   });
 });

--- a/src/lib/analytics/customer-journey-conversion.ts
+++ b/src/lib/analytics/customer-journey-conversion.ts
@@ -35,7 +35,7 @@ export interface PathConversionRow {
 
 export const CLOSE_STAGES = new Set(["Closed Won", "Subscription", "Active"]);
 
-const CANONICAL_STAGE_ORDER = [
+export const CANONICAL_STAGE_ORDER = [
   "Prospect",
   "Lead",
   "Demo Scheduled",
@@ -67,6 +67,14 @@ export const CHANNEL_LABELS: Record<TouchpointChannel, string> = {
   "reddit-ads": "Reddit Ads",
   pylon: "Pylon",
   mercury: "Mercury",
+  "paid-search": "Paid Search",
+  "paid-social": "Paid Social",
+  "organic-search": "Organic Search",
+  referral: "Referral",
+  direct: "Direct",
+  email: "Email",
+  partner: "Partner",
+  outbound: "Outbound",
 };
 
 export const CHANNEL_COLORS: Record<TouchpointChannel, string> = {
@@ -82,6 +90,14 @@ export const CHANNEL_COLORS: Record<TouchpointChannel, string> = {
   "reddit-ads": "#ff4500",
   pylon: "#6366f1",
   mercury: "#1c1c1e",
+  "paid-search": "#34a853",
+  "paid-social": "#1877f2",
+  "organic-search": "#fbbc04",
+  referral: "#ea4335",
+  direct: "#9aa0a6",
+  email: "#f59e0b",
+  partner: "#8b5cf6",
+  outbound: "#10b981",
 };
 
 export function pct(numerator: number, denominator: number): number {

--- a/src/lib/analytics/customer-journey.ts
+++ b/src/lib/analytics/customer-journey.ts
@@ -1,5 +1,6 @@
 import type {
   AnalyticsDashboardData,
+  BuyerJourneyPhase,
   ChannelAttribution,
   CustomerJourneyData,
   CustomerJourneyRecord,
@@ -8,6 +9,33 @@ import type {
   TouchpointChannel,
   TouchpointSummary,
 } from "@/lib/analytics/types";
+import { CANONICAL_STAGE_ORDER } from "@/lib/analytics/customer-journey-conversion";
+
+// ── HubSpot source → synthetic channel mapping ──
+
+function mapHubSpotSourceToChannel(
+  source: string | null,
+  utmMedium: string | null,
+): TouchpointChannel | null {
+  const s = (source ?? "").toUpperCase();
+  const medium = (utmMedium ?? "").toLowerCase();
+
+  // UTM medium overrides can refine the mapping
+  if (medium.includes("cpc") || medium.includes("ppc")) return "paid-search";
+
+  switch (s) {
+    case "PAID_SEARCH": return "paid-search";
+    case "PAID_SOCIAL": return "paid-social";
+    case "ORGANIC_SEARCH": return "organic-search";
+    case "ORGANIC_SOCIAL": return "referral";
+    case "REFERRALS": return "referral";
+    case "DIRECT_TRAFFIC": return "direct";
+    case "EMAIL_MARKETING": return "email";
+    case "OTHER_CAMPAIGNS": return "email";
+    case "OFFLINE_SOURCES": return "outbound";
+    default: return null;
+  }
+}
 
 // ── Touchpoint extraction from each domain ──
 
@@ -144,6 +172,60 @@ function telemetryTouchpoints(
   }];
 }
 
+// ── Synthetic touchpoints from HubSpot contact analytics ──
+
+function contactAnalyticsTouchpoints(data: AnalyticsDashboardData): Map<string, Touchpoint[]> {
+  const dealTouchpoints = new Map<string, Touchpoint[]>();
+  const deals = data.hubspot?.deals ?? [];
+
+  for (const deal of deals) {
+    const analytics = deal.primaryContactAnalytics;
+    if (!analytics?.source) continue;
+
+    const channel = mapHubSpotSourceToChannel(analytics.source, analytics.utmMedium);
+    if (!channel) continue;
+
+    const touchpoints: Touchpoint[] = [];
+
+    // First-seen touchpoint (awareness phase)
+    if (analytics.firstSeenAt) {
+      const detail = [
+        analytics.utmSource && `src=${analytics.utmSource}`,
+        analytics.utmMedium && `med=${analytics.utmMedium}`,
+        analytics.utmCampaign && `cmp=${analytics.utmCampaign}`,
+      ].filter(Boolean).join(", ");
+
+      touchpoints.push({
+        timestamp: analytics.firstSeenAt,
+        phase: "awareness" as BuyerJourneyPhase,
+        channel,
+        type: "first-touch",
+        detail: detail || `${analytics.source} (first visit)`,
+        value: null,
+      });
+    }
+
+    // Last-seen touchpoint (website phase — only if distinct from first-seen)
+    if (analytics.lastSeenAt && analytics.lastSeenAt !== analytics.firstSeenAt) {
+      const url = analytics.lastUrl || analytics.firstUrl;
+      touchpoints.push({
+        timestamp: analytics.lastSeenAt,
+        phase: "website" as BuyerJourneyPhase,
+        channel,
+        type: "engagement",
+        detail: url ? `Last page: ${url}` : `${analytics.source} (return visit)`,
+        value: null,
+      });
+    }
+
+    if (touchpoints.length > 0) {
+      dealTouchpoints.set(deal.dealId, touchpoints);
+    }
+  }
+
+  return dealTouchpoints;
+}
+
 // ── Journey assembly ──
 
 function buildJourneys(data: AnalyticsDashboardData): CustomerJourneyRecord[] {
@@ -161,13 +243,21 @@ function buildJourneys(data: AnalyticsDashboardData): CustomerJourneyRecord[] {
     ...telemetryTouchpoints(data, "slack", "slack"),
   ].sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
 
+  // Per-deal synthetic touchpoints from HubSpot contact analytics
+  const perDealContactTouchpoints = contactAnalyticsTouchpoints(data);
+
   return deals.map((deal) => {
-    const dealTouchpoints = allTouchpoints.filter(
+    const sharedTouchpoints = allTouchpoints.filter(
       (tp) =>
         tp.detail.includes(deal.dealName) ||
         tp.channel === "hubspot" ||
         tp.type === "first-touch"
     );
+
+    // Merge shared touchpoints with deal-specific contact analytics touchpoints
+    const dealContactTps = perDealContactTouchpoints.get(deal.dealId) ?? [];
+    const dealTouchpoints = [...dealContactTps, ...sharedTouchpoints]
+      .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
 
     const timestamps = dealTouchpoints.map((tp) => new Date(tp.timestamp).getTime());
     const firstTouch = timestamps.length > 0 ? new Date(Math.min(...timestamps)).toISOString() : new Date().toISOString();
@@ -177,7 +267,7 @@ function buildJourneys(data: AnalyticsDashboardData): CustomerJourneyRecord[] {
     return {
       dealId: deal.dealId,
       dealName: deal.dealName,
-      contactEmail: null,
+      contactEmail: deal.primaryContactEmail ?? null,
       currentStage: deal.stageLabel,
       value: deal.amount,
       touchpoints: dealTouchpoints,
@@ -339,6 +429,14 @@ export function buildCustomerJourneyData(data: AnalyticsDashboardData): Customer
   const avgTouchpoints = journeys.length > 0 ? Math.round((totalTouchpoints / journeys.length) * 10) / 10 : 0;
   const medianDaysToClose = median(journeys.map((j) => j.daysInPipeline));
 
+  // Derive stage ordering from HubSpot pipeline metadata or fall back to canonical order
+  const pipelineStages = data.hubspot?.pipelineStages;
+  const stageOrder = pipelineStages && pipelineStages.length > 0
+    ? pipelineStages.map((s) => s.label)
+    : [...CANONICAL_STAGE_ORDER];
+  const stageOrderSource: "pipeline" | "fallback" =
+    pipelineStages && pipelineStages.length > 0 ? "pipeline" : "fallback";
+
   return {
     journeys,
     touchpointSummary,
@@ -346,5 +444,7 @@ export function buildCustomerJourneyData(data: AnalyticsDashboardData): Customer
     medianDaysToClose,
     topPaths: buildTopPaths(journeys),
     attribution: buildAttribution(journeys, data),
+    stageOrder,
+    stageOrderSource,
   };
 }

--- a/src/lib/analytics/fetchers.ts
+++ b/src/lib/analytics/fetchers.ts
@@ -597,6 +597,23 @@ export async function fetchHubSpotData(
     // Non-critical — skip
   }
 
+  // ── Enrich deals with contact analytics for attribution ──
+  try {
+    const dealIdsForContacts = deals.map((d) => d.dealId).filter(Boolean);
+    const contactAnalytics = await fetchDealContactAnalytics(baseUrl, headers, dealIdsForContacts);
+    for (const deal of deals) {
+      const analytics = contactAnalytics.get(deal.dealId);
+      if (analytics) {
+        (deal as Record<string, unknown>).contactIds = analytics.contactIds;
+        (deal as Record<string, unknown>).primaryContactId = analytics.primaryContactId;
+        (deal as Record<string, unknown>).primaryContactEmail = analytics.primaryContactEmail;
+        (deal as Record<string, unknown>).primaryContactAnalytics = analytics.primaryContactAnalytics;
+      }
+    }
+  } catch {
+    // Non-critical — attribution will fall back to deal-level signals only
+  }
+
   const meta = makeMeta("live");
   meta.diagnostics = {
     dealsFetched,
@@ -649,6 +666,153 @@ export async function fetchHubSpotData(
     deals,
     _meta: meta,
   };
+}
+
+// ── Contact analytics enrichment for attribution ──
+
+interface ContactAnalyticsResult {
+  contactIds: string[];
+  primaryContactId: string | null;
+  primaryContactEmail: string | null;
+  primaryContactAnalytics: {
+    createdAt?: string | null;
+    source: string | null;
+    sourceData1: string | null;
+    sourceData2: string | null;
+    firstSeenAt: string | null;
+    lastSeenAt: string | null;
+    firstUrl: string | null;
+    lastUrl: string | null;
+    numVisits: number | null;
+    numPageViews: number | null;
+    utmSource: string | null;
+    utmMedium: string | null;
+    utmCampaign: string | null;
+  } | undefined;
+}
+
+const CONTACT_ANALYTICS_PROPERTIES = [
+  "email",
+  "createdate",
+  "hs_analytics_source",
+  "hs_analytics_source_data_1",
+  "hs_analytics_source_data_2",
+  "hs_analytics_first_url",
+  "hs_analytics_last_url",
+  "hs_analytics_num_visits",
+  "hs_analytics_num_page_views",
+  "hs_analytics_first_timestamp",
+  "hs_analytics_last_timestamp",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+];
+
+async function fetchDealContactAnalytics(
+  baseUrl: string,
+  headers: Record<string, string>,
+  dealIds: string[],
+): Promise<Map<string, ContactAnalyticsResult>> {
+  const resultMap = new Map<string, ContactAnalyticsResult>();
+  if (dealIds.length === 0) return resultMap;
+
+  // Step 1: Batch-fetch deal→contact associations (100 per batch)
+  const dealContactMap = new Map<string, string[]>();
+  const batchSize = 100;
+
+  for (let i = 0; i < dealIds.length; i += batchSize) {
+    const batch = dealIds.slice(i, i + batchSize);
+    try {
+      const res = await fetch(`${baseUrl}/crm/v4/associations/deal/contact/batch/read`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ inputs: batch.map((id) => ({ id })) }),
+      });
+      if (!res.ok) continue;
+      const data = await res.json();
+      for (const result of data.results ?? []) {
+        const fromId = String(result.from?.id ?? "");
+        const toIds = (result.to ?? []).map((t: { toObjectId?: number }) => String(t.toObjectId ?? "")).filter(Boolean);
+        if (fromId && toIds.length > 0) {
+          dealContactMap.set(fromId, toIds);
+        }
+      }
+    } catch {
+      // Non-critical — continue without associations for this batch
+    }
+  }
+
+  // Step 2: Collect unique contact IDs and batch-fetch their analytics properties
+  const allContactIds = new Set<string>();
+  for (const contactIds of dealContactMap.values()) {
+    for (const id of contactIds) allContactIds.add(id);
+  }
+  if (allContactIds.size === 0) {
+    // No contacts found — populate empty results
+    for (const dealId of dealIds) {
+      resultMap.set(dealId, { contactIds: [], primaryContactId: null, primaryContactEmail: null, primaryContactAnalytics: undefined });
+    }
+    return resultMap;
+  }
+
+  const contactPropsMap = new Map<string, Record<string, string>>();
+  const contactIdArray = [...allContactIds];
+
+  for (let i = 0; i < contactIdArray.length; i += batchSize) {
+    const batch = contactIdArray.slice(i, i + batchSize);
+    try {
+      const res = await fetch(`${baseUrl}/crm/v3/objects/contacts/batch/read`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          inputs: batch.map((id) => ({ id })),
+          properties: CONTACT_ANALYTICS_PROPERTIES,
+        }),
+      });
+      if (!res.ok) continue;
+      const data = await res.json();
+      for (const contact of data.results ?? []) {
+        const id = String(contact.id ?? "");
+        if (id) contactPropsMap.set(id, contact.properties ?? {});
+      }
+    } catch {
+      // Non-critical — continue
+    }
+  }
+
+  // Step 3: Assemble results per deal
+  for (const dealId of dealIds) {
+    const contactIds = dealContactMap.get(dealId) ?? [];
+    const primaryContactId = contactIds[0] ?? null;
+    const primaryProps = primaryContactId ? contactPropsMap.get(primaryContactId) : undefined;
+
+    resultMap.set(dealId, {
+      contactIds,
+      primaryContactId,
+      primaryContactEmail: primaryProps?.email ?? null,
+      primaryContactAnalytics: primaryProps ? {
+        createdAt: primaryProps.createdate ? new Date(primaryProps.createdate).toISOString() : null,
+        source: primaryProps.hs_analytics_source || null,
+        sourceData1: primaryProps.hs_analytics_source_data_1 || null,
+        sourceData2: primaryProps.hs_analytics_source_data_2 || null,
+        firstSeenAt: primaryProps.hs_analytics_first_timestamp
+          ? new Date(Number(primaryProps.hs_analytics_first_timestamp)).toISOString()
+          : null,
+        lastSeenAt: primaryProps.hs_analytics_last_timestamp
+          ? new Date(Number(primaryProps.hs_analytics_last_timestamp)).toISOString()
+          : null,
+        firstUrl: primaryProps.hs_analytics_first_url || null,
+        lastUrl: primaryProps.hs_analytics_last_url || null,
+        numVisits: primaryProps.hs_analytics_num_visits ? Number(primaryProps.hs_analytics_num_visits) : null,
+        numPageViews: primaryProps.hs_analytics_num_page_views ? Number(primaryProps.hs_analytics_num_page_views) : null,
+        utmSource: primaryProps.utm_source || null,
+        utmMedium: primaryProps.utm_medium || null,
+        utmCampaign: primaryProps.utm_campaign || null,
+      } : undefined,
+    });
+  }
+
+  return resultMap;
 }
 
 export async function fetchHubSpotContacts(

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -983,7 +983,7 @@ export type BuyerJourneyPhase =
 
 export interface Touchpoint {
   timestamp: string;
-  phase: BuyerJourneyPhase;
+  phase?: BuyerJourneyPhase;
   channel: TouchpointChannel;
   type: TouchpointType;
   detail: string;
@@ -1012,7 +1012,7 @@ export interface TouchpointSummary {
 }
 
 export interface JourneyPath {
-  segments: Array<{ phase: BuyerJourneyPhase; channels: TouchpointChannel[] }>;
+  sequence: TouchpointChannel[];
   count: number;
   kanbanCards: number;
   freeTrials: number;
@@ -1043,8 +1043,8 @@ export interface CustomerJourneyData {
   medianDaysToClose: number;
   topPaths: JourneyPath[];
   attribution: ChannelAttribution[];
-  stageOrder: string[];
-  stageOrderSource: "pipeline" | "fallback";
+  stageOrder?: string[];
+  stageOrderSource?: "pipeline" | "fallback";
 }
 
 // ══════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Fetch deal→contact associations and analytics properties from HubSpot API, generating synthetic pre-CRM touchpoints (paid-search, organic-search, referral, direct, email, partner, outbound) with buyer-journey phases
- Populate pipeline stage ordering from HubSpot metadata with canonical fallback
- Fix type mismatches (`JourneyPath` segments→sequence, optional phase/stageOrder), add missing `cj-conversion` API route entry, and remove duplicate `buildCustomerJourneyData()` call
- Add synthetic channel labels and colors across all 3 customer journey UI components

## Test plan
- [x] All 18 customer journey tests pass (`vitest run src/lib/__tests__/analytics-customer-journey`)
- [ ] Manual: Load `/analytics/customer-journey` — overview tab shows synthetic channels in attribution table when deals have associated contacts with analytics data
- [ ] Verify new channels appear in touchpoint summary and path analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)