### PR TITLE
fix: Sprint 1 P0 security and CI hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: package-lock.json
 

--- a/migrate.cjs
+++ b/migrate.cjs
@@ -260,7 +260,7 @@ async function run() {
     connectionTimeoutMillis: 30000,
   };
   if (useSSL) {
-    poolOptions.ssl = { rejectUnauthorized: false };
+    poolOptions.ssl = { rejectUnauthorized: true };
   }
 
   const pool = new Pool(poolOptions);

--- a/src/app/api/debug/route.ts
+++ b/src/app/api/debug/route.ts
@@ -1,12 +1,25 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
+  // Security: block in production, require auth in development
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   try {
     const metaPage = await prisma.integrationConnection.findFirst({
-      where: { provider: "META_PAGE" }
+      where: { provider: "META_PAGE" },
+      // Only return non-sensitive fields
+      select: { id: true, provider: true, status: true, updatedAt: true },
     });
 
     return NextResponse.json({ metaPage });

--- a/src/lib/integrations/token-crypto.ts
+++ b/src/lib/integrations/token-crypto.ts
@@ -11,6 +11,17 @@ function getSecret(): string {
   );
 }
 
+function requireSecret(): string {
+  const secret = getSecret();
+  if (!secret) {
+    throw new Error(
+      "INTEGRATION_TOKEN_SECRET or NEXTAUTH_SECRET must be set. " +
+        "Refusing to store integration tokens as plaintext."
+    );
+  }
+  return secret;
+}
+
 function getKey(secret: string): Buffer {
   return createHash("sha256").update(secret).digest();
 }
@@ -20,10 +31,7 @@ export function protectIntegrationSecret(
 ): string | null {
   if (!value) return null;
 
-  const secret = getSecret();
-  if (!secret) {
-    return `${PLAINTEXT_PREFIX}.${value}`;
-  }
+  const secret = requireSecret();
 
   const key = getKey(secret);
   const iv = randomBytes(12);
@@ -44,7 +52,12 @@ export function unprotectIntegrationSecret(
 ): string | null {
   if (!value) return null;
 
+  // Support reading legacy plaintext tokens for migration
   if (value.startsWith(`${PLAINTEXT_PREFIX}.`)) {
+    console.warn(
+      "token-crypto: Reading legacy plaintext token. " +
+        "Re-encrypt by updating the integration connection."
+    );
     return value.slice(PLAINTEXT_PREFIX.length + 1);
   }
   if (!value.startsWith(`${ENCRYPTED_PREFIX}.`)) {
@@ -58,7 +71,9 @@ export function unprotectIntegrationSecret(
 
   const secret = getSecret();
   if (!secret) {
-    return null;
+    throw new Error(
+      "INTEGRATION_TOKEN_SECRET or NEXTAUTH_SECRET must be set to decrypt tokens."
+    );
   }
 
   try {

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -22,11 +22,13 @@ const globalForPrisma = globalThis as unknown as {
 type PrismaClientType = ReturnType<typeof createPrismaClient>;
 
 function createPrismaClient(connectionString: string) {
+  const useSSL = connectionString.includes("sslmode=require") || process.env.DB_SSL === "true";
   const pool = new Pool({
     connectionString,
     max: maxPoolSize,
     idleTimeoutMillis,
     connectionTimeoutMillis,
+    ...(useSSL ? { ssl: { rejectUnauthorized: true } } : {}),
   });
 
   // Attach pool monitoring


### PR DESCRIPTION
## Summary
- Gate `/api/debug` endpoint — add `NODE_ENV` production block + session auth + restrict returned fields to non-sensitive data
- Token encryption now throws on missing secret instead of silently storing plaintext
- Enable SSL certificate verification (`rejectUnauthorized: true`) in `migrate.cjs`
- Add SSL support with `rejectUnauthorized: true` to `prisma.ts` pool
- CI Node version → 22 to match Dockerfile runtime

## Issues closed
Closes #345, closes #338, closes #361

## Test plan
- [ ] Verify `/api/debug` returns 404 in production, 401 without session
- [ ] Verify token encryption throws when no secret env var is set
- [ ] Verify Railway DB connections still work with SSL verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)