### PR TITLE
Fix Reddit Ads reports range + status

### DIFF
--- a/src/hooks/__tests__/use-connection-status.test.ts
+++ b/src/hooks/__tests__/use-connection-status.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { AnalyticsDashboardData, ProviderFreshness } from "@/lib/analytics/types";
+import { populateConnectionStatus, useConnectionStatus } from "../use-connection-status";
+
+describe("use-connection-status", () => {
+  beforeEach(() => {
+    useConnectionStatus.getState().setEntries([]);
+  });
+
+  it("downgrades provider freshness when the dashboard payload is missing", () => {
+    const freshness: Record<string, ProviderFreshness> = {
+      reddit: {
+        provider: "reddit",
+        source: "connection",
+        status: "CONNECTED",
+        connectedAt: "2026-03-01T00:00:00.000Z",
+        lastSyncedAt: "2026-03-03T00:00:00.000Z",
+        lastError: null,
+        stale: false,
+        lastSnapshotAt: null,
+      },
+    };
+
+    const dashboard = {
+      redditAds: null,
+      staleDomains: [],
+      freshness: {},
+    } as unknown as AnalyticsDashboardData;
+
+    populateConnectionStatus(freshness as unknown as AnalyticsDashboardData["freshness"], dashboard);
+    expect(useConnectionStatus.getState().getStatus("redditAds")).toBe("disconnected");
+  });
+});
+

--- a/src/hooks/use-connection-status.ts
+++ b/src/hooks/use-connection-status.ts
@@ -40,6 +40,12 @@ export function mapFreshnessToStatus(freshness: {
   return "connected";
 }
 
+function mergeStatuses(a: ConnectionStatus, b: ConnectionStatus): ConnectionStatus {
+  if (a === "disconnected" || b === "disconnected") return "disconnected";
+  if (a === "stale" || b === "stale") return "stale";
+  return "connected";
+}
+
 /**
  * Maps IntegrationProviderKey (snake_case) → dataDomain (camelCase) used in the
  * section registry and sidebar. A single provider can map to multiple dataDomains
@@ -134,6 +140,11 @@ export function populateConnectionStatus(
         entriesByDomain.set(domain, {
           dataDomain: domain,
           status: inferredStatus,
+        });
+      } else {
+        entriesByDomain.set(domain, {
+          ...existing,
+          status: mergeStatuses(existing.status, inferredStatus),
         });
       }
     }

--- a/src/lib/__tests__/analytics-fetchers-ads.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-ads.test.ts
@@ -427,6 +427,40 @@ describe("analytics ads fetchers", () => {
     ).rejects.toThrow("Reddit campaigns error (403): insufficient_scope");
   });
 
+  it("clamps Reddit report end dates to the last complete UTC day by default", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-03T12:34:56.000Z"));
+
+    try {
+      const fetchMock = vi.fn();
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ access_token: "reddit-token" }))
+        .mockResolvedValueOnce(jsonResponse({ data: [] }))
+        .mockResolvedValueOnce(jsonResponse({ data: { metrics: [] } }));
+
+      vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+      await fetchRedditAdsData(
+        "reddit-client",
+        "reddit-secret",
+        "reddit-refresh",
+        "acc-1",
+        "WIPGuard-Test/1.0"
+      );
+
+      const reportsCall = fetchMock.mock.calls[2];
+      const reportInit = reportsCall?.[1] as RequestInit;
+      const payload = JSON.parse(String(reportInit.body ?? "{}")) as {
+        data?: { starts_at?: string; ends_at?: string };
+      };
+
+      expect(payload.data?.starts_at).toBe("2026-02-01T00:00:00Z");
+      expect(payload.data?.ends_at).toBe("2026-03-03T00:00:00Z");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("resolves Instagram account via Page when direct profile fetch fails", async () => {
     const fetchMock = vi.fn();
     fetchMock


### PR DESCRIPTION
- Clamp Reddit reports end boundary to last complete UTC day (avoid 400 Bad Request)\n- Ensure Reddit provider freshness reflects redditAds domain failures\n- Merge dashboard payload status with provider freshness so sidebar dot matches reality\n- Add regression tests