### PR TITLE
feat: add Coda funnel analytics

### DIFF
--- a/src/lib/__tests__/analytics-fetchers-coda.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-coda.test.ts
@@ -320,6 +320,89 @@ describe("coda analytics fetcher", () => {
     expect(data.rangeSummary?.downloadersDeltaPct).toBe(100);
   });
 
+  it("builds funnel metrics and limits recent submitters", async () => {
+    const fetchMock = vi.fn();
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{ id: "grid-tasks", name: "Tasks" }],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            { id: "col-1", name: "Name" },
+            { id: "col-2", name: "Status" },
+            { id: "col-3", name: "Created By" },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              id: "row-1",
+              createdAt: "2026-02-10T10:00:00.000Z",
+              updatedAt: "2026-02-10T10:00:00.000Z",
+              values: ["Card A", "Backlog", { name: "Alice", email: "alice@example.com" }],
+            },
+            {
+              id: "row-2",
+              createdAt: "2026-02-11T10:00:00.000Z",
+              updatedAt: "2026-02-11T10:00:00.000Z",
+              values: ["Card B", "Active", { name: "Bob", email: "bob@example.com" }],
+            },
+            {
+              id: "row-3",
+              createdAt: "2026-02-12T10:00:00.000Z",
+              updatedAt: "2026-02-12T10:00:00.000Z",
+              values: ["Card C", "Downloaded", { name: "Alice", email: "alice@example.com" }],
+            },
+            {
+              id: "row-4",
+              createdAt: "2026-02-13T10:00:00.000Z",
+              updatedAt: "2026-02-13T10:00:00.000Z",
+              values: ["Card D", "Done", { name: "Cara", email: "cara@example.com" }],
+            },
+            {
+              id: "row-5",
+              createdAt: "2026-02-14T10:00:00.000Z",
+              updatedAt: "2026-02-14T10:00:00.000Z",
+              values: ["Card E", "Needs Review", { name: "Dana", email: "dana@example.com" }],
+            },
+          ],
+        })
+      );
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const data = await fetchCodaData("token", "doc-id", {
+      fromDate: new Date("2026-02-01T00:00:00.000Z"),
+      toDate: new Date("2026-02-28T23:59:59.999Z"),
+      maxRecentSubmitters: 2,
+    });
+
+    expect(data.funnel?.stages).toEqual([
+      { key: "submissions", label: "Submissions", count: 4 },
+      { key: "cardsCreated", label: "Cards Created", count: 5 },
+      { key: "cardsCompleted", label: "Cards Completed", count: 2 },
+    ]);
+    expect(data.funnel?.conversions).toEqual([
+      { from: "submissions", to: "cardsCreated", ratePct: 125 },
+      { from: "cardsCreated", to: "cardsCompleted", ratePct: 40 },
+      { from: "submissions", to: "cardsCompleted", ratePct: 50 },
+    ]);
+    expect(data.funnel?.topDropOffStatuses).toEqual([
+      { status: "Backlog", count: 1, sharePct: 33.3 },
+      { status: "Active", count: 1, sharePct: 33.3 },
+      { status: "Needs Review", count: 1, sharePct: 33.3 },
+    ]);
+    expect(data.recentSubmitters?.map((entry) => entry.email)).toEqual([
+      "alice@example.com",
+      "dana@example.com",
+    ]);
+  });
+
   it("uses explicit creator column override and builds creator intelligence windows", async () => {
     const fetchMock = vi.fn();
     fetchMock

--- a/src/lib/analytics/fetchers-coda.ts
+++ b/src/lib/analytics/fetchers-coda.ts
@@ -78,8 +78,6 @@ export interface FetchCodaDataOptions {
   fromDate?: Date;
   toDate?: Date;
   now?: Date;
-  fromDate?: Date;
-  toDate?: Date;
 }
 
 interface EnrichedCard extends CodaCard {
@@ -140,6 +138,15 @@ function isWithinRange(iso: string | null, from: Date, to: Date): boolean {
   const t = new Date(iso).getTime();
   if (!Number.isFinite(t)) return false;
   return t >= from.getTime() && t <= to.getTime();
+}
+
+function isCompletedStatus(status: string | null | undefined): boolean {
+  const normalized = (status ?? "").trim().toLowerCase();
+  if (!normalized) return false;
+  if (normalized === "downloaded") return true;
+  return ["done", "complete", "completed", "closed", "resolved", "shipped"].some((token) =>
+    normalized.includes(token)
+  );
 }
 function readRowValue(
   row: CodaRow,
@@ -720,12 +727,16 @@ export async function fetchCodaData(
     submitterAgg.set(email, existing);
   }
 
-  const recentSubmitters = [...submitterAgg.values()]
+  const submitterEntries = [...submitterAgg.values()]
     .sort((a, b) => {
       if (b.cardsCreated !== a.cardsCreated) return b.cardsCreated - a.cardsCreated;
       return String(b.lastSubmittedAt ?? "").localeCompare(String(a.lastSubmittedAt ?? ""));
-    })
-    .slice(0, 25)
+    });
+
+  const submissions = submitterEntries.length;
+  const recentSubmitterLimit = Math.max(1, options.maxRecentSubmitters ?? 25);
+  const recentSubmitters = submitterEntries
+    .slice(0, recentSubmitterLimit)
     .map((entry) => ({
       creator: entry.creator,
       email: entry.email,
@@ -737,12 +748,49 @@ export async function fetchCodaData(
       hubspotSearchUrl: buildHubspotSearchUrl(entry.email),
     }));
 
+  const cardsCompleted = cardsInRange.filter((card) => isCompletedStatus(card.status)).length;
+  const incompleteCards = cardsInRange.length - cardsCompleted;
+  const topDropOffStatuses = cardsByStatus
+    .filter((entry) => !isCompletedStatus(entry.status))
+    .map((entry) => ({
+      status: entry.status,
+      count: entry.count,
+      sharePct: incompleteCards > 0 ? Math.round((entry.count / incompleteCards) * 1000) / 10 : 0,
+    }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5);
+
+  const funnel = {
+    stages: [
+      { key: "submissions" as const, label: "Submissions", count: submissions },
+      { key: "cardsCreated" as const, label: "Cards Created", count: cardsInRange.length },
+      { key: "cardsCompleted" as const, label: "Cards Completed", count: cardsCompleted },
+    ],
+    conversions: [
+      {
+        from: "submissions" as const,
+        to: "cardsCreated" as const,
+        ratePct: submissions > 0 ? Math.round((cardsInRange.length / submissions) * 1000) / 10 : null,
+      },
+      {
+        from: "cardsCreated" as const,
+        to: "cardsCompleted" as const,
+        ratePct: cardsInRange.length > 0 ? Math.round((cardsCompleted / cardsInRange.length) * 1000) / 10 : null,
+      },
+      {
+        from: "submissions" as const,
+        to: "cardsCompleted" as const,
+        ratePct: submissions > 0 ? Math.round((cardsCompleted / submissions) * 1000) / 10 : null,
+      },
+    ],
+    topDropOffStatuses,
+  };
+
   const rangeSummary = shouldFilterByRange
     ? (() => {
         const from = options.fromDate!.toISOString().slice(0, 10);
         const to = options.toDate!.toISOString().slice(0, 10);
         const cardsCreated = cardsInRange.length;
-        const submissions = recentSubmitters.length;
 
         const msPerDay = 24 * 60 * 60 * 1000;
         const days = Math.max(1, Math.round((options.toDate!.getTime() - options.fromDate!.getTime()) / msPerDay) + 1);
@@ -750,19 +798,14 @@ export async function fetchCodaData(
         const prevEnd = new Date(options.fromDate!.getTime() - msPerDay);
 
         let downloadsPrev = 0;
-        const prevEmails = new Set<string>();
+        const previousSubmitters = new Set<string>();
         for (const card of cards) {
           if (!isWithinRange(card.createdAtIso, prevStart, prevEnd)) continue;
           downloadsPrev += 1;
           const email = normalizeEmail(card.creatorEmail);
-          if (email) prevEmails.add(email);
+          if (email) previousSubmitters.add(email);
         }
-        const downloadersPrev = prevEmails.size;
-
-        const downloadsDeltaPct =
-          downloadsPrev > 0 ? Math.round(((cardsCreated - downloadsPrev) / downloadsPrev) * 100) : null;
-        const downloadersDeltaPct =
-          downloadersPrev > 0 ? Math.round(((submissions - downloadersPrev) / downloadersPrev) * 100) : null;
+        const downloadersPrev = previousSubmitters.size;
 
         return {
           from,
@@ -772,8 +815,8 @@ export async function fetchCodaData(
           unknownEmailCards,
           downloadsPrev,
           downloadersPrev,
-          downloadsDeltaPct,
-          downloadersDeltaPct,
+          downloadsDeltaPct: pctDelta(cardsCreated, downloadsPrev),
+          downloadersDeltaPct: pctDelta(submissions, downloadersPrev),
         };
       })()
     : undefined;
@@ -804,7 +847,10 @@ export async function fetchCodaData(
     trends: {
       newCreators30d: newCreatorsTrend,
       cardsCreated90d: cardsCreatedTrend,
+      downloadsDaily,
+      downloadersDaily,
     },
+    funnel,
     engagedLeadCandidates: leadEnrichment.candidates,
     rangeSummary,
     recentSubmitters: enrichedRecentSubmitters,

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -640,6 +640,30 @@ export interface CodaDiagnostics {
   hubspotMatchingErrors: number;
 }
 
+export interface CodaKanbanFunnelStage {
+  key: "submissions" | "cardsCreated" | "cardsCompleted";
+  label: string;
+  count: number;
+}
+
+export interface CodaKanbanFunnelConversion {
+  from: CodaKanbanFunnelStage["key"];
+  to: CodaKanbanFunnelStage["key"];
+  ratePct: number | null;
+}
+
+export interface CodaKanbanDropoffStatus {
+  status: string;
+  count: number;
+  sharePct: number;
+}
+
+export interface CodaKanbanFunnel {
+  stages: CodaKanbanFunnelStage[];
+  conversions: CodaKanbanFunnelConversion[];
+  topDropOffStatuses: CodaKanbanDropoffStatus[];
+}
+
 export interface CodaKanbanData {
   totalCards: number;
   cardsByStatus: { status: string; count: number }[];
@@ -647,6 +671,7 @@ export interface CodaKanbanData {
   creatorWindows?: CodaCreatorWindow[];
   newCreatorFeed?: CodaNewCreatorFeedEntry[];
   trends?: CodaCreatorTrends;
+  funnel?: CodaKanbanFunnel;
   engagedLeadCandidates?: CodaEngagedLeadCandidate[];
   rangeSummary?: {
     from: string;


### PR DESCRIPTION
## Summary
- add funnel stages, conversions, and drop-off status analytics to the Coda fetcher
- include the funnel payload in the analytics response types
- add unit coverage for funnel metrics and `maxRecentSubmitters` behavior

Closes #303

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shape and semantics of the Coda analytics response (new `funnel` field and revised submitter counting), which may affect downstream consumers and dashboards. Logic is contained to analytics calculations with no auth/security impact.
> 
> **Overview**
> Adds a new `funnel` payload to the Coda analytics fetcher, computing **stages** (submissions/cards created/cards completed), **conversion rates**, and **top drop-off statuses** using a new completed-status classifier.
> 
> Updates `maxRecentSubmitters` behavior to cap the returned `recentSubmitters` list without changing the underlying submission counts used in metrics/range summaries, refactors previous-period delta calculations to use `pctDelta`, and extends `CodaKanbanData` types plus unit tests to cover the new funnel output and submitter limiting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aff8fe65879b06a4a9d1925c815457d9036bb47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->