### PR TITLE
Railway: make migrations best-effort

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,23 @@
 #!/bin/sh
 set -e
 
-echo "Running migrations..."
-node /app/migrate.cjs
+MIGRATIONS_MODE="${MIGRATIONS_MODE:-best-effort}"
+
+case "$MIGRATIONS_MODE" in
+  skip)
+    echo "Skipping migrations (MIGRATIONS_MODE=skip)"
+    ;;
+  strict)
+    echo "Running migrations (MIGRATIONS_MODE=strict)..."
+    node /app/migrate.cjs
+    ;;
+  best-effort|*)
+    echo "Running migrations (MIGRATIONS_MODE=best-effort)..."
+    if ! node /app/migrate.cjs; then
+      echo "WARNING: migrations failed; starting server anyway"
+    fi
+    ;;
+esac
 
 echo "Starting server..."
 export HOSTNAME=${HOSTNAME:-0.0.0.0}


### PR DESCRIPTION
Production deploys are currently blocked because the runtime migration runner fails applying legacy Prisma migrations (e.g. missing Deal table).\n\nThis changes docker-entrypoint.sh to run migrations in best-effort mode by default so the server can start even if migrations fail, while still allowing MIGRATIONS_MODE=strict or MIGRATIONS_MODE=skip overrides.