### PR TITLE
Add customer success Prisma schema foundation

### DIFF
--- a/prisma/migrations/20260307153000_add_customer_success_models/migration.sql
+++ b/prisma/migrations/20260307153000_add_customer_success_models/migration.sql
@@ -1,0 +1,653 @@
+-- Customer Success foundation
+-- Adds merged customer records plus dedicated CS persistence for notes,
+-- plans, alerts, outreach, and account linkage from tasks/meetings.
+
+-- CreateEnum
+DO $$
+BEGIN
+  CREATE TYPE "CustomerLifecycleStage" AS ENUM (
+    'ONBOARDING',
+    'ADOPTION',
+    'ACTIVE',
+    'EXPANSION',
+    'RENEWAL',
+    'AT_RISK',
+    'CHURNED'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- CreateEnum
+DO $$
+BEGIN
+  CREATE TYPE "CustomerRecordStatus" AS ENUM ('ACTIVE', 'ARCHIVED', 'MERGED');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- CreateEnum
+DO $$
+BEGIN
+  CREATE TYPE "CustomerExternalProvider" AS ENUM (
+    'INTERNAL',
+    'HUBSPOT',
+    'STRIPE',
+    'PYLON',
+    'CODA',
+    'SLACK',
+    'GOOGLE_WORKSPACE'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- CreateEnum
+DO $$
+BEGIN
+  CREATE TYPE "CustomerSuccessNoteSource" AS ENUM (
+    'MANUAL',
+    'MEETING',
+    'SUPPORT',
+    'CRM',
+    'AI',
+    'SYSTEM'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- CreateEnum
+DO $$
+BEGIN
+  CREATE TYPE "CustomerSuccessNoteVisibility" AS ENUM ('INTERNAL', 'RESTRICTED');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- CreateEnum
+DO $$
+BEGIN
+  CREATE TYPE "CustomerSuccessPlanStatus" AS ENUM ('DRAFT', 'ACTIVE', 'COMPLETED', 'ARCHIVED');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- CreateEnum
+DO $$
+BEGIN
+  CREATE TYPE "CustomerSuccessMilestoneStatus" AS ENUM (
+    'NOT_STARTED',
+    'IN_PROGRESS',
+    'BLOCKED',
+    'COMPLETED'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- CreateEnum
+DO $$
+BEGIN
+  CREATE TYPE "CustomerSuccessAlertCategory" AS ENUM ('RISK', 'OPPORTUNITY', 'ACTION_REQUIRED');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- CreateEnum
+DO $$
+BEGIN
+  CREATE TYPE "CustomerSuccessAlertSeverity" AS ENUM ('LOW', 'MEDIUM', 'HIGH', 'CRITICAL');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- CreateEnum
+DO $$
+BEGIN
+  CREATE TYPE "CustomerSuccessAlertStatus" AS ENUM ('OPEN', 'IN_PROGRESS', 'RESOLVED', 'DISMISSED');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- CreateEnum
+DO $$
+BEGIN
+  CREATE TYPE "CustomerSuccessSlaStatus" AS ENUM ('NONE', 'ON_TRACK', 'AT_RISK', 'BREACHED');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- CreateEnum
+DO $$
+BEGIN
+  CREATE TYPE "CustomerSuccessAlertSource" AS ENUM (
+    'HEALTH',
+    'SUPPORT',
+    'COMMERCIAL',
+    'RELATIONSHIP',
+    'WORKFLOW'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- CreateEnum
+DO $$
+BEGIN
+  CREATE TYPE "CustomerSuccessOutreachChannel" AS ENUM ('EMAIL', 'SLACK');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- CreateEnum
+DO $$
+BEGIN
+  CREATE TYPE "CustomerSuccessOutreachStatus" AS ENUM (
+    'DRAFT',
+    'QUEUED',
+    'SENT',
+    'FAILED',
+    'CANCELED'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AlterTable
+ALTER TABLE "Task"
+  ADD COLUMN IF NOT EXISTS "customerRecordId" TEXT;
+
+-- AlterTable
+ALTER TABLE "DealMeeting"
+  ADD COLUMN IF NOT EXISTS "customerRecordId" TEXT;
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "CustomerRecord" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "segment" TEXT,
+    "tier" TEXT,
+    "lifecycleStage" "CustomerLifecycleStage" NOT NULL DEFAULT 'ONBOARDING',
+    "status" "CustomerRecordStatus" NOT NULL DEFAULT 'ACTIVE',
+    "metadata" JSONB,
+    "ownerId" TEXT,
+    "dealCompanyId" TEXT,
+    "primaryDealId" TEXT,
+    "mergedIntoId" TEXT,
+    "organizationId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CustomerRecord_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "CustomerRecordExternalRef" (
+    "id" TEXT NOT NULL,
+    "customerRecordId" TEXT NOT NULL,
+    "provider" "CustomerExternalProvider" NOT NULL,
+    "externalObjectType" TEXT NOT NULL DEFAULT 'account',
+    "externalId" TEXT NOT NULL,
+    "label" TEXT,
+    "isPrimary" BOOLEAN NOT NULL DEFAULT false,
+    "metadata" JSONB,
+    "organizationId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CustomerRecordExternalRef_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "CustomerSuccessNote" (
+    "id" TEXT NOT NULL,
+    "customerRecordId" TEXT NOT NULL,
+    "authorUserId" TEXT,
+    "title" TEXT,
+    "body" TEXT NOT NULL,
+    "source" "CustomerSuccessNoteSource" NOT NULL DEFAULT 'MANUAL',
+    "visibility" "CustomerSuccessNoteVisibility" NOT NULL DEFAULT 'INTERNAL',
+    "metadata" JSONB,
+    "organizationId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CustomerSuccessNote_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "CustomerSuccessPlan" (
+    "id" TEXT NOT NULL,
+    "customerRecordId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "templateKey" TEXT,
+    "status" "CustomerSuccessPlanStatus" NOT NULL DEFAULT 'DRAFT',
+    "ownerUserId" TEXT,
+    "startedAt" TIMESTAMP(3),
+    "targetDate" TIMESTAMP(3),
+    "completedAt" TIMESTAMP(3),
+    "metadata" JSONB,
+    "organizationId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CustomerSuccessPlan_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "CustomerSuccessPlanMilestone" (
+    "id" TEXT NOT NULL,
+    "planId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "status" "CustomerSuccessMilestoneStatus" NOT NULL DEFAULT 'NOT_STARTED',
+    "dueDate" TIMESTAMP(3),
+    "completedAt" TIMESTAMP(3),
+    "linkedTaskId" TEXT,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "metadata" JSONB,
+    "organizationId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CustomerSuccessPlanMilestone_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "CustomerSuccessAlertRecord" (
+    "id" TEXT NOT NULL,
+    "customerRecordId" TEXT NOT NULL,
+    "alertKey" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "category" "CustomerSuccessAlertCategory" NOT NULL,
+    "severity" "CustomerSuccessAlertSeverity" NOT NULL DEFAULT 'MEDIUM',
+    "status" "CustomerSuccessAlertStatus" NOT NULL DEFAULT 'OPEN',
+    "slaStatus" "CustomerSuccessSlaStatus" NOT NULL DEFAULT 'NONE',
+    "source" "CustomerSuccessAlertSource" NOT NULL,
+    "evidence" JSONB,
+    "suggestedAction" TEXT,
+    "ownerUserId" TEXT,
+    "linkedTaskId" TEXT,
+    "openedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "resolvedAt" TIMESTAMP(3),
+    "lastEvaluatedAt" TIMESTAMP(3),
+    "metadata" JSONB,
+    "organizationId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CustomerSuccessAlertRecord_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "CustomerSuccessOutreachMessage" (
+    "id" TEXT NOT NULL,
+    "customerRecordId" TEXT NOT NULL,
+    "authorUserId" TEXT,
+    "channel" "CustomerSuccessOutreachChannel" NOT NULL,
+    "status" "CustomerSuccessOutreachStatus" NOT NULL DEFAULT 'DRAFT',
+    "templateKey" TEXT,
+    "recipientName" TEXT,
+    "recipientAddress" TEXT NOT NULL,
+    "subject" TEXT,
+    "body" TEXT NOT NULL,
+    "providerMessageId" TEXT,
+    "providerThreadId" TEXT,
+    "queuedAt" TIMESTAMP(3),
+    "sentAt" TIMESTAMP(3),
+    "failedAt" TIMESTAMP(3),
+    "error" TEXT,
+    "metadata" JSONB,
+    "organizationId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CustomerSuccessOutreachMessage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "Task_customerRecordId_idx" ON "Task"("customerRecordId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "DealMeeting_customerRecordId_idx" ON "DealMeeting"("customerRecordId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "CustomerRecord_dealCompanyId_key" ON "CustomerRecord"("dealCompanyId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerRecord_organizationId_idx" ON "CustomerRecord"("organizationId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerRecord_ownerId_idx" ON "CustomerRecord"("ownerId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerRecord_mergedIntoId_idx" ON "CustomerRecord"("mergedIntoId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerRecord_status_lifecycleStage_idx" ON "CustomerRecord"("status", "lifecycleStage");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "CustomerRecordExternalRef_customerRecordId_provider_externalObjectType_externalId_key"
+  ON "CustomerRecordExternalRef"("customerRecordId", "provider", "externalObjectType", "externalId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerRecordExternalRef_organizationId_idx" ON "CustomerRecordExternalRef"("organizationId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerRecordExternalRef_provider_externalId_idx"
+  ON "CustomerRecordExternalRef"("provider", "externalId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerSuccessNote_customerRecordId_createdAt_idx"
+  ON "CustomerSuccessNote"("customerRecordId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerSuccessNote_organizationId_idx" ON "CustomerSuccessNote"("organizationId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerSuccessNote_authorUserId_idx" ON "CustomerSuccessNote"("authorUserId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerSuccessPlan_customerRecordId_status_idx"
+  ON "CustomerSuccessPlan"("customerRecordId", "status");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerSuccessPlan_organizationId_idx" ON "CustomerSuccessPlan"("organizationId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerSuccessPlan_ownerUserId_idx" ON "CustomerSuccessPlan"("ownerUserId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerSuccessPlanMilestone_planId_sortOrder_idx"
+  ON "CustomerSuccessPlanMilestone"("planId", "sortOrder");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerSuccessPlanMilestone_organizationId_idx"
+  ON "CustomerSuccessPlanMilestone"("organizationId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerSuccessPlanMilestone_linkedTaskId_idx"
+  ON "CustomerSuccessPlanMilestone"("linkedTaskId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "CustomerSuccessAlertRecord_customerRecordId_alertKey_key"
+  ON "CustomerSuccessAlertRecord"("customerRecordId", "alertKey");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerSuccessAlertRecord_organizationId_status_severity_idx"
+  ON "CustomerSuccessAlertRecord"("organizationId", "status", "severity");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerSuccessAlertRecord_ownerUserId_idx"
+  ON "CustomerSuccessAlertRecord"("ownerUserId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerSuccessAlertRecord_linkedTaskId_idx"
+  ON "CustomerSuccessAlertRecord"("linkedTaskId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerSuccessOutreachMessage_customerRecordId_status_createdAt_idx"
+  ON "CustomerSuccessOutreachMessage"("customerRecordId", "status", "createdAt");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerSuccessOutreachMessage_organizationId_idx"
+  ON "CustomerSuccessOutreachMessage"("organizationId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerSuccessOutreachMessage_authorUserId_idx"
+  ON "CustomerSuccessOutreachMessage"("authorUserId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "CustomerSuccessOutreachMessage_providerMessageId_idx"
+  ON "CustomerSuccessOutreachMessage"("providerMessageId");
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'Task_customerRecordId_fkey') THEN
+    ALTER TABLE "Task"
+      ADD CONSTRAINT "Task_customerRecordId_fkey"
+      FOREIGN KEY ("customerRecordId") REFERENCES "CustomerRecord"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'DealMeeting_customerRecordId_fkey') THEN
+    ALTER TABLE "DealMeeting"
+      ADD CONSTRAINT "DealMeeting_customerRecordId_fkey"
+      FOREIGN KEY ("customerRecordId") REFERENCES "CustomerRecord"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerRecord_ownerId_fkey') THEN
+    ALTER TABLE "CustomerRecord"
+      ADD CONSTRAINT "CustomerRecord_ownerId_fkey"
+      FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerRecord_dealCompanyId_fkey') THEN
+    ALTER TABLE "CustomerRecord"
+      ADD CONSTRAINT "CustomerRecord_dealCompanyId_fkey"
+      FOREIGN KEY ("dealCompanyId") REFERENCES "DealCompany"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerRecord_primaryDealId_fkey') THEN
+    ALTER TABLE "CustomerRecord"
+      ADD CONSTRAINT "CustomerRecord_primaryDealId_fkey"
+      FOREIGN KEY ("primaryDealId") REFERENCES "Deal"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerRecord_mergedIntoId_fkey') THEN
+    ALTER TABLE "CustomerRecord"
+      ADD CONSTRAINT "CustomerRecord_mergedIntoId_fkey"
+      FOREIGN KEY ("mergedIntoId") REFERENCES "CustomerRecord"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerRecord_organizationId_fkey') THEN
+    ALTER TABLE "CustomerRecord"
+      ADD CONSTRAINT "CustomerRecord_organizationId_fkey"
+      FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerRecordExternalRef_customerRecordId_fkey') THEN
+    ALTER TABLE "CustomerRecordExternalRef"
+      ADD CONSTRAINT "CustomerRecordExternalRef_customerRecordId_fkey"
+      FOREIGN KEY ("customerRecordId") REFERENCES "CustomerRecord"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerRecordExternalRef_organizationId_fkey') THEN
+    ALTER TABLE "CustomerRecordExternalRef"
+      ADD CONSTRAINT "CustomerRecordExternalRef_organizationId_fkey"
+      FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerSuccessNote_customerRecordId_fkey') THEN
+    ALTER TABLE "CustomerSuccessNote"
+      ADD CONSTRAINT "CustomerSuccessNote_customerRecordId_fkey"
+      FOREIGN KEY ("customerRecordId") REFERENCES "CustomerRecord"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerSuccessNote_authorUserId_fkey') THEN
+    ALTER TABLE "CustomerSuccessNote"
+      ADD CONSTRAINT "CustomerSuccessNote_authorUserId_fkey"
+      FOREIGN KEY ("authorUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerSuccessNote_organizationId_fkey') THEN
+    ALTER TABLE "CustomerSuccessNote"
+      ADD CONSTRAINT "CustomerSuccessNote_organizationId_fkey"
+      FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerSuccessPlan_customerRecordId_fkey') THEN
+    ALTER TABLE "CustomerSuccessPlan"
+      ADD CONSTRAINT "CustomerSuccessPlan_customerRecordId_fkey"
+      FOREIGN KEY ("customerRecordId") REFERENCES "CustomerRecord"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerSuccessPlan_ownerUserId_fkey') THEN
+    ALTER TABLE "CustomerSuccessPlan"
+      ADD CONSTRAINT "CustomerSuccessPlan_ownerUserId_fkey"
+      FOREIGN KEY ("ownerUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerSuccessPlan_organizationId_fkey') THEN
+    ALTER TABLE "CustomerSuccessPlan"
+      ADD CONSTRAINT "CustomerSuccessPlan_organizationId_fkey"
+      FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerSuccessPlanMilestone_planId_fkey') THEN
+    ALTER TABLE "CustomerSuccessPlanMilestone"
+      ADD CONSTRAINT "CustomerSuccessPlanMilestone_planId_fkey"
+      FOREIGN KEY ("planId") REFERENCES "CustomerSuccessPlan"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerSuccessPlanMilestone_linkedTaskId_fkey') THEN
+    ALTER TABLE "CustomerSuccessPlanMilestone"
+      ADD CONSTRAINT "CustomerSuccessPlanMilestone_linkedTaskId_fkey"
+      FOREIGN KEY ("linkedTaskId") REFERENCES "Task"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerSuccessPlanMilestone_organizationId_fkey') THEN
+    ALTER TABLE "CustomerSuccessPlanMilestone"
+      ADD CONSTRAINT "CustomerSuccessPlanMilestone_organizationId_fkey"
+      FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerSuccessAlertRecord_customerRecordId_fkey') THEN
+    ALTER TABLE "CustomerSuccessAlertRecord"
+      ADD CONSTRAINT "CustomerSuccessAlertRecord_customerRecordId_fkey"
+      FOREIGN KEY ("customerRecordId") REFERENCES "CustomerRecord"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerSuccessAlertRecord_ownerUserId_fkey') THEN
+    ALTER TABLE "CustomerSuccessAlertRecord"
+      ADD CONSTRAINT "CustomerSuccessAlertRecord_ownerUserId_fkey"
+      FOREIGN KEY ("ownerUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerSuccessAlertRecord_linkedTaskId_fkey') THEN
+    ALTER TABLE "CustomerSuccessAlertRecord"
+      ADD CONSTRAINT "CustomerSuccessAlertRecord_linkedTaskId_fkey"
+      FOREIGN KEY ("linkedTaskId") REFERENCES "Task"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerSuccessAlertRecord_organizationId_fkey') THEN
+    ALTER TABLE "CustomerSuccessAlertRecord"
+      ADD CONSTRAINT "CustomerSuccessAlertRecord_organizationId_fkey"
+      FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerSuccessOutreachMessage_customerRecordId_fkey') THEN
+    ALTER TABLE "CustomerSuccessOutreachMessage"
+      ADD CONSTRAINT "CustomerSuccessOutreachMessage_customerRecordId_fkey"
+      FOREIGN KEY ("customerRecordId") REFERENCES "CustomerRecord"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerSuccessOutreachMessage_authorUserId_fkey') THEN
+    ALTER TABLE "CustomerSuccessOutreachMessage"
+      ADD CONSTRAINT "CustomerSuccessOutreachMessage_authorUserId_fkey"
+      FOREIGN KEY ("authorUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- AddForeignKey
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'CustomerSuccessOutreachMessage_organizationId_fkey') THEN
+    ALTER TABLE "CustomerSuccessOutreachMessage"
+      ADD CONSTRAINT "CustomerSuccessOutreachMessage_organizationId_fkey"
+      FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,15 +18,22 @@ model Organization {
   updatedAt DateTime @updatedAt
 
   // Relations to all tenant-scoped models
-  users                  User[]
-  projects               Project[]
-  tasks                  Task[]
-  sprints                Sprint[]
-  deals                  Deal[]
-  departments            Department[]
-  companyPriorities      CompanyPriority[]
-  integrationConnections IntegrationConnection[]
-  conferences            Conference[]
+  users                           User[]
+  projects                        Project[]
+  tasks                           Task[]
+  sprints                         Sprint[]
+  deals                           Deal[]
+  departments                     Department[]
+  companyPriorities               CompanyPriority[]
+  integrationConnections          IntegrationConnection[]
+  conferences                     Conference[]
+  customerRecords                 CustomerRecord[]
+  customerRecordExternalRefs      CustomerRecordExternalRef[]
+  customerSuccessNotes            CustomerSuccessNote[]
+  customerSuccessPlans            CustomerSuccessPlan[]
+  customerSuccessPlanMilestones   CustomerSuccessPlanMilestone[]
+  customerSuccessAlertRecords     CustomerSuccessAlertRecord[]
+  customerSuccessOutreachMessages CustomerSuccessOutreachMessage[]
 }
 
 // ============================================================
@@ -41,27 +48,27 @@ model User {
   image         String?
   role          String    @default("member")
 
-  accounts Account[]
-  sessions Session[]
-  integrationConnections IntegrationConnection[]
-  integrationRules       IntegrationRule[]
-  analyticsSnapshots     AnalyticsSnapshot[]
+  accounts                 Account[]
+  sessions                 Session[]
+  integrationConnections   IntegrationConnection[]
+  integrationRules         IntegrationRule[]
+  analyticsSnapshots       AnalyticsSnapshot[]
   integrationCircuitStates IntegrationCircuitState[]
-  stripeCustomerLinks    StripeCustomerLink[]
-  metricHistory          MetricHistory[]
-  insightFeedback        InsightFeedback[]
-  uiPreference           UserUiPreference?
-  savedViews             UserSavedView[]
-  ownedWorkflows         WorkflowDefinition[] @relation("WorkflowOwner")
-  workflowRunRequests    WorkflowRun[]        @relation("WorkflowRunRequestedBy")
-  workflowApprovalRequests WorkflowApproval[] @relation("WorkflowApprovalRequestedBy")
-  workflowApprovals      WorkflowApproval[]   @relation("WorkflowApprovalApprover")
-  securityAuditEvents SecurityAuditEvent[]
+  stripeCustomerLinks      StripeCustomerLink[]
+  metricHistory            MetricHistory[]
+  insightFeedback          InsightFeedback[]
+  uiPreference             UserUiPreference?
+  savedViews               UserSavedView[]
+  ownedWorkflows           WorkflowDefinition[]      @relation("WorkflowOwner")
+  workflowRunRequests      WorkflowRun[]             @relation("WorkflowRunRequestedBy")
+  workflowApprovalRequests WorkflowApproval[]        @relation("WorkflowApprovalRequestedBy")
+  workflowApprovals        WorkflowApproval[]        @relation("WorkflowApprovalApprover")
+  securityAuditEvents      SecurityAuditEvent[]
 
-  responsibleTasks  Task[]    @relation("TaskResponsible")
-  accountableTasks  Task[]    @relation("TaskAccountable")
-  consultedTasks    Task[]    @relation("TaskConsulted")
-  informedTasks     Task[]    @relation("TaskInformed")
+  responsibleTasks Task[] @relation("TaskResponsible")
+  accountableTasks Task[] @relation("TaskAccountable")
+  consultedTasks   Task[] @relation("TaskConsulted")
+  informedTasks    Task[] @relation("TaskInformed")
 
   responsibleProjects Project[] @relation("ProjectResponsible")
   accountableProjects Project[] @relation("ProjectAccountable")
@@ -80,24 +87,29 @@ model User {
   financialGoals    FinancialGoal[]
   forecastScenarios ForecastScenario[]
 
-  ownedDeals Deal[] @relation("DealOwner")
+  ownedDeals                              Deal[]                           @relation("DealOwner")
+  ownedCustomerRecords                    CustomerRecord[]                 @relation("CustomerRecordOwner")
+  authoredCustomerSuccessNotes            CustomerSuccessNote[]            @relation("CustomerSuccessNoteAuthor")
+  ownedCustomerSuccessPlans               CustomerSuccessPlan[]            @relation("CustomerSuccessPlanOwner")
+  ownedCustomerSuccessAlertRecords        CustomerSuccessAlertRecord[]     @relation("CustomerSuccessAlertOwner")
+  authoredCustomerSuccessOutreachMessages CustomerSuccessOutreachMessage[] @relation("CustomerSuccessOutreachAuthor")
 
-  ownedConferences Conference[] @relation("ConferenceOwner")
-  ownedConferenceDeadlines ConferenceDeadline[] @relation("ConferenceDeadlineOwner")
-  paidConferenceExpenses ConferenceExpense[] @relation("ConferenceExpensePaidBy")
-  capturedConferenceLeads ConferenceLead[] @relation("ConferenceLeadCapturedBy")
-  assignedConferenceLeads ConferenceLead[] @relation("ConferenceLeadAssignedTo")
-  conferenceTeamMemberships ConferenceTeamMember[] @relation("ConferenceTeamMemberUser")
+  ownedConferences              Conference[]              @relation("ConferenceOwner")
+  ownedConferenceDeadlines      ConferenceDeadline[]      @relation("ConferenceDeadlineOwner")
+  paidConferenceExpenses        ConferenceExpense[]       @relation("ConferenceExpensePaidBy")
+  capturedConferenceLeads       ConferenceLead[]          @relation("ConferenceLeadCapturedBy")
+  assignedConferenceLeads       ConferenceLead[]          @relation("ConferenceLeadAssignedTo")
+  conferenceTeamMemberships     ConferenceTeamMember[]    @relation("ConferenceTeamMemberUser")
   ownedConferenceInventoryItems ConferenceInventoryItem[] @relation("ConferenceInventoryItemOwner")
 
-  submissionEvents SubmissionEvent[]
+  submissionEvents   SubmissionEvent[]
   insightPreferences InsightPreference[]
 
   organizationId String?
   organization   Organization? @relation(fields: [organizationId], references: [id])
 
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([organizationId])
 }
@@ -170,10 +182,10 @@ model CompanyPriority {
 // ============================================================
 
 model Department {
-  id        String    @id @default(cuid())
-  name      String    @unique
-  color     String?
-  projects  Project[]
+  id       String    @id @default(cuid())
+  name     String    @unique
+  color    String?
+  projects Project[]
 
   organizationId String?
   organization   Organization? @relation(fields: [organizationId], references: [id])
@@ -195,8 +207,8 @@ model Project {
   status      ProjectStatus @default(ACTIVE)
   projectType ProjectType   @default(ONE_OFF)
 
-  conferenceId String?
-  conference   Conference? @relation("ConferenceProjects", fields: [conferenceId], references: [id], onDelete: SetNull)
+  conferenceId         String?
+  conference           Conference? @relation("ConferenceProjects", fields: [conferenceId], references: [id], onDelete: SetNull)
   primaryForConference Conference? @relation("ConferencePrimaryProject")
 
   parentId String?
@@ -262,8 +274,8 @@ model Task {
   conferenceId String?
   conference   Conference? @relation("ConferenceTasks", fields: [conferenceId], references: [id], onDelete: SetNull)
 
-  conferenceDeadline ConferenceDeadline? @relation("ConferenceDeadlineTask")
-  conferenceLeadFollowup ConferenceLead? @relation("ConferenceLeadFollowupTask")
+  conferenceDeadline     ConferenceDeadline? @relation("ConferenceDeadlineTask")
+  conferenceLeadFollowup ConferenceLead?     @relation("ConferenceLeadFollowupTask")
 
   parentId String?
   parent   Task?   @relation("TaskHierarchy", fields: [parentId], references: [id], onDelete: Restrict)
@@ -292,14 +304,18 @@ model Task {
   planningSessionId String?
   planningSession   PlanningSession? @relation(fields: [planningSessionId], references: [id])
 
-  slackThread String?
-  metadata    Json?
-  columnOrder Int     @default(0)
+  slackThread      String?
+  metadata         Json?
+  columnOrder      Int             @default(0)
+  customerRecordId String?
+  customerRecord   CustomerRecord? @relation(fields: [customerRecordId], references: [id], onDelete: SetNull)
 
-  statusHistory   StatusHistory[]
-  logbookEntries  LogbookEntry[]
-  policyOverrides PolicyOverride[]
-  integrationReceipts IntegrationReceipt[]
+  statusHistory                 StatusHistory[]
+  logbookEntries                LogbookEntry[]
+  policyOverrides               PolicyOverride[]
+  integrationReceipts           IntegrationReceipt[]
+  customerSuccessPlanMilestones CustomerSuccessPlanMilestone[]
+  customerSuccessAlertRecords   CustomerSuccessAlertRecord[]
 
   organizationId String?
   organization   Organization? @relation(fields: [organizationId], references: [id])
@@ -308,6 +324,7 @@ model Task {
   updatedAt DateTime @updatedAt
 
   @@index([conferenceId])
+  @@index([customerRecordId])
   @@index([organizationId])
 }
 
@@ -418,14 +435,14 @@ enum ConferenceReimbursementStatus {
 }
 
 model Conference {
-  id         String @id @default(cuid())
-  slug       String @unique
+  id         String  @id @default(cuid())
+  slug       String  @unique
   name       String
   websiteUrl String?
 
   startDate DateTime
   endDate   DateTime
-  timezone  String  @default("UTC")
+  timezone  String   @default("UTC")
 
   city    String?
   region  String?
@@ -443,9 +460,9 @@ model Conference {
   codaDocUrl       String?
 
   ownerId String?
-  owner   User? @relation("ConferenceOwner", fields: [ownerId], references: [id], onDelete: SetNull)
+  owner   User?   @relation("ConferenceOwner", fields: [ownerId], references: [id], onDelete: SetNull)
 
-  primaryProjectId String? @unique
+  primaryProjectId String?  @unique
   primaryProject   Project? @relation("ConferencePrimaryProject", fields: [primaryProjectId], references: [id], onDelete: SetNull)
 
   projects Project[] @relation("ConferenceProjects")
@@ -475,19 +492,19 @@ model ConferenceDeadline {
   conferenceId String
   conference   Conference @relation(fields: [conferenceId], references: [id], onDelete: Cascade)
 
-  type ConferenceDeadlineType
-  name String
+  type  ConferenceDeadlineType
+  name  String
   dueAt DateTime
 
   completedAt DateTime?
   ownerId     String?
-  owner       User? @relation("ConferenceDeadlineOwner", fields: [ownerId], references: [id], onDelete: SetNull)
+  owner       User?     @relation("ConferenceDeadlineOwner", fields: [ownerId], references: [id], onDelete: SetNull)
 
   notes     String? @db.Text
   sourceUrl String?
 
   taskId String? @unique
-  task   Task? @relation("ConferenceDeadlineTask", fields: [taskId], references: [id], onDelete: SetNull)
+  task   Task?   @relation("ConferenceDeadlineTask", fields: [taskId], references: [id], onDelete: SetNull)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -502,7 +519,7 @@ model ConferenceBudget {
   conferenceId String     @unique
   conference   Conference @relation(fields: [conferenceId], references: [id], onDelete: Cascade)
 
-  currency String @default("USD")
+  currency String  @default("USD")
   notes    String? @db.Text
 
   lineItems ConferenceBudgetLineItem[]
@@ -534,20 +551,20 @@ model ConferenceExpense {
   conferenceId String
   conference   Conference @relation(fields: [conferenceId], references: [id], onDelete: Cascade)
 
-  category  ConferenceExpenseCategory
-  amount    Float
-  currency  String @default("USD")
+  category   ConferenceExpenseCategory
+  amount     Float
+  currency   String                    @default("USD")
   incurredAt DateTime
 
   vendor      String?
   description String? @db.Text
   receiptUrl  String?
 
-  reimbursable Boolean @default(false)
+  reimbursable        Boolean                       @default(false)
   reimbursementStatus ConferenceReimbursementStatus @default(NONE)
 
   paidByUserId String?
-  paidByUser   User? @relation("ConferenceExpensePaidBy", fields: [paidByUserId], references: [id], onDelete: SetNull)
+  paidByUser   User?   @relation("ConferenceExpensePaidBy", fields: [paidByUserId], references: [id], onDelete: SetNull)
 
   budgetLineItemId String?
   budgetLineItem   ConferenceBudgetLineItem? @relation("ConferenceExpenseBudgetLineItem", fields: [budgetLineItemId], references: [id], onDelete: SetNull)
@@ -582,19 +599,19 @@ model ConferenceLead {
   capturedAt DateTime @default(now())
 
   capturedByUserId String?
-  capturedByUser   User? @relation("ConferenceLeadCapturedBy", fields: [capturedByUserId], references: [id], onDelete: SetNull)
+  capturedByUser   User?   @relation("ConferenceLeadCapturedBy", fields: [capturedByUserId], references: [id], onDelete: SetNull)
 
   assignedToUserId String?
-  assignedToUser   User? @relation("ConferenceLeadAssignedTo", fields: [assignedToUserId], references: [id], onDelete: SetNull)
+  assignedToUser   User?   @relation("ConferenceLeadAssignedTo", fields: [assignedToUserId], references: [id], onDelete: SetNull)
 
   followupTaskId String? @unique
-  followupTask   Task? @relation("ConferenceLeadFollowupTask", fields: [followupTaskId], references: [id], onDelete: SetNull)
+  followupTask   Task?   @relation("ConferenceLeadFollowupTask", fields: [followupTaskId], references: [id], onDelete: SetNull)
 
   followedUpAt DateTime?
 
-  hubspotCompanyId String?
-  hubspotContactId String?
-  hubspotDealId    String?
+  hubspotCompanyId  String?
+  hubspotContactId  String?
+  hubspotDealId     String?
   pushedToHubspotAt DateTime?
 
   createdAt DateTime @default(now())
@@ -611,12 +628,12 @@ model ConferenceTeamMember {
   conference   Conference @relation(fields: [conferenceId], references: [id], onDelete: Cascade)
 
   userId String
-  user   User @relation("ConferenceTeamMemberUser", fields: [userId], references: [id], onDelete: Cascade)
+  user   User   @relation("ConferenceTeamMemberUser", fields: [userId], references: [id], onDelete: Cascade)
 
-  role ConferenceTeamRole
+  role        ConferenceTeamRole
   arrivalAt   DateTime?
   departureAt DateTime?
-  notes       String? @db.Text
+  notes       String?            @db.Text
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -639,7 +656,7 @@ model ConferenceInventoryItem {
   qtyRemaining Int @default(0)
 
   ownerId String?
-  owner   User? @relation("ConferenceInventoryItemOwner", fields: [ownerId], references: [id], onDelete: SetNull)
+  owner   User?   @relation("ConferenceInventoryItemOwner", fields: [ownerId], references: [id], onDelete: SetNull)
 
   notes String? @db.Text
 
@@ -660,9 +677,9 @@ model Sprint {
   endDate   DateTime
   isActive  Boolean  @default(false)
 
-  tasks             Task[]
-  commitments       SprintCommitment[]
-  planningSessions  PlanningSession[]
+  tasks            Task[]
+  commitments      SprintCommitment[]
+  planningSessions PlanningSession[]
 
   organizationId String?
   organization   Organization? @relation(fields: [organizationId], references: [id])
@@ -685,7 +702,7 @@ model SprintCommitment {
   sprint        Sprint   @relation(fields: [sprintId], references: [id], onDelete: Cascade)
   snapshotAt    DateTime @default(now())
   createdBy     String
-  taskSnapshots Json     // Array of {taskId, title, status, projectId, priority}
+  taskSnapshots Json // Array of {taskId, title, status, projectId, priority}
 
   @@index([sprintId, snapshotAt])
 }
@@ -744,10 +761,10 @@ model LogbookEntry {
 // ============================================================
 
 model BoardSettings {
-  id          String @id @default(cuid())
-  columnName  String @unique
-  wipLimit    Int    @default(0)
-  columnOrder Int    @default(0)
+  id          String  @id @default(cuid())
+  columnName  String  @unique
+  wipLimit    Int     @default(0)
+  columnOrder Int     @default(0)
   color       String?
 
   createdAt DateTime @default(now())
@@ -779,11 +796,11 @@ enum EnforcementMode {
 // ============================================================
 
 model PolicyOverride {
-  id        String     @id @default(cuid())
+  id        String  @id @default(cuid())
   taskId    String
-  task      Task       @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  task      Task    @relation(fields: [taskId], references: [id], onDelete: Cascade)
   action    String
-  reason    String     @db.Text
+  reason    String  @db.Text
   actorId   String
   actorName String?
   actorRole String?
@@ -799,10 +816,10 @@ model PolicyOverride {
 // ============================================================
 
 model SecurityAuditEvent {
-  id        String  @id @default(cuid())
-  action    String
-  category  String
-  outcome   String
+  id       String @id @default(cuid())
+  action   String
+  category String
+  outcome  String
 
   actorId   String?
   actor     User?   @relation(fields: [actorId], references: [id], onDelete: SetNull)
@@ -855,20 +872,20 @@ enum AnalyticsSnapshotStatus {
 }
 
 model IntegrationConnection {
-  id        String                      @id @default(cuid())
-  userId    String
-  user      User                        @relation(fields: [userId], references: [id], onDelete: Cascade)
-  provider  IntegrationProvider
-  status    IntegrationConnectionStatus @default(CONNECTED)
+  id       String                      @id @default(cuid())
+  userId   String
+  user     User                        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  provider IntegrationProvider
+  status   IntegrationConnectionStatus @default(CONNECTED)
 
   providerAccountId String?
   accountLabel      String?
-  scopes            String[]            @default([])
-  accessToken       String?             @db.Text
-  refreshToken      String?             @db.Text
+  scopes            String[]  @default([])
+  accessToken       String?   @db.Text
+  refreshToken      String?   @db.Text
   tokenType         String?
   expiresAt         DateTime?
-  connectedAt       DateTime            @default(now())
+  connectedAt       DateTime  @default(now())
   lastSyncedAt      DateTime?
   lastError         String?
   metadata          Json?
@@ -885,12 +902,12 @@ model IntegrationConnection {
 }
 
 model AnalyticsSnapshot {
-  id       String @id @default(cuid())
-  userId   String
-  user     User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id     String @id @default(cuid())
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   providerKey String
-  contextKey  String @default("default")
+  contextKey  String   @default("default")
   rangePreset String
   fromDate    DateTime
   toDate      DateTime
@@ -911,9 +928,9 @@ model AnalyticsSnapshot {
 }
 
 model StripeCustomerLink {
-  id               String   @id @default(cuid())
-  userId           String
-  user             User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id     String @id @default(cuid())
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   stripeCustomerId String
   hubspotDealId    String
@@ -932,9 +949,9 @@ model StripeCustomerLink {
 // ============================================================
 
 model MetricHistory {
-  id          String   @id @default(cuid())
-  userId      String
-  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id     String @id @default(cuid())
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   metricKey   String
   section     String
@@ -958,9 +975,9 @@ enum InsightFeedbackAction {
 }
 
 model InsightFeedback {
-  id        String                @id @default(cuid())
-  userId    String
-  user      User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id     String @id @default(cuid())
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   insightId String
   action    InsightFeedbackAction
@@ -1002,10 +1019,10 @@ model IntegrationCircuitState {
   key String
 
   state               String
-  consecutiveFailures Int    @default(0)
+  consecutiveFailures Int       @default(0)
   openedAt            DateTime?
-  currentCooldownMs   Int    @default(0)
-  openCount           Int    @default(0)
+  currentCooldownMs   Int       @default(0)
+  openCount           Int       @default(0)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1063,10 +1080,10 @@ model UserSavedView {
   scope     SavedViewScope
   slug      String
   name      String
-  isDefault Boolean @default(false)
-  isSystem  Boolean @default(false)
+  isDefault Boolean        @default(false)
+  isSystem  Boolean        @default(false)
   config    Json
-  position  Int     @default(0)
+  position  Int            @default(0)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1136,9 +1153,9 @@ model WorkflowDefinition {
   owner   User   @relation("WorkflowOwner", fields: [ownerId], references: [id], onDelete: Cascade)
 
   name        String
-  description String? @db.Text
-  scope       WorkflowScope @default(PRIVATE)
-  status      WorkflowStatus @default(DRAFT)
+  description String?               @db.Text
+  scope       WorkflowScope         @default(PRIVATE)
+  status      WorkflowStatus        @default(DRAFT)
   providers   IntegrationProvider[] @default([])
   rolePolicy  Json?
 
@@ -1148,13 +1165,13 @@ model WorkflowDefinition {
 
   lastPublishedAt DateTime?
   lastRunAt       DateTime?
-  lastError       String? @db.Text
+  lastError       String?   @db.Text
 
-  nodes        WorkflowNode[]
-  edges        WorkflowEdge[]
-  runs         WorkflowRun[]
+  nodes          WorkflowNode[]
+  edges          WorkflowEdge[]
+  runs           WorkflowRun[]
   triggerCursors WorkflowTriggerCursor[]
-  triggerEvents WorkflowTriggerEvent[]
+  triggerEvents  WorkflowTriggerEvent[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1194,7 +1211,7 @@ model WorkflowEdge {
   targetNodeKey  String
   conditionLabel String?
   conditionExpr  Json?
-  priority       Int @default(0)
+  priority       Int     @default(0)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1216,13 +1233,13 @@ model WorkflowRun {
   triggerType     String?
   triggerId       String?
   triggerPayload  Json?
-  dedupeKey       String? @unique
+  dedupeKey       String?              @unique
 
-  status WorkflowRunStatus @default(QUEUED)
+  status        WorkflowRunStatus @default(QUEUED)
   correlationId String?
-  startedAt DateTime?
-  finishedAt DateTime?
-  error String? @db.Text
+  startedAt     DateTime?
+  finishedAt    DateTime?
+  error         String?           @db.Text
 
   steps     WorkflowRunStep[]
   approvals WorkflowApproval[]
@@ -1240,17 +1257,17 @@ model WorkflowRunStep {
   runId String
   run   WorkflowRun @relation(fields: [runId], references: [id], onDelete: Cascade)
 
-  nodeKey String
+  nodeKey  String
   nodeType WorkflowNodeType
-  status WorkflowStepStatus @default(PENDING)
-  attempt Int @default(0)
+  status   WorkflowStepStatus @default(PENDING)
+  attempt  Int                @default(0)
 
   idempotencyKey String? @unique
-  input  Json?
-  output Json?
-  error  String? @db.Text
+  input          Json?
+  output         Json?
+  error          String? @db.Text
 
-  startedAt DateTime?
+  startedAt  DateTime?
   finishedAt DateTime?
 
   approvals WorkflowApproval[]
@@ -1278,11 +1295,11 @@ model WorkflowApproval {
   approverId String?
   approver   User?   @relation("WorkflowApprovalApprover", fields: [approverId], references: [id], onDelete: SetNull)
 
-  status WorkflowApprovalStatus @default(PENDING)
-  decisionNote String? @db.Text
+  status       WorkflowApprovalStatus @default(PENDING)
+  decisionNote String?                @db.Text
 
-  timeoutAt DateTime?
-  resolvedAt DateTime?
+  timeoutAt      DateTime?
+  resolvedAt     DateTime?
   fallbackEdgeId String?
 
   createdAt DateTime @default(now())
@@ -1298,12 +1315,12 @@ model WorkflowTriggerCursor {
   workflowId String
   workflow   WorkflowDefinition @relation(fields: [workflowId], references: [id], onDelete: Cascade)
 
-  provider IntegrationProvider
-  cursorKey String
+  provider    IntegrationProvider
+  cursorKey   String
   cursorValue Json?
 
   lastEventAt DateTime?
-  lastRunAt DateTime?
+  lastRunAt   DateTime?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1317,17 +1334,17 @@ model WorkflowTriggerEvent {
   workflowId String?
   workflow   WorkflowDefinition? @relation(fields: [workflowId], references: [id], onDelete: SetNull)
 
-  provider IntegrationProvider
-  eventType String
-  externalId String?
-  idempotencyKey String @unique
-  payload Json
-  observedAt DateTime @default(now())
+  provider       IntegrationProvider
+  eventType      String
+  externalId     String?
+  idempotencyKey String              @unique
+  payload        Json
+  observedAt     DateTime            @default(now())
 
-  status WorkflowEventStatus @default(QUEUED)
-  attemptCount Int @default(0)
-  nextAttemptAt DateTime @default(now())
-  lastError String? @db.Text
+  status        WorkflowEventStatus @default(QUEUED)
+  attemptCount  Int                 @default(0)
+  nextAttemptAt DateTime            @default(now())
+  lastError     String?             @db.Text
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1348,21 +1365,21 @@ enum OutboxEventStatus {
 }
 
 model OutboxEvent {
-  id            String           @id @default(cuid())
+  id            String @id @default(cuid())
   eventType     String
   aggregateType String
   aggregateId   String
-  schemaVersion Int              @default(1)
+  schemaVersion Int    @default(1)
   payload       Json
 
-  idempotencyKey String          @unique
+  idempotencyKey String            @unique
   status         OutboxEventStatus @default(PENDING)
-  retryCount     Int             @default(0)
-  nextAttemptAt  DateTime        @default(now())
+  retryCount     Int               @default(0)
+  nextAttemptAt  DateTime          @default(now())
   lastAttemptAt  DateTime?
   dispatchedAt   DateTime?
   failedAt       DateTime?
-  error          String?         @db.Text
+  error          String?           @db.Text
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1385,26 +1402,26 @@ enum ProspectStatus {
 }
 
 model ManufacturerProspect {
-  id               String         @id @default(cuid())
-  userId           String
-  companyName      String
-  domain           String?
-  industry         String?
-  location         String?
-  employeeCount    Int?
-  kanbanEvidence   Json           // [{ url, snippet, confidence }]
-  contactName      String?
-  contactEmail     String?
-  contactTitle     String?
-  sourceType       String         // "google_cse" | "website_scrape" | "directory"
-  sourceUrl        String
-  confidence       Float          @default(0.5)
-  status           ProspectStatus @default(DISCOVERED)
-  hubspotCompanyId String?
-  hubspotContactId String?
+  id                String         @id @default(cuid())
+  userId            String
+  companyName       String
+  domain            String?
+  industry          String?
+  location          String?
+  employeeCount     Int?
+  kanbanEvidence    Json // [{ url, snippet, confidence }]
+  contactName       String?
+  contactEmail      String?
+  contactTitle      String?
+  sourceType        String // "google_cse" | "website_scrape" | "directory"
+  sourceUrl         String
+  confidence        Float          @default(0.5)
+  status            ProspectStatus @default(DISCOVERED)
+  hubspotCompanyId  String?
+  hubspotContactId  String?
   pushedToHubspotAt DateTime?
-  discoveredAt     DateTime       @default(now())
-  metadata         Json?
+  discoveredAt      DateTime       @default(now())
+  metadata          Json?
 
   @@unique([userId, domain])
   @@index([userId, status])
@@ -1442,6 +1459,108 @@ enum MeetingStatus {
   NO_SHOW
 }
 
+enum CustomerLifecycleStage {
+  ONBOARDING
+  ADOPTION
+  ACTIVE
+  EXPANSION
+  RENEWAL
+  AT_RISK
+  CHURNED
+}
+
+enum CustomerRecordStatus {
+  ACTIVE
+  ARCHIVED
+  MERGED
+}
+
+enum CustomerExternalProvider {
+  INTERNAL
+  HUBSPOT
+  STRIPE
+  PYLON
+  CODA
+  SLACK
+  GOOGLE_WORKSPACE
+}
+
+enum CustomerSuccessNoteSource {
+  MANUAL
+  MEETING
+  SUPPORT
+  CRM
+  AI
+  SYSTEM
+}
+
+enum CustomerSuccessNoteVisibility {
+  INTERNAL
+  RESTRICTED
+}
+
+enum CustomerSuccessPlanStatus {
+  DRAFT
+  ACTIVE
+  COMPLETED
+  ARCHIVED
+}
+
+enum CustomerSuccessMilestoneStatus {
+  NOT_STARTED
+  IN_PROGRESS
+  BLOCKED
+  COMPLETED
+}
+
+enum CustomerSuccessAlertCategory {
+  RISK
+  OPPORTUNITY
+  ACTION_REQUIRED
+}
+
+enum CustomerSuccessAlertSeverity {
+  LOW
+  MEDIUM
+  HIGH
+  CRITICAL
+}
+
+enum CustomerSuccessAlertStatus {
+  OPEN
+  IN_PROGRESS
+  RESOLVED
+  DISMISSED
+}
+
+enum CustomerSuccessSlaStatus {
+  NONE
+  ON_TRACK
+  AT_RISK
+  BREACHED
+}
+
+enum CustomerSuccessAlertSource {
+  HEALTH
+  SUPPORT
+  COMMERCIAL
+  RELATIONSHIP
+  WORKFLOW
+}
+
+enum CustomerSuccessOutreachChannel {
+  EMAIL
+  SLACK
+}
+
+enum CustomerSuccessOutreachStatus {
+  DRAFT
+  QUEUED
+  SENT
+  FAILED
+  CANCELED
+}
+
 model DealCompany {
   id       String  @id @default(cuid())
   name     String
@@ -1451,9 +1570,10 @@ model DealCompany {
 
   hubspotCompanyId String? @unique
 
-  contacts DealContact[]
-  deals    Deal[]
-  meetings DealMeeting[]
+  contacts       DealContact[]
+  deals          Deal[]
+  meetings       DealMeeting[]
+  customerRecord CustomerRecord?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1486,27 +1606,28 @@ model DealContact {
 }
 
 model Deal {
-  id     String    @id @default(cuid())
+  id     String     @id @default(cuid())
   name   String
-  stage  DealStage @default(LEAD)
-  amount Float     @default(0)
+  stage  DealStage  @default(LEAD)
+  amount Float      @default(0)
   source DealSource @default(OTHER)
 
   expectedCloseDate DateTime?
   closedAt          DateTime?
-  notes             String? @db.Text
+  notes             String?   @db.Text
 
   companyId String?
   company   DealCompany? @relation(fields: [companyId], references: [id], onDelete: SetNull)
 
   ownerId String?
-  owner   User? @relation("DealOwner", fields: [ownerId], references: [id], onDelete: SetNull)
+  owner   User?   @relation("DealOwner", fields: [ownerId], references: [id], onDelete: SetNull)
 
   hubspotDealId String? @unique
 
-  contacts     DealContact[]    @relation("DealContacts")
-  meetings     DealMeeting[]
-  stageHistory DealStageHistory[]
+  contacts                  DealContact[]      @relation("DealContacts")
+  meetings                  DealMeeting[]
+  stageHistory              DealStageHistory[]
+  primaryForCustomerRecords CustomerRecord[]
 
   organizationId String?
   organization   Organization? @relation(fields: [organizationId], references: [id])
@@ -1542,16 +1663,19 @@ model DealMeeting {
   startAt  DateTime
   endAt    DateTime?
   location String?
-  notes    String? @db.Text
+  notes    String?   @db.Text
 
   expectedAttendees Int @default(0)
   actualAttendees   Int @default(0)
 
   dealId String?
-  deal   Deal? @relation(fields: [dealId], references: [id], onDelete: SetNull)
+  deal   Deal?   @relation(fields: [dealId], references: [id], onDelete: SetNull)
 
   companyId String?
   company   DealCompany? @relation(fields: [companyId], references: [id], onDelete: SetNull)
+
+  customerRecordId String?
+  customerRecord   CustomerRecord? @relation(fields: [customerRecordId], references: [id], onDelete: SetNull)
 
   hubspotMeetingId String? @unique
 
@@ -1562,8 +1686,214 @@ model DealMeeting {
 
   @@index([dealId])
   @@index([companyId])
+  @@index([customerRecordId])
   @@index([startAt])
   @@index([status])
+}
+
+model CustomerRecord {
+  id             String                 @id @default(cuid())
+  name           String
+  segment        String?
+  tier           String?
+  lifecycleStage CustomerLifecycleStage @default(ONBOARDING)
+  status         CustomerRecordStatus   @default(ACTIVE)
+  metadata       Json?
+
+  ownerId String?
+  owner   User?   @relation("CustomerRecordOwner", fields: [ownerId], references: [id], onDelete: SetNull)
+
+  dealCompanyId String?      @unique
+  dealCompany   DealCompany? @relation(fields: [dealCompanyId], references: [id], onDelete: SetNull)
+
+  primaryDealId String?
+  primaryDeal   Deal?   @relation(fields: [primaryDealId], references: [id], onDelete: SetNull)
+
+  mergedIntoId String?
+  mergedInto   CustomerRecord?  @relation("CustomerRecordMerge", fields: [mergedIntoId], references: [id], onDelete: SetNull)
+  mergedFrom   CustomerRecord[] @relation("CustomerRecordMerge")
+
+  externalRefs     CustomerRecordExternalRef[]
+  notes            CustomerSuccessNote[]
+  plans            CustomerSuccessPlan[]
+  alerts           CustomerSuccessAlertRecord[]
+  outreachMessages CustomerSuccessOutreachMessage[]
+  tasks            Task[]
+  meetings         DealMeeting[]
+
+  organizationId String?
+  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([organizationId])
+  @@index([ownerId])
+  @@index([mergedIntoId])
+  @@index([status, lifecycleStage])
+}
+
+model CustomerRecordExternalRef {
+  id                 String                   @id @default(cuid())
+  customerRecordId   String
+  customerRecord     CustomerRecord           @relation(fields: [customerRecordId], references: [id], onDelete: Cascade)
+  provider           CustomerExternalProvider
+  externalObjectType String                   @default("account")
+  externalId         String
+  label              String?
+  isPrimary          Boolean                  @default(false)
+  metadata           Json?
+
+  organizationId String?
+  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([customerRecordId, provider, externalObjectType, externalId])
+  @@index([organizationId])
+  @@index([provider, externalId])
+}
+
+model CustomerSuccessNote {
+  id               String                        @id @default(cuid())
+  customerRecordId String
+  customerRecord   CustomerRecord                @relation(fields: [customerRecordId], references: [id], onDelete: Cascade)
+  authorUserId     String?
+  authorUser       User?                         @relation("CustomerSuccessNoteAuthor", fields: [authorUserId], references: [id], onDelete: SetNull)
+  title            String?
+  body             String
+  source           CustomerSuccessNoteSource     @default(MANUAL)
+  visibility       CustomerSuccessNoteVisibility @default(INTERNAL)
+  metadata         Json?
+
+  organizationId String?
+  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([customerRecordId, createdAt])
+  @@index([organizationId])
+  @@index([authorUserId])
+}
+
+model CustomerSuccessPlan {
+  id               String                         @id @default(cuid())
+  customerRecordId String
+  customerRecord   CustomerRecord                 @relation(fields: [customerRecordId], references: [id], onDelete: Cascade)
+  name             String
+  templateKey      String?
+  status           CustomerSuccessPlanStatus      @default(DRAFT)
+  ownerUserId      String?
+  ownerUser        User?                          @relation("CustomerSuccessPlanOwner", fields: [ownerUserId], references: [id], onDelete: SetNull)
+  startedAt        DateTime?
+  targetDate       DateTime?
+  completedAt      DateTime?
+  metadata         Json?
+  milestones       CustomerSuccessPlanMilestone[]
+
+  organizationId String?
+  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([customerRecordId, status])
+  @@index([organizationId])
+  @@index([ownerUserId])
+}
+
+model CustomerSuccessPlanMilestone {
+  id           String                         @id @default(cuid())
+  planId       String
+  plan         CustomerSuccessPlan            @relation(fields: [planId], references: [id], onDelete: Cascade)
+  title        String
+  description  String?
+  status       CustomerSuccessMilestoneStatus @default(NOT_STARTED)
+  dueDate      DateTime?
+  completedAt  DateTime?
+  linkedTaskId String?
+  linkedTask   Task?                          @relation(fields: [linkedTaskId], references: [id], onDelete: SetNull)
+  sortOrder    Int                            @default(0)
+  metadata     Json?
+
+  organizationId String?
+  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([planId, sortOrder])
+  @@index([organizationId])
+  @@index([linkedTaskId])
+}
+
+model CustomerSuccessAlertRecord {
+  id               String                       @id @default(cuid())
+  customerRecordId String
+  customerRecord   CustomerRecord               @relation(fields: [customerRecordId], references: [id], onDelete: Cascade)
+  alertKey         String
+  title            String
+  category         CustomerSuccessAlertCategory
+  severity         CustomerSuccessAlertSeverity @default(MEDIUM)
+  status           CustomerSuccessAlertStatus   @default(OPEN)
+  slaStatus        CustomerSuccessSlaStatus     @default(NONE)
+  source           CustomerSuccessAlertSource
+  evidence         Json?
+  suggestedAction  String?
+  ownerUserId      String?
+  ownerUser        User?                        @relation("CustomerSuccessAlertOwner", fields: [ownerUserId], references: [id], onDelete: SetNull)
+  linkedTaskId     String?
+  linkedTask       Task?                        @relation(fields: [linkedTaskId], references: [id], onDelete: SetNull)
+  openedAt         DateTime                     @default(now())
+  resolvedAt       DateTime?
+  lastEvaluatedAt  DateTime?
+  metadata         Json?
+
+  organizationId String?
+  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([customerRecordId, alertKey])
+  @@index([organizationId, status, severity])
+  @@index([ownerUserId])
+  @@index([linkedTaskId])
+}
+
+model CustomerSuccessOutreachMessage {
+  id                String                         @id @default(cuid())
+  customerRecordId  String
+  customerRecord    CustomerRecord                 @relation(fields: [customerRecordId], references: [id], onDelete: Cascade)
+  authorUserId      String?
+  authorUser        User?                          @relation("CustomerSuccessOutreachAuthor", fields: [authorUserId], references: [id], onDelete: SetNull)
+  channel           CustomerSuccessOutreachChannel
+  status            CustomerSuccessOutreachStatus  @default(DRAFT)
+  templateKey       String?
+  recipientName     String?
+  recipientAddress  String
+  subject           String?
+  body              String
+  providerMessageId String?
+  providerThreadId  String?
+  queuedAt          DateTime?
+  sentAt            DateTime?
+  failedAt          DateTime?
+  error             String?
+  metadata          Json?
+
+  organizationId String?
+  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([customerRecordId, status, createdAt])
+  @@index([organizationId])
+  @@index([authorUserId])
+  @@index([providerMessageId])
 }
 
 // ── Financial Planning ──
@@ -1600,16 +1930,16 @@ enum GoalStatus {
 }
 
 model Budget {
-  id        String       @id @default(cuid())
+  id        String           @id @default(cuid())
   userId    String
-  user      User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user      User             @relation(fields: [userId], references: [id], onDelete: Cascade)
   name      String
   period    BudgetPeriod
   startDate DateTime
   endDate   DateTime
   lineItems BudgetLineItem[]
-  createdAt DateTime     @default(now())
-  updatedAt DateTime     @updatedAt
+  createdAt DateTime         @default(now())
+  updatedAt DateTime         @updatedAt
 
   @@index([userId])
 }
@@ -1656,8 +1986,8 @@ model ForecastScenario {
 
 model SubmissionEvent {
   id          String   @id @default(cuid())
-  type        String                        // e.g. "download_request", "form_submission"
-  referenceId String?                       // optional external reference
+  type        String // e.g. "download_request", "form_submission"
+  referenceId String? // optional external reference
   metadata    Json     @default("{}")
   userId      String
   user        User     @relation(fields: [userId], references: [id])
@@ -1676,7 +2006,7 @@ model InsightPreference {
   id        String   @id @default(cuid())
   userId    String
   insightId String   @db.VarChar(256)
-  status    String   @db.VarChar(20)  // "pinned" | "dismissed"
+  status    String   @db.VarChar(20) // "pinned" | "dismissed"
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 


### PR DESCRIPTION
## Summary
- add the customer success Prisma enums, models, relations, indexes, and unique constraints needed for merged customer records, CS notes, plans, milestones, alerts, and outreach
- wire `Task` and `DealMeeting` to `CustomerRecord` via nullable `customerRecordId` relations so existing work can be linked into the CS workspace
- include the matching SQL migration so the Prisma schema and database changes land together

## Test plan
- [x] `npx prisma validate --schema prisma/schema.prisma`
- [x] `npm run db:generate`
- [ ] Run full CI on the PR branch


Made with [Cursor](https://cursor.com)