### PR TITLE
Add automation operator workflow foundations

### DIFF
--- a/prisma/migrations/20260308111500_add_gtm_operator_automation_models/migration.sql
+++ b/prisma/migrations/20260308111500_add_gtm_operator_automation_models/migration.sql
@@ -1,0 +1,233 @@
+-- Extend enums used by the existing automation runtime.
+ALTER TYPE "IntegrationProvider" ADD VALUE 'GOOGLE_SEARCH_CONSOLE';
+ALTER TYPE "IntegrationProvider" ADD VALUE 'WIPGUARD';
+ALTER TYPE "WorkflowRunStatus" ADD VALUE 'WAITING_EXTERNAL';
+ALTER TYPE "WorkflowStepStatus" ADD VALUE 'WAITING_EXTERNAL';
+
+-- Create enums for operator-specific automation persistence.
+CREATE TYPE "AutomationOperatorKey" AS ENUM (
+    'SALES_FOLLOWUP',
+    'CUSTOMER_HEALTH',
+    'GTM_SCRUM',
+    'SEO_GROWTH',
+    'ADS_OPTIMIZER',
+    'ROADMAP_INTELLIGENCE'
+);
+
+CREATE TYPE "AutomationSourceDocumentStatus" AS ENUM ('READY', 'ERROR', 'ARCHIVED');
+CREATE TYPE "AutomationArtifactStatus" AS ENUM ('DRAFT', 'READY', 'ERROR', 'ARCHIVED');
+CREATE TYPE "AutomationRecommendationStatus" AS ENUM (
+    'PENDING_APPROVAL',
+    'APPROVED',
+    'REJECTED',
+    'EXECUTED',
+    'FAILED'
+);
+CREATE TYPE "AutomationAiJobStatus" AS ENUM (
+    'QUEUED',
+    'REQUESTED',
+    'RUNNING',
+    'SUCCEEDED',
+    'FAILED',
+    'CANCELED'
+);
+
+ALTER TABLE "WorkflowDefinition"
+  ADD COLUMN "operatorKey" "AutomationOperatorKey";
+
+CREATE TABLE "AutomationSourceDocument" (
+    "id" TEXT NOT NULL,
+    "workflowId" TEXT NOT NULL,
+    "runId" TEXT NOT NULL,
+    "operatorKey" "AutomationOperatorKey",
+    "provider" "IntegrationProvider",
+    "eventType" TEXT,
+    "externalId" TEXT,
+    "documentType" TEXT NOT NULL,
+    "status" "AutomationSourceDocumentStatus" NOT NULL DEFAULT 'READY',
+    "title" TEXT,
+    "mimeType" TEXT,
+    "sourceUrl" TEXT,
+    "dedupeKey" TEXT,
+    "textContent" TEXT,
+    "structuredData" JSONB,
+    "metadata" JSONB,
+    "observedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AutomationSourceDocument_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "AutomationAiJob" (
+    "id" TEXT NOT NULL,
+    "workflowId" TEXT NOT NULL,
+    "runId" TEXT NOT NULL,
+    "stepId" TEXT,
+    "operatorKey" "AutomationOperatorKey",
+    "nodeKey" TEXT NOT NULL,
+    "jobType" TEXT NOT NULL,
+    "status" "AutomationAiJobStatus" NOT NULL DEFAULT 'QUEUED',
+    "provider" TEXT NOT NULL DEFAULT 'openai',
+    "model" TEXT NOT NULL,
+    "promptVersion" TEXT,
+    "requestPayload" JSONB NOT NULL,
+    "responseId" TEXT,
+    "responseStatus" TEXT,
+    "responsePayload" JSONB,
+    "outputText" TEXT,
+    "parsedOutput" JSONB,
+    "lastError" TEXT,
+    "attemptCount" INTEGER NOT NULL DEFAULT 0,
+    "nextAttemptAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+    "dedupeKey" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AutomationAiJob_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "AutomationArtifact" (
+    "id" TEXT NOT NULL,
+    "workflowId" TEXT NOT NULL,
+    "runId" TEXT NOT NULL,
+    "sourceDocumentId" TEXT,
+    "aiJobId" TEXT,
+    "operatorKey" "AutomationOperatorKey",
+    "artifactType" TEXT NOT NULL,
+    "status" "AutomationArtifactStatus" NOT NULL DEFAULT 'DRAFT',
+    "title" TEXT NOT NULL,
+    "summary" TEXT,
+    "content" TEXT,
+    "contentJson" JSONB,
+    "dedupeKey" TEXT,
+    "metadata" JSONB,
+    "createdByNodeKey" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AutomationArtifact_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "AutomationRecommendation" (
+    "id" TEXT NOT NULL,
+    "workflowId" TEXT NOT NULL,
+    "runId" TEXT NOT NULL,
+    "artifactId" TEXT,
+    "aiJobId" TEXT,
+    "operatorKey" "AutomationOperatorKey",
+    "recommendationType" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "summary" TEXT NOT NULL,
+    "detail" TEXT,
+    "actionType" TEXT NOT NULL,
+    "actionPayload" JSONB,
+    "requiresApproval" BOOLEAN NOT NULL DEFAULT false,
+    "status" "AutomationRecommendationStatus" NOT NULL DEFAULT 'PENDING_APPROVAL',
+    "priority" TEXT,
+    "requestedById" TEXT,
+    "approverId" TEXT,
+    "executedById" TEXT,
+    "decisionNote" TEXT,
+    "executionResult" JSONB,
+    "executionError" TEXT,
+    "dueAt" TIMESTAMP(3),
+    "approvedAt" TIMESTAMP(3),
+    "executedAt" TIMESTAMP(3),
+    "resolvedAt" TIMESTAMP(3),
+    "dedupeKey" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AutomationRecommendation_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "AutomationSourceDocument_dedupeKey_key" ON "AutomationSourceDocument"("dedupeKey");
+CREATE INDEX "AutomationSourceDocument_workflowId_documentType_observedAt_idx" ON "AutomationSourceDocument"("workflowId", "documentType", "observedAt");
+CREATE INDEX "AutomationSourceDocument_runId_documentType_observedAt_idx" ON "AutomationSourceDocument"("runId", "documentType", "observedAt");
+CREATE INDEX "AutomationSourceDocument_provider_eventType_observedAt_idx" ON "AutomationSourceDocument"("provider", "eventType", "observedAt");
+
+CREATE UNIQUE INDEX "AutomationAiJob_responseId_key" ON "AutomationAiJob"("responseId");
+CREATE UNIQUE INDEX "AutomationAiJob_dedupeKey_key" ON "AutomationAiJob"("dedupeKey");
+CREATE INDEX "AutomationAiJob_status_nextAttemptAt_idx" ON "AutomationAiJob"("status", "nextAttemptAt");
+CREATE INDEX "AutomationAiJob_runId_status_createdAt_idx" ON "AutomationAiJob"("runId", "status", "createdAt");
+CREATE INDEX "AutomationAiJob_workflowId_operatorKey_status_idx" ON "AutomationAiJob"("workflowId", "operatorKey", "status");
+
+CREATE UNIQUE INDEX "AutomationArtifact_dedupeKey_key" ON "AutomationArtifact"("dedupeKey");
+CREATE INDEX "AutomationArtifact_workflowId_artifactType_createdAt_idx" ON "AutomationArtifact"("workflowId", "artifactType", "createdAt");
+CREATE INDEX "AutomationArtifact_runId_artifactType_createdAt_idx" ON "AutomationArtifact"("runId", "artifactType", "createdAt");
+CREATE INDEX "AutomationArtifact_operatorKey_artifactType_status_idx" ON "AutomationArtifact"("operatorKey", "artifactType", "status");
+
+CREATE UNIQUE INDEX "AutomationRecommendation_dedupeKey_key" ON "AutomationRecommendation"("dedupeKey");
+CREATE INDEX "AutomationRecommendation_status_approverId_createdAt_idx" ON "AutomationRecommendation"("status", "approverId", "createdAt");
+CREATE INDEX "AutomationRecommendation_runId_status_createdAt_idx" ON "AutomationRecommendation"("runId", "status", "createdAt");
+CREATE INDEX "AutomationRecommendation_workflowId_operatorKey_status_idx" ON "AutomationRecommendation"("workflowId", "operatorKey", "status");
+
+CREATE INDEX "WorkflowDefinition_operatorKey_status_idx" ON "WorkflowDefinition"("operatorKey", "status");
+
+ALTER TABLE "AutomationSourceDocument"
+  ADD CONSTRAINT "AutomationSourceDocument_workflowId_fkey"
+  FOREIGN KEY ("workflowId") REFERENCES "WorkflowDefinition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AutomationSourceDocument"
+  ADD CONSTRAINT "AutomationSourceDocument_runId_fkey"
+  FOREIGN KEY ("runId") REFERENCES "WorkflowRun"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AutomationAiJob"
+  ADD CONSTRAINT "AutomationAiJob_workflowId_fkey"
+  FOREIGN KEY ("workflowId") REFERENCES "WorkflowDefinition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AutomationAiJob"
+  ADD CONSTRAINT "AutomationAiJob_runId_fkey"
+  FOREIGN KEY ("runId") REFERENCES "WorkflowRun"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AutomationAiJob"
+  ADD CONSTRAINT "AutomationAiJob_stepId_fkey"
+  FOREIGN KEY ("stepId") REFERENCES "WorkflowRunStep"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "AutomationArtifact"
+  ADD CONSTRAINT "AutomationArtifact_workflowId_fkey"
+  FOREIGN KEY ("workflowId") REFERENCES "WorkflowDefinition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AutomationArtifact"
+  ADD CONSTRAINT "AutomationArtifact_runId_fkey"
+  FOREIGN KEY ("runId") REFERENCES "WorkflowRun"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AutomationArtifact"
+  ADD CONSTRAINT "AutomationArtifact_sourceDocumentId_fkey"
+  FOREIGN KEY ("sourceDocumentId") REFERENCES "AutomationSourceDocument"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "AutomationArtifact"
+  ADD CONSTRAINT "AutomationArtifact_aiJobId_fkey"
+  FOREIGN KEY ("aiJobId") REFERENCES "AutomationAiJob"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "AutomationRecommendation"
+  ADD CONSTRAINT "AutomationRecommendation_workflowId_fkey"
+  FOREIGN KEY ("workflowId") REFERENCES "WorkflowDefinition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AutomationRecommendation"
+  ADD CONSTRAINT "AutomationRecommendation_runId_fkey"
+  FOREIGN KEY ("runId") REFERENCES "WorkflowRun"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AutomationRecommendation"
+  ADD CONSTRAINT "AutomationRecommendation_artifactId_fkey"
+  FOREIGN KEY ("artifactId") REFERENCES "AutomationArtifact"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "AutomationRecommendation"
+  ADD CONSTRAINT "AutomationRecommendation_aiJobId_fkey"
+  FOREIGN KEY ("aiJobId") REFERENCES "AutomationAiJob"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "AutomationRecommendation"
+  ADD CONSTRAINT "AutomationRecommendation_requestedById_fkey"
+  FOREIGN KEY ("requestedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "AutomationRecommendation"
+  ADD CONSTRAINT "AutomationRecommendation_approverId_fkey"
+  FOREIGN KEY ("approverId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "AutomationRecommendation"
+  ADD CONSTRAINT "AutomationRecommendation_executedById_fkey"
+  FOREIGN KEY ("executedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,22 +18,15 @@ model Organization {
   updatedAt DateTime @updatedAt
 
   // Relations to all tenant-scoped models
-  users                           User[]
-  projects                        Project[]
-  tasks                           Task[]
-  sprints                         Sprint[]
-  deals                           Deal[]
-  departments                     Department[]
-  companyPriorities               CompanyPriority[]
-  integrationConnections          IntegrationConnection[]
-  conferences                     Conference[]
-  customerRecords                 CustomerRecord[]
-  customerRecordExternalRefs      CustomerRecordExternalRef[]
-  customerSuccessNotes            CustomerSuccessNote[]
-  customerSuccessPlans            CustomerSuccessPlan[]
-  customerSuccessPlanMilestones   CustomerSuccessPlanMilestone[]
-  customerSuccessAlertRecords     CustomerSuccessAlertRecord[]
-  customerSuccessOutreachMessages CustomerSuccessOutreachMessage[]
+  users                  User[]
+  projects               Project[]
+  tasks                  Task[]
+  sprints                Sprint[]
+  deals                  Deal[]
+  departments            Department[]
+  companyPriorities      CompanyPriority[]
+  integrationConnections IntegrationConnection[]
+  conferences            Conference[]
 }
 
 // ============================================================
@@ -48,27 +41,30 @@ model User {
   image         String?
   role          String    @default("member")
 
-  accounts                 Account[]
-  sessions                 Session[]
-  integrationConnections   IntegrationConnection[]
-  integrationRules         IntegrationRule[]
-  analyticsSnapshots       AnalyticsSnapshot[]
+  accounts Account[]
+  sessions Session[]
+  integrationConnections IntegrationConnection[]
+  integrationRules       IntegrationRule[]
+  analyticsSnapshots     AnalyticsSnapshot[]
   integrationCircuitStates IntegrationCircuitState[]
-  stripeCustomerLinks      StripeCustomerLink[]
-  metricHistory            MetricHistory[]
-  insightFeedback          InsightFeedback[]
-  uiPreference             UserUiPreference?
-  savedViews               UserSavedView[]
-  ownedWorkflows           WorkflowDefinition[]      @relation("WorkflowOwner")
-  workflowRunRequests      WorkflowRun[]             @relation("WorkflowRunRequestedBy")
-  workflowApprovalRequests WorkflowApproval[]        @relation("WorkflowApprovalRequestedBy")
-  workflowApprovals        WorkflowApproval[]        @relation("WorkflowApprovalApprover")
-  securityAuditEvents      SecurityAuditEvent[]
+  stripeCustomerLinks    StripeCustomerLink[]
+  metricHistory          MetricHistory[]
+  insightFeedback        InsightFeedback[]
+  uiPreference           UserUiPreference?
+  savedViews             UserSavedView[]
+  ownedWorkflows         WorkflowDefinition[] @relation("WorkflowOwner")
+  workflowRunRequests    WorkflowRun[]        @relation("WorkflowRunRequestedBy")
+  workflowApprovalRequests WorkflowApproval[] @relation("WorkflowApprovalRequestedBy")
+  workflowApprovals      WorkflowApproval[]   @relation("WorkflowApprovalApprover")
+  automationRecommendationRequests AutomationRecommendation[] @relation("AutomationRecommendationRequestedBy")
+  automationRecommendationApprovals AutomationRecommendation[] @relation("AutomationRecommendationApprovedBy")
+  automationRecommendationExecutions AutomationRecommendation[] @relation("AutomationRecommendationExecutedBy")
+  securityAuditEvents SecurityAuditEvent[]
 
-  responsibleTasks Task[] @relation("TaskResponsible")
-  accountableTasks Task[] @relation("TaskAccountable")
-  consultedTasks   Task[] @relation("TaskConsulted")
-  informedTasks    Task[] @relation("TaskInformed")
+  responsibleTasks  Task[]    @relation("TaskResponsible")
+  accountableTasks  Task[]    @relation("TaskAccountable")
+  consultedTasks    Task[]    @relation("TaskConsulted")
+  informedTasks     Task[]    @relation("TaskInformed")
 
   responsibleProjects Project[] @relation("ProjectResponsible")
   accountableProjects Project[] @relation("ProjectAccountable")
@@ -87,29 +83,24 @@ model User {
   financialGoals    FinancialGoal[]
   forecastScenarios ForecastScenario[]
 
-  ownedDeals                              Deal[]                           @relation("DealOwner")
-  ownedCustomerRecords                    CustomerRecord[]                 @relation("CustomerRecordOwner")
-  authoredCustomerSuccessNotes            CustomerSuccessNote[]            @relation("CustomerSuccessNoteAuthor")
-  ownedCustomerSuccessPlans               CustomerSuccessPlan[]            @relation("CustomerSuccessPlanOwner")
-  ownedCustomerSuccessAlertRecords        CustomerSuccessAlertRecord[]     @relation("CustomerSuccessAlertOwner")
-  authoredCustomerSuccessOutreachMessages CustomerSuccessOutreachMessage[] @relation("CustomerSuccessOutreachAuthor")
+  ownedDeals Deal[] @relation("DealOwner")
 
-  ownedConferences              Conference[]              @relation("ConferenceOwner")
-  ownedConferenceDeadlines      ConferenceDeadline[]      @relation("ConferenceDeadlineOwner")
-  paidConferenceExpenses        ConferenceExpense[]       @relation("ConferenceExpensePaidBy")
-  capturedConferenceLeads       ConferenceLead[]          @relation("ConferenceLeadCapturedBy")
-  assignedConferenceLeads       ConferenceLead[]          @relation("ConferenceLeadAssignedTo")
-  conferenceTeamMemberships     ConferenceTeamMember[]    @relation("ConferenceTeamMemberUser")
+  ownedConferences Conference[] @relation("ConferenceOwner")
+  ownedConferenceDeadlines ConferenceDeadline[] @relation("ConferenceDeadlineOwner")
+  paidConferenceExpenses ConferenceExpense[] @relation("ConferenceExpensePaidBy")
+  capturedConferenceLeads ConferenceLead[] @relation("ConferenceLeadCapturedBy")
+  assignedConferenceLeads ConferenceLead[] @relation("ConferenceLeadAssignedTo")
+  conferenceTeamMemberships ConferenceTeamMember[] @relation("ConferenceTeamMemberUser")
   ownedConferenceInventoryItems ConferenceInventoryItem[] @relation("ConferenceInventoryItemOwner")
 
-  submissionEvents   SubmissionEvent[]
+  submissionEvents SubmissionEvent[]
   insightPreferences InsightPreference[]
 
   organizationId String?
   organization   Organization? @relation(fields: [organizationId], references: [id])
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
 
   @@index([organizationId])
 }
@@ -182,10 +173,10 @@ model CompanyPriority {
 // ============================================================
 
 model Department {
-  id       String    @id @default(cuid())
-  name     String    @unique
-  color    String?
-  projects Project[]
+  id        String    @id @default(cuid())
+  name      String    @unique
+  color     String?
+  projects  Project[]
 
   organizationId String?
   organization   Organization? @relation(fields: [organizationId], references: [id])
@@ -207,8 +198,8 @@ model Project {
   status      ProjectStatus @default(ACTIVE)
   projectType ProjectType   @default(ONE_OFF)
 
-  conferenceId         String?
-  conference           Conference? @relation("ConferenceProjects", fields: [conferenceId], references: [id], onDelete: SetNull)
+  conferenceId String?
+  conference   Conference? @relation("ConferenceProjects", fields: [conferenceId], references: [id], onDelete: SetNull)
   primaryForConference Conference? @relation("ConferencePrimaryProject")
 
   parentId String?
@@ -274,8 +265,8 @@ model Task {
   conferenceId String?
   conference   Conference? @relation("ConferenceTasks", fields: [conferenceId], references: [id], onDelete: SetNull)
 
-  conferenceDeadline     ConferenceDeadline? @relation("ConferenceDeadlineTask")
-  conferenceLeadFollowup ConferenceLead?     @relation("ConferenceLeadFollowupTask")
+  conferenceDeadline ConferenceDeadline? @relation("ConferenceDeadlineTask")
+  conferenceLeadFollowup ConferenceLead? @relation("ConferenceLeadFollowupTask")
 
   parentId String?
   parent   Task?   @relation("TaskHierarchy", fields: [parentId], references: [id], onDelete: Restrict)
@@ -304,18 +295,14 @@ model Task {
   planningSessionId String?
   planningSession   PlanningSession? @relation(fields: [planningSessionId], references: [id])
 
-  slackThread      String?
-  metadata         Json?
-  columnOrder      Int             @default(0)
-  customerRecordId String?
-  customerRecord   CustomerRecord? @relation(fields: [customerRecordId], references: [id], onDelete: SetNull)
+  slackThread String?
+  metadata    Json?
+  columnOrder Int     @default(0)
 
-  statusHistory                 StatusHistory[]
-  logbookEntries                LogbookEntry[]
-  policyOverrides               PolicyOverride[]
-  integrationReceipts           IntegrationReceipt[]
-  customerSuccessPlanMilestones CustomerSuccessPlanMilestone[]
-  customerSuccessAlertRecords   CustomerSuccessAlertRecord[]
+  statusHistory   StatusHistory[]
+  logbookEntries  LogbookEntry[]
+  policyOverrides PolicyOverride[]
+  integrationReceipts IntegrationReceipt[]
 
   organizationId String?
   organization   Organization? @relation(fields: [organizationId], references: [id])
@@ -324,7 +311,6 @@ model Task {
   updatedAt DateTime @updatedAt
 
   @@index([conferenceId])
-  @@index([customerRecordId])
   @@index([organizationId])
 }
 
@@ -435,14 +421,14 @@ enum ConferenceReimbursementStatus {
 }
 
 model Conference {
-  id         String  @id @default(cuid())
-  slug       String  @unique
+  id         String @id @default(cuid())
+  slug       String @unique
   name       String
   websiteUrl String?
 
   startDate DateTime
   endDate   DateTime
-  timezone  String   @default("UTC")
+  timezone  String  @default("UTC")
 
   city    String?
   region  String?
@@ -460,9 +446,9 @@ model Conference {
   codaDocUrl       String?
 
   ownerId String?
-  owner   User?   @relation("ConferenceOwner", fields: [ownerId], references: [id], onDelete: SetNull)
+  owner   User? @relation("ConferenceOwner", fields: [ownerId], references: [id], onDelete: SetNull)
 
-  primaryProjectId String?  @unique
+  primaryProjectId String? @unique
   primaryProject   Project? @relation("ConferencePrimaryProject", fields: [primaryProjectId], references: [id], onDelete: SetNull)
 
   projects Project[] @relation("ConferenceProjects")
@@ -492,19 +478,19 @@ model ConferenceDeadline {
   conferenceId String
   conference   Conference @relation(fields: [conferenceId], references: [id], onDelete: Cascade)
 
-  type  ConferenceDeadlineType
-  name  String
+  type ConferenceDeadlineType
+  name String
   dueAt DateTime
 
   completedAt DateTime?
   ownerId     String?
-  owner       User?     @relation("ConferenceDeadlineOwner", fields: [ownerId], references: [id], onDelete: SetNull)
+  owner       User? @relation("ConferenceDeadlineOwner", fields: [ownerId], references: [id], onDelete: SetNull)
 
   notes     String? @db.Text
   sourceUrl String?
 
   taskId String? @unique
-  task   Task?   @relation("ConferenceDeadlineTask", fields: [taskId], references: [id], onDelete: SetNull)
+  task   Task? @relation("ConferenceDeadlineTask", fields: [taskId], references: [id], onDelete: SetNull)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -519,7 +505,7 @@ model ConferenceBudget {
   conferenceId String     @unique
   conference   Conference @relation(fields: [conferenceId], references: [id], onDelete: Cascade)
 
-  currency String  @default("USD")
+  currency String @default("USD")
   notes    String? @db.Text
 
   lineItems ConferenceBudgetLineItem[]
@@ -551,20 +537,20 @@ model ConferenceExpense {
   conferenceId String
   conference   Conference @relation(fields: [conferenceId], references: [id], onDelete: Cascade)
 
-  category   ConferenceExpenseCategory
-  amount     Float
-  currency   String                    @default("USD")
+  category  ConferenceExpenseCategory
+  amount    Float
+  currency  String @default("USD")
   incurredAt DateTime
 
   vendor      String?
   description String? @db.Text
   receiptUrl  String?
 
-  reimbursable        Boolean                       @default(false)
+  reimbursable Boolean @default(false)
   reimbursementStatus ConferenceReimbursementStatus @default(NONE)
 
   paidByUserId String?
-  paidByUser   User?   @relation("ConferenceExpensePaidBy", fields: [paidByUserId], references: [id], onDelete: SetNull)
+  paidByUser   User? @relation("ConferenceExpensePaidBy", fields: [paidByUserId], references: [id], onDelete: SetNull)
 
   budgetLineItemId String?
   budgetLineItem   ConferenceBudgetLineItem? @relation("ConferenceExpenseBudgetLineItem", fields: [budgetLineItemId], references: [id], onDelete: SetNull)
@@ -599,19 +585,19 @@ model ConferenceLead {
   capturedAt DateTime @default(now())
 
   capturedByUserId String?
-  capturedByUser   User?   @relation("ConferenceLeadCapturedBy", fields: [capturedByUserId], references: [id], onDelete: SetNull)
+  capturedByUser   User? @relation("ConferenceLeadCapturedBy", fields: [capturedByUserId], references: [id], onDelete: SetNull)
 
   assignedToUserId String?
-  assignedToUser   User?   @relation("ConferenceLeadAssignedTo", fields: [assignedToUserId], references: [id], onDelete: SetNull)
+  assignedToUser   User? @relation("ConferenceLeadAssignedTo", fields: [assignedToUserId], references: [id], onDelete: SetNull)
 
   followupTaskId String? @unique
-  followupTask   Task?   @relation("ConferenceLeadFollowupTask", fields: [followupTaskId], references: [id], onDelete: SetNull)
+  followupTask   Task? @relation("ConferenceLeadFollowupTask", fields: [followupTaskId], references: [id], onDelete: SetNull)
 
   followedUpAt DateTime?
 
-  hubspotCompanyId  String?
-  hubspotContactId  String?
-  hubspotDealId     String?
+  hubspotCompanyId String?
+  hubspotContactId String?
+  hubspotDealId    String?
   pushedToHubspotAt DateTime?
 
   createdAt DateTime @default(now())
@@ -628,12 +614,12 @@ model ConferenceTeamMember {
   conference   Conference @relation(fields: [conferenceId], references: [id], onDelete: Cascade)
 
   userId String
-  user   User   @relation("ConferenceTeamMemberUser", fields: [userId], references: [id], onDelete: Cascade)
+  user   User @relation("ConferenceTeamMemberUser", fields: [userId], references: [id], onDelete: Cascade)
 
-  role        ConferenceTeamRole
+  role ConferenceTeamRole
   arrivalAt   DateTime?
   departureAt DateTime?
-  notes       String?            @db.Text
+  notes       String? @db.Text
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -656,7 +642,7 @@ model ConferenceInventoryItem {
   qtyRemaining Int @default(0)
 
   ownerId String?
-  owner   User?   @relation("ConferenceInventoryItemOwner", fields: [ownerId], references: [id], onDelete: SetNull)
+  owner   User? @relation("ConferenceInventoryItemOwner", fields: [ownerId], references: [id], onDelete: SetNull)
 
   notes String? @db.Text
 
@@ -677,9 +663,9 @@ model Sprint {
   endDate   DateTime
   isActive  Boolean  @default(false)
 
-  tasks            Task[]
-  commitments      SprintCommitment[]
-  planningSessions PlanningSession[]
+  tasks             Task[]
+  commitments       SprintCommitment[]
+  planningSessions  PlanningSession[]
 
   organizationId String?
   organization   Organization? @relation(fields: [organizationId], references: [id])
@@ -702,7 +688,7 @@ model SprintCommitment {
   sprint        Sprint   @relation(fields: [sprintId], references: [id], onDelete: Cascade)
   snapshotAt    DateTime @default(now())
   createdBy     String
-  taskSnapshots Json // Array of {taskId, title, status, projectId, priority}
+  taskSnapshots Json     // Array of {taskId, title, status, projectId, priority}
 
   @@index([sprintId, snapshotAt])
 }
@@ -761,10 +747,11 @@ model LogbookEntry {
 // ============================================================
 
 model BoardSettings {
-  id          String  @id @default(cuid())
-  columnName  String  @unique
-  wipLimit    Int     @default(0)
-  columnOrder Int     @default(0)
+  id          String @id @default(cuid())
+  columnName  String @unique
+  wipLimit    Int    @default(0)
+  columnOrder Int    @default(0)
+  columnVersion Int  @default(0)
   color       String?
 
   createdAt DateTime @default(now())
@@ -796,11 +783,11 @@ enum EnforcementMode {
 // ============================================================
 
 model PolicyOverride {
-  id        String  @id @default(cuid())
+  id        String     @id @default(cuid())
   taskId    String
-  task      Task    @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  task      Task       @relation(fields: [taskId], references: [id], onDelete: Cascade)
   action    String
-  reason    String  @db.Text
+  reason    String     @db.Text
   actorId   String
   actorName String?
   actorRole String?
@@ -816,10 +803,10 @@ model PolicyOverride {
 // ============================================================
 
 model SecurityAuditEvent {
-  id       String @id @default(cuid())
-  action   String
-  category String
-  outcome  String
+  id        String  @id @default(cuid())
+  action    String
+  category  String
+  outcome   String
 
   actorId   String?
   actor     User?   @relation(fields: [actorId], references: [id], onDelete: SetNull)
@@ -858,6 +845,8 @@ enum IntegrationProvider {
   SEMRUSH
   PYLON
   GOOGLE_ANALYTICS
+  GOOGLE_SEARCH_CONSOLE
+  WIPGUARD
 }
 
 enum IntegrationConnectionStatus {
@@ -872,20 +861,20 @@ enum AnalyticsSnapshotStatus {
 }
 
 model IntegrationConnection {
-  id       String                      @id @default(cuid())
-  userId   String
-  user     User                        @relation(fields: [userId], references: [id], onDelete: Cascade)
-  provider IntegrationProvider
-  status   IntegrationConnectionStatus @default(CONNECTED)
+  id        String                      @id @default(cuid())
+  userId    String
+  user      User                        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  provider  IntegrationProvider
+  status    IntegrationConnectionStatus @default(CONNECTED)
 
   providerAccountId String?
   accountLabel      String?
-  scopes            String[]  @default([])
-  accessToken       String?   @db.Text
-  refreshToken      String?   @db.Text
+  scopes            String[]            @default([])
+  accessToken       String?             @db.Text
+  refreshToken      String?             @db.Text
   tokenType         String?
   expiresAt         DateTime?
-  connectedAt       DateTime  @default(now())
+  connectedAt       DateTime            @default(now())
   lastSyncedAt      DateTime?
   lastError         String?
   metadata          Json?
@@ -902,12 +891,12 @@ model IntegrationConnection {
 }
 
 model AnalyticsSnapshot {
-  id     String @id @default(cuid())
-  userId String
-  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id       String @id @default(cuid())
+  userId   String
+  user     User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   providerKey String
-  contextKey  String   @default("default")
+  contextKey  String @default("default")
   rangePreset String
   fromDate    DateTime
   toDate      DateTime
@@ -928,9 +917,9 @@ model AnalyticsSnapshot {
 }
 
 model StripeCustomerLink {
-  id     String @id @default(cuid())
-  userId String
-  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id               String   @id @default(cuid())
+  userId           String
+  user             User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   stripeCustomerId String
   hubspotDealId    String
@@ -949,9 +938,9 @@ model StripeCustomerLink {
 // ============================================================
 
 model MetricHistory {
-  id     String @id @default(cuid())
-  userId String
-  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id          String   @id @default(cuid())
+  userId      String
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   metricKey   String
   section     String
@@ -975,9 +964,9 @@ enum InsightFeedbackAction {
 }
 
 model InsightFeedback {
-  id     String @id @default(cuid())
-  userId String
-  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id        String                @id @default(cuid())
+  userId    String
+  user      User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   insightId String
   action    InsightFeedbackAction
@@ -1019,10 +1008,10 @@ model IntegrationCircuitState {
   key String
 
   state               String
-  consecutiveFailures Int       @default(0)
+  consecutiveFailures Int    @default(0)
   openedAt            DateTime?
-  currentCooldownMs   Int       @default(0)
-  openCount           Int       @default(0)
+  currentCooldownMs   Int    @default(0)
+  openCount           Int    @default(0)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1080,10 +1069,10 @@ model UserSavedView {
   scope     SavedViewScope
   slug      String
   name      String
-  isDefault Boolean        @default(false)
-  isSystem  Boolean        @default(false)
+  isDefault Boolean @default(false)
+  isSystem  Boolean @default(false)
   config    Json
-  position  Int            @default(0)
+  position  Int     @default(0)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1117,6 +1106,7 @@ enum WorkflowRunStatus {
   QUEUED
   RUNNING
   WAITING_APPROVAL
+  WAITING_EXTERNAL
   SUCCEEDED
   FAILED
   CANCELED
@@ -1129,6 +1119,7 @@ enum WorkflowStepStatus {
   FAILED
   SKIPPED
   WAITING_APPROVAL
+  WAITING_EXTERNAL
 }
 
 enum WorkflowApprovalStatus {
@@ -1146,6 +1137,45 @@ enum WorkflowEventStatus {
   DEAD_LETTER
 }
 
+enum AutomationOperatorKey {
+  SALES_FOLLOWUP
+  CUSTOMER_HEALTH
+  GTM_SCRUM
+  SEO_GROWTH
+  ADS_OPTIMIZER
+  ROADMAP_INTELLIGENCE
+}
+
+enum AutomationSourceDocumentStatus {
+  READY
+  ERROR
+  ARCHIVED
+}
+
+enum AutomationArtifactStatus {
+  DRAFT
+  READY
+  ERROR
+  ARCHIVED
+}
+
+enum AutomationRecommendationStatus {
+  PENDING_APPROVAL
+  APPROVED
+  REJECTED
+  EXECUTED
+  FAILED
+}
+
+enum AutomationAiJobStatus {
+  QUEUED
+  REQUESTED
+  RUNNING
+  SUCCEEDED
+  FAILED
+  CANCELED
+}
+
 model WorkflowDefinition {
   id String @id @default(cuid())
 
@@ -1153,9 +1183,10 @@ model WorkflowDefinition {
   owner   User   @relation("WorkflowOwner", fields: [ownerId], references: [id], onDelete: Cascade)
 
   name        String
-  description String?               @db.Text
-  scope       WorkflowScope         @default(PRIVATE)
-  status      WorkflowStatus        @default(DRAFT)
+  description String? @db.Text
+  operatorKey AutomationOperatorKey?
+  scope       WorkflowScope @default(PRIVATE)
+  status      WorkflowStatus @default(DRAFT)
   providers   IntegrationProvider[] @default([])
   rolePolicy  Json?
 
@@ -1165,19 +1196,24 @@ model WorkflowDefinition {
 
   lastPublishedAt DateTime?
   lastRunAt       DateTime?
-  lastError       String?   @db.Text
+  lastError       String? @db.Text
 
-  nodes          WorkflowNode[]
-  edges          WorkflowEdge[]
-  runs           WorkflowRun[]
+  nodes        WorkflowNode[]
+  edges        WorkflowEdge[]
+  runs         WorkflowRun[]
   triggerCursors WorkflowTriggerCursor[]
-  triggerEvents  WorkflowTriggerEvent[]
+  triggerEvents WorkflowTriggerEvent[]
+  sourceDocuments AutomationSourceDocument[]
+  artifacts AutomationArtifact[]
+  recommendations AutomationRecommendation[]
+  aiJobs AutomationAiJob[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   @@index([ownerId, status])
   @@index([scope, status])
+  @@index([operatorKey, status])
 }
 
 model WorkflowNode {
@@ -1211,7 +1247,7 @@ model WorkflowEdge {
   targetNodeKey  String
   conditionLabel String?
   conditionExpr  Json?
-  priority       Int     @default(0)
+  priority       Int @default(0)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1233,16 +1269,20 @@ model WorkflowRun {
   triggerType     String?
   triggerId       String?
   triggerPayload  Json?
-  dedupeKey       String?              @unique
+  dedupeKey       String? @unique
 
-  status        WorkflowRunStatus @default(QUEUED)
+  status WorkflowRunStatus @default(QUEUED)
   correlationId String?
-  startedAt     DateTime?
-  finishedAt    DateTime?
-  error         String?           @db.Text
+  startedAt DateTime?
+  finishedAt DateTime?
+  error String? @db.Text
 
   steps     WorkflowRunStep[]
   approvals WorkflowApproval[]
+  sourceDocuments AutomationSourceDocument[]
+  artifacts AutomationArtifact[]
+  recommendations AutomationRecommendation[]
+  aiJobs AutomationAiJob[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1257,20 +1297,21 @@ model WorkflowRunStep {
   runId String
   run   WorkflowRun @relation(fields: [runId], references: [id], onDelete: Cascade)
 
-  nodeKey  String
+  nodeKey String
   nodeType WorkflowNodeType
-  status   WorkflowStepStatus @default(PENDING)
-  attempt  Int                @default(0)
+  status WorkflowStepStatus @default(PENDING)
+  attempt Int @default(0)
 
   idempotencyKey String? @unique
-  input          Json?
-  output         Json?
-  error          String? @db.Text
+  input  Json?
+  output Json?
+  error  String? @db.Text
 
-  startedAt  DateTime?
+  startedAt DateTime?
   finishedAt DateTime?
 
   approvals WorkflowApproval[]
+  aiJobs AutomationAiJob[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1295,11 +1336,11 @@ model WorkflowApproval {
   approverId String?
   approver   User?   @relation("WorkflowApprovalApprover", fields: [approverId], references: [id], onDelete: SetNull)
 
-  status       WorkflowApprovalStatus @default(PENDING)
-  decisionNote String?                @db.Text
+  status WorkflowApprovalStatus @default(PENDING)
+  decisionNote String? @db.Text
 
-  timeoutAt      DateTime?
-  resolvedAt     DateTime?
+  timeoutAt DateTime?
+  resolvedAt DateTime?
   fallbackEdgeId String?
 
   createdAt DateTime @default(now())
@@ -1315,12 +1356,12 @@ model WorkflowTriggerCursor {
   workflowId String
   workflow   WorkflowDefinition @relation(fields: [workflowId], references: [id], onDelete: Cascade)
 
-  provider    IntegrationProvider
-  cursorKey   String
+  provider IntegrationProvider
+  cursorKey String
   cursorValue Json?
 
   lastEventAt DateTime?
-  lastRunAt   DateTime?
+  lastRunAt DateTime?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1334,23 +1375,192 @@ model WorkflowTriggerEvent {
   workflowId String?
   workflow   WorkflowDefinition? @relation(fields: [workflowId], references: [id], onDelete: SetNull)
 
-  provider       IntegrationProvider
-  eventType      String
-  externalId     String?
-  idempotencyKey String              @unique
-  payload        Json
-  observedAt     DateTime            @default(now())
+  provider IntegrationProvider
+  eventType String
+  externalId String?
+  idempotencyKey String @unique
+  payload Json
+  observedAt DateTime @default(now())
 
-  status        WorkflowEventStatus @default(QUEUED)
-  attemptCount  Int                 @default(0)
-  nextAttemptAt DateTime            @default(now())
-  lastError     String?             @db.Text
+  status WorkflowEventStatus @default(QUEUED)
+  attemptCount Int @default(0)
+  nextAttemptAt DateTime @default(now())
+  lastError String? @db.Text
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   @@index([status, nextAttemptAt])
   @@index([provider, eventType, observedAt])
+}
+
+model AutomationSourceDocument {
+  id String @id @default(cuid())
+
+  workflowId String
+  workflow   WorkflowDefinition @relation(fields: [workflowId], references: [id], onDelete: Cascade)
+
+  runId String
+  run   WorkflowRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+
+  operatorKey AutomationOperatorKey?
+  provider    IntegrationProvider?
+  eventType   String?
+  externalId  String?
+  documentType String
+  status      AutomationSourceDocumentStatus @default(READY)
+
+  title      String?
+  mimeType   String?
+  sourceUrl  String?
+  dedupeKey  String? @unique
+  textContent String? @db.Text
+  structuredData Json?
+  metadata   Json?
+
+  artifacts  AutomationArtifact[]
+
+  observedAt DateTime @default(now())
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  @@index([workflowId, documentType, observedAt])
+  @@index([runId, documentType, observedAt])
+  @@index([provider, eventType, observedAt])
+}
+
+model AutomationAiJob {
+  id String @id @default(cuid())
+
+  workflowId String
+  workflow   WorkflowDefinition @relation(fields: [workflowId], references: [id], onDelete: Cascade)
+
+  runId String
+  run   WorkflowRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+
+  stepId String?
+  step   WorkflowRunStep? @relation(fields: [stepId], references: [id], onDelete: SetNull)
+
+  operatorKey AutomationOperatorKey?
+  nodeKey     String
+  jobType     String
+  status      AutomationAiJobStatus @default(QUEUED)
+
+  provider       String @default("openai")
+  model          String
+  promptVersion  String?
+  requestPayload Json
+  responseId     String? @unique
+  responseStatus String?
+  responsePayload Json?
+  outputText     String? @db.Text
+  parsedOutput   Json?
+  lastError      String? @db.Text
+
+  attemptCount Int @default(0)
+  nextAttemptAt DateTime @default(now())
+  completedAt DateTime?
+  dedupeKey String? @unique
+  metadata Json?
+
+  artifacts AutomationArtifact[]
+  recommendations AutomationRecommendation[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([status, nextAttemptAt])
+  @@index([runId, status, createdAt])
+  @@index([workflowId, operatorKey, status])
+}
+
+model AutomationArtifact {
+  id String @id @default(cuid())
+
+  workflowId String
+  workflow   WorkflowDefinition @relation(fields: [workflowId], references: [id], onDelete: Cascade)
+
+  runId String
+  run   WorkflowRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+
+  sourceDocumentId String?
+  sourceDocument   AutomationSourceDocument? @relation(fields: [sourceDocumentId], references: [id], onDelete: SetNull)
+
+  aiJobId String?
+  aiJob   AutomationAiJob? @relation(fields: [aiJobId], references: [id], onDelete: SetNull)
+
+  operatorKey AutomationOperatorKey?
+  artifactType String
+  status       AutomationArtifactStatus @default(DRAFT)
+  title        String
+  summary      String?
+  content      String? @db.Text
+  contentJson  Json?
+  dedupeKey    String? @unique
+  metadata     Json?
+  createdByNodeKey String?
+
+  recommendations AutomationRecommendation[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([workflowId, artifactType, createdAt])
+  @@index([runId, artifactType, createdAt])
+  @@index([operatorKey, artifactType, status])
+}
+
+model AutomationRecommendation {
+  id String @id @default(cuid())
+
+  workflowId String
+  workflow   WorkflowDefinition @relation(fields: [workflowId], references: [id], onDelete: Cascade)
+
+  runId String
+  run   WorkflowRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+
+  artifactId String?
+  artifact   AutomationArtifact? @relation(fields: [artifactId], references: [id], onDelete: SetNull)
+
+  aiJobId String?
+  aiJob   AutomationAiJob? @relation(fields: [aiJobId], references: [id], onDelete: SetNull)
+
+  operatorKey AutomationOperatorKey?
+  recommendationType String
+  title    String
+  summary  String
+  detail   String? @db.Text
+  actionType String
+  actionPayload Json?
+  requiresApproval Boolean @default(false)
+  status AutomationRecommendationStatus @default(PENDING_APPROVAL)
+  priority String?
+
+  requestedById String?
+  requestedBy   User? @relation("AutomationRecommendationRequestedBy", fields: [requestedById], references: [id], onDelete: SetNull)
+
+  approverId String?
+  approver   User? @relation("AutomationRecommendationApprovedBy", fields: [approverId], references: [id], onDelete: SetNull)
+
+  executedById String?
+  executedBy   User? @relation("AutomationRecommendationExecutedBy", fields: [executedById], references: [id], onDelete: SetNull)
+
+  decisionNote  String? @db.Text
+  executionResult Json?
+  executionError String? @db.Text
+  dueAt       DateTime?
+  approvedAt  DateTime?
+  executedAt  DateTime?
+  resolvedAt  DateTime?
+  dedupeKey   String? @unique
+  metadata    Json?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([status, approverId, createdAt])
+  @@index([runId, status, createdAt])
+  @@index([workflowId, operatorKey, status])
 }
 
 // ============================================================
@@ -1365,21 +1575,21 @@ enum OutboxEventStatus {
 }
 
 model OutboxEvent {
-  id            String @id @default(cuid())
+  id            String           @id @default(cuid())
   eventType     String
   aggregateType String
   aggregateId   String
-  schemaVersion Int    @default(1)
+  schemaVersion Int              @default(1)
   payload       Json
 
-  idempotencyKey String            @unique
+  idempotencyKey String          @unique
   status         OutboxEventStatus @default(PENDING)
-  retryCount     Int               @default(0)
-  nextAttemptAt  DateTime          @default(now())
+  retryCount     Int             @default(0)
+  nextAttemptAt  DateTime        @default(now())
   lastAttemptAt  DateTime?
   dispatchedAt   DateTime?
   failedAt       DateTime?
-  error          String?           @db.Text
+  error          String?         @db.Text
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1402,26 +1612,26 @@ enum ProspectStatus {
 }
 
 model ManufacturerProspect {
-  id                String         @id @default(cuid())
-  userId            String
-  companyName       String
-  domain            String?
-  industry          String?
-  location          String?
-  employeeCount     Int?
-  kanbanEvidence    Json // [{ url, snippet, confidence }]
-  contactName       String?
-  contactEmail      String?
-  contactTitle      String?
-  sourceType        String // "google_cse" | "website_scrape" | "directory"
-  sourceUrl         String
-  confidence        Float          @default(0.5)
-  status            ProspectStatus @default(DISCOVERED)
-  hubspotCompanyId  String?
-  hubspotContactId  String?
+  id               String         @id @default(cuid())
+  userId           String
+  companyName      String
+  domain           String?
+  industry         String?
+  location         String?
+  employeeCount    Int?
+  kanbanEvidence   Json           // [{ url, snippet, confidence }]
+  contactName      String?
+  contactEmail     String?
+  contactTitle     String?
+  sourceType       String         // "google_cse" | "website_scrape" | "directory"
+  sourceUrl        String
+  confidence       Float          @default(0.5)
+  status           ProspectStatus @default(DISCOVERED)
+  hubspotCompanyId String?
+  hubspotContactId String?
   pushedToHubspotAt DateTime?
-  discoveredAt      DateTime       @default(now())
-  metadata          Json?
+  discoveredAt     DateTime       @default(now())
+  metadata         Json?
 
   @@unique([userId, domain])
   @@index([userId, status])
@@ -1459,108 +1669,6 @@ enum MeetingStatus {
   NO_SHOW
 }
 
-enum CustomerLifecycleStage {
-  ONBOARDING
-  ADOPTION
-  ACTIVE
-  EXPANSION
-  RENEWAL
-  AT_RISK
-  CHURNED
-}
-
-enum CustomerRecordStatus {
-  ACTIVE
-  ARCHIVED
-  MERGED
-}
-
-enum CustomerExternalProvider {
-  INTERNAL
-  HUBSPOT
-  STRIPE
-  PYLON
-  CODA
-  SLACK
-  GOOGLE_WORKSPACE
-}
-
-enum CustomerSuccessNoteSource {
-  MANUAL
-  MEETING
-  SUPPORT
-  CRM
-  AI
-  SYSTEM
-}
-
-enum CustomerSuccessNoteVisibility {
-  INTERNAL
-  RESTRICTED
-}
-
-enum CustomerSuccessPlanStatus {
-  DRAFT
-  ACTIVE
-  COMPLETED
-  ARCHIVED
-}
-
-enum CustomerSuccessMilestoneStatus {
-  NOT_STARTED
-  IN_PROGRESS
-  BLOCKED
-  COMPLETED
-}
-
-enum CustomerSuccessAlertCategory {
-  RISK
-  OPPORTUNITY
-  ACTION_REQUIRED
-}
-
-enum CustomerSuccessAlertSeverity {
-  LOW
-  MEDIUM
-  HIGH
-  CRITICAL
-}
-
-enum CustomerSuccessAlertStatus {
-  OPEN
-  IN_PROGRESS
-  RESOLVED
-  DISMISSED
-}
-
-enum CustomerSuccessSlaStatus {
-  NONE
-  ON_TRACK
-  AT_RISK
-  BREACHED
-}
-
-enum CustomerSuccessAlertSource {
-  HEALTH
-  SUPPORT
-  COMMERCIAL
-  RELATIONSHIP
-  WORKFLOW
-}
-
-enum CustomerSuccessOutreachChannel {
-  EMAIL
-  SLACK
-}
-
-enum CustomerSuccessOutreachStatus {
-  DRAFT
-  QUEUED
-  SENT
-  FAILED
-  CANCELED
-}
-
 model DealCompany {
   id       String  @id @default(cuid())
   name     String
@@ -1570,10 +1678,9 @@ model DealCompany {
 
   hubspotCompanyId String? @unique
 
-  contacts       DealContact[]
-  deals          Deal[]
-  meetings       DealMeeting[]
-  customerRecord CustomerRecord?
+  contacts DealContact[]
+  deals    Deal[]
+  meetings DealMeeting[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1606,28 +1713,27 @@ model DealContact {
 }
 
 model Deal {
-  id     String     @id @default(cuid())
+  id     String    @id @default(cuid())
   name   String
-  stage  DealStage  @default(LEAD)
-  amount Float      @default(0)
+  stage  DealStage @default(LEAD)
+  amount Float     @default(0)
   source DealSource @default(OTHER)
 
   expectedCloseDate DateTime?
   closedAt          DateTime?
-  notes             String?   @db.Text
+  notes             String? @db.Text
 
   companyId String?
   company   DealCompany? @relation(fields: [companyId], references: [id], onDelete: SetNull)
 
   ownerId String?
-  owner   User?   @relation("DealOwner", fields: [ownerId], references: [id], onDelete: SetNull)
+  owner   User? @relation("DealOwner", fields: [ownerId], references: [id], onDelete: SetNull)
 
   hubspotDealId String? @unique
 
-  contacts                  DealContact[]      @relation("DealContacts")
-  meetings                  DealMeeting[]
-  stageHistory              DealStageHistory[]
-  primaryForCustomerRecords CustomerRecord[]
+  contacts     DealContact[]    @relation("DealContacts")
+  meetings     DealMeeting[]
+  stageHistory DealStageHistory[]
 
   organizationId String?
   organization   Organization? @relation(fields: [organizationId], references: [id])
@@ -1663,19 +1769,16 @@ model DealMeeting {
   startAt  DateTime
   endAt    DateTime?
   location String?
-  notes    String?   @db.Text
+  notes    String? @db.Text
 
   expectedAttendees Int @default(0)
   actualAttendees   Int @default(0)
 
   dealId String?
-  deal   Deal?   @relation(fields: [dealId], references: [id], onDelete: SetNull)
+  deal   Deal? @relation(fields: [dealId], references: [id], onDelete: SetNull)
 
   companyId String?
   company   DealCompany? @relation(fields: [companyId], references: [id], onDelete: SetNull)
-
-  customerRecordId String?
-  customerRecord   CustomerRecord? @relation(fields: [customerRecordId], references: [id], onDelete: SetNull)
 
   hubspotMeetingId String? @unique
 
@@ -1686,214 +1789,8 @@ model DealMeeting {
 
   @@index([dealId])
   @@index([companyId])
-  @@index([customerRecordId])
   @@index([startAt])
   @@index([status])
-}
-
-model CustomerRecord {
-  id             String                 @id @default(cuid())
-  name           String
-  segment        String?
-  tier           String?
-  lifecycleStage CustomerLifecycleStage @default(ONBOARDING)
-  status         CustomerRecordStatus   @default(ACTIVE)
-  metadata       Json?
-
-  ownerId String?
-  owner   User?   @relation("CustomerRecordOwner", fields: [ownerId], references: [id], onDelete: SetNull)
-
-  dealCompanyId String?      @unique
-  dealCompany   DealCompany? @relation(fields: [dealCompanyId], references: [id], onDelete: SetNull)
-
-  primaryDealId String?
-  primaryDeal   Deal?   @relation(fields: [primaryDealId], references: [id], onDelete: SetNull)
-
-  mergedIntoId String?
-  mergedInto   CustomerRecord?  @relation("CustomerRecordMerge", fields: [mergedIntoId], references: [id], onDelete: SetNull)
-  mergedFrom   CustomerRecord[] @relation("CustomerRecordMerge")
-
-  externalRefs     CustomerRecordExternalRef[]
-  notes            CustomerSuccessNote[]
-  plans            CustomerSuccessPlan[]
-  alerts           CustomerSuccessAlertRecord[]
-  outreachMessages CustomerSuccessOutreachMessage[]
-  tasks            Task[]
-  meetings         DealMeeting[]
-
-  organizationId String?
-  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@index([organizationId])
-  @@index([ownerId])
-  @@index([mergedIntoId])
-  @@index([status, lifecycleStage])
-}
-
-model CustomerRecordExternalRef {
-  id                 String                   @id @default(cuid())
-  customerRecordId   String
-  customerRecord     CustomerRecord           @relation(fields: [customerRecordId], references: [id], onDelete: Cascade)
-  provider           CustomerExternalProvider
-  externalObjectType String                   @default("account")
-  externalId         String
-  label              String?
-  isPrimary          Boolean                  @default(false)
-  metadata           Json?
-
-  organizationId String?
-  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@unique([customerRecordId, provider, externalObjectType, externalId])
-  @@index([organizationId])
-  @@index([provider, externalId])
-}
-
-model CustomerSuccessNote {
-  id               String                        @id @default(cuid())
-  customerRecordId String
-  customerRecord   CustomerRecord                @relation(fields: [customerRecordId], references: [id], onDelete: Cascade)
-  authorUserId     String?
-  authorUser       User?                         @relation("CustomerSuccessNoteAuthor", fields: [authorUserId], references: [id], onDelete: SetNull)
-  title            String?
-  body             String
-  source           CustomerSuccessNoteSource     @default(MANUAL)
-  visibility       CustomerSuccessNoteVisibility @default(INTERNAL)
-  metadata         Json?
-
-  organizationId String?
-  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@index([customerRecordId, createdAt])
-  @@index([organizationId])
-  @@index([authorUserId])
-}
-
-model CustomerSuccessPlan {
-  id               String                         @id @default(cuid())
-  customerRecordId String
-  customerRecord   CustomerRecord                 @relation(fields: [customerRecordId], references: [id], onDelete: Cascade)
-  name             String
-  templateKey      String?
-  status           CustomerSuccessPlanStatus      @default(DRAFT)
-  ownerUserId      String?
-  ownerUser        User?                          @relation("CustomerSuccessPlanOwner", fields: [ownerUserId], references: [id], onDelete: SetNull)
-  startedAt        DateTime?
-  targetDate       DateTime?
-  completedAt      DateTime?
-  metadata         Json?
-  milestones       CustomerSuccessPlanMilestone[]
-
-  organizationId String?
-  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@index([customerRecordId, status])
-  @@index([organizationId])
-  @@index([ownerUserId])
-}
-
-model CustomerSuccessPlanMilestone {
-  id           String                         @id @default(cuid())
-  planId       String
-  plan         CustomerSuccessPlan            @relation(fields: [planId], references: [id], onDelete: Cascade)
-  title        String
-  description  String?
-  status       CustomerSuccessMilestoneStatus @default(NOT_STARTED)
-  dueDate      DateTime?
-  completedAt  DateTime?
-  linkedTaskId String?
-  linkedTask   Task?                          @relation(fields: [linkedTaskId], references: [id], onDelete: SetNull)
-  sortOrder    Int                            @default(0)
-  metadata     Json?
-
-  organizationId String?
-  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@index([planId, sortOrder])
-  @@index([organizationId])
-  @@index([linkedTaskId])
-}
-
-model CustomerSuccessAlertRecord {
-  id               String                       @id @default(cuid())
-  customerRecordId String
-  customerRecord   CustomerRecord               @relation(fields: [customerRecordId], references: [id], onDelete: Cascade)
-  alertKey         String
-  title            String
-  category         CustomerSuccessAlertCategory
-  severity         CustomerSuccessAlertSeverity @default(MEDIUM)
-  status           CustomerSuccessAlertStatus   @default(OPEN)
-  slaStatus        CustomerSuccessSlaStatus     @default(NONE)
-  source           CustomerSuccessAlertSource
-  evidence         Json?
-  suggestedAction  String?
-  ownerUserId      String?
-  ownerUser        User?                        @relation("CustomerSuccessAlertOwner", fields: [ownerUserId], references: [id], onDelete: SetNull)
-  linkedTaskId     String?
-  linkedTask       Task?                        @relation(fields: [linkedTaskId], references: [id], onDelete: SetNull)
-  openedAt         DateTime                     @default(now())
-  resolvedAt       DateTime?
-  lastEvaluatedAt  DateTime?
-  metadata         Json?
-
-  organizationId String?
-  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@unique([customerRecordId, alertKey])
-  @@index([organizationId, status, severity])
-  @@index([ownerUserId])
-  @@index([linkedTaskId])
-}
-
-model CustomerSuccessOutreachMessage {
-  id                String                         @id @default(cuid())
-  customerRecordId  String
-  customerRecord    CustomerRecord                 @relation(fields: [customerRecordId], references: [id], onDelete: Cascade)
-  authorUserId      String?
-  authorUser        User?                          @relation("CustomerSuccessOutreachAuthor", fields: [authorUserId], references: [id], onDelete: SetNull)
-  channel           CustomerSuccessOutreachChannel
-  status            CustomerSuccessOutreachStatus  @default(DRAFT)
-  templateKey       String?
-  recipientName     String?
-  recipientAddress  String
-  subject           String?
-  body              String
-  providerMessageId String?
-  providerThreadId  String?
-  queuedAt          DateTime?
-  sentAt            DateTime?
-  failedAt          DateTime?
-  error             String?
-  metadata          Json?
-
-  organizationId String?
-  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@index([customerRecordId, status, createdAt])
-  @@index([organizationId])
-  @@index([authorUserId])
-  @@index([providerMessageId])
 }
 
 // ── Financial Planning ──
@@ -1930,16 +1827,16 @@ enum GoalStatus {
 }
 
 model Budget {
-  id        String           @id @default(cuid())
+  id        String       @id @default(cuid())
   userId    String
-  user      User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user      User         @relation(fields: [userId], references: [id], onDelete: Cascade)
   name      String
   period    BudgetPeriod
   startDate DateTime
   endDate   DateTime
   lineItems BudgetLineItem[]
-  createdAt DateTime         @default(now())
-  updatedAt DateTime         @updatedAt
+  createdAt DateTime     @default(now())
+  updatedAt DateTime     @updatedAt
 
   @@index([userId])
 }
@@ -1986,8 +1883,8 @@ model ForecastScenario {
 
 model SubmissionEvent {
   id          String   @id @default(cuid())
-  type        String // e.g. "download_request", "form_submission"
-  referenceId String? // optional external reference
+  type        String                        // e.g. "download_request", "form_submission"
+  referenceId String?                       // optional external reference
   metadata    Json     @default("{}")
   userId      String
   user        User     @relation(fields: [userId], references: [id])
@@ -2006,7 +1903,7 @@ model InsightPreference {
   id        String   @id @default(cuid())
   userId    String
   insightId String   @db.VarChar(256)
-  status    String   @db.VarChar(20) // "pinned" | "dismissed"
+  status    String   @db.VarChar(20)  // "pinned" | "dismissed"
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/src/lib/__tests__/automations-actions.test.ts
+++ b/src/lib/__tests__/automations-actions.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TaskStatus } from "@/generated/prisma/client";
+import { executeAutomationAction } from "@/lib/automations/actions";
+import { prisma } from "@/lib/prisma";
+import { getNextColumnOrder } from "@/lib/task-order";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    workflowRun: {
+      findUnique: vi.fn(),
+    },
+    task: {
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/task-order", () => ({
+  getNextColumnOrder: vi.fn(),
+}));
+
+vi.mock("@/lib/integrations/token-refresh", () => ({
+  getValidIntegrationAccessToken: vi.fn(),
+}));
+
+vi.mock("@/lib/integrations/http-client", () => ({
+  fetchJsonWithResilience: vi.fn(),
+  fetchWithResilience: vi.fn(),
+}));
+
+vi.mock("@/lib/integrations/slack-notifications", () => ({
+  sendSlackDirectMessage: vi.fn(),
+}));
+
+describe("automation actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma.workflowRun.findUnique).mockResolvedValue({
+      requestedById: "user_1",
+      workflow: {
+        ownerId: "owner_1",
+      },
+    } as never);
+  });
+
+  it("creates tasks using prisma-aware column ordering", async () => {
+    vi.mocked(getNextColumnOrder).mockResolvedValue(4);
+    vi.mocked(prisma.task.create).mockResolvedValue({
+      id: "task_1",
+      title: "Follow up",
+    } as never);
+
+    const result = await executeAutomationAction({
+      runId: "run_1",
+      actionType: "create_task",
+      actionPayload: {
+        title: "Follow up",
+        status: "active",
+        responsibleId: "user_2",
+      },
+    });
+
+    expect(getNextColumnOrder).toHaveBeenCalledWith(prisma, TaskStatus.ACTIVE);
+    expect(prisma.task.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        title: "Follow up",
+        status: TaskStatus.ACTIVE,
+        columnOrder: 4,
+        accountable: {
+          connect: [{ id: "user_1" }],
+        },
+        responsible: {
+          connect: [{ id: "user_2" }],
+        },
+      }),
+      select: { id: true, title: true },
+    });
+    expect(result).toEqual({
+      actionType: "create_task",
+      status: "executed",
+      targetId: "task_1",
+      detail: "Follow up",
+    });
+  });
+
+  it("updates tasks with only normalized fields", async () => {
+    vi.mocked(prisma.task.update).mockResolvedValue({
+      id: "task_2",
+      title: "Renamed",
+    } as never);
+
+    const result = await executeAutomationAction({
+      runId: "run_1",
+      actionType: "update_task",
+      actionPayload: {
+        taskId: "task_2",
+        title: " Renamed ",
+        notes: "   ",
+        status: "done",
+      },
+    });
+
+    expect(prisma.task.update).toHaveBeenCalledWith({
+      where: { id: "task_2" },
+      data: {
+        title: "Renamed",
+        status: TaskStatus.DONE,
+      },
+      select: { id: true, title: true },
+    });
+    expect(result).toEqual({
+      actionType: "update_task",
+      status: "executed",
+      targetId: "task_2",
+      detail: "Renamed",
+    });
+  });
+});

--- a/src/lib/__tests__/automations-store.test.ts
+++ b/src/lib/__tests__/automations-store.test.ts
@@ -1,0 +1,244 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AutomationRecommendationStatus,
+  AutomationSourceDocumentStatus,
+  IntegrationProvider,
+  Prisma,
+} from "@/generated/prisma/client";
+import {
+  buildRunExecutionContext,
+  materializeSourceDocumentsFromTrigger,
+  persistAutomationEnvelope,
+} from "@/lib/automations/store";
+import { prisma } from "@/lib/prisma";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    automationSourceDocument: {
+      upsert: vi.fn(),
+    },
+    automationArtifact: {
+      upsert: vi.fn(),
+    },
+    automationRecommendation: {
+      upsert: vi.fn(),
+    },
+    workflowRun: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+describe("automation store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("materializes fallback source documents with db-null structured data", async () => {
+    vi.mocked(prisma.automationSourceDocument.upsert).mockResolvedValue({} as never);
+
+    const count = await materializeSourceDocumentsFromTrigger({
+      workflowId: "wf_1",
+      runId: "run_1",
+      operatorKey: "GTM_SCRUM",
+      provider: IntegrationProvider.HUBSPOT,
+      eventType: "meeting.completed",
+      eventDedupeKey: "evt_1",
+      payload: {
+        transcript: "Customer asked for a recap",
+        title: "Demo recap",
+      },
+    });
+
+    expect(count).toBe(1);
+    expect(prisma.automationSourceDocument.upsert).toHaveBeenCalledWith({
+      where: { dedupeKey: "run_1:evt_1:document:fallback" },
+      create: expect.objectContaining({
+        workflowId: "wf_1",
+        runId: "run_1",
+        provider: IntegrationProvider.HUBSPOT,
+        eventType: "meeting.completed",
+        documentType: "transcript",
+        status: AutomationSourceDocumentStatus.READY,
+        structuredData: Prisma.DbNull,
+        metadata: {
+          eventDedupeKey: "evt_1",
+        },
+      }),
+      update: expect.objectContaining({
+        structuredData: Prisma.DbNull,
+        observedAt: expect.any(Date),
+      }),
+    });
+  });
+
+  it("persists artifacts and approval-gated recommendations", async () => {
+    vi.mocked(prisma.automationArtifact.upsert).mockResolvedValueOnce({
+      id: "artifact_1",
+    } as never);
+    vi.mocked(prisma.automationRecommendation.upsert)
+      .mockResolvedValueOnce({ id: "rec_1" } as never)
+      .mockResolvedValueOnce({ id: "rec_2" } as never);
+
+    const result = await persistAutomationEnvelope({
+      workflowId: "wf_1",
+      runId: "run_1",
+      operatorKey: "GTM_SCRUM",
+      createdByNodeKey: "draft_recommendations",
+      requestedById: "user_1",
+      envelope: {
+        artifacts: [
+          {
+            artifactType: "brief",
+            title: "Account brief",
+            contentJson: {
+              customer: "Acme",
+            },
+          },
+        ],
+        recommendations: [
+          {
+            recommendationType: "task",
+            title: "Create task",
+            summary: "Create a follow-up task.",
+            actionType: "create_task",
+          },
+          {
+            recommendationType: "email",
+            title: "Email customer",
+            summary: "Send a follow-up email.",
+            actionType: "send_gmail_message",
+          },
+        ],
+      },
+    });
+
+    expect(result).toEqual({
+      artifactIds: ["artifact_1"],
+      recommendationIds: ["rec_1", "rec_2"],
+    });
+
+    expect(prisma.automationRecommendation.upsert).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        create: expect.objectContaining({
+          artifactId: "artifact_1",
+          requiresApproval: false,
+          status: AutomationRecommendationStatus.APPROVED,
+          approvedAt: expect.any(Date),
+        }),
+      })
+    );
+    expect(prisma.automationRecommendation.upsert).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        create: expect.objectContaining({
+          artifactId: "artifact_1",
+          requiresApproval: true,
+          status: AutomationRecommendationStatus.PENDING_APPROVAL,
+          approvedAt: null,
+        }),
+      })
+    );
+  });
+
+  it("builds execution context from run relations", async () => {
+    vi.mocked(prisma.workflowRun.findUnique).mockResolvedValue({
+      triggerProvider: IntegrationProvider.HUBSPOT,
+      triggerType: "deal.updated",
+      triggerId: "deal_1",
+      triggerPayload: {
+        source: "webhook",
+      },
+      steps: [
+        {
+          nodeKey: "draft_brief",
+          output: {
+            summary: "Healthy pipeline",
+          },
+        },
+      ],
+      sourceDocuments: [
+        {
+          id: "doc_1",
+          documentType: "notes",
+          title: "Call notes",
+          sourceUrl: null,
+          textContent: "Need pricing details",
+          structuredData: null,
+          metadata: null,
+          provider: IntegrationProvider.HUBSPOT,
+          eventType: "deal.updated",
+          externalId: "deal_1",
+        },
+      ],
+      artifacts: [
+        {
+          id: "artifact_1",
+          artifactType: "brief",
+          title: "Brief",
+          summary: "Account summary",
+          content: null,
+          contentJson: null,
+          metadata: null,
+          status: "READY",
+        },
+      ],
+      recommendations: [
+        {
+          id: "rec_1",
+          recommendationType: "task",
+          title: "Create task",
+          summary: "Follow up with pricing.",
+          detail: null,
+          actionType: "create_task",
+          actionPayload: { priority: "P1" },
+          requiresApproval: false,
+          status: AutomationRecommendationStatus.APPROVED,
+          priority: "P1",
+          dueAt: new Date("2026-03-08T12:00:00.000Z"),
+        },
+      ],
+    } as never);
+
+    const context = await buildRunExecutionContext("run_1");
+
+    expect(context).toEqual({
+      trigger: {
+        provider: IntegrationProvider.HUBSPOT,
+        eventType: "deal.updated",
+        externalId: "deal_1",
+        payload: {
+          source: "webhook",
+        },
+      },
+      state: {
+        draft_brief: {
+          summary: "Healthy pipeline",
+        },
+      },
+      sourceDocuments: [
+        expect.objectContaining({
+          id: "doc_1",
+          documentType: "notes",
+          title: "Call notes",
+        }),
+      ],
+      artifacts: [
+        expect.objectContaining({
+          id: "artifact_1",
+          artifactType: "brief",
+          title: "Brief",
+        }),
+      ],
+      recommendations: [
+        expect.objectContaining({
+          id: "rec_1",
+          recommendationType: "task",
+          title: "Create task",
+          dueAt: "2026-03-08T12:00:00.000Z",
+        }),
+      ],
+    });
+  });
+});

--- a/src/lib/automations/actions.ts
+++ b/src/lib/automations/actions.ts
@@ -1,0 +1,527 @@
+import { IntegrationProvider, TaskStatus, type Prisma } from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+import { sendSlackDirectMessage } from "@/lib/integrations/slack-notifications";
+import { getValidIntegrationAccessToken } from "@/lib/integrations/token-refresh";
+import { fetchJsonWithResilience, fetchWithResilience } from "@/lib/integrations/http-client";
+import { getNextColumnOrder } from "@/lib/task-order";
+
+export interface AutomationActionExecutionResult {
+  actionType: string;
+  status: "executed" | "skipped";
+  targetId?: string | null;
+  detail?: string | null;
+  payload?: Record<string, unknown>;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => asString(item))
+    .filter((item): item is string => Boolean(item));
+}
+
+function resolveTaskStatus(input: string | null | undefined): TaskStatus {
+  switch (input?.toUpperCase()) {
+    case "BACKLOG":
+      return TaskStatus.BACKLOG;
+    case "WORKING_ON_TODAY":
+      return TaskStatus.WORKING_ON_TODAY;
+    case "ACTIVE":
+      return TaskStatus.ACTIVE;
+    case "NOT_DONE":
+      return TaskStatus.NOT_DONE;
+    case "DONE":
+      return TaskStatus.DONE;
+    case "QUEUED":
+    default:
+      return TaskStatus.QUEUED;
+  }
+}
+
+function base64UrlEncode(input: string): string {
+  return Buffer.from(input, "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+async function resolveAutomationActor(runId: string): Promise<string> {
+  const run = await prisma.workflowRun.findUnique({
+    where: { id: runId },
+    select: {
+      requestedById: true,
+      workflow: {
+        select: {
+          ownerId: true,
+        },
+      },
+    },
+  });
+
+  const actorUserId = run?.requestedById ?? run?.workflow.ownerId ?? null;
+  if (!actorUserId) {
+    throw new Error("Unable to resolve workflow actor");
+  }
+  return actorUserId;
+}
+
+async function createTaskFromAction(runId: string, payload: Record<string, unknown>) {
+  const actorUserId = await resolveAutomationActor(runId);
+  const title = asString(payload.title) ?? "Automation task";
+  const notes = asString(payload.notes);
+  const priority = asString(payload.priority) ?? "P2";
+  const projectId = asString(payload.projectId);
+  const responsibleId = asString(payload.responsibleId);
+  const status = resolveTaskStatus(asString(payload.status));
+  const columnOrder = await getNextColumnOrder(prisma, status);
+
+  const task = await prisma.task.create({
+    data: {
+      title,
+      notes,
+      priority: priority === "P0" || priority === "P1" || priority === "P2" || priority === "P3" ? priority : "P2",
+      status,
+      projectId,
+      columnOrder,
+      metadata: {
+        automation: {
+          runId,
+          actionType: "create_task",
+        },
+      } as Prisma.JsonObject,
+      ...(responsibleId
+        ? {
+            responsible: {
+              connect: [{ id: responsibleId }],
+            },
+          }
+        : {}),
+      accountable: {
+        connect: [{ id: actorUserId }],
+      },
+    },
+    select: { id: true, title: true },
+  });
+
+  return {
+    actionType: "create_task",
+    status: "executed" as const,
+    targetId: task.id,
+    detail: task.title,
+  };
+}
+
+async function updateTaskFromAction(payload: Record<string, unknown>) {
+  const taskId = asString(payload.taskId);
+  if (!taskId) {
+    return {
+      actionType: "update_task",
+      status: "skipped" as const,
+      detail: "taskId missing",
+    };
+  }
+
+  const title = asString(payload.title);
+  const notes = asString(payload.notes);
+  const status = asString(payload.status);
+  const data: Prisma.TaskUpdateInput = {};
+
+  if (title) {
+    data.title = title;
+  }
+  if (notes) {
+    data.notes = notes;
+  }
+  if (status) {
+    data.status = resolveTaskStatus(status);
+  }
+
+  const task = await prisma.task.update({
+    where: { id: taskId },
+    data,
+    select: { id: true, title: true },
+  });
+
+  return {
+    actionType: "update_task",
+    status: "executed" as const,
+    targetId: task.id,
+    detail: task.title,
+  };
+}
+
+async function getGoogleToken(userId: string): Promise<string> {
+  return getValidIntegrationAccessToken({
+    userId,
+    provider: IntegrationProvider.GOOGLE_WORKSPACE,
+  });
+}
+
+async function createGmailDraftAction(runId: string, payload: Record<string, unknown>) {
+  const userId = await resolveAutomationActor(runId);
+  const token = await getGoogleToken(userId);
+  const to = asStringArray(payload.to);
+  const cc = asStringArray(payload.cc);
+  const bcc = asStringArray(payload.bcc);
+  const subject = asString(payload.subject) ?? "Follow-up";
+  const body = asString(payload.body) ?? "";
+
+  if (to.length === 0) {
+    return {
+      actionType: "create_gmail_draft",
+      status: "skipped" as const,
+      detail: "No recipients",
+    };
+  }
+
+  const rawLines = [
+    `To: ${to.join(", ")}`,
+    ...(cc.length > 0 ? [`Cc: ${cc.join(", ")}`] : []),
+    ...(bcc.length > 0 ? [`Bcc: ${bcc.join(", ")}`] : []),
+    `Subject: ${subject}`,
+    "Content-Type: text/plain; charset=utf-8",
+    "",
+    body,
+  ];
+
+  const response = await fetchJsonWithResilience<{ id?: string; message?: { id?: string } }>({
+    url: "https://gmail.googleapis.com/gmail/v1/users/me/drafts",
+    init: {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        message: {
+          raw: base64UrlEncode(rawLines.join("\r\n")),
+        },
+      }),
+    },
+    timeoutMs: 12_000,
+    maxAttempts: 3,
+  });
+
+  return {
+    actionType: "create_gmail_draft",
+    status: "executed" as const,
+    targetId: response.id ?? response.message?.id ?? null,
+    detail: subject,
+  };
+}
+
+async function sendGmailMessageAction(runId: string, payload: Record<string, unknown>) {
+  const userId = await resolveAutomationActor(runId);
+  const token = await getGoogleToken(userId);
+  const to = asStringArray(payload.to);
+  const cc = asStringArray(payload.cc);
+  const bcc = asStringArray(payload.bcc);
+  const subject = asString(payload.subject) ?? "Follow-up";
+  const body = asString(payload.body) ?? "";
+
+  if (to.length === 0) {
+    return {
+      actionType: "send_gmail_message",
+      status: "skipped" as const,
+      detail: "No recipients",
+    };
+  }
+
+  const rawLines = [
+    `To: ${to.join(", ")}`,
+    ...(cc.length > 0 ? [`Cc: ${cc.join(", ")}`] : []),
+    ...(bcc.length > 0 ? [`Bcc: ${bcc.join(", ")}`] : []),
+    `Subject: ${subject}`,
+    "Content-Type: text/plain; charset=utf-8",
+    "",
+    body,
+  ];
+
+  const response = await fetchJsonWithResilience<{ id?: string }>({
+    url: "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
+    init: {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        raw: base64UrlEncode(rawLines.join("\r\n")),
+      }),
+    },
+    timeoutMs: 12_000,
+    maxAttempts: 3,
+  });
+
+  return {
+    actionType: "send_gmail_message",
+    status: "executed" as const,
+    targetId: response.id ?? null,
+    detail: subject,
+  };
+}
+
+async function createCalendarDraftAction(runId: string, payload: Record<string, unknown>) {
+  const userId = await resolveAutomationActor(runId);
+  const token = await getGoogleToken(userId);
+  const calendarId = asString(payload.calendarId) ?? "primary";
+  const summary = asString(payload.summary) ?? "Follow-up";
+  const description = asString(payload.description) ?? "";
+  const attendees = asStringArray(payload.attendees).map((email) => ({ email }));
+  const start = asString(payload.start);
+  const end = asString(payload.end);
+
+  if (!start || !end) {
+    return {
+      actionType: "create_calendar_draft",
+      status: "skipped" as const,
+      detail: "Missing start or end timestamp",
+    };
+  }
+
+  const response = await fetchJsonWithResilience<{ id?: string; htmlLink?: string }>({
+    url: `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events?sendUpdates=none`,
+    init: {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        summary,
+        description,
+        start: { dateTime: start },
+        end: { dateTime: end },
+        attendees,
+        status: "tentative",
+      }),
+    },
+    timeoutMs: 12_000,
+    maxAttempts: 3,
+  });
+
+  return {
+    actionType: "create_calendar_draft",
+    status: "executed" as const,
+    targetId: response.id ?? null,
+    detail: response.htmlLink ?? summary,
+  };
+}
+
+async function updateHubSpotAction(runId: string, payload: Record<string, unknown>) {
+  const userId = await resolveAutomationActor(runId);
+  const token = await getValidIntegrationAccessToken({
+    userId,
+    provider: IntegrationProvider.HUBSPOT,
+  });
+  const dealId = asString(payload.dealId);
+  const noteBody = asString(payload.noteBody) ?? asString(payload.body);
+  const properties = asRecord(payload.properties) ?? null;
+
+  if (!dealId) {
+    return {
+      actionType: "update_hubspot",
+      status: "skipped" as const,
+      detail: "dealId missing",
+    };
+  }
+
+  if (properties) {
+    await fetchWithResilience({
+      url: `https://api.hubapi.com/crm/v3/objects/deals/${dealId}`,
+      init: {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ properties }),
+      },
+      timeoutMs: 12_000,
+      maxAttempts: 3,
+    });
+  }
+
+  if (noteBody) {
+    const note = await fetchJsonWithResilience<{ id?: string }>({
+      url: "https://api.hubapi.com/crm/v3/objects/notes",
+      init: {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          properties: {
+            hs_note_body: noteBody,
+            hs_timestamp: new Date().toISOString(),
+          },
+          associations: [
+            {
+              to: { id: dealId },
+              types: [
+                {
+                  associationCategory: "HUBSPOT_DEFINED",
+                  associationTypeId: 214,
+                },
+              ],
+            },
+          ],
+        }),
+      },
+      timeoutMs: 12_000,
+      maxAttempts: 3,
+    });
+
+    return {
+      actionType: "update_hubspot",
+      status: "executed" as const,
+      targetId: note.id ?? dealId,
+      detail: "HubSpot deal updated",
+    };
+  }
+
+  return {
+    actionType: "update_hubspot",
+    status: "executed" as const,
+    targetId: dealId,
+    detail: "HubSpot deal updated",
+  };
+}
+
+async function createGitHubIssueAction(payload: Record<string, unknown>) {
+  const token = process.env.GITHUB_TOKEN?.trim();
+  const owner = process.env.GITHUB_REPO_OWNER?.trim() ?? "khenson99";
+  const repo = process.env.GITHUB_REPO_NAME?.trim() ?? "WIPGuard";
+
+  if (!token) {
+    return {
+      actionType: "create_github_issue",
+      status: "skipped" as const,
+      detail: "GITHUB_TOKEN missing",
+    };
+  }
+
+  const title = asString(payload.title) ?? "Automation issue";
+  const body = asString(payload.body) ?? "";
+  const labels = asStringArray(payload.labels);
+
+  const issue = await fetchJsonWithResilience<{ id?: number; number?: number; html_url?: string; node_id?: string }>({
+    url: `https://api.github.com/repos/${owner}/${repo}/issues`,
+    init: {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        title,
+        body,
+        labels,
+      }),
+    },
+    timeoutMs: 12_000,
+    maxAttempts: 3,
+  });
+
+  const projectId =
+    process.env.GITHUB_PROJECT_V2_ID?.trim() ??
+    process.env.GITHUB_PROJECT_ID?.trim() ??
+    null;
+
+  if (projectId && issue.node_id) {
+    await fetchWithResilience({
+      url: "https://api.github.com/graphql",
+      init: {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          query:
+            "mutation($projectId:ID!, $contentId:ID!) { addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}) { item { id } } }",
+          variables: {
+            projectId,
+            contentId: issue.node_id,
+          },
+        }),
+      },
+      timeoutMs: 12_000,
+      maxAttempts: 3,
+    });
+  }
+
+  return {
+    actionType: "create_github_issue",
+    status: "executed" as const,
+    targetId: issue.number ? String(issue.number) : null,
+    detail: issue.html_url ?? title,
+  };
+}
+
+async function postSlackDigestAction(runId: string, payload: Record<string, unknown>) {
+  const userId = await resolveAutomationActor(runId);
+  const message = asString(payload.message) ?? asString(payload.body) ?? "Automation digest";
+  const slackUserId = asString(payload.slackUserId);
+
+  const result = await sendSlackDirectMessage({
+    userId,
+    message,
+    slackUserId: slackUserId ?? undefined,
+  });
+
+  return {
+    actionType: "post_slack_digest",
+    status: "executed" as const,
+    targetId: result.messageTs,
+    detail: result.channelId,
+  };
+}
+
+export async function executeAutomationAction(input: {
+  runId: string;
+  actionType: string;
+  actionPayload?: Record<string, unknown> | null;
+}): Promise<AutomationActionExecutionResult> {
+  const payload = input.actionPayload ?? {};
+
+  switch (input.actionType) {
+    case "create_task":
+      return createTaskFromAction(input.runId, payload);
+    case "update_task":
+      return updateTaskFromAction(payload);
+    case "create_gmail_draft":
+      return createGmailDraftAction(input.runId, payload);
+    case "send_gmail_message":
+      return sendGmailMessageAction(input.runId, payload);
+    case "create_calendar_draft":
+      return createCalendarDraftAction(input.runId, payload);
+    case "update_hubspot":
+      return updateHubSpotAction(input.runId, payload);
+    case "create_github_issue":
+      return createGitHubIssueAction(payload);
+    case "post_slack_digest":
+      return postSlackDigestAction(input.runId, payload);
+    default:
+      return {
+        actionType: input.actionType,
+        status: "skipped",
+        detail: "Unsupported action type",
+      };
+  }
+}

--- a/src/lib/automations/operators.ts
+++ b/src/lib/automations/operators.ts
@@ -1,0 +1,96 @@
+import type { AutomationOperatorKey } from "@/generated/prisma/client";
+
+export interface AutomationOperatorDefinition {
+  key: AutomationOperatorKey;
+  slug: string;
+  label: string;
+  description: string;
+}
+
+export const AUTOMATION_OPERATORS: readonly AutomationOperatorDefinition[] = [
+  {
+    key: "SALES_FOLLOWUP",
+    slug: "sales_followup",
+    label: "Sales Follow-up",
+    description:
+      "Post-demo coaching, follow-up drafting, CRM hygiene, and meeting-next-step automation.",
+  },
+  {
+    key: "CUSTOMER_HEALTH",
+    slug: "customer_health",
+    label: "Customer Health",
+    description:
+      "Churn-risk detection, intervention playbooks, and account-health monitoring.",
+  },
+  {
+    key: "GTM_SCRUM",
+    slug: "gtm_scrum",
+    label: "GTM Scrum",
+    description:
+      "Cross-operator prioritization, digest generation, and execution-backlog orchestration.",
+  },
+  {
+    key: "SEO_GROWTH",
+    slug: "seo_growth",
+    label: "SEO & Growth",
+    description:
+      "SEO, content, and traffic optimization recommendations backed by marketing analytics.",
+  },
+  {
+    key: "ADS_OPTIMIZER",
+    slug: "ads_optimizer",
+    label: "Ads Optimizer",
+    description:
+      "Paid channel anomaly detection, experiment proposals, and spend-allocation recommendations.",
+  },
+  {
+    key: "ROADMAP_INTELLIGENCE",
+    slug: "roadmap_intelligence",
+    label: "Roadmap Intelligence",
+    description:
+      "Roadmap synthesis from support, sales, meetings, and competitive inputs.",
+  },
+] as const;
+
+const OPERATOR_BY_SLUG = new Map(
+  AUTOMATION_OPERATORS.map((operator) => [operator.slug, operator] as const)
+);
+
+const OPERATOR_BY_KEY = new Map(
+  AUTOMATION_OPERATORS.map((operator) => [operator.key, operator] as const)
+);
+
+export function resolveAutomationOperatorBySlug(
+  slug: string | null | undefined
+): AutomationOperatorDefinition | null {
+  if (!slug) return null;
+  return OPERATOR_BY_SLUG.get(slug.trim().toLowerCase()) ?? null;
+}
+
+export function resolveAutomationOperatorByKey(
+  key: AutomationOperatorKey | null | undefined
+): AutomationOperatorDefinition | null {
+  if (!key) return null;
+  return OPERATOR_BY_KEY.get(key) ?? null;
+}
+
+export function normalizeAutomationOperatorKey(
+  value: unknown
+): AutomationOperatorKey | null {
+  if (typeof value !== "string") return null;
+
+  const normalized = value.trim().toUpperCase();
+  const direct = OPERATOR_BY_KEY.get(normalized as AutomationOperatorKey);
+  if (direct) {
+    return direct.key;
+  }
+
+  const bySlug = resolveAutomationOperatorBySlug(value);
+  return bySlug?.key ?? null;
+}
+
+export function automationOperatorLabel(
+  key: AutomationOperatorKey | null | undefined
+): string {
+  return resolveAutomationOperatorByKey(key)?.label ?? "General Automation";
+}

--- a/src/lib/automations/store.ts
+++ b/src/lib/automations/store.ts
@@ -1,0 +1,446 @@
+import {
+  AutomationArtifactStatus,
+  AutomationRecommendationStatus,
+  AutomationSourceDocumentStatus,
+  type AutomationOperatorKey,
+  type IntegrationProvider,
+  Prisma,
+} from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+
+export interface AutomationSourceDocumentInput {
+  provider?: IntegrationProvider | null;
+  eventType?: string | null;
+  externalId?: string | null;
+  documentType: string;
+  title?: string | null;
+  mimeType?: string | null;
+  sourceUrl?: string | null;
+  textContent?: string | null;
+  structuredData?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
+  dedupeKey?: string | null;
+}
+
+export interface AutomationArtifactInput {
+  sourceDocumentId?: string | null;
+  artifactType: string;
+  title: string;
+  summary?: string | null;
+  content?: string | null;
+  contentJson?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
+  dedupeKey?: string | null;
+}
+
+export interface AutomationRecommendationInput {
+  artifactId?: string | null;
+  recommendationType: string;
+  title: string;
+  summary: string;
+  detail?: string | null;
+  actionType: string;
+  actionPayload?: Record<string, unknown> | null;
+  requiresApproval?: boolean;
+  priority?: string | null;
+  dueAt?: string | Date | null;
+  metadata?: Record<string, unknown> | null;
+  dedupeKey?: string | null;
+}
+
+export interface AutomationResultEnvelope {
+  sourceDocuments?: AutomationSourceDocumentInput[];
+  artifacts?: AutomationArtifactInput[];
+  recommendations?: AutomationRecommendationInput[];
+  summary?: string | null;
+  raw?: Record<string, unknown> | null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeTimestamp(value: string | Date | null | undefined): Date | null {
+  if (!value) return null;
+  const parsed = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+type NullableJsonInput =
+  | Prisma.InputJsonValue
+  | Prisma.NullableJsonNullValueInput;
+
+function toNullableJsonValue(
+  value: Record<string, unknown> | null | undefined
+): NullableJsonInput {
+  if (value == null) {
+    return Prisma.DbNull;
+  }
+  return value as Prisma.InputJsonValue;
+}
+
+export function recommendationRequiresApproval(actionType: string): boolean {
+  return (
+    actionType === "send_gmail_message" ||
+    actionType === "create_calendar_draft" ||
+    actionType === "adjust_ad_spend"
+  );
+}
+
+export async function materializeSourceDocumentsFromTrigger(input: {
+  workflowId: string;
+  runId: string;
+  operatorKey?: AutomationOperatorKey | null;
+  provider?: IntegrationProvider | null;
+  eventType: string;
+  payload: Record<string, unknown>;
+  eventDedupeKey: string;
+}): Promise<number> {
+  const documents = Array.isArray(input.payload.documents)
+    ? input.payload.documents
+    : [];
+
+  const prepared: Prisma.AutomationSourceDocumentUncheckedCreateInput[] = documents
+    .map((candidate, index) => {
+      const record = asRecord(candidate);
+      if (!record) return null;
+
+      const documentType = asString(record.documentType) ?? asString(record.type) ?? "context";
+      const title = asString(record.title);
+      const textContent =
+        asString(record.textContent) ?? asString(record.content) ?? asString(record.text);
+      const sourceUrl = asString(record.sourceUrl) ?? asString(record.url);
+      const externalId = asString(record.externalId) ?? asString(record.id);
+      const mimeType = asString(record.mimeType);
+
+      return {
+        workflowId: input.workflowId,
+        runId: input.runId,
+        operatorKey: input.operatorKey ?? null,
+        provider: input.provider ?? null,
+        eventType: input.eventType,
+        externalId,
+        documentType,
+        status: AutomationSourceDocumentStatus.READY,
+        title,
+        mimeType,
+        sourceUrl,
+        textContent,
+        structuredData: toNullableJsonValue(
+          asRecord(record.structuredData) ?? asRecord(record.payload)
+        ),
+        metadata: toNullableJsonValue({
+          eventDedupeKey: input.eventDedupeKey,
+          documentIndex: index,
+          originalShape: record,
+        }),
+        dedupeKey: `${input.runId}:${input.eventDedupeKey}:document:${index}`,
+      };
+    })
+    .filter((value): value is NonNullable<typeof value> => Boolean(value));
+
+  if (prepared.length === 0) {
+    const transcript = asString(input.payload.transcript);
+    const notes = asString(input.payload.notes);
+    if (!transcript && !notes) {
+      return 0;
+    }
+
+    prepared.push({
+      workflowId: input.workflowId,
+      runId: input.runId,
+      operatorKey: input.operatorKey ?? null,
+      provider: input.provider ?? null,
+      eventType: input.eventType,
+      externalId: asString(input.payload.externalId),
+      documentType: transcript ? "transcript" : "notes",
+      status: AutomationSourceDocumentStatus.READY,
+      title:
+        asString(input.payload.title) ??
+        (transcript ? "Transcript" : "Context Notes"),
+      mimeType: transcript ? "text/plain" : null,
+      sourceUrl: asString(input.payload.sourceUrl),
+      textContent: transcript ?? notes,
+      structuredData: Prisma.DbNull,
+      metadata: toNullableJsonValue({
+        eventDedupeKey: input.eventDedupeKey,
+      }),
+      dedupeKey: `${input.runId}:${input.eventDedupeKey}:document:fallback`,
+    });
+  }
+
+  for (const document of prepared) {
+    const dedupeKey = document.dedupeKey;
+    if (!dedupeKey) {
+      continue;
+    }
+
+    await prisma.automationSourceDocument.upsert({
+      where: { dedupeKey },
+      create: {
+        ...document,
+        dedupeKey,
+      },
+      update: {
+        title: document.title,
+        mimeType: document.mimeType,
+        sourceUrl: document.sourceUrl,
+        textContent: document.textContent,
+        structuredData: document.structuredData,
+        metadata: document.metadata,
+        status: document.status,
+        observedAt: new Date(),
+      },
+    });
+  }
+
+  return prepared.length;
+}
+
+export async function buildRunExecutionContext(runId: string): Promise<Record<string, unknown>> {
+  const run = await prisma.workflowRun.findUnique({
+    where: { id: runId },
+    include: {
+      steps: {
+        orderBy: { createdAt: "asc" },
+      },
+      sourceDocuments: {
+        orderBy: { createdAt: "asc" },
+      },
+      artifacts: {
+        orderBy: { createdAt: "asc" },
+      },
+      recommendations: {
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  if (!run) {
+    throw new Error("Workflow run not found");
+  }
+
+  const state = run.steps.reduce<Record<string, unknown>>((acc, step) => {
+    const output = asRecord(step.output);
+    if (!output) return acc;
+    acc[step.nodeKey] = output;
+    return acc;
+  }, {});
+
+  return {
+    trigger: {
+      provider: run.triggerProvider,
+      eventType: run.triggerType,
+      externalId: run.triggerId,
+      payload: asRecord(run.triggerPayload) ?? {},
+    },
+    state,
+    sourceDocuments: run.sourceDocuments.map((document) => ({
+      id: document.id,
+      documentType: document.documentType,
+      title: document.title,
+      sourceUrl: document.sourceUrl,
+      textContent: document.textContent,
+      structuredData: document.structuredData,
+      metadata: document.metadata,
+      provider: document.provider,
+      eventType: document.eventType,
+      externalId: document.externalId,
+    })),
+    artifacts: run.artifacts.map((artifact) => ({
+      id: artifact.id,
+      artifactType: artifact.artifactType,
+      title: artifact.title,
+      summary: artifact.summary,
+      content: artifact.content,
+      contentJson: artifact.contentJson,
+      metadata: artifact.metadata,
+      status: artifact.status,
+    })),
+    recommendations: run.recommendations.map((recommendation) => ({
+      id: recommendation.id,
+      recommendationType: recommendation.recommendationType,
+      title: recommendation.title,
+      summary: recommendation.summary,
+      detail: recommendation.detail,
+      actionType: recommendation.actionType,
+      actionPayload: recommendation.actionPayload,
+      requiresApproval: recommendation.requiresApproval,
+      status: recommendation.status,
+      priority: recommendation.priority,
+      dueAt: recommendation.dueAt?.toISOString() ?? null,
+    })),
+  };
+}
+
+export async function persistAutomationEnvelope(input: {
+  workflowId: string;
+  runId: string;
+  aiJobId?: string | null;
+  operatorKey?: AutomationOperatorKey | null;
+  createdByNodeKey?: string | null;
+  requestedById?: string | null;
+  envelope: AutomationResultEnvelope;
+}): Promise<{
+  artifactIds: string[];
+  recommendationIds: string[];
+}> {
+  const artifactIds: string[] = [];
+  const recommendationIds: string[] = [];
+
+  if (Array.isArray(input.envelope.sourceDocuments)) {
+    for (const [index, document] of input.envelope.sourceDocuments.entries()) {
+      await prisma.automationSourceDocument.upsert({
+        where: {
+          dedupeKey:
+            document.dedupeKey ?? `${input.runId}:${input.createdByNodeKey ?? "ai"}:source:${index}`,
+        },
+        create: {
+          workflowId: input.workflowId,
+          runId: input.runId,
+          operatorKey: input.operatorKey ?? null,
+          provider: document.provider ?? null,
+          eventType: document.eventType ?? null,
+          externalId: document.externalId ?? null,
+          documentType: document.documentType,
+          status: AutomationSourceDocumentStatus.READY,
+          title: document.title ?? null,
+          mimeType: document.mimeType ?? null,
+          sourceUrl: document.sourceUrl ?? null,
+          textContent: document.textContent ?? null,
+          structuredData: toNullableJsonValue(document.structuredData),
+          metadata: toNullableJsonValue(document.metadata),
+          dedupeKey:
+            document.dedupeKey ?? `${input.runId}:${input.createdByNodeKey ?? "ai"}:source:${index}`,
+        },
+        update: {
+          title: document.title ?? null,
+          mimeType: document.mimeType ?? null,
+          sourceUrl: document.sourceUrl ?? null,
+          textContent: document.textContent ?? null,
+          structuredData: toNullableJsonValue(document.structuredData),
+          metadata: toNullableJsonValue(document.metadata),
+          status: AutomationSourceDocumentStatus.READY,
+          observedAt: new Date(),
+        },
+      });
+    }
+  }
+
+  const createdArtifacts: string[] = [];
+
+  if (Array.isArray(input.envelope.artifacts)) {
+    for (const [index, artifact] of input.envelope.artifacts.entries()) {
+      const record = await prisma.automationArtifact.upsert({
+        where: {
+          dedupeKey:
+            artifact.dedupeKey ?? `${input.runId}:${input.createdByNodeKey ?? "ai"}:artifact:${index}`,
+        },
+        create: {
+          workflowId: input.workflowId,
+          runId: input.runId,
+          aiJobId: input.aiJobId ?? null,
+          operatorKey: input.operatorKey ?? null,
+          sourceDocumentId: artifact.sourceDocumentId ?? null,
+          artifactType: artifact.artifactType,
+          status: AutomationArtifactStatus.READY,
+          title: artifact.title,
+          summary: artifact.summary ?? null,
+          content: artifact.content ?? null,
+          contentJson: toNullableJsonValue(artifact.contentJson),
+          metadata: toNullableJsonValue(artifact.metadata),
+          createdByNodeKey: input.createdByNodeKey ?? null,
+          dedupeKey:
+            artifact.dedupeKey ?? `${input.runId}:${input.createdByNodeKey ?? "ai"}:artifact:${index}`,
+        },
+        update: {
+          status: AutomationArtifactStatus.READY,
+          title: artifact.title,
+          summary: artifact.summary ?? null,
+          content: artifact.content ?? null,
+          contentJson: toNullableJsonValue(artifact.contentJson),
+          metadata: toNullableJsonValue(artifact.metadata),
+          createdByNodeKey: input.createdByNodeKey ?? null,
+        },
+        select: { id: true },
+      });
+
+      createdArtifacts.push(record.id);
+      artifactIds.push(record.id);
+    }
+  }
+
+  if (Array.isArray(input.envelope.recommendations)) {
+    for (const [index, recommendation] of input.envelope.recommendations.entries()) {
+      const requiresApproval =
+        recommendation.requiresApproval ??
+        recommendationRequiresApproval(recommendation.actionType);
+      const status = requiresApproval
+        ? AutomationRecommendationStatus.PENDING_APPROVAL
+        : AutomationRecommendationStatus.APPROVED;
+
+      const record = await prisma.automationRecommendation.upsert({
+        where: {
+          dedupeKey:
+            recommendation.dedupeKey ??
+            `${input.runId}:${input.createdByNodeKey ?? "ai"}:recommendation:${index}`,
+        },
+        create: {
+          workflowId: input.workflowId,
+          runId: input.runId,
+          aiJobId: input.aiJobId ?? null,
+          operatorKey: input.operatorKey ?? null,
+          artifactId:
+            recommendation.artifactId ??
+            createdArtifacts[Math.min(index, Math.max(createdArtifacts.length - 1, 0))] ??
+            null,
+          recommendationType: recommendation.recommendationType,
+          title: recommendation.title,
+          summary: recommendation.summary,
+          detail: recommendation.detail ?? null,
+          actionType: recommendation.actionType,
+          actionPayload: toNullableJsonValue(recommendation.actionPayload),
+          requiresApproval,
+          status,
+          priority: recommendation.priority ?? null,
+          requestedById: input.requestedById ?? null,
+          approvedAt: requiresApproval ? null : new Date(),
+          dueAt: normalizeTimestamp(recommendation.dueAt),
+          metadata: toNullableJsonValue(recommendation.metadata),
+          dedupeKey:
+            recommendation.dedupeKey ??
+            `${input.runId}:${input.createdByNodeKey ?? "ai"}:recommendation:${index}`,
+        },
+        update: {
+          title: recommendation.title,
+          summary: recommendation.summary,
+          detail: recommendation.detail ?? null,
+          actionPayload: toNullableJsonValue(recommendation.actionPayload),
+          requiresApproval,
+          status,
+          priority: recommendation.priority ?? null,
+          dueAt: normalizeTimestamp(recommendation.dueAt),
+          metadata: toNullableJsonValue(recommendation.metadata),
+          approvedAt: requiresApproval ? null : new Date(),
+        },
+        select: { id: true },
+      });
+
+      recommendationIds.push(record.id);
+    }
+  }
+
+  return {
+    artifactIds,
+    recommendationIds,
+  };
+}


### PR DESCRIPTION
## Summary
- add automation operator/source document/artifact/recommendation schema and migration
- add automation action/store helper modules for task/email/calendar/slack/github execution and persistence
- add focused unit coverage for automation actions and persistence helpers

## Validation
- npx vitest run src/lib/__tests__/automations-actions.test.ts src/lib/__tests__/automations-store.test.ts src/lib/__tests__/automations-graph.test.ts
- npx eslint src/lib/automations/actions.ts src/lib/automations/operators.ts src/lib/automations/store.ts src/lib/__tests__/automations-actions.test.ts src/lib/__tests__/automations-store.test.ts
- node ./scripts/typecheck-staged.mjs src/lib/automations/actions.ts src/lib/automations/operators.ts src/lib/automations/store.ts src/lib/__tests__/automations-actions.test.ts src/lib/__tests__/automations-store.test.ts

## Notes
- left the unrelated local openai dependency drift out of this PR