### PR TITLE
Document customer success foundation and align analytics typing

### DIFF
--- a/docs/customer-success/arda-customer-dashboard-audit.md
+++ b/docs/customer-success/arda-customer-dashboard-audit.md
@@ -1,0 +1,1076 @@
+# Arda Customer Dashboard Audit for WIPGuard Customer Success
+
+Audited live deployment: 2026-03-07
+
+Legacy app under review: [arda-customer-dashboard.vercel.app](https://arda-customer-dashboard.vercel.app/)
+
+This document turns the legacy Arda customer dashboard into a repo-grounded specification for WIPGuard's Customer Success section. It is not a UI port plan. It is a route-by-route audit, a failure analysis, and an implementation blueprint for a WIPGuard-native customer success surface.
+
+## Decision Summary
+
+- Reuse concepts, workflows, and page structure from the legacy app.
+- Do not reuse Arda-specific visuals, terminology, browser auth, or client-side persistence patterns.
+- Build customer success in two phases:
+  1. Portfolio cockpit at `/analytics/customer-success`
+  2. Account workspace at `/analytics/customer-success/accounts/[accountId]`
+- Keep `/api/analytics?section=customer-success` as a summary feed. Do not turn it into the account workspace payload.
+- Add dedicated internal APIs for customer success data assembly:
+  - `GET /api/customer-success/portfolio`
+  - `GET /api/customer-success/accounts/[accountId]`
+  - `GET /api/customer-success/alerts`
+  - `GET /api/customer-success/activity`
+
+## Resolved Product Decisions
+
+These decisions were confirmed after the initial audit.
+
+- The canonical customer-success account identifier should be a WIPGuard-owned merged customer record.
+- Customer success notes, plans, alerts, and outreach history should persist in dedicated customer-success tables, not in `Task.notes`, `Deal.notes`, or ad hoc metadata blobs.
+- WIPGuard should send outbound customer-success messages in-product.
+- Existing `Task`, `LogbookEntry`, `DealCompany`, `DealContact`, `Deal`, `DealMeeting`, and `OutboxEvent` models should be reused as inputs and linked records, not replaced.
+
+## Current WIPGuard Baseline
+
+WIPGuard already has a Customer Success entry inside Analytics, but it is a provider-and-ops summary, not an account-centric workspace.
+
+Relevant code paths:
+
+- `src/components/analytics/customer-success-tab.tsx`
+- `src/app/api/analytics/route.ts`
+- `src/lib/analytics/section-registry.ts`
+- `docs/dashboard-walkthrough.md`
+
+Current behavior of `/analytics/customer-success`:
+
+- Renders support KPI cards from Pylon.
+- Renders product adoption and throughput panels from the analytics pipeline.
+- Renders integration delivery status for Google Workspace, Slack, and Coda.
+- Derives a short list of recommended actions from thresholds.
+- Does not expose:
+  - account-level health rollups,
+  - attention queues,
+  - customer drill-through,
+  - alert workflow,
+  - account 360 tabs,
+  - success plans,
+  - outreach templates/history.
+
+Implication: WIPGuard already has some data sources needed for customer success, but the current surface is too monolithic and too provider-centric to absorb the Arda concepts directly.
+
+## Audit Inputs
+
+The audit is grounded in three sources:
+
+1. Live route inspection of the deployed Arda dashboard on 2026-03-07.
+2. Live API probes against the deployed app's `/api/cs/*` and `/api/v1/*` surfaces.
+3. Public source maps from the deployed bundle, including:
+   - `assets/index-DMvgcK_2.js.map`
+   - `assets/forecasting-kYPw2rQ2.js.map`
+   - `assets/InsightsDashboard-B_B-m0Qt.js.map`
+   - `assets/Account360-CMgZhRDs.js.map`
+   - `assets/ChartsSection-zxL5ZJJ-.js.map`
+
+## Validated Live API Surfaces
+
+The deployed app still exposes enough of its newer customer-success API to confirm which parts of the product were successfully replatformed and which parts were left on the legacy path.
+
+Validated on 2026-03-07:
+
+- `GET /api/cs/accounts/:id`
+  - working
+  - sample responses returned complete account detail objects, health grades, lifecycle stage, alerts, and timeline data
+- `GET /api/cs/alerts`
+  - working
+  - observed 11 open alerts in the live dataset, mostly opportunity alerts with a smaller risk slice
+- `GET /api/cs/activity?mode=aggregate&days=30`
+  - working
+  - returned chart-friendly activity buckets and top-customer rollups
+- `GET /api/cs/activity?mode=events&limit=5`
+  - working
+  - returned feed-style event rows
+- `GET /api/cs/portfolio`
+  - implemented but protected
+  - when called with the app's bundled header pattern, it returned a 15-account portfolio with an average health score of 71
+- `GET /api/ping`
+  - working
+
+Legacy raw entity path:
+
+- `POST /api/v1/tenant/tenant/query`
+  - failing in the deployed app
+- `POST /api/v1/user-account/user-account/query`
+  - failing in the deployed app
+
+Takeaway:
+
+- The newer `/api/cs/*` layer is the real product direction.
+- The broken pages are broken because they never fully moved onto that layer.
+
+## Route-by-Route Audit
+
+### `/` Customers
+
+Status: Broken
+
+What the route was designed to be:
+
+- A top-level customer portfolio dashboard rendered by `src/App.tsx`
+- Summary metrics grid
+- Alert section
+- Customer table
+- Charts section
+
+Charts and sections confirmed from source maps:
+
+- Onboarding Funnel
+- Activity by Customer
+- Stage Distribution
+- Health Distribution
+
+Observed live behavior:
+
+- UI shows `Failed to load customer data. Please try again.`
+
+Reuse value:
+
+- Medium for layout ideas
+- Low for implementation approach
+
+Recommendation:
+
+- Do not port this screen as-is.
+- Replace it with a WIPGuard-native portfolio cockpit inside `/analytics/customer-success`.
+
+### `/insights`
+
+Status: Broken
+
+What the route was designed to be:
+
+- Portfolio-level insights dashboard rendered by `src/components/InsightsDashboard.tsx`
+- Views for overview, forecast, and accounts
+- Portfolio health summary
+- Total ARR
+- At-risk ARR
+- Expansion pipeline
+- Average health
+- Active insights
+- Health distribution
+- 6-month forecast
+- Needs-attention account list
+
+Observed live behavior:
+
+- UI shows `Failed to load portfolio data for insights.`
+
+Insights engine concepts confirmed from source maps:
+
+- Insight types: `trend`, `anomaly`, `prediction`, `recommendation`, `benchmark`
+- Categories: `usage`, `health`, `commercial`, `engagement`, `risk`
+
+Forecasting concepts confirmed from source maps:
+
+- Churn model factors:
+  - health score: 25%
+  - health trend: 15%
+  - days since activity: 20%
+  - support issues: 15%
+  - payment status: 15%
+  - feature adoption: 10%
+
+Reuse value:
+
+- High for metric categories and forecast framing
+- Low for direct implementation
+
+Recommendation:
+
+- Absorb the portfolio summary and "needs attention" concepts into WIPGuard's customer success portfolio page.
+- Treat forecasting as a later extension after the core account workspace exists.
+
+### `/alerts`
+
+Status: Working
+
+What exists:
+
+- Alert inbox with severity, category, and status rollups
+- Search
+- Filters
+- Sort by urgency / ARR-at-risk style priorities
+- Expandable alert detail
+- Direct customer links
+
+Observed live signals:
+
+- Alerts API was working.
+- The live dataset was dominated by opportunity alerts, with a smaller risk slice.
+
+Reuse value:
+
+- Very high
+
+Recommendation:
+
+- This is one of the strongest concepts to port.
+- Rebuild it on WIPGuard persistence and WIPGuard identifiers.
+- Preserve the inbox model, filtering model, severity model, and drill-through behavior.
+
+### `/activity`
+
+Status: Working
+
+What exists:
+
+- Activity overview with 7d / 30d / 90d range switch
+- Platform activity chart
+- Activity-by-customer table
+- Trend displays
+
+Observed live signals:
+
+- Aggregate activity endpoint worked.
+- Event mode also worked.
+
+Reuse value:
+
+- High
+
+Recommendation:
+
+- Keep the "activity by account" concept for the WIPGuard portfolio page.
+- Translate manufacturing activity into WIPGuard-native work, support, and customer-touch events.
+
+### `/feed`
+
+Status: Working
+
+What exists:
+
+- Live feed
+- Refresh controls
+- Filter drawer
+- Daily comparison stats
+- Expandable event rows
+- Quick jump into the linked account
+
+Reuse value:
+
+- Medium to high
+
+Recommendation:
+
+- Fold the feed concept into `GET /api/customer-success/activity` and the account timeline.
+- Do not preserve the exact standalone screen unless WIPGuard later needs a dedicated live operations view.
+
+### `/status`
+
+Status: Working
+
+What exists:
+
+- API base
+- API key / auth header diagnostics
+- Health probe
+- API probe utility
+
+Reuse value:
+
+- Low for end users
+- Medium for internal debugging
+
+Recommendation:
+
+- Do not ship this as part of customer success.
+- Keep the idea as an internal runbook/debug surface only if CS APIs become complex enough to justify it.
+
+### `/account/:tenantId`
+
+Status: Working
+
+What exists:
+
+- Full Account 360 workspace
+- Strongest artifact in the legacy app
+- Tabs confirmed from source maps and live inspection:
+  - Overview
+  - Health Details
+  - Commercial
+  - Timeline
+  - Stakeholders
+  - Tasks
+  - Success Plan
+  - Outreach
+
+Other confirmed concepts:
+
+- AI insights widget
+- Recommended actions
+- Commercial panel
+- Stakeholder coverage analysis
+- Success plan templates
+- Outreach templates and history
+
+Template categories confirmed from source maps:
+
+- Outreach:
+  - onboarding
+  - check_in
+  - at_risk
+  - expansion
+  - renewal
+  - reactivation
+- Success plans:
+  - Standard Onboarding
+  - Enterprise Onboarding
+  - Adoption Acceleration
+  - Renewal Success
+  - At-Risk Recovery
+
+Reuse value:
+
+- Extremely high
+
+Recommendation:
+
+- Use this route as the structural reference for WIPGuard's account-level customer success workspace.
+- Translate every tab into WIPGuard-native entities and language.
+
+## Why the Legacy Customers and Insights Routes Break
+
+The failure is not random. It is caused by a production build that still executes the legacy browser-side data path.
+
+### Root cause
+
+The deployed bundle exposes an environment object with:
+
+- `MODE: "production"`
+- `DEV: true`
+- `PROD: false`
+
+Source maps show the legacy data layer relies on `import.meta.env.PROD` to decide whether to use the newer `/api/cs/*` path or the older browser-side raw entity path.
+
+That is the wrong seam to copy into WIPGuard.
+
+Observed legacy behavior:
+
+- The root dashboard still executes legacy client queries from `src/lib/arda-client.ts`.
+- Those legacy queries hit raw entity endpoints such as:
+  - `/api/v1/tenant/tenant/query`
+  - `/api/v1/user-account/user-account/query`
+- Those raw queries fail in the deployed app.
+- Meanwhile, the newer customer success APIs exist and work:
+  - `/api/cs/accounts/:id`
+  - `/api/cs/alerts`
+  - `/api/cs/activity`
+  - `/api/cs/portfolio` exists but is guarded and not wired correctly into the broken routes
+
+Why account detail still works:
+
+- The Account 360 hook attempts the newer CS API first and has a fallback path.
+- The broken top-level routes remain tied to the older legacy portfolio fetch path.
+
+Implementation lesson for WIPGuard:
+
+- Do not branch runtime data source selection on fragile build-time env flags.
+- Do not let the browser decide between raw source queries and normalized internal APIs.
+- Normalize once on the server, then render from stable internal view models.
+
+## Legacy Concepts Worth Reusing
+
+Highest value concepts to carry into WIPGuard:
+
+- Account-centered customer success, not provider-centered customer success
+- Alert inbox with severity, category, SLA state, and account drill-through
+- Portfolio attention queue
+- Activity-by-account rollup
+- Account 360 tab model
+- Stakeholder coverage analysis
+- Recommended next actions
+- Success plan templates
+- Outreach template library and history
+
+Concepts to discard:
+
+- Arda-specific visual language and copy
+- Manufacturing-specific metrics like `items`, `kanban cards`, and `orders` as first-class product language
+- Browser-side raw `/api/v1/*` queries
+- localStorage notes/tasks/overrides
+- Supabase-only persistence assumptions
+- Publicly embedded auth-header patterns
+
+## WIPGuard-Native Domain Layer
+
+The customer success layer should be explicit and stable. It should not be inferred from the generic analytics payload.
+
+Suggested core types:
+
+```ts
+export interface CustomerSuccessHealthComponent {
+  score: number;
+  weight: number;
+  weightedScore: number;
+  trend: "improving" | "stable" | "declining";
+  status: "healthy" | "watch" | "risk";
+  evidence: string[];
+  lastUpdatedAt: string;
+}
+
+export interface CustomerSuccessHealth {
+  score: number;
+  grade: "A" | "B" | "C" | "D" | "F";
+  trend: "improving" | "stable" | "declining";
+  confidence: number;
+  updatedAt: string;
+  components: {
+    adoption: CustomerSuccessHealthComponent;
+    engagement: CustomerSuccessHealthComponent;
+    relationship: CustomerSuccessHealthComponent;
+    support: CustomerSuccessHealthComponent;
+    commercial: CustomerSuccessHealthComponent;
+  };
+}
+
+export interface CustomerSuccessAlert {
+  id: string;
+  accountId: string;
+  title: string;
+  category: "risk" | "opportunity" | "action_required";
+  severity: "low" | "medium" | "high" | "critical";
+  status: "open" | "in_progress" | "resolved" | "dismissed";
+  slaStatus: "none" | "on_track" | "at_risk" | "breached";
+  source: "health" | "support" | "commercial" | "relationship" | "workflow";
+  evidence: string[];
+  suggestedAction?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CustomerSuccessEvent {
+  id: string;
+  accountId: string;
+  type:
+    | "support"
+    | "product"
+    | "workflow"
+    | "commercial"
+    | "relationship"
+    | "lifecycle";
+  title: string;
+  description?: string;
+  actorName?: string;
+  occurredAt: string;
+  metadata?: Record<string, string | number | boolean | null>;
+}
+
+export interface CustomerSuccessPortfolio {
+  generatedAt: string;
+  summary: {
+    totalAccounts: number;
+    avgHealthScore: number;
+    atRiskAccounts: number;
+    openAlerts: number;
+  };
+  healthDistribution: Array<{ label: "A" | "B" | "C" | "D" | "F"; count: number }>;
+  attentionAccounts: Array<{
+    accountId: string;
+    name: string;
+    ownerName?: string;
+    health: CustomerSuccessHealth;
+    openAlertCount: number;
+    lifecycleStage: string;
+    nextAction?: string;
+  }>;
+  alerts: CustomerSuccessAlert[];
+  recentActivity: CustomerSuccessEvent[];
+  accounts: Array<{
+    accountId: string;
+    name: string;
+    segment?: string;
+    tier?: string;
+    ownerName?: string;
+    health: CustomerSuccessHealth;
+    lastActivityAt?: string;
+    activeUsers30d?: number;
+    renewalDate?: string;
+    openAlertCount: number;
+  }>;
+}
+
+export interface CustomerSuccessAccountDetail {
+  accountId: string;
+  name: string;
+  segment?: string;
+  tier?: string;
+  lifecycleStage: string;
+  ownerName?: string;
+  health: CustomerSuccessHealth;
+  alerts: CustomerSuccessAlert[];
+  timeline: CustomerSuccessEvent[];
+  stakeholders: Array<{
+    id: string;
+    name: string;
+    email?: string;
+    role: string;
+    coverageStatus?: "covered" | "missing" | "stale";
+    lastTouchAt?: string;
+  }>;
+  tasks: Array<{
+    id: string;
+    title: string;
+    status: string;
+    dueDate?: string;
+    priority?: string;
+  }>;
+  successPlan: {
+    templateKey?: string;
+    milestones: Array<{
+      id: string;
+      title: string;
+      status: string;
+      dueDate?: string;
+    }>;
+  };
+  outreach: {
+    recommendedTemplates: string[];
+    recentMessages: Array<{
+      id: string;
+      subject: string;
+      sentAt?: string;
+      status: string;
+    }>;
+  };
+  commercial?: {
+    arr?: number;
+    renewalDate?: string;
+    paymentStatus?: string;
+    expansionPotential?: string;
+  };
+}
+```
+
+## Persistence Recommendation
+
+WIPGuard already has useful primitives in Prisma:
+
+- `Organization` for tenant scoping
+- `Task` for execution and ownership
+- `LogbookEntry` for historical completion records
+- `DealCompany`, `DealContact`, `Deal`, and `DealMeeting` for CRM context
+- `OutboxEvent` for reliable dispatch
+
+That is enough to avoid creating a second workflow system, but it is not enough to make customer success state explicit. The recommended approach is to add a customer-success aggregate rooted in a merged customer record.
+
+### Canonical root: `CustomerRecord`
+
+Recommendation:
+
+- Add a new org-scoped `CustomerRecord` model.
+- Make `CustomerRecord.id` the canonical `accountId` used across `/api/customer-success/*`.
+- Use it to merge multiple external representations of the same customer into one WIPGuard record.
+
+Suggested responsibilities:
+
+- stable account identity
+- owner assignment
+- segment and tier
+- lifecycle stage
+- link to primary CRM company/deal context
+- link to external system identifiers
+
+Suggested fields:
+
+- `id`
+- `organizationId`
+- `name`
+- `ownerId`
+- `segment`
+- `tier`
+- `lifecycleStage`
+- `status`
+- `dealCompanyId` nullable
+- `primaryDealId` nullable
+- `createdAt`
+- `updatedAt`
+
+### External identity mapping
+
+Do not treat HubSpot company ID, Stripe customer ID, Pylon account ID, or tenant ID as the canonical key.
+
+Recommendation:
+
+- Add `CustomerRecordExternalRef` rows under `CustomerRecord`.
+- Use one row per provider/id pair.
+
+Suggested fields:
+
+- `customerRecordId`
+- `provider`
+- `externalId`
+- `label` nullable
+- `isPrimary`
+- `metadata`
+
+This cleanly handles:
+
+- multiple tenant IDs rolling up to one customer
+- one company with several product workspaces
+- future provider additions without schema churn
+
+### Where customer success notes should persist
+
+Recommendation:
+
+- Add a dedicated `CustomerSuccessNote` model linked to `CustomerRecord`.
+- Do not overload `Task.notes` or `Deal.notes`.
+
+Reasoning:
+
+- task notes describe execution work
+- deal notes describe pipeline state
+- customer-success notes capture relationship context, risk context, meeting takeaways, and account strategy
+
+Suggested fields:
+
+- `id`
+- `customerRecordId`
+- `authorUserId`
+- `title` nullable
+- `body`
+- `source` such as `manual`, `meeting`, `support`, `crm`, `ai`
+- `visibility`
+- `createdAt`
+- `updatedAt`
+
+### Where success plans and milestones should persist
+
+Recommendation:
+
+- Add `CustomerSuccessPlan` and `CustomerSuccessPlanMilestone` as first-class models under `CustomerRecord`.
+- Keep tasks as execution items that may be linked to milestones, not as the milestones themselves.
+
+Reasoning:
+
+- milestones need durable status even when there is no single task driving them
+- plans need template identity and health context
+- milestones should survive task completion, deletion, or replanning
+
+Suggested `CustomerSuccessPlan` fields:
+
+- `id`
+- `customerRecordId`
+- `templateKey`
+- `name`
+- `status`
+- `ownerUserId`
+- `startedAt`
+- `targetDate`
+- `completedAt`
+- `createdAt`
+- `updatedAt`
+
+Suggested `CustomerSuccessPlanMilestone` fields:
+
+- `id`
+- `planId`
+- `title`
+- `description`
+- `status`
+- `dueDate`
+- `completedAt`
+- `linkedTaskId` nullable
+- `sortOrder`
+
+### Where alerts should persist
+
+Recommendation:
+
+- Persist alerts in a `CustomerSuccessAlertRecord` table keyed to `CustomerRecord`.
+- Generate candidate alerts from current signals, then upsert/resolve them into persisted records so ownership, status, and history survive refreshes.
+
+Suggested fields:
+
+- `id`
+- `customerRecordId`
+- `alertKey`
+- `title`
+- `category`
+- `severity`
+- `status`
+- `slaStatus`
+- `evidence`
+- `suggestedAction`
+- `ownerUserId` nullable
+- `openedAt`
+- `resolvedAt` nullable
+- `updatedAt`
+
+### How existing models should be reused
+
+Recommendation:
+
+- Keep `Task` as the action engine.
+- Link tasks to customer-success context with a nullable `customerRecordId` foreign key instead of burying that link in `metadata`.
+- Derive stakeholder lists from `DealContact` plus HubSpot sync.
+- Derive relationship timeline entries from `DealMeeting`, notes, support events, and outbound outreach logs.
+- Continue using `LogbookEntry` as the completed-work archive for customer-success tasks.
+
+Minimum schema links to add:
+
+- nullable `customerRecordId` on `Task`
+- nullable `customerRecordId` on `DealMeeting`
+- optional relation from `CustomerRecord` to `DealCompany`
+- optional relation from `CustomerRecord` to a primary `Deal`
+
+## Write API Requirements
+
+The original plan only listed read endpoints. That is not sufficient once notes, plans, alert workflow, and outbound outreach are first-class.
+
+Required write endpoints:
+
+- `POST /api/customer-success/accounts/[accountId]/notes`
+- `POST /api/customer-success/accounts/[accountId]/alerts/[alertId]/status`
+- `POST /api/customer-success/accounts/[accountId]/tasks`
+- `POST /api/customer-success/accounts/[accountId]/success-plan`
+- `POST /api/customer-success/accounts/[accountId]/outreach/send`
+- `POST /api/customer-success/accounts/[accountId]/outreach/drafts`
+
+## Internal API Blueprint
+
+### `GET /api/customer-success/portfolio`
+
+Purpose:
+
+- Power the main portfolio cockpit at `/analytics/customer-success`
+
+Should include:
+
+- Summary cards
+- Health distribution
+- Attention queue
+- Account table rows
+- Alert rollup
+- Recent activity slice
+
+Should not include:
+
+- Full timeline history
+- Full stakeholder detail
+- Full outreach history
+- Full success plan detail
+
+### `GET /api/customer-success/accounts/[accountId]`
+
+Purpose:
+
+- Power the account workspace route
+
+Should include:
+
+- Header summary
+- Full health breakdown
+- Alerts
+- Timeline
+- Commercial state
+- Stakeholders
+- Tasks
+- Success plan
+- Outreach history and recommendations
+
+### `GET /api/customer-success/alerts`
+
+Purpose:
+
+- Back the alert inbox and alert counts on the portfolio page
+
+Should include:
+
+- Filterable alert list
+- Severity/category/status/SLA counts
+- Account identity needed for drill-through
+
+### `GET /api/customer-success/activity`
+
+Purpose:
+
+- Feed the portfolio activity chart, recent feed, and account timeline slices
+
+Should support:
+
+- aggregate mode for charts
+- event mode for feed/timeline rows
+- date range filtering
+- account filtering
+
+## Signal Translation: Legacy Health Model to WIPGuard Health Model
+
+The legacy app used a manufacturing-flavored activity model. WIPGuard should translate those signals into customer-success language immediately.
+
+| Health component | WIPGuard signal family | Primary sources |
+|---|---|---|
+| Adoption | Product usage, Coda/task completion, feature completion, workflow completion | internal tasks/projects, Coda, product telemetry |
+| Engagement | Recency, active collaborators, Slack/Workspace/workflow activity | Slack, Google Workspace, internal activity, logbook |
+| Relationship | Contact coverage, owner/champion presence, recent CS touches | HubSpot contacts/companies, meetings, notes, communication history |
+| Support | Backlog, urgency, SLA pressure, escalations | Pylon, support-linked tasks, escalation markers |
+| Commercial | Renewal, payment, expansion, ARR movement | Stripe, HubSpot, deal/revenue objects |
+
+Recommended behavior:
+
+- Keep the five components explicit in the UI and API.
+- Publish the final score and grade, but always preserve component-level evidence.
+- Treat missing providers as reduced confidence, not as automatic failure.
+
+## Operational Module Translation
+
+### Alerts
+
+Legacy concept:
+
+- Alert inbox with severity, category, status, and recommended action
+
+WIPGuard implementation:
+
+- Persist alerts in WIPGuard data storage.
+- Link alerts to accounts, tasks, and timeline entries.
+- Allow status transitions like `open -> in_progress -> resolved`.
+
+### Playbooks and recommended actions
+
+Legacy concept:
+
+- Recommended actions and playbook-style responses
+
+WIPGuard implementation:
+
+- Convert playbook actions into first-class WIPGuard tasks.
+- Allow tasks to be created from alerts or account detail context.
+
+### Timeline
+
+Legacy concept:
+
+- Product events, commercial events, and account activity in one place
+
+WIPGuard implementation:
+
+- Merge logbook entries, tasks, support events, lifecycle changes, meeting/contact activity, and commercial milestones into one timeline.
+
+### Success Plan
+
+Legacy concept:
+
+- Template-driven plans for onboarding, adoption, renewal, and recovery
+
+WIPGuard implementation:
+
+- Persist plans and milestones in WIPGuard.
+- Seed from the legacy template taxonomy:
+  - onboarding
+  - adoption
+  - renewal
+  - recovery
+
+### Outreach
+
+Legacy concept:
+
+- Outreach templates and history scoped to account state
+
+WIPGuard implementation:
+
+- Store template recommendations and message history against the account.
+- Seed template categories from the legacy app:
+  - onboarding
+  - check-in
+  - at-risk
+  - expansion
+  - renewal
+  - reactivation
+- Send outbound messages through WIPGuard rather than treating outreach as read-only history.
+- Record outbound state transitions like `draft -> queued -> sent -> failed`.
+- Persist provider message IDs, send timestamps, and failure reasons.
+- Dispatch message sends through the existing outbox so retries and delivery telemetry use the current platform model.
+
+Recommended outbound channels for V1:
+
+- email via Google Workspace
+- Slack direct message or channel thread reply where appropriate
+
+Required platform changes:
+
+- extend Google Workspace scopes beyond read-only to include `https://www.googleapis.com/auth/gmail.send`
+- extend the outbox dispatcher beyond `automation.slack.notify` to handle customer-success outreach events
+- add a dedicated outreach message store so the account workspace can show drafts, queued sends, sent history, and failures
+
+## Phased Product Plan
+
+### Phase 1: Portfolio cockpit
+
+Target route:
+
+- `/analytics/customer-success`
+
+Goal:
+
+- Replace the current provider summary with an account-centered CS cockpit
+
+Must include:
+
+- Health distribution
+- Attention queue
+- Alert summary and alert inbox entry point
+- Activity-by-account summary
+- Account table with drill-through
+- Short recent activity feed
+
+Can reuse from current WIPGuard page:
+
+- Existing analytics framing and range controls where useful
+- Existing provider fetchers as inputs, not as the final UI model
+
+### Phase 2: Account workspace
+
+Target route:
+
+- `/analytics/customer-success/accounts/[accountId]`
+
+Goal:
+
+- Add the full customer success workspace modeled on the legacy Account 360 structure
+
+Tabs to ship:
+
+- Overview
+- Health Details
+- Commercial
+- Timeline
+- Stakeholders
+- Tasks
+- Success Plan
+- Outreach
+
+Priority order inside the route:
+
+1. Overview
+2. Health Details
+3. Timeline
+4. Tasks
+5. Stakeholders
+6. Commercial
+7. Success Plan
+8. Outreach
+
+## Suggested WIPGuard File Layout
+
+This document does not implement the code, but it does define the shape of the implementation.
+
+Suggested additions:
+
+- `prisma/schema.prisma` customer-success models and relations
+- `src/lib/customer-success/types.ts`
+- `src/lib/customer-success/customer-record.ts`
+- `src/lib/customer-success/health.ts`
+- `src/lib/customer-success/portfolio.ts`
+- `src/lib/customer-success/account-detail.ts`
+- `src/lib/customer-success/alerts.ts`
+- `src/lib/customer-success/activity.ts`
+- `src/lib/customer-success/outreach.ts`
+- `src/lib/customer-success/notes.ts`
+- `src/lib/customer-success/success-plan.ts`
+- `src/lib/integrations/google-gmail-send.ts`
+- `src/app/api/customer-success/portfolio/route.ts`
+- `src/app/api/customer-success/accounts/[accountId]/route.ts`
+- `src/app/api/customer-success/alerts/route.ts`
+- `src/app/api/customer-success/activity/route.ts`
+- `src/app/api/customer-success/accounts/[accountId]/notes/route.ts`
+- `src/app/api/customer-success/accounts/[accountId]/outreach/send/route.ts`
+- `src/components/customer-success/portfolio/*`
+- `src/components/customer-success/account/*`
+- `src/app/(dashboard)/analytics/customer-success/accounts/[accountId]/page.tsx`
+
+Suggested refactor boundary:
+
+- Keep `src/app/api/analytics/route.ts` focused on analytics summary sections.
+- Move customer-success normalization into `src/lib/customer-success/*`.
+- Let the analytics summary page call the portfolio endpoint or a thin shared builder, not the reverse.
+
+## Test Plan
+
+### Fixture coverage
+
+Create at least four fixtures:
+
+1. Stalled onboarding account
+2. Healthy active account
+3. Expansion-ready account
+4. Partial-data account with missing providers
+
+### Assertions
+
+Portfolio:
+
+- Health distribution renders correctly.
+- Attention queue ranks at-risk accounts above healthy accounts.
+- Alert counts, severity counts, and SLA counts are correct.
+- Account rows drill into the account workspace route.
+
+Health model:
+
+- The final health score is composed from the five WIPGuard components.
+- Grade mapping is deterministic.
+- Missing providers reduce confidence but do not crash the score builder.
+
+Alerts:
+
+- Alert generation uses WIPGuard data only.
+- Filtering by severity/category/status works.
+- SLA ordering is stable.
+
+Account workspace:
+
+- Every tab renders without breaking when commercial, HubSpot, or Pylon data is missing.
+- Timeline merges events from multiple sources in descending time order.
+- Success plan and outreach sections tolerate empty-state accounts.
+
+Outbound messaging:
+
+- Sending an outreach message creates a persisted outreach record before dispatch.
+- Email and Slack sends queue outbox events rather than performing fragile inline dispatch from the request handler.
+- Success updates provider message IDs and timestamps on the outreach record.
+- Failed sends remain visible in the account workspace with retryable status.
+
+Architecture:
+
+- No customer-success route depends on raw Arda-style browser queries.
+- No customer-success route depends on env-flag branching to decide between legacy and new data paths.
+
+## Non-Goals
+
+- Porting the old Arda visuals or copy
+- Porting raw `/api/v1/*` browser calls
+- Porting embedded auth-header patterns
+- Porting localStorage notes/tasks/overrides
+- Porting Supabase-specific persistence as the customer success storage model
+- Preserving manufacturing-specific metrics as WIPGuard product language
+
+## Final Architecture Call
+
+The right implementation is:
+
+- a new `CustomerRecord` aggregate as the canonical CS account ID,
+- dedicated customer-success persistence for notes, plans, alerts, and outreach,
+- existing `Task`, `Deal*`, and `LogbookEntry` models reused as linked operational records,
+- and outbound outreach sent through the existing outbox infrastructure.
+
+## Final Recommendation
+
+The legacy Arda dashboard should be treated as a pattern library for customer success operations, not as a codebase to port.
+
+The best assets are:
+
+- the alert workflow,
+- the attention queue,
+- the activity framing,
+- and especially the Account 360 workspace.
+
+The broken top-level routes are useful mainly as a warning: customer-success pages should render from server-built, WIPGuard-native view models, never from fragile client-side source switching.

--- a/src/components/analytics/rep-scoreboard-card.test.tsx
+++ b/src/components/analytics/rep-scoreboard-card.test.tsx
@@ -68,6 +68,10 @@ describe("RepScoreboardCard", () => {
             updatedAt: null,
             createdAt: null,
             stripeCustomerId: "cus_1",
+            pipelineId: null,
+            contactIds: [],
+            primaryContactId: null,
+            primaryContactEmail: null,
           },
           {
             dealId: "2",
@@ -81,6 +85,10 @@ describe("RepScoreboardCard", () => {
             updatedAt: null,
             createdAt: null,
             stripeCustomerId: null,
+            pipelineId: null,
+            contactIds: [],
+            primaryContactId: null,
+            primaryContactEmail: null,
           },
           {
             dealId: "3",
@@ -94,6 +102,10 @@ describe("RepScoreboardCard", () => {
             updatedAt: null,
             createdAt: null,
             stripeCustomerId: null,
+            pipelineId: null,
+            contactIds: [],
+            primaryContactId: null,
+            primaryContactEmail: null,
           },
           {
             dealId: "4",
@@ -107,6 +119,10 @@ describe("RepScoreboardCard", () => {
             updatedAt: null,
             createdAt: null,
             stripeCustomerId: "cus_churn",
+            pipelineId: null,
+            contactIds: [],
+            primaryContactId: null,
+            primaryContactEmail: null,
           },
         ]}
         stripeChurnEvents={[{ customer: "cus_churn", canceledAt: new Date().toISOString(), amount: 99 }]}

--- a/src/lib/__tests__/analytics-fetchers-ads.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-ads.test.ts
@@ -278,6 +278,95 @@ describe("analytics ads fetchers", () => {
     expect(data.campaigns[0]?.conversions).toBe(3);
   });
 
+  it("retries Reddit reports with smaller payloads when the rich request is rejected", async () => {
+    const fetchMock = vi.fn();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ access_token: "reddit-token" }))
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: "cmp-1", name: "Launch" }] }))
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            error: {
+              message: "Bad request.",
+              fields: [{ field: "fields[4]", message: "Unsupported field." }],
+            },
+          },
+          400
+        )
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            error: {
+              message: "Bad request.",
+              fields: [{ field: "time_zone_id", message: "Invalid for this breakdown." }],
+            },
+          },
+          400
+        )
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: {
+            metrics: [
+              { CAMPAIGN_ID: "cmp-1", SPEND: "12.5", IMPRESSIONS: "1000", CLICKS: "25" },
+            ],
+          },
+        })
+      );
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const data = await fetchRedditAdsData(
+      "reddit-client",
+      "reddit-secret",
+      "reddit-refresh",
+      "acc-1",
+      "The-Mother-Node-Test/1.0"
+    );
+
+    expect(data.totalSpend30d).toBeCloseTo(12.5);
+    expect(data.totalConversions).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+
+    const firstReport = JSON.parse(String((fetchMock.mock.calls[2]?.[1] as RequestInit).body)) as {
+      data?: { fields?: string[]; time_zone_id?: string };
+    };
+    expect(firstReport.data?.time_zone_id).toBe("UTC");
+    expect(firstReport.data?.fields).toEqual([
+      "CAMPAIGN_ID",
+      "SPEND",
+      "IMPRESSIONS",
+      "CLICKS",
+      "KEY_CONVERSION_TOTAL_COUNT",
+      "REDDIT_LEADS",
+    ]);
+
+    const secondReport = JSON.parse(String((fetchMock.mock.calls[3]?.[1] as RequestInit).body)) as {
+      data?: { fields?: string[]; time_zone_id?: string };
+    };
+    expect(secondReport.data?.time_zone_id).toBeUndefined();
+    expect(secondReport.data?.fields).toEqual([
+      "CAMPAIGN_ID",
+      "SPEND",
+      "IMPRESSIONS",
+      "CLICKS",
+      "KEY_CONVERSION_TOTAL_COUNT",
+      "REDDIT_LEADS",
+    ]);
+
+    const thirdReport = JSON.parse(String((fetchMock.mock.calls[4]?.[1] as RequestInit).body)) as {
+      data?: { fields?: string[]; time_zone_id?: string };
+    };
+    expect(thirdReport.data?.time_zone_id).toBeUndefined();
+    expect(thirdReport.data?.fields).toEqual([
+      "CAMPAIGN_ID",
+      "SPEND",
+      "IMPRESSIONS",
+      "CLICKS",
+    ]);
+  });
+
   it("clamps Reddit report windows to the latest completed UTC day", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-07T23:10:00.000Z"));

--- a/src/lib/__tests__/analytics-fetchers-stripe.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-stripe.test.ts
@@ -99,11 +99,10 @@ describe("analytics stripe fetcher", () => {
 
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
-    const data = await fetchStripeData(
-      "sk_test_123",
-      new Date("2026-01-01T00:00:00.000Z"),
-      new Date("2026-02-01T00:00:00.000Z")
-    );
+    const data = await fetchStripeData("sk_test_123", {
+      fromDate: new Date("2026-01-01T00:00:00.000Z"),
+      toDate: new Date("2026-02-01T00:00:00.000Z"),
+    });
 
     expect(data.subscriptions.pastDue).toBe(3);
     expect(data.subscriptions.trialing).toBe(4);

--- a/src/lib/__tests__/analytics-process-analytics.test.ts
+++ b/src/lib/__tests__/analytics-process-analytics.test.ts
@@ -5,6 +5,7 @@ import { buildSalesPerformancePack } from "@/lib/analytics/fetchers";
 import type { AnalyticsDashboardData, HubSpotContactRecord, HubSpotData } from "@/lib/analytics/types";
 
 const META = { fetchedAt: "2026-02-10T00:00:00.000Z", nextRefresh: "2026-02-10T01:00:00.000Z", source: "live" as const };
+const DEAL_CONTACT_DEFAULTS = { pipelineId: null as string | null, contactIds: [] as string[], primaryContactId: null as string | null, primaryContactEmail: null as string | null };
 
 function baseData(): AnalyticsDashboardData {
   return createEmptyAnalyticsDashboardData({
@@ -62,6 +63,10 @@ describe("buildProcessAnalyticsData", () => {
           ownerId: "owner-1",
           createdAt: oldDate,
           updatedAt: oldDate,
+          pipelineId: null,
+          contactIds: [],
+          primaryContactId: null,
+          primaryContactEmail: null,
         },
         {
           dealId: "deal-2",
@@ -73,6 +78,10 @@ describe("buildProcessAnalyticsData", () => {
           ownerId: "owner-2",
           createdAt: recentDate,
           updatedAt: recentDate,
+          pipelineId: null,
+          contactIds: [],
+          primaryContactId: null,
+          primaryContactEmail: null,
         },
       ],
       _meta: META,
@@ -104,6 +113,7 @@ describe("buildSalesPerformancePack", () => {
         createdAt: "2026-01-31T23:00:00.000Z",
         closedAt: "2026-02-01T00:00:00.000Z",
         stripeCustomerId: null,
+        ...DEAL_CONTACT_DEFAULTS,
       },
     ];
 
@@ -137,6 +147,7 @@ describe("buildSalesPerformancePack", () => {
         createdAt: "2026-01-01T00:00:00.000Z",
         closedAt: "2026-02-10T00:00:00.000Z",
         stripeCustomerId: null,
+        ...DEAL_CONTACT_DEFAULTS,
       },
     ];
 
@@ -167,6 +178,7 @@ describe("buildSalesPerformancePack", () => {
         createdAt: "2026-01-01T00:00:00.000Z",
         closedAt: "2026-03-15T00:00:00.000Z",
         stripeCustomerId: null,
+        ...DEAL_CONTACT_DEFAULTS,
       },
       {
         dealId: "d2",
@@ -181,6 +193,7 @@ describe("buildSalesPerformancePack", () => {
         createdAt: "2026-01-01T00:00:00.000Z",
         closedAt: "2026-05-05T00:00:00.000Z",
         stripeCustomerId: null,
+        ...DEAL_CONTACT_DEFAULTS,
       },
     ];
 
@@ -213,6 +226,7 @@ describe("buildSalesPerformancePack", () => {
         createdAt: "2026-01-01T00:00:00.000Z",
         closedAt: "2026-02-01T00:00:00.000Z",
         stripeCustomerId: "cus_1",
+        ...DEAL_CONTACT_DEFAULTS,
       },
       {
         dealId: "d2",
@@ -227,6 +241,7 @@ describe("buildSalesPerformancePack", () => {
         createdAt: "2026-01-01T00:00:00.000Z",
         closedAt: "2026-02-20T00:00:00.000Z",
         stripeCustomerId: "cus_1",
+        ...DEAL_CONTACT_DEFAULTS,
       },
     ];
 
@@ -268,6 +283,7 @@ describe("buildSalesPerformancePack", () => {
         createdAt: "2026-02-10T00:00:00.000Z",
         closedAt: null,
         stripeCustomerId: null,
+        ...DEAL_CONTACT_DEFAULTS,
       },
     ];
 

--- a/src/lib/analytics/fetchers-ads.ts
+++ b/src/lib/analytics/fetchers-ads.ts
@@ -68,6 +68,31 @@ function extractApiErrorMessage(payload: unknown): string | null {
   return null;
 }
 
+function extractApiErrorFields(payload: unknown): string[] {
+  const record = asRecord(payload);
+  if (!record) return [];
+
+  const candidates = [asArray(asRecord(record.error)?.fields), asArray(record.fields)];
+  const messages: string[] = [];
+
+  for (const candidateList of candidates) {
+    for (const item of candidateList) {
+      const fieldRecord = asRecord(item);
+      if (!fieldRecord) continue;
+      const field = typeof fieldRecord.field === "string" ? fieldRecord.field.trim() : "";
+      const message =
+        typeof fieldRecord.message === "string" ? fieldRecord.message.trim() : "";
+      if (!field && !message) continue;
+      messages.push(field && message ? `${field}: ${message}` : field || message);
+      if (messages.length >= 5) {
+        return messages;
+      }
+    }
+  }
+
+  return messages;
+}
+
 async function parseErrorBody(response: Response): Promise<string> {
   const text = await response.text().catch(() => "");
   const trimmed = text.trim();
@@ -79,7 +104,13 @@ async function parseErrorBody(response: Response): Promise<string> {
     try {
       const parsed = JSON.parse(trimmed) as unknown;
       const message = extractApiErrorMessage(parsed);
-      if (message) return message.slice(0, 500);
+      const fields = extractApiErrorFields(parsed);
+      if (message || fields.length > 0) {
+        const details = [message, fields.length > 0 ? `fields: ${fields.join("; ")}` : null]
+          .filter(Boolean)
+          .join(" ");
+        if (details) return details.slice(0, 500);
+      }
     } catch {
       // Fall back to raw text.
     }
@@ -220,6 +251,112 @@ function addUtcDays(date: Date, days: number): Date {
   const value = new Date(date);
   value.setUTCDate(value.getUTCDate() + days);
   return value;
+}
+
+const REDDIT_REPORT_CORE_FIELDS = [
+  "CAMPAIGN_ID",
+  "SPEND",
+  "IMPRESSIONS",
+  "CLICKS",
+] as const;
+
+const REDDIT_REPORT_CONVERSION_FIELDS = [
+  "KEY_CONVERSION_TOTAL_COUNT",
+  "REDDIT_LEADS",
+] as const;
+
+interface RedditReportVariant {
+  label: string;
+  includeTimeZone: boolean;
+  fields: readonly string[];
+}
+
+async function fetchRedditReportMetrics(input: {
+  accessToken: string;
+  adAccountId: string;
+  baseHeaders: Record<string, string>;
+  startsAtIso: string;
+  endsAtIso: string;
+}): Promise<UnknownRecord[]> {
+  const variants: RedditReportVariant[] = [
+    {
+      label: "full",
+      includeTimeZone: true,
+      fields: [...REDDIT_REPORT_CORE_FIELDS, ...REDDIT_REPORT_CONVERSION_FIELDS],
+    },
+    {
+      label: "full-no-timezone",
+      includeTimeZone: false,
+      fields: [...REDDIT_REPORT_CORE_FIELDS, ...REDDIT_REPORT_CONVERSION_FIELDS],
+    },
+    {
+      label: "core",
+      includeTimeZone: false,
+      fields: REDDIT_REPORT_CORE_FIELDS,
+    },
+  ];
+
+  const attemptedLabels: string[] = [];
+  let lastErrorMessage = "";
+  let lastStatus = 0;
+  let lastVariantLabel = variants[0]?.label ?? "full";
+
+  for (const variant of variants) {
+    const payload = {
+      data: {
+        starts_at: input.startsAtIso,
+        ends_at: input.endsAtIso,
+        ...(variant.includeTimeZone ? { time_zone_id: "UTC" } : {}),
+        breakdowns: ["CAMPAIGN_ID"],
+        fields: [...variant.fields],
+      },
+    };
+
+    const reportsResponse = await fetch(
+      `https://ads-api.reddit.com/api/v3/ad_accounts/${input.adAccountId}/reports`,
+      {
+        method: "POST",
+        headers: {
+          ...input.baseHeaders,
+          Authorization: `Bearer ${input.accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      }
+    );
+
+    if (reportsResponse.ok) {
+      const reportsPayload = (await safeJson<{
+        data?: {
+          metrics?: UnknownRecord[];
+        };
+      }>(reportsResponse, "Reddit reports")) as {
+        data?: {
+          metrics?: UnknownRecord[];
+        };
+      };
+
+      return reportsPayload.data?.metrics ?? [];
+    }
+
+    const errorMessage = await parseErrorBody(reportsResponse);
+    attemptedLabels.push(variant.label);
+    lastErrorMessage = errorMessage;
+    lastStatus = reportsResponse.status;
+    lastVariantLabel = variant.label;
+
+    if (reportsResponse.status !== 400 || variant.label === "core") {
+      break;
+    }
+  }
+
+  const retrySuffix =
+    attemptedLabels.length > 1
+      ? ` after retrying ${attemptedLabels.slice(0, -1).join(", ")}`
+      : "";
+  throw new Error(
+    `Reddit reports error (${lastStatus}): ${lastErrorMessage}. starts_at=${input.startsAtIso} ends_at=${input.endsAtIso} request=${lastVariantLabel}${retrySuffix}`
+  );
 }
 
 /**
@@ -1020,51 +1157,13 @@ export async function fetchRedditAdsData(
 
   const startsAtIso = startsAtNorm.toISOString().replace(/\.\d{3}Z$/, "Z");
   const endsAtIso = endsAtNorm.toISOString().replace(/\.\d{3}Z$/, "Z");
-  const reportsResponse = await fetch(
-    `https://ads-api.reddit.com/api/v3/ad_accounts/${cleanAccountId}/reports`,
-    {
-      method: "POST",
-      headers: {
-        ...baseHeaders,
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        data: {
-          starts_at: startsAtIso,
-          ends_at: endsAtIso,
-          time_zone_id: "UTC",
-          breakdowns: ["CAMPAIGN_ID"],
-          fields: [
-            "CAMPAIGN_ID",
-            "SPEND",
-            "IMPRESSIONS",
-            "CLICKS",
-            "KEY_CONVERSION_TOTAL_COUNT",
-            "REDDIT_LEADS",
-          ],
-        },
-      }),
-    }
-  );
-
-  if (!reportsResponse.ok) {
-    throw new Error(
-      `Reddit reports error (${reportsResponse.status}): ${await parseErrorBody(
-        reportsResponse
-      )}. starts_at=${startsAtIso} ends_at=${endsAtIso}`
-    );
-  }
-
-  const reportsPayload = (await safeJson<{
-    data?: {
-      metrics?: UnknownRecord[];
-    };
-  }>(reportsResponse, "Reddit reports")) as {
-    data?: {
-      metrics?: UnknownRecord[];
-    };
-  };
+  const reportMetrics = await fetchRedditReportMetrics({
+    accessToken,
+    adAccountId: cleanAccountId,
+    baseHeaders,
+    startsAtIso,
+    endsAtIso,
+  });
 
   let totalSpend = 0;
   let totalImpressions = 0;
@@ -1072,7 +1171,7 @@ export async function fetchRedditAdsData(
   let totalConversions = 0;
   const campaignRollup = new Map<string, { spend: number; impressions: number; clicks: number; conversions: number }>();
 
-  for (const metricRaw of reportsPayload.data?.metrics ?? []) {
+  for (const metricRaw of reportMetrics) {
     const metric = asRecord(metricRaw);
     if (!metric) continue;
     const campaignId = extractRedditCampaignId(metric) || "unknown";

--- a/src/lib/analytics/fetchers.ts
+++ b/src/lib/analytics/fetchers.ts
@@ -261,7 +261,7 @@ export async function fetchHubSpotData(
     Boolean(rangeFrom && rangeTo && rangeFrom <= rangeTo);
 
   const properties =
-    "dealstage,amount,dealname,closedate,createdate,hs_analytics_source,num_associated_contacts,hubspot_owner_id,hs_lastmodifieddate,stripe_customer_id,stripe_customer";
+    "dealstage,amount,dealname,closedate,createdate,hs_analytics_source,num_associated_contacts,hubspot_owner_id,hs_lastmodifieddate,stripe_customer_id,stripe_customer,pipeline";
   const historyKey = "dealstage";
 
   const [activeDealsResult, archivedDealsResult] = await Promise.all([
@@ -392,6 +392,10 @@ export async function fetchHubSpotData(
       createdAt: props.createdate ? new Date(props.createdate).toISOString() : null,
       closedAt: props.closedate ? new Date(props.closedate).toISOString() : null,
       stripeCustomerId: props.stripe_customer_id || props.stripe_customer || null,
+      pipelineId: props.pipeline || null,
+      contactIds: [] as string[],
+      primaryContactId: null as string | null,
+      primaryContactEmail: null as string | null,
     };
   });
 
@@ -624,9 +628,9 @@ export async function fetchHubSpotData(
     for (const deal of deals) {
       const analytics = contactAnalytics.get(deal.dealId);
       if (analytics) {
-        (deal as Record<string, unknown>).contactIds = analytics.contactIds;
-        (deal as Record<string, unknown>).primaryContactId = analytics.primaryContactId;
-        (deal as Record<string, unknown>).primaryContactEmail = analytics.primaryContactEmail;
+        deal.contactIds = analytics.contactIds;
+        deal.primaryContactId = analytics.primaryContactId;
+        deal.primaryContactEmail = analytics.primaryContactEmail;
         (deal as Record<string, unknown>).primaryContactAnalytics = analytics.primaryContactAnalytics;
       }
     }

--- a/src/lib/customer-success/types.ts
+++ b/src/lib/customer-success/types.ts
@@ -1,0 +1,365 @@
+export type CustomerLifecycleStage =
+  | "ONBOARDING"
+  | "ADOPTION"
+  | "ACTIVE"
+  | "EXPANSION"
+  | "RENEWAL"
+  | "AT_RISK"
+  | "CHURNED";
+
+export type CustomerRecordStatus = "ACTIVE" | "ARCHIVED" | "MERGED";
+
+export type CustomerExternalProvider =
+  | "INTERNAL"
+  | "HUBSPOT"
+  | "STRIPE"
+  | "PYLON"
+  | "CODA"
+  | "SLACK"
+  | "GOOGLE_WORKSPACE";
+
+export type CustomerSuccessNoteSource =
+  | "MANUAL"
+  | "MEETING"
+  | "SUPPORT"
+  | "CRM"
+  | "AI"
+  | "SYSTEM";
+
+export type CustomerSuccessNoteVisibility = "INTERNAL" | "RESTRICTED";
+
+export type CustomerSuccessPlanStatus = "DRAFT" | "ACTIVE" | "COMPLETED" | "ARCHIVED";
+
+export type CustomerSuccessMilestoneStatus =
+  | "NOT_STARTED"
+  | "IN_PROGRESS"
+  | "BLOCKED"
+  | "COMPLETED";
+
+export type CustomerSuccessAlertCategory = "RISK" | "OPPORTUNITY" | "ACTION_REQUIRED";
+
+export type CustomerSuccessAlertSeverity = "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+
+export type CustomerSuccessAlertStatus = "OPEN" | "IN_PROGRESS" | "RESOLVED" | "DISMISSED";
+
+export type CustomerSuccessSlaStatus = "NONE" | "ON_TRACK" | "AT_RISK" | "BREACHED";
+
+export type CustomerSuccessAlertSource =
+  | "HEALTH"
+  | "SUPPORT"
+  | "COMMERCIAL"
+  | "RELATIONSHIP"
+  | "WORKFLOW";
+
+export type CustomerSuccessOutreachChannel = "EMAIL" | "SLACK";
+
+export type CustomerSuccessOutreachStatus = "DRAFT" | "QUEUED" | "SENT" | "FAILED" | "CANCELED";
+
+export type CustomerSuccessHealthTrend = "improving" | "stable" | "declining";
+
+export type CustomerSuccessHealthStatus = "healthy" | "watch" | "risk";
+
+export type CustomerSuccessHealthGrade = "A" | "B" | "C" | "D" | "F";
+
+export interface CustomerRecordEntity {
+  id: string;
+  organizationId: string | null;
+  name: string;
+  segment: string | null;
+  tier: string | null;
+  lifecycleStage: CustomerLifecycleStage;
+  status: CustomerRecordStatus;
+  ownerId: string | null;
+  dealCompanyId: string | null;
+  primaryDealId: string | null;
+  mergedIntoId: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CustomerRecordExternalRefEntity {
+  id: string;
+  organizationId: string | null;
+  customerRecordId: string;
+  provider: CustomerExternalProvider;
+  externalObjectType: string;
+  externalId: string;
+  label: string | null;
+  isPrimary: boolean;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CustomerSuccessNoteEntity {
+  id: string;
+  organizationId: string | null;
+  customerRecordId: string;
+  authorUserId: string | null;
+  title: string | null;
+  body: string;
+  source: CustomerSuccessNoteSource;
+  visibility: CustomerSuccessNoteVisibility;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CustomerSuccessPlanMilestoneEntity {
+  id: string;
+  organizationId: string | null;
+  planId: string;
+  title: string;
+  description: string | null;
+  status: CustomerSuccessMilestoneStatus;
+  dueDate: string | null;
+  completedAt: string | null;
+  linkedTaskId: string | null;
+  sortOrder: number;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CustomerSuccessPlanEntity {
+  id: string;
+  organizationId: string | null;
+  customerRecordId: string;
+  name: string;
+  templateKey: string | null;
+  status: CustomerSuccessPlanStatus;
+  ownerUserId: string | null;
+  startedAt: string | null;
+  targetDate: string | null;
+  completedAt: string | null;
+  metadata: Record<string, unknown> | null;
+  milestones: CustomerSuccessPlanMilestoneEntity[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CustomerSuccessAlertEntity {
+  id: string;
+  organizationId: string | null;
+  customerRecordId: string;
+  alertKey: string;
+  title: string;
+  category: CustomerSuccessAlertCategory;
+  severity: CustomerSuccessAlertSeverity;
+  status: CustomerSuccessAlertStatus;
+  slaStatus: CustomerSuccessSlaStatus;
+  source: CustomerSuccessAlertSource;
+  evidence: unknown[] | null;
+  suggestedAction: string | null;
+  ownerUserId: string | null;
+  linkedTaskId: string | null;
+  openedAt: string;
+  resolvedAt: string | null;
+  lastEvaluatedAt: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CustomerSuccessOutreachMessageEntity {
+  id: string;
+  organizationId: string | null;
+  customerRecordId: string;
+  authorUserId: string | null;
+  channel: CustomerSuccessOutreachChannel;
+  status: CustomerSuccessOutreachStatus;
+  templateKey: string | null;
+  recipientName: string | null;
+  recipientAddress: string;
+  subject: string | null;
+  body: string;
+  providerMessageId: string | null;
+  providerThreadId: string | null;
+  queuedAt: string | null;
+  sentAt: string | null;
+  failedAt: string | null;
+  error: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CustomerSuccessHealthComponent {
+  score: number;
+  weight: number;
+  weightedScore: number;
+  trend: CustomerSuccessHealthTrend;
+  status: CustomerSuccessHealthStatus;
+  evidence: string[];
+  lastUpdatedAt: string;
+}
+
+export interface CustomerSuccessHealth {
+  score: number;
+  grade: CustomerSuccessHealthGrade;
+  trend: CustomerSuccessHealthTrend;
+  confidence: number;
+  updatedAt: string;
+  components: {
+    adoption: CustomerSuccessHealthComponent;
+    engagement: CustomerSuccessHealthComponent;
+    relationship: CustomerSuccessHealthComponent;
+    support: CustomerSuccessHealthComponent;
+    commercial: CustomerSuccessHealthComponent;
+  };
+}
+
+export interface CustomerSuccessAlert {
+  id: string;
+  accountId: string;
+  title: string;
+  category: "risk" | "opportunity" | "action_required";
+  severity: "low" | "medium" | "high" | "critical";
+  status: "open" | "in_progress" | "resolved" | "dismissed";
+  slaStatus: "none" | "on_track" | "at_risk" | "breached";
+  source: "health" | "support" | "commercial" | "relationship" | "workflow";
+  evidence: string[];
+  suggestedAction?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CustomerSuccessEvent {
+  id: string;
+  accountId: string;
+  type: "support" | "product" | "workflow" | "commercial" | "relationship" | "lifecycle";
+  title: string;
+  description?: string;
+  actorName?: string;
+  occurredAt: string;
+  metadata?: Record<string, string | number | boolean | null>;
+}
+
+export interface CustomerSuccessStakeholder {
+  id: string;
+  name: string;
+  email?: string;
+  role: string;
+  coverageStatus?: "covered" | "missing" | "stale";
+  lastTouchAt?: string;
+}
+
+export interface CustomerSuccessTaskSummary {
+  id: string;
+  title: string;
+  status: string;
+  dueDate?: string;
+  priority?: string;
+}
+
+export interface CustomerSuccessPortfolioAccount {
+  accountId: string;
+  name: string;
+  segment?: string;
+  tier?: string;
+  ownerName?: string;
+  health: CustomerSuccessHealth;
+  lastActivityAt?: string;
+  activeUsers30d?: number;
+  renewalDate?: string;
+  openAlertCount: number;
+}
+
+export interface CustomerSuccessPortfolio {
+  generatedAt: string;
+  summary: {
+    totalAccounts: number;
+    avgHealthScore: number;
+    atRiskAccounts: number;
+    openAlerts: number;
+  };
+  healthDistribution: Array<{
+    label: CustomerSuccessHealthGrade;
+    count: number;
+  }>;
+  attentionAccounts: Array<{
+    accountId: string;
+    name: string;
+    ownerName?: string;
+    health: CustomerSuccessHealth;
+    openAlertCount: number;
+    lifecycleStage: string;
+    nextAction?: string;
+  }>;
+  alerts: CustomerSuccessAlert[];
+  recentActivity: CustomerSuccessEvent[];
+  accounts: CustomerSuccessPortfolioAccount[];
+}
+
+export interface CustomerSuccessAccountDetail {
+  accountId: string;
+  name: string;
+  segment?: string;
+  tier?: string;
+  lifecycleStage: string;
+  ownerName?: string;
+  health: CustomerSuccessHealth;
+  alerts: CustomerSuccessAlert[];
+  timeline: CustomerSuccessEvent[];
+  stakeholders: CustomerSuccessStakeholder[];
+  tasks: CustomerSuccessTaskSummary[];
+  successPlan: {
+    templateKey?: string;
+    milestones: Array<{
+      id: string;
+      title: string;
+      status: string;
+      dueDate?: string;
+    }>;
+  };
+  outreach: {
+    recommendedTemplates: string[];
+    recentMessages: Array<{
+      id: string;
+      subject: string;
+      sentAt?: string;
+      status: string;
+    }>;
+  };
+  commercial?: {
+    arr?: number;
+    renewalDate?: string;
+    paymentStatus?: string;
+    expansionPotential?: string;
+  };
+}
+
+export interface CreateCustomerSuccessNoteInput {
+  accountId: string;
+  title?: string;
+  body: string;
+  source?: CustomerSuccessNoteSource;
+  visibility?: CustomerSuccessNoteVisibility;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CreateCustomerSuccessPlanInput {
+  accountId: string;
+  name: string;
+  templateKey?: string;
+  targetDate?: string;
+  milestoneTitles?: string[];
+}
+
+export interface UpdateCustomerSuccessAlertStatusInput {
+  accountId: string;
+  alertId: string;
+  status: CustomerSuccessAlertStatus;
+}
+
+export interface SendCustomerSuccessOutreachInput {
+  accountId: string;
+  channel: CustomerSuccessOutreachChannel;
+  recipientAddress: string;
+  recipientName?: string;
+  templateKey?: string;
+  subject?: string;
+  body: string;
+  metadata?: Record<string, unknown>;
+}

--- a/src/lib/integrations/oauth.ts
+++ b/src/lib/integrations/oauth.ts
@@ -752,9 +752,6 @@ export async function fetchOAuthAccountProfile(
   if (definition.slug === "google-workspace" || definition.slug === "google-ads") {
     return fetchGoogleProfile(accessToken);
   }
-  if (definition.slug === "google-ads") {
-    return fetchGoogleProfile(accessToken);
-  }
   if (definition.slug === "hubspot") {
     return fetchHubSpotProfile(accessToken);
   }


### PR DESCRIPTION
## Summary
- add a repo-grounded customer-success audit and initial `src/lib/customer-success/types.ts` contract file for the planned account-centric CS surface
- align analytics deal fixtures with the expanded HubSpot deal shape, request the HubSpot pipeline field, and remove a duplicate Google Ads profile branch in OAuth profile resolution
- add self-contained Reddit Ads fallback handling so report requests retry with smaller payload variants when the richer v3 request is rejected

## Notes
- I intentionally did **not** include `prisma/migrations/20260307153000_add_customer_success_models/migration.sql` in this PR.
- That migration currently has no matching updates in `prisma/schema.prisma`, so merging it as-is would put the database schema ahead of the generated Prisma client.
- The migration remains local for follow-up once the Prisma schema/models are added.

## Test plan
- [x] `npm run db:generate`
- [x] `npx vitest run src/lib/__tests__/analytics-fetchers-ads.test.ts src/lib/__tests__/analytics-fetchers-stripe.test.ts src/lib/__tests__/analytics-process-analytics.test.ts src/components/analytics/rep-scoreboard-card.test.tsx`
- [x] `npx eslint src/lib/analytics/fetchers-ads.ts src/lib/analytics/fetchers.ts src/lib/integrations/oauth.ts src/lib/__tests__/analytics-fetchers-ads.test.ts src/lib/__tests__/analytics-fetchers-stripe.test.ts src/lib/__tests__/analytics-process-analytics.test.ts src/components/analytics/rep-scoreboard-card.test.tsx src/lib/customer-success/types.ts`
- [ ] Run full CI on the PR branch


Made with [Cursor](https://cursor.com)