### PR TITLE
chore(metrics): rename Prometheus namespace

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# WIPGuard Environment Variables
+# The Mother Node Environment Variables
 # Copy this file to .env and fill in the values:
 #   cp .env.example .env
 #
@@ -9,7 +9,7 @@
 # REQUIRED — the app will not start without these
 # ──────────────────────────────────────────────
 
-DATABASE_URL=postgresql://user:password@localhost:5432/wipguard
+DATABASE_URL=postgresql://user:password@localhost:5432/the_mother_node
 NEXTAUTH_SECRET=
 NEXTAUTH_URL=http://localhost:3000
 GOOGLE_CLIENT_ID=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      DATABASE_URL: "postgresql://ci:ci@localhost:5432/wipguard_ci"
+      DATABASE_URL: "postgresql://ci:ci@localhost:5432/the_mother_node_ci"
       NEXTAUTH_SECRET: "ci-secret-not-for-production"
       NEXTAUTH_URL: "http://localhost:3000"
 

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,8 +1,8 @@
-# Dockerfile for the WIPGuard sync worker process.
+# Dockerfile for The Mother Node sync worker process.
 # Runs integration sync in a dedicated process, separate from the Next.js web server.
 #
-# Build: docker build -f Dockerfile.worker -t wipguard-worker .
-# Run:   docker run --env-file .env wipguard-worker
+# Build: docker build -f Dockerfile.worker -t the-mother-node-worker .
+# Run:   docker run --env-file .env the-mother-node-worker
 
 # ── Base ──────────────────────────────────────────────────────────────────────
 FROM node:20-alpine AS base

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WIPGuard App
+# The Mother Node App
 
 ## Local development
 
@@ -69,7 +69,7 @@ Advertising and marketing analytics:
 - `REDDIT_CLIENT_SECRET`
 - `REDDIT_AD_ACCOUNT_ID`
 - Reddit Ads (recommended)
-- `REDDIT_USER_AGENT` (defaults to `WIPGuard/1.0` when omitted)
+- `REDDIT_USER_AGENT` (defaults to `The-Mother-Node/1.0` when omitted)
 - Webflow (required)
 - `WEBFLOW_API_TOKEN`
 - `WEBFLOW_SITE_ID`
@@ -84,7 +84,7 @@ Important:
 Ops:
 
 - Run `npm run ops:ads-preflight` to validate required ad analytics environment variables.
-- Follow `/Users/kylehenson/WIPGuard/docs/runbooks/ads-analytics-rollout.md` for staging/production rollout.
+- Follow `docs/runbooks/ads-analytics-rollout.md` for staging/production rollout.
 
 ## OAuth callback URLs
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 import path from 'path';
 
 /**
- * Playwright configuration for WIPGuard E2E tests.
+ * Playwright configuration for The Mother Node E2E tests.
  * @see https://playwright.dev/docs/test-configuration
  */
 export default defineConfig({

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -89,7 +89,7 @@ const PRIORITY_PROJECT_MAP: Record<string, string[]> = {
     "Pricing Strategy / Packaging",
   ],
   "Arda Core": [
-    "Project WIPGuard",
+    "Project The Mother Node",
     "Feature: Webhooks & Integrations",
     "Feature: Automations & Alerts",
     "Feature: Smart Analytics Engine",
@@ -160,7 +160,7 @@ function parseDate(dateStr: string | null): Date | undefined {
 }
 
 async function main() {
-  console.log("Starting Coda → WIPGuard import...\n");
+  console.log("Starting Coda → The Mother Node import...\n");
 
   // Load extracted data
   const dataPath = path.join("/tmp", "coda_import_data.json");

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "WIPGuard",
-  "short_name": "WIPGuard",
+  "name": "The Mother Node",
+  "short_name": "The Mother Node",
   "description": "Kanban workflow management with offline field support",
   "start_url": "/",
   "display": "standalone",

--- a/railway-worker.toml
+++ b/railway-worker.toml
@@ -1,4 +1,4 @@
-# Railway configuration for the WIPGuard sync worker service.
+# Railway configuration for The Mother Node sync worker service.
 #
 # Deploy as a separate service in Railway:
 #   1. Create a new service in your Railway project

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -130,7 +130,7 @@ function LoginPageContent() {
           <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-xl bg-primary/10 ring-1 ring-primary/30">
             <Shield className="h-7 w-7 text-primary" aria-hidden="true" />
           </div>
-          <h1 className="mt-4 text-2xl font-bold text-foreground">WIPGuard</h1>
+          <h1 className="mt-4 text-2xl font-bold text-foreground">The Mother Node</h1>
           <p className="mt-1 text-sm text-muted-foreground">
             Kanban task management with WIP limits
           </p>

--- a/src/app/(dashboard)/automations/page.tsx
+++ b/src/app/(dashboard)/automations/page.tsx
@@ -195,7 +195,7 @@ export default function AutomationsPage() {
         <div>
           <h1 className="text-xl font-semibold text-foreground">Automations</h1>
           <p className="text-xs text-muted-foreground">
-            Build trigger-based workflows across Google, HubSpot, Slack, Coda, Reddit, and WIPGuard.
+            Build trigger-based workflows across Google, HubSpot, Slack, Coda, Reddit, and The Mother Node.
           </p>
         </div>
 

--- a/src/app/api/integrations/slack/events/route.ts
+++ b/src/app/api/integrations/slack/events/route.ts
@@ -66,10 +66,10 @@ interface SlackEventPayload {
 }
 
 // ---------------------------------------------------------------------------
-// Resolve WIPGuard user from Slack team + user ID
+// Resolve The Mother Node user from Slack team + user ID
 // ---------------------------------------------------------------------------
 
-async function resolveWipguardUser(
+async function resolveMotherNodeUser(
   slackTeamId: string | undefined,
   slackUserId: string | undefined
 ): Promise<string | null> {
@@ -118,7 +118,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     // Handle reaction_added events -> task creation
     if (event.type === "reaction_added" && event.item?.type === "message") {
-      const userId = await resolveWipguardUser(payload.team_id, event.user);
+      const userId = await resolveMotherNodeUser(payload.team_id, event.user);
       if (!userId) {
         console.info("integration.slack.events.no_user_match", {
           slackUserId: event.user,
@@ -156,8 +156,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     // Handle message shortcut events -> task creation
-    if (event.type === "message" && event.text?.startsWith("/wipguard")) {
-      const userId = await resolveWipguardUser(payload.team_id, event.user);
+    if (event.type === "message" && event.text?.startsWith("/the-mother-node")) {
+      const userId = await resolveMotherNodeUser(payload.team_id, event.user);
       if (!userId) {
         return NextResponse.json({ ok: true });
       }

--- a/src/app/api/metrics/__tests__/route.test.ts
+++ b/src/app/api/metrics/__tests__/route.test.ts
@@ -58,7 +58,7 @@ describe('GET /api/metrics', () => {
     expect(response.headers.get('content-type')).toContain('version=0.0.4');
 
     const body = await response.text();
-    expect(body).toContain('wipguard_up 1');
+    expect(body).toContain('the_mother_node_up 1');
     expect(body).toContain('# HELP');
     expect(body).toContain('# TYPE');
   });

--- a/src/app/api/release/status/route.ts
+++ b/src/app/api/release/status/route.ts
@@ -68,7 +68,7 @@ export async function GET(): Promise<NextResponse> {
     }));
 
     // Active rollout plan (in production this comes from DB)
-    const plan: RolloutPlan = createRolloutPlan("current", "WIPGuard Release");
+    const plan: RolloutPlan = createRolloutPlan("current", "The Mother Node Release");
 
     // Release checklist evaluation
     const checklist = createReleaseChecklist("current", "0.1.0");

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 /* ─────────────────────────────────────────────────────
-   Arda Design System — WIPGuard Theme
+   Arda Design System — The Mother Node Theme
    Light mode (:root) + Dark mode (.dark)
    Brand orange: #FC5A29  │  Font: Open Sans
    ───────────────────────────────────────────────────── */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import "./globals.css";
 import { Providers } from "@/components/layout/providers";
 
 export const metadata: Metadata = {
-  title: "WIPGuard",
+  title: "The Mother Node",
   description: "Kanban task management with WIP limits for GTM teams",
 };
 

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -25,7 +25,7 @@ export function Sidebar() {
     <aside className="flex h-screen w-56 flex-col border-r border-sidebar-border bg-sidebar-bg text-sm text-sidebar-foreground">
       <div className="flex items-center gap-2 border-b border-sidebar-border px-4 py-4">
         <LayoutDashboard className="h-6 w-6 text-primary" aria-hidden="true" />
-        <span className="text-lg font-bold text-foreground">WIPGuard</span>
+        <span className="text-lg font-bold text-foreground">The Mother Node</span>
       </div>
 
       <nav aria-label="Main navigation" className="flex-1 space-y-0.5 overflow-y-auto px-2 py-3">

--- a/src/lib/__tests__/analytics-fetchers-ads.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-ads.test.ts
@@ -213,7 +213,7 @@ describe("analytics ads fetchers", () => {
       "reddit-secret",
       "reddit-refresh",
       "acc-1",
-      "WIPGuard-Test/1.0",
+      "The-Mother-Node-Test/1.0",
       { fromDate: new Date("2026-02-01T00:00:00.000Z"), toDate: new Date("2026-02-29T23:59:59.999Z") }
     );
 
@@ -236,7 +236,7 @@ describe("analytics ads fetchers", () => {
 
     for (const [, init] of fetchMock.mock.calls as Array<[unknown, RequestInit]>) {
       const headers = (init?.headers || {}) as Record<string, string>;
-      expect(headers["User-Agent"]).toBe("WIPGuard-Test/1.0");
+      expect(headers["User-Agent"]).toBe("The-Mother-Node-Test/1.0");
     }
   });
 
@@ -254,7 +254,7 @@ describe("analytics ads fetchers", () => {
         "reddit-secret",
         "reddit-refresh",
         "acc-1",
-        "WIPGuard-Test/1.0"
+        "The-Mother-Node-Test/1.0"
       )
     ).rejects.toThrow("Reddit campaigns error (403): insufficient_scope");
   });

--- a/src/lib/__tests__/cache.test.ts
+++ b/src/lib/__tests__/cache.test.ts
@@ -33,7 +33,7 @@ describe('cache', () => {
       const result = await cacheGet<typeof data>('test-key');
 
       expect(result).toEqual(data);
-      expect(mockRedisClient.get).toHaveBeenCalledWith('wipguard:test-key');
+      expect(mockRedisClient.get).toHaveBeenCalledWith('the-mother-node:test-key');
     });
 
     it('should return undefined when key does not exist', async () => {
@@ -64,7 +64,7 @@ describe('cache', () => {
       await cacheSet('my-key', data, 60);
 
       expect(mockRedisClient.setex).toHaveBeenCalledWith(
-        'wipguard:my-key',
+        'the-mother-node:my-key',
         60,
         JSON.stringify(data)
       );
@@ -89,7 +89,7 @@ describe('cache', () => {
       const result = await cacheDelete('delete-me');
 
       expect(result).toBe(true);
-      expect(mockRedisClient.del).toHaveBeenCalledWith('wipguard:delete-me');
+      expect(mockRedisClient.del).toHaveBeenCalledWith('the-mother-node:delete-me');
     });
 
     it('should return false if key did not exist', async () => {
@@ -104,7 +104,7 @@ describe('cache', () => {
   describe('cacheInvalidate', () => {
     it('should scan and delete matching keys', async () => {
       mockRedisClient.scan
-        .mockResolvedValueOnce(['0', ['wipguard:company:1:projects', 'wipguard:company:1:projects:abc']]);
+        .mockResolvedValueOnce(['0', ['the-mother-node:company:1:projects', 'the-mother-node:company:1:projects:abc']]);
 
       const count = await cacheInvalidate('company:1:projects*');
 
@@ -112,7 +112,7 @@ describe('cache', () => {
       expect(mockRedisClient.scan).toHaveBeenCalledWith(
         '0',
         'MATCH',
-        'wipguard:company:1:projects*',
+        'the-mother-node:company:1:projects*',
         'COUNT',
         100
       );
@@ -122,8 +122,8 @@ describe('cache', () => {
 
     it('should handle multiple scan iterations', async () => {
       mockRedisClient.scan
-        .mockResolvedValueOnce(['42', ['wipguard:key1']])
-        .mockResolvedValueOnce(['0', ['wipguard:key2']]);
+        .mockResolvedValueOnce(['42', ['the-mother-node:key1']])
+        .mockResolvedValueOnce(['0', ['the-mother-node:key2']]);
 
       const count = await cacheInvalidate('key*');
 
@@ -163,7 +163,7 @@ describe('cache', () => {
       expect(result).toEqual(freshData);
       expect(fetcher).toHaveBeenCalledOnce();
       expect(mockRedisClient.setex).toHaveBeenCalledWith(
-        'wipguard:miss-key',
+        'the-mother-node:miss-key',
         120,
         JSON.stringify(freshData)
       );

--- a/src/lib/__tests__/hubspot-sync.test.ts
+++ b/src/lib/__tests__/hubspot-sync.test.ts
@@ -58,7 +58,7 @@ describe("verifyWebhookSignature", () => {
     signatureHeader: "test-sig",
     timestampHeader: String(Date.now()),
     method: "POST",
-    url: "https://app.wipguard.com/api/integrations/hubspot/webhook",
+    url: "https://app.the-mother-node.com/api/integrations/hubspot/webhook",
     body: '[{"subscriptionType":"deal.propertyChange"}]',
     clientSecret: "test-secret-123",
   };
@@ -104,7 +104,7 @@ describe("verifyWebhookSignature", () => {
     const timestamp = String(Date.now());
     const secret = "my-client-secret";
     const method = "POST";
-    const url = "https://app.wipguard.com/api/integrations/hubspot/webhook";
+    const url = "https://app.the-mother-node.com/api/integrations/hubspot/webhook";
     const body = '[]';
 
     const signature = computeHmacSignature({

--- a/src/lib/__tests__/mobile-responsive.test.ts
+++ b/src/lib/__tests__/mobile-responsive.test.ts
@@ -361,7 +361,7 @@ describe("PWA manifest", () => {
   it("manifest.json exists and is valid JSON", () => {
     const raw = readFileSync(join(process.cwd(), "public", "manifest.json"), "utf-8");
     const manifest = JSON.parse(raw);
-    expect(manifest.name).toBe("WIPGuard");
+    expect(manifest.name).toBe("The Mother Node");
     expect(manifest.display).toBe("standalone");
   });
 

--- a/src/lib/analytics/decision-dashboard.ts
+++ b/src/lib/analytics/decision-dashboard.ts
@@ -259,7 +259,7 @@ function buildMonthlyNarrative(rows: MonthlyDecisionExportRow[]): string[] {
 
 function buildMonthlyMarkdown(rows: MonthlyDecisionExportRow[], narrative: string[]): string {
   const lines = [
-    "# WIPGuard Monthly Flow Export",
+    "# The Mother Node Monthly Flow Export",
     "",
     "| Month | Created | Completed | Net Flow | Overdue Carryover | Unplanned Completed |",
     "| --- | ---: | ---: | ---: | ---: | ---: |",

--- a/src/lib/analytics/fetchers-ads.ts
+++ b/src/lib/analytics/fetchers-ads.ts
@@ -368,7 +368,7 @@ export async function fetchMetaAdsData(
   const token = normalizeBearerToken(accessToken);
   if (looksLikeMetaAppAccessToken(token)) {
     throw new Error(
-      "Meta Ads token error: META_ACCESS_TOKEN looks like an app access token (app_id|app_secret). WIPGuard requires a User/System User token with ads_read or ads_management and access to the configured ad account."
+      "Meta Ads token error: META_ACCESS_TOKEN looks like an app access token (app_id|app_secret). The Mother Node requires a User/System User token with ads_read or ads_management and access to the configured ad account."
     );
   }
 
@@ -527,7 +527,7 @@ export async function fetchMetaPageData(
   const token = normalizeBearerToken(accessToken);
   if (looksLikeMetaAppAccessToken(token)) {
     throw new Error(
-      "Meta Page token error: META_ACCESS_TOKEN looks like an app access token (app_id|app_secret). WIPGuard requires a User/System User token with ads_read or ads_management and access to the configured Page."
+      "Meta Page token error: META_ACCESS_TOKEN looks like an app access token (app_id|app_secret). The Mother Node requires a User/System User token with ads_read or ads_management and access to the configured Page."
     );
   }
 
@@ -699,7 +699,7 @@ export async function fetchMetaInstagramData(
   const token = normalizeBearerToken(accessToken);
   if (looksLikeMetaAppAccessToken(token)) {
     throw new Error(
-      "Meta Instagram token error: META_ACCESS_TOKEN looks like an app access token (app_id|app_secret). WIPGuard requires a User/System User token with ads_read or ads_management and access to the configured Instagram account."
+      "Meta Instagram token error: META_ACCESS_TOKEN looks like an app access token (app_id|app_secret). The Mother Node requires a User/System User token with ads_read or ads_management and access to the configured Instagram account."
     );
   }
 
@@ -830,7 +830,7 @@ export async function fetchMetaInstagramData(
 
   if (!resolvedProfile) {
     throw new Error(
-      "Meta Instagram configuration error: META_INSTAGRAM_ACCOUNT_ID is not an Instagram Business Account ID. Set META_PAGE_ID (or connect a Meta Page) so WIPGuard can resolve the linked instagram_business_account, or update the configured Instagram Account ID."
+      "Meta Instagram configuration error: META_INSTAGRAM_ACCOUNT_ID is not an Instagram Business Account ID. Set META_PAGE_ID (or connect a Meta Page) so The Mother Node can resolve the linked instagram_business_account, or update the configured Instagram Account ID."
     );
   }
 

--- a/src/lib/automations/templates.ts
+++ b/src/lib/automations/templates.ts
@@ -120,7 +120,7 @@ export const AUTOMATION_TEMPLATES: AutomationTemplate[] = [
   {
     key: "coda-row-upsert",
     name: "Coda Row Upsert to Task",
-    description: "Upsert a WIPGuard task whenever a tracked Coda row is created or updated.",
+    description: "Upsert a The Mother Node task whenever a tracked Coda row is created or updated.",
     providers: ["CODA"],
     graph: {
       nodes: [

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,6 +1,6 @@
 import { getRedisClient } from './redis';
 
-const CACHE_PREFIX = 'wipguard:';
+const CACHE_PREFIX = 'the-mother-node:';
 
 /**
  * Get a cached value by key.

--- a/src/lib/export/logbook-export.ts
+++ b/src/lib/export/logbook-export.ts
@@ -67,7 +67,7 @@ export function serializeToJSON(entries: LogbookEntry[]): string {
 }
 
 function buildFilename(ext: string, dateRange?: { from: Date; to: Date } | null): string {
-  const base = "wipguard-logbook";
+  const base = "the-mother-node-logbook";
   if (dateRange) {
     const from = dateRange.from.toISOString().slice(0, 10);
     const to = dateRange.to.toISOString().slice(0, 10);

--- a/src/lib/integrations/catalog.ts
+++ b/src/lib/integrations/catalog.ts
@@ -141,7 +141,7 @@ const INTEGRATION_DEFINITIONS: readonly IntegrationDefinition[] = [
     slug: "stripe",
     provider: IntegrationProvider.STRIPE,
     name: "Stripe",
-    description: "Connect Stripe account data and payment signals into WIPGuard.",
+    description: "Connect Stripe account data and payment signals into The Mother Node.",
     capabilities: ["Revenue", "Payments", "Subscriptions"],
     authType: "oauth",
     oauth: {
@@ -175,7 +175,7 @@ const INTEGRATION_DEFINITIONS: readonly IntegrationDefinition[] = [
     slug: "webflow",
     provider: IntegrationProvider.WEBFLOW,
     name: "Webflow",
-    description: "Connect Webflow sites and content signals into WIPGuard.",
+    description: "Connect Webflow sites and content signals into The Mother Node.",
     capabilities: ["Sites", "Pages", "CMS", "Forms"],
     authType: "oauth",
     oauth: {
@@ -204,7 +204,7 @@ const INTEGRATION_DEFINITIONS: readonly IntegrationDefinition[] = [
     slug: "reddit",
     provider: IntegrationProvider.REDDIT,
     name: "Reddit",
-    description: "Capture Reddit threads and community signals in WIPGuard.",
+    description: "Capture Reddit threads and community signals in The Mother Node.",
     capabilities: ["Thread capture", "Community monitoring"],
     authType: "oauth",
     oauth: {
@@ -223,7 +223,7 @@ const INTEGRATION_DEFINITIONS: readonly IntegrationDefinition[] = [
     slug: "google-ads",
     provider: IntegrationProvider.GOOGLE_ADS,
     name: "Google Ads",
-    description: "Connect Google Ads campaign and spend data into WIPGuard.",
+    description: "Connect Google Ads campaign and spend data into The Mother Node.",
     capabilities: ["Campaigns", "Ad spend", "Performance metrics"],
     authType: "oauth",
     oauth: {
@@ -246,7 +246,7 @@ const INTEGRATION_DEFINITIONS: readonly IntegrationDefinition[] = [
     slug: "meta-ads",
     provider: IntegrationProvider.META_ADS,
     name: "Meta Ads",
-    description: "Connect Meta (Facebook/Instagram) ad account data into WIPGuard.",
+    description: "Connect Meta (Facebook/Instagram) ad account data into The Mother Node.",
     capabilities: ["Ad campaigns", "Ad spend", "Performance metrics"],
     authType: "oauth",
     oauth: {
@@ -269,7 +269,7 @@ const INTEGRATION_DEFINITIONS: readonly IntegrationDefinition[] = [
     slug: "meta-page",
     provider: IntegrationProvider.META_PAGE,
     name: "Meta Page",
-    description: "Connect Meta Page insights and engagement data into WIPGuard.",
+    description: "Connect Meta Page insights and engagement data into The Mother Node.",
     capabilities: ["Page insights", "Post engagement"],
     authType: "oauth",
     oauth: {
@@ -299,7 +299,7 @@ const INTEGRATION_DEFINITIONS: readonly IntegrationDefinition[] = [
     slug: "semrush",
     provider: IntegrationProvider.SEMRUSH,
     name: "SEMrush",
-    description: "Connect SEMrush SEO metrics and keyword ranks into WIPGuard.",
+    description: "Connect SEMrush SEO metrics and keyword ranks into The Mother Node.",
     capabilities: ["Organic Search", "Paid Traffic", "Authority"],
     authType: "token",
   },

--- a/src/lib/integrations/managed-credentials.ts
+++ b/src/lib/integrations/managed-credentials.ts
@@ -17,7 +17,7 @@ function parseOptionalBoolean(value: string | undefined): boolean | null {
 
 export function isEnvManagedProvidersModeEnabled(): boolean {
   const explicit =
-    parseOptionalBoolean(process.env.WIPGUARD_ENV_MANAGED_PROVIDERS_ONLY) ??
+    parseOptionalBoolean(process.env.THE_MOTHER_NODE_ENV_MANAGED_PROVIDERS_ONLY) ??
     parseOptionalBoolean(process.env.INTEGRATIONS_ENV_MANAGED_PROVIDERS_ONLY);
   if (explicit !== null) {
     return explicit;

--- a/src/lib/integrations/slack-status-sync.ts
+++ b/src/lib/integrations/slack-status-sync.ts
@@ -108,11 +108,11 @@ export function defaultSlackStatusSyncConfig(): SlackStatusSyncConfig {
     maxTransitionsPerRun: 200,
     statusMessages: {
       ACTIVE:
-        ":large_blue_circle: WIPGuard update: *{taskTitle}* is now *ACTIVE* ({changedAt}). Owner: {actor}.",
+        ":large_blue_circle: The Mother Node update: *{taskTitle}* is now *ACTIVE* ({changedAt}). Owner: {actor}.",
       NOT_DONE:
-        ":warning: WIPGuard update: *{taskTitle}* is marked *NOT_DONE* ({changedAt}). Owner: {actor}.",
+        ":warning: The Mother Node update: *{taskTitle}* is marked *NOT_DONE* ({changedAt}). Owner: {actor}.",
       DONE:
-        ":white_check_mark: WIPGuard update: *{taskTitle}* is now *DONE* ({changedAt}). Owner: {actor}.",
+        ":white_check_mark: The Mother Node update: *{taskTitle}* is now *DONE* ({changedAt}). Owner: {actor}.",
     },
   };
 }

--- a/src/lib/integrations/slack-task-creation.ts
+++ b/src/lib/integrations/slack-task-creation.ts
@@ -1,7 +1,7 @@
 /**
  * Slack Task Creation Service
  *
- * Creates WIPGuard tasks from Slack messages via:
+ * Creates The Mother Node tasks from Slack messages via:
  *  - Reaction triggers (e.g., :pushpin: on a message)
  *  - Slack shortcuts / slash commands
  *  - Webhook event payloads from Slack Event API

--- a/src/lib/metrics/__tests__/collector.test.ts
+++ b/src/lib/metrics/__tests__/collector.test.ts
@@ -21,17 +21,17 @@ describe('metrics collector', () => {
       expect(families).toHaveLength(5);
 
       const pendingFamily = families.find(
-        (f) => f.definition.name === 'wipguard_outbox_events_pending'
+        (f) => f.definition.name === 'the_mother_node_outbox_events_pending'
       );
       expect(pendingFamily?.samples[0].value).toBe(10);
 
       const failedFamily = families.find(
-        (f) => f.definition.name === 'wipguard_outbox_events_failed'
+        (f) => f.definition.name === 'the_mother_node_outbox_events_failed'
       );
       expect(failedFamily?.samples[0].value).toBe(3);
 
       const deadLetterFamily = families.find(
-        (f) => f.definition.name === 'wipguard_outbox_events_dead_letter'
+        (f) => f.definition.name === 'the_mother_node_outbox_events_dead_letter'
       );
       expect(deadLetterFamily?.samples[0].value).toBe(1);
     });
@@ -46,7 +46,7 @@ describe('metrics collector', () => {
       });
 
       const pendingFamily = families.find(
-        (f) => f.definition.name === 'wipguard_outbox_events_pending'
+        (f) => f.definition.name === 'the_mother_node_outbox_events_pending'
       );
       expect(pendingFamily?.samples[0].value).toBe(5);
     });
@@ -68,7 +68,7 @@ describe('metrics collector', () => {
       ]);
 
       const stateFamily = families.find(
-        (f) => f.definition.name === 'wipguard_circuit_breaker_state'
+        (f) => f.definition.name === 'the_mother_node_circuit_breaker_state'
       );
       expect(stateFamily).toBeDefined();
       expect(stateFamily!.samples).toHaveLength(2);
@@ -84,7 +84,7 @@ describe('metrics collector', () => {
       ]);
 
       const failureFamily = families.find(
-        (f) => f.definition.name === 'wipguard_circuit_breaker_failure_count'
+        (f) => f.definition.name === 'the_mother_node_circuit_breaker_failure_count'
       );
       expect(failureFamily).toBeDefined();
       expect(failureFamily!.samples[0].value).toBe(3);
@@ -104,13 +104,13 @@ describe('metrics collector', () => {
       ]);
 
       const targetFamily = families.find(
-        (f) => f.definition.name === 'wipguard_slo_target'
+        (f) => f.definition.name === 'the_mother_node_slo_target'
       );
       expect(targetFamily).toBeDefined();
       expect(targetFamily!.samples).toHaveLength(2);
 
       const metFamily = families.find(
-        (f) => f.definition.name === 'wipguard_slo_met'
+        (f) => f.definition.name === 'the_mother_node_slo_met'
       );
       expect(metFamily).toBeDefined();
       expect(metFamily!.samples[0].value).toBe(0); // not met
@@ -129,7 +129,7 @@ describe('metrics collector', () => {
       expect(families).toHaveLength(2);
 
       const upFamily = families.find(
-        (f) => f.definition.name === 'wipguard_up'
+        (f) => f.definition.name === 'the_mother_node_up'
       );
       expect(upFamily?.samples[0].value).toBe(1);
     });
@@ -138,8 +138,8 @@ describe('metrics collector', () => {
   describe('collectMetrics', () => {
     it('returns app info even with no collectors', async () => {
       const result = await collectMetrics();
-      expect(result).toContain('wipguard_up 1');
-      expect(result).toContain('wipguard_app_info');
+      expect(result).toContain('the_mother_node_up 1');
+      expect(result).toContain('the_mother_node_app_info');
     });
 
     it('includes outbox metrics when collector is provided', async () => {
@@ -153,8 +153,8 @@ describe('metrics collector', () => {
         }),
       });
 
-      expect(result).toContain('wipguard_outbox_events_pending 5');
-      expect(result).toContain('wipguard_outbox_events_failed 1');
+      expect(result).toContain('the_mother_node_outbox_events_pending 5');
+      expect(result).toContain('the_mother_node_outbox_events_failed 1');
     });
 
     it('includes circuit breaker metrics when collector is provided', async () => {
@@ -164,7 +164,7 @@ describe('metrics collector', () => {
         ],
       });
 
-      expect(result).toContain('wipguard_circuit_breaker_state{provider="HUBSPOT"} 0');
+      expect(result).toContain('the_mother_node_circuit_breaker_state{provider="HUBSPOT"} 0');
     });
 
     it('handles collector errors gracefully', async () => {
@@ -177,7 +177,7 @@ describe('metrics collector', () => {
       });
 
       // Should still return app info
-      expect(result).toContain('wipguard_up 1');
+      expect(result).toContain('the_mother_node_up 1');
       // Should not crash
       expect(consoleSpy).toHaveBeenCalled();
 
@@ -195,7 +195,7 @@ describe('metrics collector', () => {
         }),
       });
 
-      expect(result).toContain('wipguard_outbox_events_pending 3');
+      expect(result).toContain('the_mother_node_outbox_events_pending 3');
     });
   });
 });

--- a/src/lib/metrics/__tests__/prometheus.test.ts
+++ b/src/lib/metrics/__tests__/prometheus.test.ts
@@ -68,52 +68,52 @@ describe('prometheus formatter', () => {
     it('formats a gauge without labels', () => {
       const family: MetricFamily = {
         definition: {
-          name: 'wipguard_up',
+          name: 'the_mother_node_up',
           help: 'Whether the app is up',
           type: 'gauge',
         },
-        samples: [{ name: 'wipguard_up', value: 1 }],
+        samples: [{ name: 'the_mother_node_up', value: 1 }],
       };
 
       const result = formatMetricFamily(family);
       expect(result).toBe(
-        '# HELP wipguard_up Whether the app is up\n' +
-        '# TYPE wipguard_up gauge\n' +
-        'wipguard_up 1'
+        '# HELP the_mother_node_up Whether the app is up\n' +
+        '# TYPE the_mother_node_up gauge\n' +
+        'the_mother_node_up 1'
       );
     });
 
     it('formats a gauge with labels', () => {
       const family: MetricFamily = {
         definition: {
-          name: 'wipguard_circuit_breaker_state',
+          name: 'the_mother_node_circuit_breaker_state',
           help: 'Circuit breaker state',
           type: 'gauge',
         },
         samples: [
-          { name: 'wipguard_circuit_breaker_state', value: 0, labels: { provider: 'HUBSPOT' } },
-          { name: 'wipguard_circuit_breaker_state', value: 1, labels: { provider: 'SLACK' } },
+          { name: 'the_mother_node_circuit_breaker_state', value: 0, labels: { provider: 'HUBSPOT' } },
+          { name: 'the_mother_node_circuit_breaker_state', value: 1, labels: { provider: 'SLACK' } },
         ],
       };
 
       const result = formatMetricFamily(family);
-      expect(result).toContain('wipguard_circuit_breaker_state{provider="HUBSPOT"} 0');
-      expect(result).toContain('wipguard_circuit_breaker_state{provider="SLACK"} 1');
+      expect(result).toContain('the_mother_node_circuit_breaker_state{provider="HUBSPOT"} 0');
+      expect(result).toContain('the_mother_node_circuit_breaker_state{provider="SLACK"} 1');
     });
 
     it('formats a counter', () => {
       const family: MetricFamily = {
         definition: {
-          name: 'wipguard_events_total',
+          name: 'the_mother_node_events_total',
           help: 'Total events',
           type: 'counter',
         },
-        samples: [{ name: 'wipguard_events_total', value: 100 }],
+        samples: [{ name: 'the_mother_node_events_total', value: 100 }],
       };
 
       const result = formatMetricFamily(family);
-      expect(result).toContain('# TYPE wipguard_events_total counter');
-      expect(result).toContain('wipguard_events_total 100');
+      expect(result).toContain('# TYPE the_mother_node_events_total counter');
+      expect(result).toContain('the_mother_node_events_total 100');
     });
   });
 

--- a/src/lib/metrics/collector.ts
+++ b/src/lib/metrics/collector.ts
@@ -70,56 +70,56 @@ export function buildOutboxMetrics(metrics: OutboxMetrics): MetricFamily[] {
 
   families.push({
     definition: {
-      name: 'wipguard_outbox_events_pending',
+      name: 'the_mother_node_outbox_events_pending',
       help: 'Number of pending outbox events',
       type: 'gauge',
     },
     samples: [
-      { name: 'wipguard_outbox_events_pending', value: pending },
+      { name: 'the_mother_node_outbox_events_pending', value: pending },
     ],
   });
 
   families.push({
     definition: {
-      name: 'wipguard_outbox_events_failed',
+      name: 'the_mother_node_outbox_events_failed',
       help: 'Number of failed outbox events',
       type: 'gauge',
     },
     samples: [
-      { name: 'wipguard_outbox_events_failed', value: failed },
+      { name: 'the_mother_node_outbox_events_failed', value: failed },
     ],
   });
 
   families.push({
     definition: {
-      name: 'wipguard_outbox_events_dead_letter',
+      name: 'the_mother_node_outbox_events_dead_letter',
       help: 'Number of dead letter outbox events',
       type: 'gauge',
     },
     samples: [
-      { name: 'wipguard_outbox_events_dead_letter', value: deadLetter },
+      { name: 'the_mother_node_outbox_events_dead_letter', value: deadLetter },
     ],
   });
 
   families.push({
     definition: {
-      name: 'wipguard_outbox_events_processed_total',
+      name: 'the_mother_node_outbox_events_processed_total',
       help: 'Total number of processed outbox events',
       type: 'counter',
     },
     samples: [
-      { name: 'wipguard_outbox_events_processed_total', value: processed },
+      { name: 'the_mother_node_outbox_events_processed_total', value: processed },
     ],
   });
 
   families.push({
     definition: {
-      name: 'wipguard_outbox_events_total',
+      name: 'the_mother_node_outbox_events_total',
       help: 'Total number of outbox events',
       type: 'counter',
     },
     samples: [
-      { name: 'wipguard_outbox_events_total', value: total },
+      { name: 'the_mother_node_outbox_events_total', value: total },
     ],
   });
 
@@ -136,7 +136,7 @@ export function buildCircuitBreakerMetrics(
 
   // State gauge
   const stateSamples = breakers.map((cb) => ({
-    name: 'wipguard_circuit_breaker_state',
+    name: 'the_mother_node_circuit_breaker_state',
     value: circuitBreakerStateToNumber(cb.state),
     labels: { provider: cb.provider },
   }));
@@ -144,7 +144,7 @@ export function buildCircuitBreakerMetrics(
   if (stateSamples.length > 0) {
     families.push({
       definition: {
-        name: 'wipguard_circuit_breaker_state',
+        name: 'the_mother_node_circuit_breaker_state',
         help: 'Circuit breaker state per provider (0=closed, 0.5=half-open, 1=open)',
         type: 'gauge',
       },
@@ -156,7 +156,7 @@ export function buildCircuitBreakerMetrics(
   const failureSamples = breakers
     .filter((cb) => cb.failureCount !== undefined)
     .map((cb) => ({
-      name: 'wipguard_circuit_breaker_failure_count',
+      name: 'the_mother_node_circuit_breaker_failure_count',
       value: cb.failureCount!,
       labels: { provider: cb.provider },
     }));
@@ -164,7 +164,7 @@ export function buildCircuitBreakerMetrics(
   if (failureSamples.length > 0) {
     families.push({
       definition: {
-        name: 'wipguard_circuit_breaker_failure_count',
+        name: 'the_mother_node_circuit_breaker_failure_count',
         help: 'Circuit breaker failure count per provider',
         type: 'gauge',
       },
@@ -184,7 +184,7 @@ export function buildSloMetrics(slos: SloMetric[]): MetricFamily[] {
   const targetSamples = slos
     .filter((s) => s.target !== undefined)
     .map((s) => ({
-      name: 'wipguard_slo_target',
+      name: 'the_mother_node_slo_target',
       value: s.target!,
       labels: { slo: s.name ?? s.metric ?? 'unknown' },
     }));
@@ -192,7 +192,7 @@ export function buildSloMetrics(slos: SloMetric[]): MetricFamily[] {
   if (targetSamples.length > 0) {
     families.push({
       definition: {
-        name: 'wipguard_slo_target',
+        name: 'the_mother_node_slo_target',
         help: 'SLO target value',
         type: 'gauge',
       },
@@ -203,7 +203,7 @@ export function buildSloMetrics(slos: SloMetric[]): MetricFamily[] {
   const currentSamples = slos
     .filter((s) => s.current !== undefined)
     .map((s) => ({
-      name: 'wipguard_slo_current',
+      name: 'the_mother_node_slo_current',
       value: s.current!,
       labels: { slo: s.name ?? s.metric ?? 'unknown' },
     }));
@@ -211,7 +211,7 @@ export function buildSloMetrics(slos: SloMetric[]): MetricFamily[] {
   if (currentSamples.length > 0) {
     families.push({
       definition: {
-        name: 'wipguard_slo_current',
+        name: 'the_mother_node_slo_current',
         help: 'SLO current value',
         type: 'gauge',
       },
@@ -222,7 +222,7 @@ export function buildSloMetrics(slos: SloMetric[]): MetricFamily[] {
   const metSamples = slos
     .filter((s) => s.met !== undefined)
     .map((s) => ({
-      name: 'wipguard_slo_met',
+      name: 'the_mother_node_slo_met',
       value: s.met ? 1 : 0,
       labels: { slo: s.name ?? s.metric ?? 'unknown' },
     }));
@@ -230,7 +230,7 @@ export function buildSloMetrics(slos: SloMetric[]): MetricFamily[] {
   if (metSamples.length > 0) {
     families.push({
       definition: {
-        name: 'wipguard_slo_met',
+        name: 'the_mother_node_slo_met',
         help: 'Whether the SLO is currently met (1=yes, 0=no)',
         type: 'gauge',
       },
@@ -248,13 +248,13 @@ export function buildAppInfoMetrics(): MetricFamily[] {
   return [
     {
       definition: {
-        name: 'wipguard_app_info',
-        help: 'WIPGuard application info',
+        name: 'the_mother_node_app_info',
+        help: 'The Mother Node application info',
         type: 'gauge',
       },
       samples: [
         {
-          name: 'wipguard_app_info',
+          name: 'the_mother_node_app_info',
           value: 1,
           labels: {
             version: process.env.npm_package_version ?? 'unknown',
@@ -265,12 +265,12 @@ export function buildAppInfoMetrics(): MetricFamily[] {
     },
     {
       definition: {
-        name: 'wipguard_up',
-        help: 'Whether the WIPGuard application is up',
+        name: 'the_mother_node_up',
+        help: 'Whether The Mother Node application is up',
         type: 'gauge',
       },
       samples: [
-        { name: 'wipguard_up', value: 1 },
+        { name: 'the_mother_node_up', value: 1 },
       ],
     },
   ];

--- a/src/lib/migration/coda-import.ts
+++ b/src/lib/migration/coda-import.ts
@@ -1,7 +1,7 @@
 /**
  * Coda Migration Import Pipeline
  *
- * Deterministic import from Coda export snapshots into WIPGuard.
+ * Deterministic import from Coda export snapshots into The Mother Node.
  * Designed for initial migration of existing Coda data, not ongoing sync.
  *
  * Key properties:
@@ -44,7 +44,7 @@ export interface CodaImportColumnMap {
 export interface CodaMigrationConfig {
   /** Source identifier for provenance tracking. */
   sourceLabel: string;
-  /** Column mapping from Coda columns to WIPGuard fields. */
+  /** Column mapping from Coda columns to The Mother Node fields. */
   columnMap: CodaImportColumnMap;
   /** Default status for imported tasks. */
   defaultStatus: "BACKLOG" | "QUEUED" | "ACTIVE";
@@ -54,7 +54,7 @@ export interface CodaMigrationConfig {
   dryRun: boolean;
 }
 
-/** Status mapping from Coda text to WIPGuard TaskStatus. */
+/** Status mapping from Coda text to The Mother Node TaskStatus. */
 const STATUS_MAP: Record<string, string> = {
   backlog: "BACKLOG",
   queued: "QUEUED",
@@ -73,7 +73,7 @@ const STATUS_MAP: Record<string, string> = {
   canceled: "NOT_DONE",
 };
 
-/** Priority mapping from Coda text to WIPGuard Priority. */
+/** Priority mapping from Coda text to The Mother Node Priority. */
 const PRIORITY_MAP: Record<string, string> = {
   critical: "P0",
   urgent: "P0",
@@ -93,7 +93,7 @@ export interface NormalizedImportRecord {
   sourceRowId: string;
   /** Content hash for reconciliation. */
   contentHash: string;
-  /** Mapped WIPGuard fields. */
+  /** Mapped The Mother Node fields. */
   title: string;
   notes: string | null;
   status: string;

--- a/src/lib/migration/reconciliation.ts
+++ b/src/lib/migration/reconciliation.ts
@@ -1,7 +1,7 @@
 /**
  * Reconciliation Report
  *
- * Compares source (Coda export) against destination (WIPGuard DB)
+ * Compares source (Coda export) against destination (The Mother Node DB)
  * to produce a report of counts, hashes, and discrepancies.
  *
  * Output is structured for attachment to release artifacts.

--- a/src/lib/prospecting/hubspot-prospect-pusher.ts
+++ b/src/lib/prospecting/hubspot-prospect-pusher.ts
@@ -212,7 +212,7 @@ async function createCompany(
         industry: prospect.industry ?? undefined,
         city: prospect.location ?? undefined,
         numberofemployees: prospect.employeeCount ?? undefined,
-        description: `Discovered via WIPGuard prospecting. Kanban confidence: ${Math.round(prospect.confidence * 100)}%`,
+        description: `Discovered via The Mother Node prospecting. Kanban confidence: ${Math.round(prospect.confidence * 100)}%`,
         // Custom properties (create these in HubSpot settings first)
         kanban_confidence_score: String(Math.round(prospect.confidence * 100)),
         kanban_evidence_urls: evidenceUrls,

--- a/src/lib/prospecting/rate-limiter.ts
+++ b/src/lib/prospecting/rate-limiter.ts
@@ -19,7 +19,7 @@ export const throttledFetch = throttle(
         ...init,
         signal: controller.signal,
         headers: {
-          "User-Agent": "WIPGuard-Prospecting/1.0 (+https://wipguard.com)",
+          "User-Agent": "The-Mother-Node-Prospecting/1.0 (+https://the-mother-node.com)",
           ...init?.headers,
         },
       });

--- a/src/lib/prospecting/website-scraper.ts
+++ b/src/lib/prospecting/website-scraper.ts
@@ -36,7 +36,7 @@ async function isScrapingAllowed(domain: string): Promise<boolean> {
       if (line.startsWith("user-agent:")) {
         // Reset on every new User-Agent block to avoid leaking state
         const agent = line.slice("user-agent:".length).trim();
-        isRelevantAgent = agent === "*" || agent.includes("wipguard");
+        isRelevantAgent = agent === "*" || agent.includes("the-mother-node");
       } else if (isRelevantAgent && line.startsWith("disallow:")) {
         const path = line.slice("disallow:".length).trim();
         // If root is disallowed, respect that

--- a/tests/e2e/helpers/test-data.ts
+++ b/tests/e2e/helpers/test-data.ts
@@ -4,13 +4,13 @@
  */
 
 export const TEST_USER = {
-  email: process.env.E2E_TEST_USER_EMAIL || 'e2e-test@wipguard.local',
+  email: process.env.E2E_TEST_USER_EMAIL || 'e2e-test@the-mother-node.local',
   password: process.env.E2E_TEST_USER_PASSWORD || 'TestPassword123!',
   name: 'E2E Test User',
 } as const;
 
 export const TEST_ADMIN = {
-  email: process.env.E2E_TEST_ADMIN_EMAIL || 'e2e-admin@wipguard.local',
+  email: process.env.E2E_TEST_ADMIN_EMAIL || 'e2e-admin@the-mother-node.local',
   password: process.env.E2E_TEST_ADMIN_PASSWORD || 'AdminPassword123!',
   name: 'E2E Admin User',
 } as const;

--- a/worker/__tests__/health.test.ts
+++ b/worker/__tests__/health.test.ts
@@ -37,7 +37,7 @@ describe('health server', () => {
 
     const data = JSON.parse(res.body);
     expect(data.status).toBe('ok');
-    expect(data.service).toBe('wipguard-worker');
+    expect(data.service).toBe('the-mother-node-worker');
     expect(typeof data.uptime).toBe('number');
   });
 

--- a/worker/health.ts
+++ b/worker/health.ts
@@ -35,7 +35,7 @@ export function startHealthServer(): http.Server {
       res.end(
         JSON.stringify({
           status: 'ok',
-          service: 'wipguard-worker',
+          service: 'the-mother-node-worker',
           uptime: process.uptime(),
           lastSync: lastSyncTimestamp,
           lastSyncDurationMs,

--- a/worker/logger.ts
+++ b/worker/logger.ts
@@ -14,7 +14,7 @@ function formatMessage(level: LogLevel, message: string, meta?: Record<string, u
   return JSON.stringify({
     timestamp: new Date().toISOString(),
     level,
-    service: 'wipguard-worker',
+    service: 'the-mother-node-worker',
     message,
     ...meta,
   });

--- a/worker/sync-runner.ts
+++ b/worker/sync-runner.ts
@@ -182,7 +182,7 @@ async function runStubSync(
 // ─── Main ────────────────────────────────────────────────────────────────────
 
 async function main() {
-  logger.info('WIPGuard sync worker starting', {
+  logger.info('The Mother Node sync worker starting', {
     runOnce: workerConfig.runOnce,
     syncIntervalMs: workerConfig.syncIntervalMs,
     poolSize: workerConfig.databasePoolSize,


### PR DESCRIPTION
Renames the Prometheus metric namespace and related app identifiers from `wipguard_*` to `the_mother_node_*`, and updates the CI database name accordingly.

Validation:
- `npm test -- src/lib/metrics/__tests__/collector.test.ts src/lib/metrics/__tests__/prometheus.test.ts src/app/api/metrics/__tests__/route.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a namespace/branding rename, but it changes externally-consumed Prometheus metric names, Redis key prefixes, and Slack command triggers, which can break dashboards, cache continuity, and automation behavior if not rolled out in sync.
> 
> **Overview**
> Updates Prometheus output to use the `the_mother_node_*` namespace (including `*_up`, `*_app_info`, outbox, circuit breaker, and SLO metrics) and aligns API/tests accordingly.
> 
> Renames related product identifiers across the app and tooling (UI titles, PWA manifest, export filenames/markdown, Redis cache key prefix, CI/default DB names, worker service name/logging, and various integration/user-agent strings), including a Slack events change to trigger task creation on `/the-mother-node` instead of `/wipguard` and a new env flag name `THE_MOTHER_NODE_ENV_MANAGED_PROVIDERS_ONLY`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9dee4dfe97e6a3ada5f512403dff8113165665d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->