### PR TITLE
fix(analytics): avoid ref writes during render

### DIFF
--- a/src/components/analytics/dismiss-undo-toast.tsx
+++ b/src/components/analytics/dismiss-undo-toast.tsx
@@ -16,7 +16,9 @@ export function DismissUndoToast({
   durationMs = 5000,
 }: DismissUndoToastProps) {
   const onCloseRef = useRef(onClose);
-  onCloseRef.current = onClose;
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
 
   useEffect(() => {
     const timer = setTimeout(() => {


### PR DESCRIPTION
Fix ESLint react-hooks/refs by updating the onClose ref inside an effect.

Made with [Cursor](https://cursor.com)