### PR TITLE
Fix Reddit Ads report fields

### DIFF
--- a/src/lib/__tests__/analytics-fetchers-ads.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-ads.test.ts
@@ -240,6 +240,44 @@ describe("analytics ads fetchers", () => {
     }
   });
 
+  it("normalizes Reddit spend micros and key conversion counts", async () => {
+    const fetchMock = vi.fn();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ access_token: "reddit-token" }))
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: "cmp-1", name: "Launch" }] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: {
+            metrics: [
+              {
+                campaign_id: "cmp-1",
+                spend: 12_500_000,
+                impressions: 1000,
+                clicks: 25,
+                key_conversion_total_count: 3,
+                reddit_leads: 1,
+              },
+            ],
+          },
+        })
+      );
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const data = await fetchRedditAdsData(
+      "reddit-client",
+      "reddit-secret",
+      "reddit-refresh",
+      "acc-1",
+      "The-Mother-Node-Test/1.0"
+    );
+
+    expect(data.totalSpend30d).toBeCloseTo(12.5);
+    expect(data.totalConversions).toBe(3);
+    expect(data.campaigns[0]?.spend).toBeCloseTo(12.5);
+    expect(data.campaigns[0]?.conversions).toBe(3);
+  });
+
   it("clamps Reddit report windows to the latest completed UTC day", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-07T23:10:00.000Z"));

--- a/src/lib/analytics/fetchers-ads.ts
+++ b/src/lib/analytics/fetchers-ads.ts
@@ -190,7 +190,11 @@ function extractRedditSpend(metric: UnknownRecord): number {
     metric.total_spend ??
     null;
   if (direct !== null) {
-    return readNumber(direct);
+    const parsed = readNumber(direct);
+    const isMicros =
+      (typeof direct === "number" && Number.isInteger(direct)) ||
+      (typeof direct === "string" && /^-?\d+$/.test(direct.trim()));
+    return isMicros ? parsed / 1_000_000 : parsed;
   }
 
   const micros =
@@ -1031,7 +1035,14 @@ export async function fetchRedditAdsData(
           ends_at: endsAtIso,
           time_zone_id: "UTC",
           breakdowns: ["CAMPAIGN_ID"],
-          fields: ["CAMPAIGN_ID", "SPEND", "IMPRESSIONS", "CLICKS", "CONVERSION_LEAD_COUNT", "CONVERSION_PURCHASE_COUNT", "CONVERSION_SIGN_UP_COUNT", "CONVERSION_CUSTOM_COUNT"],
+          fields: [
+            "CAMPAIGN_ID",
+            "SPEND",
+            "IMPRESSIONS",
+            "CLICKS",
+            "KEY_CONVERSION_TOTAL_COUNT",
+            "REDDIT_LEADS",
+          ],
         },
       }),
     }
@@ -1068,11 +1079,17 @@ export async function fetchRedditAdsData(
     const spend = extractRedditSpend(metric);
     const impressions = readNumber(metric.impressions ?? metric.IMPRESSIONS);
     const clicks = readNumber(metric.clicks ?? metric.CLICKS);
-    const conversions = 
-      readNumber(metric.conversion_lead_count ?? metric.CONVERSION_LEAD_COUNT) +
-      readNumber(metric.conversion_purchase_count ?? metric.CONVERSION_PURCHASE_COUNT) +
-      readNumber(metric.conversion_sign_up_count ?? metric.CONVERSION_SIGN_UP_COUNT) +
-      readNumber(metric.conversion_custom_count ?? metric.CONVERSION_CUSTOM_COUNT);
+    const conversions =
+      readNumber(
+        metric.key_conversion_total_count ??
+          metric.KEY_CONVERSION_TOTAL_COUNT ??
+          metric.reddit_leads ??
+          metric.REDDIT_LEADS
+      ) ||
+      (readNumber(metric.conversion_lead_count ?? metric.CONVERSION_LEAD_COUNT) +
+        readNumber(metric.conversion_purchase_count ?? metric.CONVERSION_PURCHASE_COUNT) +
+        readNumber(metric.conversion_sign_up_count ?? metric.CONVERSION_SIGN_UP_COUNT) +
+        readNumber(metric.conversion_custom_count ?? metric.CONVERSION_CUSTOM_COUNT));
 
     totalSpend += spend;
     totalImpressions += impressions;


### PR DESCRIPTION
## Summary
- replace the unsupported Reddit Ads report fields that were causing prod 400s
- normalize Reddit spend values that come back in micros so spend/cpc stay sane
- add regression coverage for the accepted report payload and spend normalization

## Testing
- npx vitest run src/lib/__tests__/analytics-fetchers-ads.test.ts src/app/api/analytics/route.test.ts src/app/api/integrations/route.test.ts src/lib/__tests__/integrations-catalog.test.ts