### PR TITLE
Fix Stripe analytics normalization

### DIFF
--- a/src/components/analytics/finance-stripe-tab.tsx
+++ b/src/components/analytics/finance-stripe-tab.tsx
@@ -2,15 +2,16 @@
 
 import {
   CreditCard, DollarSign, ShieldCheck, TrendingUp,
-  Users, AlertTriangle, BarChart3, Activity,
+  Users, AlertTriangle, Activity,
 } from "lucide-react";
 import type { AnalyticsDashboardData } from "@/lib/analytics/types";
+import { normalizePercentValue } from "@/lib/analytics/percentage-utils";
 import { FinanceDataEmptyState } from "@/components/analytics/finance-empty-state";
 import { RingStat } from "@/components/analytics/bar-display";
 import { StatCard } from "@/components/analytics/stat-card";
 import {
   fmt$, fmtPct, pctChange, timeAgo,
-  AlertBanner, ChangeIndicator, DataTable, InsightCard,
+  AlertBanner, DataTable, InsightCard,
   SectionCard, type DataTableColumn,
 } from "./dashboard-primitives";
 import { AiInsightsPanel } from "./ai-insights-panel";
@@ -40,21 +41,23 @@ export function FinanceStripeTab({ data }: FinanceStripeTabProps) {
   }
 
   const { revenue, subscriptions, payments, revenueTrend } = stripe;
+  const churnRate = normalizePercentValue(subscriptions.churnRate);
+  const paymentSuccessRate = normalizePercentValue(payments.successRate);
   const maxTrend = Math.max(...(revenueTrend?.map((t) => t.revenue) ?? [0]), 1);
 
   // Determine alerts
   const alerts: { severity: "critical" | "warning" | "info"; title: string; description: string }[] = [];
-  if (subscriptions.churnRate > 5) {
+  if (churnRate > 5) {
     alerts.push({
       severity: "critical",
-      title: `Churn rate at ${fmtPct(subscriptions.churnRate)}`,
+      title: `Churn rate at ${fmtPct(churnRate)}`,
       description: `${subscriptions.canceled} subscriptions canceled. Implement retention workflows and 30/60/90-day check-ins.`,
     });
   }
-  if (payments.successRate < 95) {
+  if (paymentSuccessRate < 95) {
     alerts.push({
       severity: "critical",
-      title: `Payment success rate at ${fmtPct(payments.successRate)}`,
+      title: `Payment success rate at ${fmtPct(paymentSuccessRate)}`,
       description: `${payments.failed} failed payments out of ${payments.succeeded + payments.failed}. Review failed payment retry logic and card updater.`,
     });
   }
@@ -92,7 +95,7 @@ export function FinanceStripeTab({ data }: FinanceStripeTabProps) {
       severity: trialPct > 30 ? "warning" : "info",
     });
   }
-  if (subscriptions.churnRate <= 5 && payments.successRate >= 95) {
+  if (churnRate <= 5 && paymentSuccessRate >= 95) {
     insights.push({
       title: "Subscription Health",
       insight: "Churn rate and payment success are within healthy ranges.",
@@ -162,14 +165,14 @@ export function FinanceStripeTab({ data }: FinanceStripeTabProps) {
         />
         <StatCard
           label="Churn Rate"
-          value={fmtPct(subscriptions.churnRate)}
-          changeType={subscriptions.churnRate > 5 ? "negative" : "positive"}
+          value={fmtPct(churnRate)}
+          changeType={churnRate > 5 ? "negative" : "positive"}
           icon={Activity}
         />
         <StatCard
           label="Payment Success"
-          value={fmtPct(payments.successRate)}
-          changeType={payments.successRate >= 95 ? "positive" : "negative"}
+          value={fmtPct(paymentSuccessRate)}
+          changeType={paymentSuccessRate >= 95 ? "positive" : "negative"}
           icon={ShieldCheck}
         />
       </div>
@@ -224,10 +227,10 @@ export function FinanceStripeTab({ data }: FinanceStripeTabProps) {
         <SectionCard title="Payment Reliability" subtitle="Payment success and failure breakdown">
           <div className="flex items-center justify-center gap-6">
             <RingStat
-              value={payments.successRate}
+              value={paymentSuccessRate}
               max={100}
               label="Success Rate"
-              color={payments.successRate >= 95 ? "#22c55e" : "#ef4444"}
+              color={paymentSuccessRate >= 95 ? "#22c55e" : "#ef4444"}
               size={110}
             />
           </div>
@@ -244,7 +247,7 @@ export function FinanceStripeTab({ data }: FinanceStripeTabProps) {
             <div className="mt-2 h-3 overflow-hidden rounded-full bg-secondary">
               <div
                 className="h-full rounded-full bg-emerald-500 transition-all"
-                style={{ width: `${payments.successRate}%` }}
+                style={{ width: `${paymentSuccessRate}%` }}
               />
             </div>
           </div>

--- a/src/components/analytics/finance-tab.tsx
+++ b/src/components/analytics/finance-tab.tsx
@@ -16,6 +16,7 @@ import {
   AlertTriangle,
 } from "lucide-react";
 import type { AnalyticsDashboardData, PnLRow, ForecastScenarioData } from "@/lib/analytics/types";
+import { normalizePercentValue } from "@/lib/analytics/percentage-utils";
 import { fmtDelta, fmtMonths, fmtRatio, runwayColor, ltvCacSeverity } from "@/lib/analytics/finance-utils";
 import { StatCard } from "./stat-card";
 import { RingStat } from "./bar-display";
@@ -185,8 +186,8 @@ export function FinanceTab({ data }: FinanceTabProps) {
   const cashBalance = mercury?.cashFlow?.totalBalance ?? 0;
   const runway = mercury?.cashFlow?.runway ?? 0;
   const netCashFlow = mercury?.cashFlow?.netCashFlow ?? 0;
-  const successRate = stripe?.payments?.successRate ?? 0;
-  const churnRate = stripe?.subscriptions?.churnRate ?? 0;
+  const successRate = normalizePercentValue(stripe?.payments?.successRate ?? 0);
+  const churnRate = normalizePercentValue(stripe?.subscriptions?.churnRate ?? 0);
   const recentChurns = stripe?.subscriptions?.recentChurnEvents ?? [];
 
   return (

--- a/src/components/analytics/finance-tabs.test.tsx
+++ b/src/components/analytics/finance-tabs.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
 import { createEmptyAnalyticsDashboardData } from "@/lib/analytics/response-shape";
 import { FinanceTab } from "@/components/analytics/finance-tab";
 import { FinanceStripeTab } from "@/components/analytics/finance-stripe-tab";
@@ -107,6 +108,47 @@ describe("finance tabs", () => {
 
     expect(screen.getByText("Stripe finance data is unavailable")).toBeTruthy();
     expect(screen.getByText(/subscription and payment analytics/)).toBeTruthy();
+  });
+
+  it("normalizes ratio-style Stripe percentages in the stripe finance tab", () => {
+    const data = makeEmptyData();
+    if (data.freshness.stripe) {
+      data.freshness.stripe.lastError = null;
+    }
+    data.stripe = {
+      revenue: {
+        mrr: 12000,
+        mrrChange: 500,
+        totalRevenue30d: 15000,
+        totalRevenuePrev30d: 14000,
+        revenueGrowth: 7.1,
+        avgRevenuePerCustomer: 300,
+      },
+      subscriptions: {
+        active: 40,
+        pastDue: 2,
+        canceled: 1,
+        trialing: 3,
+        churnRate: 0.04,
+        recentChurnEvents: [],
+      },
+      payments: {
+        succeeded: 79,
+        failed: 1,
+        successRate: 0.987,
+      },
+      revenueTrend: [],
+      _meta: {
+        fetchedAt: "2026-02-16T00:00:00.000Z",
+        nextRefresh: "2026-02-16T01:00:00.000Z",
+        source: "live",
+      },
+    };
+
+    render(<FinanceStripeTab data={data} />);
+
+    expect(screen.getAllByText("4.0%").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("98.7%").length).toBeGreaterThan(0);
   });
 
   it("shows finance-stage hubspot empty state when lifecycle stages are missing", () => {

--- a/src/components/analytics/overview-tab.tsx
+++ b/src/components/analytics/overview-tab.tsx
@@ -7,6 +7,7 @@ import {
   Globe, Megaphone,
 } from "lucide-react";
 import type { AnalyticsDashboardData } from "@/lib/analytics/types";
+import { normalizePercentValue } from "@/lib/analytics/percentage-utils";
 import { StatCard } from "./stat-card";
 import { BarDisplay, RingStat } from "./bar-display";
 
@@ -180,7 +181,7 @@ export function OverviewTab({ data }: { data: AnalyticsDashboardData | null }) {
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">Payment Success</span>
                   <span className="font-medium tabular-nums text-emerald-500">
-                    {stripe ? fmtPct(stripe.payments.successRate) : "—"}
+                    {stripe ? fmtPct(normalizePercentValue(stripe.payments.successRate)) : "—"}
                   </span>
                 </div>
               </div>

--- a/src/components/analytics/sales-stripe-tab.tsx
+++ b/src/components/analytics/sales-stripe-tab.tsx
@@ -5,6 +5,7 @@ import {
   DollarSign, Activity, CheckCircle2, XCircle,
 } from "lucide-react";
 import type { AnalyticsDashboardData } from "@/lib/analytics/types";
+import { normalizePercentValue } from "@/lib/analytics/percentage-utils";
 import { FinanceDataEmptyState } from "@/components/analytics/finance-empty-state";
 import { RingStat } from "@/components/analytics/bar-display";
 import { StatCard } from "@/components/analytics/stat-card";
@@ -35,16 +36,18 @@ export function SalesStripeTab({ data }: SalesStripeTabProps) {
   const rev = stripe.revenue;
   const subs = stripe.subscriptions;
   const pay = stripe.payments;
+  const churnRate = normalizePercentValue(subs.churnRate);
+  const paymentSuccessRate = normalizePercentValue(pay.successRate);
 
   /* ── Alerts ──────────────────────────────────────── */
 
   const alerts: { severity: "critical" | "warning" | "info"; title: string; description: string }[] = [];
 
-  if (subs.churnRate > 5) {
+  if (churnRate > 5) {
     alerts.push({
       severity: "critical",
       title: "Churn rate above threshold",
-      description: `${subs.churnRate.toFixed(1)}% churn rate — retention efforts need immediate attention.`,
+      description: `${churnRate.toFixed(1)}% churn rate — retention efforts need immediate attention.`,
     });
   }
 
@@ -110,21 +113,21 @@ export function SalesStripeTab({ data }: SalesStripeTabProps) {
     });
   }
 
-  if (subs.churnRate > 3) {
+  if (churnRate > 3) {
     insights.push({
       title: "Retention Risk",
-      insight: `Churn at ${subs.churnRate.toFixed(1)}% with ${subs.canceled} recent cancellations.`,
+      insight: `Churn at ${churnRate.toFixed(1)}% with ${subs.canceled} recent cancellations.`,
       action: "Implement win-back campaigns and analyze cancellation reasons.",
-      severity: subs.churnRate > 5 ? "critical" : "warning",
+      severity: churnRate > 5 ? "critical" : "warning",
     });
   }
 
   if (pay.failed > 0) {
     insights.push({
       title: "Payment Failures",
-      insight: `${pay.failed} payment failures (${fmtPct(100 - pay.successRate)} failure rate).`,
+      insight: `${pay.failed} payment failures (${fmtPct(100 - paymentSuccessRate)} failure rate).`,
       action: "Review dunning configuration and ensure retry logic is optimized.",
-      severity: pay.successRate < 95 ? "warning" : "info",
+      severity: paymentSuccessRate < 95 ? "warning" : "info",
     });
   }
 
@@ -164,9 +167,9 @@ export function SalesStripeTab({ data }: SalesStripeTabProps) {
         />
         <StatCard
           title="Churn Rate"
-          value={fmtPct(subs.churnRate)}
+          value={fmtPct(churnRate)}
           icon={<TrendingUp className="h-4 w-4" />}
-          className={subs.churnRate > 5 ? "border-red-500/30 bg-red-500/5" : undefined}
+          className={churnRate > 5 ? "border-red-500/30 bg-red-500/5" : undefined}
         />
         <StatCard
           title="Past Due"
@@ -182,7 +185,7 @@ export function SalesStripeTab({ data }: SalesStripeTabProps) {
         />
         <StatCard
           title="Payment Success"
-          value={fmtPct(pay.successRate)}
+          value={fmtPct(paymentSuccessRate)}
           icon={<CheckCircle2 className="h-4 w-4" />}
         />
         <StatCard

--- a/src/lib/__tests__/analytics-ai-insights.test.ts
+++ b/src/lib/__tests__/analytics-ai-insights.test.ts
@@ -430,6 +430,33 @@ describe("finance insights", () => {
     expect(pf!.subsectionId).toBe("finance-stripe");
   });
 
+  it("normalizes percent-style Stripe churn and payment success values", () => {
+    const data = baseData();
+    data.stripe = {
+      revenue: {
+        mrr: 20000, mrrChange: 2,
+        totalRevenue30d: 22000, totalRevenuePrev30d: 21000,
+        revenueGrowth: 4.8, avgRevenuePerCustomer: 500,
+      },
+      subscriptions: {
+        active: 40, pastDue: 2, canceled: 4, trialing: 1,
+        churnRate: 10, recentChurnEvents: [],
+      },
+      payments: { succeeded: 85, failed: 15, successRate: 85 },
+      revenueTrend: [],
+      _meta: META,
+    };
+
+    const bundle = buildAiInsightsBundle(data);
+    const churn = bundle.global.find((i) => i.id === "ai-finance-churn");
+    const paymentFailures = bundle.global.find((i) => i.id === "ai-finance-payment-failures");
+
+    expect(churn).toBeDefined();
+    expect(churn!.evidence[0].value).toBe("10.0%");
+    expect(paymentFailures).toBeDefined();
+    expect(paymentFailures!.evidence[0].value).toBe("85.0%");
+  });
+
   it("fires MRR decline alert when mrrChange < -5", () => {
     const data = baseData();
     data.stripe = {

--- a/src/lib/__tests__/analytics-fetchers-stripe.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-stripe.test.ts
@@ -111,4 +111,164 @@ describe("analytics stripe fetcher", () => {
     expect(requestUrls.some((url) => url.includes("status=past_due") && url.includes("limit=100"))).toBe(true);
     expect(requestUrls.some((url) => url.includes("status=trialing") && url.includes("limit=100"))).toBe(true);
   });
+
+  it("paginates active and canceled subscriptions and sorts churn events newest-first", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+
+      if (url.pathname === "/v1/subscriptions") {
+        const status = url.searchParams.get("status");
+        const startingAfter = url.searchParams.get("starting_after");
+
+        if (status === "active") {
+          if (!startingAfter) {
+            return jsonResponse({
+              data: [
+                {
+                  id: "sub_active_1",
+                  customer: "cus_active_1",
+                  canceled_at: null,
+                  items: { data: [{ price: { unit_amount: 1000, recurring: { interval: "month", interval_count: 1 } } }] },
+                },
+                {
+                  id: "sub_active_2",
+                  customer: "cus_active_2",
+                  canceled_at: null,
+                  items: { data: [{ price: { unit_amount: 2000, recurring: { interval: "month", interval_count: 1 } } }] },
+                },
+              ],
+              has_more: true,
+            });
+          }
+
+          if (startingAfter === "sub_active_2") {
+            return jsonResponse({
+              data: [
+                {
+                  id: "sub_active_3",
+                  customer: "cus_active_3",
+                  canceled_at: null,
+                  items: { data: [{ price: { unit_amount: 3000, recurring: { interval: "month", interval_count: 1 } } }] },
+                },
+              ],
+              has_more: false,
+            });
+          }
+        }
+
+        if (status === "canceled") {
+          if (!startingAfter) {
+            return jsonResponse({
+              data: [
+                {
+                  id: "sub_canceled_1",
+                  customer: "cus_oldest",
+                  canceled_at: 1_700_000_100,
+                  items: { data: [{ price: { unit_amount: 1000, recurring: { interval: "month", interval_count: 1 } } }] },
+                },
+                {
+                  id: "sub_canceled_2",
+                  customer: "cus_mid",
+                  canceled_at: 1_700_000_300,
+                  items: { data: [{ price: { unit_amount: 2000, recurring: { interval: "month", interval_count: 1 } } }] },
+                },
+              ],
+              has_more: true,
+            });
+          }
+
+          if (startingAfter === "sub_canceled_2") {
+            return jsonResponse({
+              data: [
+                {
+                  id: "sub_canceled_3",
+                  customer: { id: "cus_object_customer" },
+                  canceled_at: 1_700_000_200,
+                  items: { data: [{ price: { unit_amount: 3000, recurring: { interval: "month", interval_count: 1 } } }] },
+                },
+                {
+                  id: "sub_canceled_4",
+                  customer: "cus_newest",
+                  canceled_at: 1_700_000_500,
+                  items: { data: [{ price: { unit_amount: 4000, recurring: { interval: "month", interval_count: 1 } } }] },
+                },
+                {
+                  id: "sub_canceled_5",
+                  customer: "cus_second_newest",
+                  canceled_at: 1_700_000_400,
+                  items: { data: [{ price: { unit_amount: 5000, recurring: { interval: "month", interval_count: 1 } } }] },
+                },
+                {
+                  id: "sub_canceled_6",
+                  customer: "cus_missing_timestamp",
+                  canceled_at: null,
+                  items: { data: [{ price: { unit_amount: 6000, recurring: { interval: "month", interval_count: 1 } } }] },
+                },
+              ],
+              has_more: false,
+            });
+          }
+        }
+
+        if (status === "past_due" || status === "trialing") {
+          return jsonResponse({ data: [], has_more: false });
+        }
+      }
+
+      if (url.pathname === "/v1/charges") {
+        return jsonResponse({ data: [], has_more: false });
+      }
+
+      return jsonResponse({ error: "unexpected request", url: String(url) }, 500);
+    });
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const data = await fetchStripeData("sk_test_123", {
+      fromDate: new Date("2026-01-01T00:00:00.000Z"),
+      toDate: new Date("2026-02-01T00:00:00.000Z"),
+    });
+
+    expect(data.subscriptions.active).toBe(3);
+    expect(data.subscriptions.canceled).toBe(6);
+    expect(data.subscriptions.recentChurnEvents).toEqual([
+      {
+        customer: "cus_newest",
+        canceledAt: new Date(1_700_000_500 * 1000).toISOString(),
+        amount: 40,
+      },
+      {
+        customer: "cus_second_newest",
+        canceledAt: new Date(1_700_000_400 * 1000).toISOString(),
+        amount: 50,
+      },
+      {
+        customer: "cus_mid",
+        canceledAt: new Date(1_700_000_300 * 1000).toISOString(),
+        amount: 20,
+      },
+      {
+        customer: "cus_object_customer",
+        canceledAt: new Date(1_700_000_200 * 1000).toISOString(),
+        amount: 30,
+      },
+      {
+        customer: "cus_oldest",
+        canceledAt: new Date(1_700_000_100 * 1000).toISOString(),
+        amount: 10,
+      },
+    ]);
+
+    const requestUrls = fetchMock.mock.calls.map(([url]) => String(url));
+    expect(
+      requestUrls.some(
+        (url) => url.includes("status=active") && url.includes("starting_after=sub_active_2")
+      )
+    ).toBe(true);
+    expect(
+      requestUrls.some(
+        (url) => url.includes("status=canceled") && url.includes("starting_after=sub_canceled_2")
+      )
+    ).toBe(true);
+  });
 });

--- a/src/lib/analytics/fetchers.ts
+++ b/src/lib/analytics/fetchers.ts
@@ -298,7 +298,6 @@ export async function fetchHubSpotData(
   const repAgg: Record<string, { count: number; value: number; closedWon: number; closedWonValue: number }> = {};
 
   let notActivatedCount = 0;
-  let actualChurnCount = 0;
 
   const activeDeals = activeDealsResult.deals;
   const shouldLoadOwners =
@@ -354,8 +353,6 @@ export async function fetchHubSpotData(
       
       if (createdMs > 0 && daysSinceCreation <= 60) {
         notActivatedCount++;
-      } else {
-        actualChurnCount++;
       }
     }
 
@@ -873,7 +870,8 @@ export async function fetchHubSpotContacts(
   const envMaxPages = Number(process.env.HUBSPOT_CONTACTS_MAX_PAGES || "");
   const maxPages = Math.max(1, Math.min(opts?.maxPages ?? (Number.isFinite(envMaxPages) ? envMaxPages : 1000), 1000));
 
-  const ownerMap = await fetchHubSpotOwnerMap(baseUrl, headers);
+  const { owners } = await fetchHubSpotOwners({ baseUrl, headers });
+  const ownerMap = Object.fromEntries(owners.map((owner) => [owner.id, owner.name]));
 
   const fromMs = from.getTime();
   const toMs = to.getTime();
@@ -948,8 +946,8 @@ interface StripeSubItem {
 interface StripeSub {
   id: string;
   items: { data: StripeSubItem[] };
-  customer: string;
-  canceled_at: number;
+  customer: string | { id?: string | null } | null;
+  canceled_at: number | null;
 }
 
 interface StripeCharge {
@@ -957,6 +955,23 @@ interface StripeCharge {
   amount: number;
   created: number;
   status: string;
+}
+
+function stripeSubscriptionCustomerId(customer: StripeSub["customer"]): string {
+  if (typeof customer === "string" && customer.trim().length > 0) {
+    return customer.trim();
+  }
+
+  if (
+    customer &&
+    typeof customer === "object" &&
+    typeof customer.id === "string" &&
+    customer.id.trim().length > 0
+  ) {
+    return customer.id.trim();
+  }
+
+  return "Unknown customer";
 }
 
 export async function fetchStripeData(
@@ -983,19 +998,32 @@ export async function fetchStripeData(
   const fetchStripe = async (url: string): Promise<Response> =>
     fetch(url, { headers, cache: "no-store" });
 
-  const fetchActiveSubscriptions = async (): Promise<StripeSub[]> => {
-    const subsRes = await fetchStripe(`${baseUrl}/subscriptions?limit=100&status=active`);
-    if (!subsRes.ok) {
-      throw new Error(`Stripe subscriptions error ${subsRes.status}`);
-    }
-    const subsData = await safeJson<{ data?: StripeSub[] }>(subsRes, "stripe subscriptions");
-    return subsData.data || [];
-  };
+  const fetchSubscriptionsByStatus = async (status: string): Promise<StripeSub[]> => {
+    const subscriptions: StripeSub[] = [];
+    let startingAfter: string | undefined;
 
-  const fetchCanceledSubscriptions = async (): Promise<StripeSub[]> => {
-    const canceledRes = await fetchStripe(`${baseUrl}/subscriptions?limit=50&status=canceled`);
-    const canceledData = await safeJson<{ data?: StripeSub[] }>(canceledRes, "stripe canceled subscriptions");
-    return canceledData.data || [];
+    for (let page = 0; page < 1000; page++) {
+      let url = `${baseUrl}/subscriptions?limit=100&status=${encodeURIComponent(status)}`;
+      if (startingAfter) url += `&starting_after=${startingAfter}`;
+
+      const res = await fetchStripe(url);
+      if (!res.ok) {
+        throw new Error(`Stripe subscriptions(${status}) error ${res.status}`);
+      }
+
+      const data = await safeJson<{ data?: StripeSub[]; has_more?: boolean }>(
+        res,
+        `stripe subscriptions (${status})`
+      );
+      const batch = data.data ?? [];
+      subscriptions.push(...batch);
+
+      if (!data.has_more || batch.length === 0) break;
+      startingAfter = batch[batch.length - 1]?.id;
+      if (!startingAfter) break;
+    }
+
+    return subscriptions;
   };
 
   const fetchPastDueAndTrialingCounts = async (): Promise<{
@@ -1003,34 +1031,9 @@ export async function fetchStripeData(
     trialingCount: number;
   }> => {
     try {
-      const countSubscriptionsByStatus = async (status: string): Promise<number> => {
-        let count = 0;
-        let startingAfter: string | undefined;
-
-        for (let page = 0; page < 1000; page++) {
-          let url = `${baseUrl}/subscriptions?limit=100&status=${encodeURIComponent(status)}`;
-          if (startingAfter) url += `&starting_after=${startingAfter}`;
-
-          const res = await fetchStripe(url);
-          if (!res.ok) {
-            throw new Error(`Stripe subscriptions(${status}) error ${res.status}`);
-          }
-
-          const data = await safeJson<{ data?: StripeSub[]; has_more?: boolean }>(res, `stripe subscriptions (${status})`);
-          const batch = data.data ?? [];
-          count += batch.length;
-
-          if (!data.has_more || batch.length === 0) break;
-          startingAfter = batch[batch.length - 1]?.id;
-          if (!startingAfter) break;
-        }
-
-        return count;
-      };
-
       const [pastDueCount, trialingCount] = await Promise.all([
-        countSubscriptionsByStatus("past_due"),
-        countSubscriptionsByStatus("trialing"),
+        fetchSubscriptionsByStatus("past_due").then((subscriptions) => subscriptions.length),
+        fetchSubscriptionsByStatus("trialing").then((subscriptions) => subscriptions.length),
       ]);
       return { pastDueCount, trialingCount };
     } catch {
@@ -1059,8 +1062,8 @@ export async function fetchStripeData(
   };
 
   const [activeSubs, canceledSubs, counts, chargesInRange, chargesPrevRange] = await Promise.all([
-    fetchActiveSubscriptions(),
-    fetchCanceledSubscriptions(),
+    fetchSubscriptionsByStatus("active"),
+    fetchSubscriptionsByStatus("canceled"),
     fetchPastDueAndTrialingCounts(),
     fetchCharges(rangeStart, rangeEnd),
     fetchCharges(previousStart, previousEnd),
@@ -1145,11 +1148,15 @@ export async function fetchStripeData(
     }
   }
 
-  const recentChurn = canceledSubs.slice(0, 5).map((s: StripeSub) => ({
-    customer: s.customer,
-    canceledAt: new Date((s.canceled_at || 0) * 1000).toISOString(),
-    amount: (s.items?.data?.[0]?.price?.unit_amount || 0) / 100,
-  }));
+  const recentChurn = [...canceledSubs]
+    .filter((subscription) => typeof subscription.canceled_at === "number" && subscription.canceled_at > 0)
+    .sort((a, b) => (b.canceled_at ?? 0) - (a.canceled_at ?? 0))
+    .slice(0, 5)
+    .map((subscription: StripeSub) => ({
+      customer: stripeSubscriptionCustomerId(subscription.customer),
+      canceledAt: new Date((subscription.canceled_at || 0) * 1000).toISOString(),
+      amount: (subscription.items?.data?.[0]?.price?.unit_amount || 0) / 100,
+    }));
 
   return {
     revenue: {
@@ -1328,6 +1335,21 @@ export async function fetchMercuryData(
   apiKey: string,
   options?: { fromDate?: Date; toDate?: Date }
 ): Promise<MercuryData> {
+  type MercuryAccount = {
+    id?: string;
+    name?: string;
+    currentBalance?: number;
+    type?: string;
+  };
+
+  type MercuryTransaction = {
+    postedAt?: string;
+    createdAt?: string;
+    timestamp?: string;
+    status?: string;
+    amount?: number;
+  };
+
   const headers: Record<string, string> = {
     Authorization: `Bearer ${apiKey}`,
     "Content-Type": "application/json",
@@ -1339,14 +1361,12 @@ export async function fetchMercuryData(
   if (!accountsRes.ok) {
     throw new Error(`Mercury accounts error ${accountsRes.status}`);
   }
-  const accountsData = await safeJson<{ accounts?: unknown[] }>(accountsRes, "mercury accounts");
-  const accounts = (accountsData.accounts || []).map((a: {
-    id: string; name: string; currentBalance: number; type: string;
-  }) => ({
-    accountId: a.id,
-    accountName: a.name,
-    balance: a.currentBalance || 0,
-    type: a.type || "checking",
+  const accountsData = await safeJson<{ accounts?: MercuryAccount[] }>(accountsRes, "mercury accounts");
+  const accounts = (accountsData.accounts ?? []).map((account) => ({
+    accountId: account.id ?? "",
+    accountName: account.name ?? "Unknown account",
+    balance: account.currentBalance ?? 0,
+    type: account.type ?? "checking",
   }));
 
   const totalBalance = accounts.reduce((s: number, a: { balance: number }) => s + a.balance, 0);
@@ -1372,18 +1392,19 @@ export async function fetchMercuryData(
         { headers }
       );
       if (!txRes.ok) continue;
-      const txData = await safeJson<{ transactions?: unknown[] }>(txRes, "mercury transactions");
-      for (const tx of txData.transactions || []) {
+      const txData = await safeJson<{ transactions?: MercuryTransaction[] }>(txRes, "mercury transactions");
+      for (const tx of txData.transactions ?? []) {
         if (useRange && rangeTo) {
-          const postedAt = (tx.postedAt || tx.createdAt || tx.timestamp || "") as string;
+          const postedAt = tx.postedAt || tx.createdAt || tx.timestamp || "";
           if (postedAt) {
             const postedMs = Date.parse(postedAt);
             if (Number.isFinite(postedMs) && postedMs > rangeTo.getTime()) continue;
           }
         }
         if (tx.status === "sent") {
-          const amt = Math.abs(tx.amount || 0);
-          if (tx.amount > 0) inflows += amt;
+          const amount = tx.amount ?? 0;
+          const amt = Math.abs(amount);
+          if (amount > 0) inflows += amt;
           else outflows += amt;
         }
       }

--- a/src/lib/analytics/insight-engine.ts
+++ b/src/lib/analytics/insight-engine.ts
@@ -7,6 +7,7 @@ import type {
 } from "@/lib/analytics/types";
 import { computeBudgetActuals, computeBudgetSummary } from "./budget-variance";
 import { buildDefaultScenarios } from "./forecast-engine";
+import { normalizePercentValue } from "./percentage-utils";
 import { buildProfitAndLoss } from "./pnl-builder";
 import { computeUnitEconomics } from "./unit-economics";
 
@@ -320,8 +321,8 @@ function buildFinanceInsights(data: AnalyticsDashboardData): AiInsight[] {
   const runway = data.mercury?.cashFlow?.runway ?? 0;
   const revenueGrowth = data.stripe?.revenue?.revenueGrowth ?? 0;
   const burnRate = data.mercury?.cashFlow?.burnRate ?? 0;
-  const churnRate = data.stripe?.subscriptions?.churnRate ?? 0;
-  const paymentSuccessRate = data.stripe?.payments?.successRate ?? 1;
+  const churnRate = normalizePercentValue(data.stripe?.subscriptions?.churnRate ?? 0);
+  const paymentSuccessRate = normalizePercentValue(data.stripe?.payments?.successRate ?? 1);
   const mrrChange = data.stripe?.revenue?.mrrChange ?? 0;
   const revenueTrend = data.stripe?.revenueTrend ?? [];
   const revenueTrendValues = revenueTrend.map((t) => t.revenue);
@@ -372,14 +373,14 @@ function buildFinanceInsights(data: AnalyticsDashboardData): AiInsight[] {
   }
 
   // 2. Churn rate alarm
-  if (churnRate > 0.08) {
+  if (churnRate > 8) {
     insights.push({
       id: "ai-finance-churn",
       section: "finance",
       subsectionId: "finance-stripe",
-      severity: churnRate > 0.12 ? "critical" : "warning",
+      severity: churnRate > 12 ? "critical" : "warning",
       title: "Subscription churn rate exceeds healthy threshold",
-      why: `Churn rate is ${(churnRate * 100).toFixed(1)}% — above the 8% warning threshold. ${data.stripe?.subscriptions?.canceled ?? 0} cancellations in period.`,
+      why: `Churn rate is ${churnRate.toFixed(1)}% — above the 8% warning threshold. ${data.stripe?.subscriptions?.canceled ?? 0} cancellations in period.`,
       confidence: clampConfidence(0.88),
       expectedImpact: "Reducing churn by 2-3pp directly improves MRR retention and LTV.",
       stale: data.staleDomains.includes("stripe"),
@@ -388,7 +389,7 @@ function buildFinanceInsights(data: AnalyticsDashboardData): AiInsight[] {
           source: "Stripe",
           domain: "stripe",
           metric: "Churn Rate",
-          value: `${(churnRate * 100).toFixed(1)}%`,
+          value: `${churnRate.toFixed(1)}%`,
           delta: `${data.stripe?.subscriptions?.canceled ?? 0} canceled`,
         },
       ],
@@ -403,14 +404,14 @@ function buildFinanceInsights(data: AnalyticsDashboardData): AiInsight[] {
   }
 
   // 3. Payment failure warning
-  if (paymentSuccessRate < 0.90) {
+  if (paymentSuccessRate < 90) {
     insights.push({
       id: "ai-finance-payment-failures",
       section: "finance",
       subsectionId: "finance-stripe",
-      severity: paymentSuccessRate < 0.80 ? "critical" : "warning",
+      severity: paymentSuccessRate < 80 ? "critical" : "warning",
       title: "Payment failure rate is eroding collected revenue",
-      why: `Payment success rate is ${(paymentSuccessRate * 100).toFixed(1)}% — ${data.stripe?.payments?.failed ?? 0} failed of ${(data.stripe?.payments?.succeeded ?? 0) + (data.stripe?.payments?.failed ?? 0)} attempts.`,
+      why: `Payment success rate is ${paymentSuccessRate.toFixed(1)}% — ${data.stripe?.payments?.failed ?? 0} failed of ${(data.stripe?.payments?.succeeded ?? 0) + (data.stripe?.payments?.failed ?? 0)} attempts.`,
       confidence: clampConfidence(0.90),
       expectedImpact: "Smart retries and card updater can recover 30-50% of failed payments.",
       stale: data.staleDomains.includes("stripe"),
@@ -419,7 +420,7 @@ function buildFinanceInsights(data: AnalyticsDashboardData): AiInsight[] {
           source: "Stripe",
           domain: "stripe",
           metric: "Payment Success Rate",
-          value: `${(paymentSuccessRate * 100).toFixed(1)}%`,
+          value: `${paymentSuccessRate.toFixed(1)}%`,
           delta: `${data.stripe?.payments?.failed ?? 0} failed`,
         },
       ],

--- a/src/lib/analytics/kpis.ts
+++ b/src/lib/analytics/kpis.ts
@@ -1,4 +1,5 @@
 import type { AnalyticsDashboardData } from "./types";
+import { normalizePercentValue } from "./percentage-utils";
 
 /**
  * Compute fallback KPIs from raw provider data when `data.kpis` is not
@@ -25,9 +26,7 @@ export function computeAnalyticsKpis(data: AnalyticsDashboardData) {
   // ── Finance KPIs ──
   const stripe = data.stripe;
   const mrr = stripe?.revenue.mrr ?? 0;
-  // successRate is a 0–1 fraction; normalise to 0–100 like bounceRatePct.
-  const rawSuccess = stripe?.payments.successRate ?? 0;
-  const paymentSuccessPct = rawSuccess >= 0 && rawSuccess <= 1 ? rawSuccess * 100 : rawSuccess;
+  const paymentSuccessPct = normalizePercentValue(stripe?.payments.successRate ?? 0);
 
   return {
     traffic: { bounceRatePct, pagesPerSession, engagementScore, pageDepthScore },

--- a/src/lib/analytics/percentage-utils.ts
+++ b/src/lib/analytics/percentage-utils.ts
@@ -1,0 +1,4 @@
+export function normalizePercentValue(value: number | null | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  return value >= -1 && value <= 1 ? value * 100 : value;
+}


### PR DESCRIPTION
## Summary
- paginate Stripe active and canceled subscription fetches so larger accounts do not undercount MRR, churn, or recent churn events
- normalize Stripe percent-like fields across finance insights and Stripe-facing dashboards so both ratio and percent payloads render correctly
- add regression coverage for subscription pagination, insight normalization, and finance tab rendering

## Testing
- npx vitest run src/lib/__tests__/analytics-ai-insights.test.ts src/components/analytics/finance-tabs.test.tsx src/lib/__tests__/analytics-kpis.test.ts src/lib/__tests__/analytics-fetchers-stripe.test.ts src/app/api/analytics/route.test.ts
- npx eslint src/lib/analytics/percentage-utils.ts src/lib/analytics/kpis.ts src/lib/analytics/insight-engine.ts src/lib/analytics/fetchers.ts src/lib/__tests__/analytics-fetchers-stripe.test.ts src/lib/__tests__/analytics-ai-insights.test.ts src/components/analytics/finance-stripe-tab.tsx src/components/analytics/sales-stripe-tab.tsx src/components/analytics/finance-tab.tsx src/components/analytics/overview-tab.tsx src/components/analytics/finance-tabs.test.tsx
