### PR TITLE
fix(a11y): wrap ref assignments in useEffect in useRovingTabindex

### DIFF
--- a/src/hooks/useRovingTabindex.ts
+++ b/src/hooks/useRovingTabindex.ts
@@ -43,8 +43,10 @@ export function useRovingTabindex(
   // Track the latest count/cols without invalidating callbacks
   const countRef = useRef(count);
   const colsRef = useRef(cols);
-  countRef.current = count;
-  colsRef.current = cols;
+  useEffect(() => {
+    countRef.current = count;
+    colsRef.current = cols;
+  }, [count, cols]);
 
   const clamp = useCallback((index: number): number => {
     const n = countRef.current;


### PR DESCRIPTION
## Summary
- Moves `countRef.current` and `colsRef.current` assignments from render-time into a `useEffect`, fixing the `react-hooks/refs` lint error introduced by the `useRovingTabindex` hook
- This resolves the lint failure blocking PRs #319, #320, #321, #322, #323, and #324, all of which share this identical file

## What changed
The two bare ref assignments during render:
```typescript
countRef.current = count;   // ERROR: react-hooks/refs
colsRef.current = cols;     // ERROR: react-hooks/refs
```
Were wrapped in a `useEffect`:
```typescript
useEffect(() => {
  countRef.current = count;
  colsRef.current = cols;
}, [count, cols]);
```

`useEffect` was already imported so no new imports were needed. All other code remains unchanged.

## Test plan
- [x] `npx eslint src/hooks/useRovingTabindex.ts` passes with zero errors
- [x] Full project `npm run lint` passes (0 errors, 73 pre-existing warnings unrelated to this file)
- [x] Confirmed the original version produces exactly 2 `react-hooks/refs` errors at the assignment lines
- [x] No functional changes -- refs are still updated synchronously after render via useEffect, preserving the existing callback-stabilization pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)