### PR TITLE
Add visitor funnel analytics

### DIFF
--- a/prisma/migrations/20260308133000_add_visitor_funnel/migration.sql
+++ b/prisma/migrations/20260308133000_add_visitor_funnel/migration.sql
@@ -1,0 +1,153 @@
+CREATE TYPE "FunnelEventType" AS ENUM (
+    'PAGE_VIEW',
+    'SESSION_STARTED',
+    'AUTH_COMPLETED',
+    'DEMO_BOOKED',
+    'KANBAN_CARD_CREATED',
+    'TRIAL_STARTED',
+    'PAID_CUSTOMER'
+);
+
+CREATE TYPE "FunnelIdentityType" AS ENUM (
+    'EMAIL',
+    'USER_ID',
+    'HUBSPOT_CONTACT_ID',
+    'HUBSPOT_DEAL_ID',
+    'STRIPE_CUSTOMER_ID',
+    'CODA_EMAIL'
+);
+
+CREATE TYPE "FunnelLinkProvenance" AS ENUM (
+    'EXACT',
+    'INFERRED',
+    'BACKFILLED'
+);
+
+CREATE TYPE "EnrichmentProvider" AS ENUM (
+    'UNIFY',
+    'CLAY',
+    'RB2B'
+);
+
+CREATE TABLE "FunnelVisitor" (
+    "id" TEXT NOT NULL,
+    "anonymousId" TEXT NOT NULL,
+    "siteHost" TEXT,
+    "firstTouchSource" TEXT,
+    "firstTouchChannel" TEXT,
+    "firstTouchCampaign" TEXT,
+    "firstTouchReferrer" TEXT,
+    "firstTouchLandingPath" TEXT,
+    "firstTouchLandingUrl" TEXT,
+    "lastTouchSource" TEXT,
+    "lastTouchChannel" TEXT,
+    "lastTouchCampaign" TEXT,
+    "lastTouchReferrer" TEXT,
+    "lastTouchPath" TEXT,
+    "lastTouchUrl" TEXT,
+    "firstSeenAt" TIMESTAMP(3) NOT NULL,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FunnelVisitor_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "FunnelEvent" (
+    "id" TEXT NOT NULL,
+    "visitorId" TEXT NOT NULL,
+    "eventType" "FunnelEventType" NOT NULL,
+    "occurredAt" TIMESTAMP(3) NOT NULL,
+    "path" TEXT,
+    "url" TEXT,
+    "referrer" TEXT,
+    "source" TEXT,
+    "channel" TEXT,
+    "campaign" TEXT,
+    "dedupeKey" TEXT,
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FunnelEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "FunnelIdentityLink" (
+    "id" TEXT NOT NULL,
+    "visitorId" TEXT NOT NULL,
+    "identityType" "FunnelIdentityType" NOT NULL,
+    "identityValue" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "provenance" "FunnelLinkProvenance" NOT NULL DEFAULT 'EXACT',
+    "confidence" DOUBLE PRECISION NOT NULL DEFAULT 1,
+    "metadata" JSONB,
+    "userId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FunnelIdentityLink_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "FunnelEnrichmentSignal" (
+    "id" TEXT NOT NULL,
+    "provider" "EnrichmentProvider" NOT NULL,
+    "signalKey" TEXT NOT NULL,
+    "visitorId" TEXT,
+    "anonymousId" TEXT,
+    "email" TEXT,
+    "domain" TEXT,
+    "fullName" TEXT,
+    "companyName" TEXT,
+    "confidence" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "occurredAt" TIMESTAMP(3),
+    "accepted" BOOLEAN NOT NULL DEFAULT false,
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "payload" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FunnelEnrichmentSignal_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "FunnelVisitor_anonymousId_key" ON "FunnelVisitor"("anonymousId");
+CREATE INDEX "FunnelVisitor_firstSeenAt_idx" ON "FunnelVisitor"("firstSeenAt");
+CREATE INDEX "FunnelVisitor_lastSeenAt_idx" ON "FunnelVisitor"("lastSeenAt");
+CREATE INDEX "FunnelVisitor_firstTouchChannel_firstSeenAt_idx" ON "FunnelVisitor"("firstTouchChannel", "firstSeenAt");
+CREATE INDEX "FunnelVisitor_firstTouchSource_firstSeenAt_idx" ON "FunnelVisitor"("firstTouchSource", "firstSeenAt");
+CREATE INDEX "FunnelVisitor_firstTouchCampaign_firstSeenAt_idx" ON "FunnelVisitor"("firstTouchCampaign", "firstSeenAt");
+CREATE INDEX "FunnelVisitor_siteHost_firstSeenAt_idx" ON "FunnelVisitor"("siteHost", "firstSeenAt");
+
+CREATE UNIQUE INDEX "FunnelEvent_dedupeKey_key" ON "FunnelEvent"("dedupeKey");
+CREATE INDEX "FunnelEvent_visitorId_occurredAt_idx" ON "FunnelEvent"("visitorId", "occurredAt");
+CREATE INDEX "FunnelEvent_eventType_occurredAt_idx" ON "FunnelEvent"("eventType", "occurredAt");
+CREATE INDEX "FunnelEvent_channel_occurredAt_idx" ON "FunnelEvent"("channel", "occurredAt");
+
+CREATE UNIQUE INDEX "FunnelIdentityLink_visitorId_identityType_identityValue_key" ON "FunnelIdentityLink"("visitorId", "identityType", "identityValue");
+CREATE INDEX "FunnelIdentityLink_identityType_identityValue_idx" ON "FunnelIdentityLink"("identityType", "identityValue");
+CREATE INDEX "FunnelIdentityLink_userId_idx" ON "FunnelIdentityLink"("userId");
+CREATE INDEX "FunnelIdentityLink_provider_provenance_idx" ON "FunnelIdentityLink"("provider", "provenance");
+
+CREATE UNIQUE INDEX "FunnelEnrichmentSignal_provider_signalKey_key" ON "FunnelEnrichmentSignal"("provider", "signalKey");
+CREATE INDEX "FunnelEnrichmentSignal_visitorId_idx" ON "FunnelEnrichmentSignal"("visitorId");
+CREATE INDEX "FunnelEnrichmentSignal_email_idx" ON "FunnelEnrichmentSignal"("email");
+CREATE INDEX "FunnelEnrichmentSignal_domain_idx" ON "FunnelEnrichmentSignal"("domain");
+CREATE INDEX "FunnelEnrichmentSignal_accepted_createdAt_idx" ON "FunnelEnrichmentSignal"("accepted", "createdAt");
+
+ALTER TABLE "FunnelEvent"
+ADD CONSTRAINT "FunnelEvent_visitorId_fkey"
+FOREIGN KEY ("visitorId") REFERENCES "FunnelVisitor"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "FunnelIdentityLink"
+ADD CONSTRAINT "FunnelIdentityLink_visitorId_fkey"
+FOREIGN KEY ("visitorId") REFERENCES "FunnelVisitor"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "FunnelIdentityLink"
+ADD CONSTRAINT "FunnelIdentityLink_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "User"("id")
+ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "FunnelEnrichmentSignal"
+ADD CONSTRAINT "FunnelEnrichmentSignal_visitorId_fkey"
+FOREIGN KEY ("visitorId") REFERENCES "FunnelVisitor"("id")
+ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -95,6 +95,7 @@ model User {
 
   submissionEvents SubmissionEvent[]
   insightPreferences InsightPreference[]
+  funnelIdentityLinks FunnelIdentityLink[] @relation("FunnelIdentityUser")
 
   organizationId String?
   organization   Organization? @relation(fields: [organizationId], references: [id])
@@ -1880,6 +1881,149 @@ model ForecastScenario {
 // ============================================================
 // FUNNEL ANALYTICS
 // ============================================================
+
+enum FunnelEventType {
+  PAGE_VIEW
+  SESSION_STARTED
+  AUTH_COMPLETED
+  DEMO_BOOKED
+  KANBAN_CARD_CREATED
+  TRIAL_STARTED
+  PAID_CUSTOMER
+}
+
+enum FunnelIdentityType {
+  EMAIL
+  USER_ID
+  HUBSPOT_CONTACT_ID
+  HUBSPOT_DEAL_ID
+  STRIPE_CUSTOMER_ID
+  CODA_EMAIL
+}
+
+enum FunnelLinkProvenance {
+  EXACT
+  INFERRED
+  BACKFILLED
+}
+
+enum EnrichmentProvider {
+  UNIFY
+  CLAY
+  RB2B
+}
+
+model FunnelVisitor {
+  id          String @id @default(cuid())
+  anonymousId String @unique
+  siteHost    String?
+
+  firstTouchSource     String?
+  firstTouchChannel    String?
+  firstTouchCampaign   String?
+  firstTouchReferrer   String? @db.Text
+  firstTouchLandingPath String?
+  firstTouchLandingUrl  String? @db.Text
+
+  lastTouchSource   String?
+  lastTouchChannel  String?
+  lastTouchCampaign String?
+  lastTouchReferrer String? @db.Text
+  lastTouchPath     String?
+  lastTouchUrl      String? @db.Text
+
+  firstSeenAt DateTime
+  lastSeenAt  DateTime
+
+  events            FunnelEvent[]
+  identityLinks     FunnelIdentityLink[]
+  enrichmentSignals FunnelEnrichmentSignal[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([firstSeenAt])
+  @@index([lastSeenAt])
+  @@index([firstTouchChannel, firstSeenAt])
+  @@index([firstTouchSource, firstSeenAt])
+  @@index([firstTouchCampaign, firstSeenAt])
+  @@index([siteHost, firstSeenAt])
+}
+
+model FunnelEvent {
+  id        String          @id @default(cuid())
+  visitorId String
+  visitor   FunnelVisitor   @relation(fields: [visitorId], references: [id], onDelete: Cascade)
+  eventType FunnelEventType
+
+  occurredAt DateTime
+  path       String?
+  url        String? @db.Text
+  referrer   String? @db.Text
+  source     String?
+  channel    String?
+  campaign   String?
+  dedupeKey  String? @unique
+  metadata   Json    @default("{}")
+
+  createdAt DateTime @default(now())
+
+  @@index([visitorId, occurredAt])
+  @@index([eventType, occurredAt])
+  @@index([channel, occurredAt])
+}
+
+model FunnelIdentityLink {
+  id           String              @id @default(cuid())
+  visitorId     String
+  visitor       FunnelVisitor      @relation(fields: [visitorId], references: [id], onDelete: Cascade)
+  identityType  FunnelIdentityType
+  identityValue String
+  provider      String
+  provenance    FunnelLinkProvenance @default(EXACT)
+  confidence    Float               @default(1)
+  metadata      Json?
+
+  userId String?
+  user   User? @relation("FunnelIdentityUser", fields: [userId], references: [id], onDelete: SetNull)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([visitorId, identityType, identityValue])
+  @@index([identityType, identityValue])
+  @@index([userId])
+  @@index([provider, provenance])
+}
+
+model FunnelEnrichmentSignal {
+  id        String             @id @default(cuid())
+  provider  EnrichmentProvider
+  signalKey String
+
+  visitorId String?
+  visitor   FunnelVisitor? @relation(fields: [visitorId], references: [id], onDelete: SetNull)
+
+  anonymousId String?
+  email       String?
+  domain      String?
+  fullName    String?
+  companyName String?
+  confidence  Float    @default(0)
+  occurredAt  DateTime?
+  accepted    Boolean  @default(false)
+  metadata    Json     @default("{}")
+  payload     Json
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([provider, signalKey])
+  @@index([visitorId])
+  @@index([email])
+  @@index([domain])
+  @@index([accepted, createdAt])
+}
 
 model SubmissionEvent {
   id          String   @id @default(cuid())

--- a/src/app/api/analytics/funnel/collect/route.ts
+++ b/src/app/api/analytics/funnel/collect/route.ts
@@ -1,0 +1,104 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { FunnelEventType, type Prisma } from "@/generated/prisma/client";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { collectVisitorEvent } from "@/lib/analytics/visitor-funnel";
+import { getAuthenticatedUser } from "@/lib/session-user";
+
+const PUBLIC_COLLECTABLE_EVENTS = new Set<FunnelEventType>([
+  FunnelEventType.PAGE_VIEW,
+  FunnelEventType.SESSION_STARTED,
+  FunnelEventType.AUTH_COMPLETED,
+]);
+
+interface CollectRequestBody {
+  anonymousId?: unknown;
+  eventType?: unknown;
+  occurredAt?: unknown;
+  path?: unknown;
+  url?: unknown;
+  referrer?: unknown;
+  utmSource?: unknown;
+  utmMedium?: unknown;
+  utmCampaign?: unknown;
+  userId?: unknown;
+  email?: unknown;
+  dedupeKey?: unknown;
+  metadata?: unknown;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth();
+    const user = getAuthenticatedUser(session);
+    const body = (await request.json().catch(() => ({}))) as CollectRequestBody;
+
+    const anonymousId = asString(body.anonymousId);
+    const rawEventType = asString(body.eventType);
+    if (!anonymousId || !rawEventType) {
+      return NextResponse.json(
+        { error: "anonymousId and eventType are required" },
+        { status: 400 },
+      );
+    }
+
+    const eventType = rawEventType as FunnelEventType;
+    if (!PUBLIC_COLLECTABLE_EVENTS.has(eventType)) {
+      return NextResponse.json(
+        { error: "Unsupported public funnel event type" },
+        { status: 400 },
+      );
+    }
+
+    const sessionUserId = user?.id ?? null;
+    const sessionEmail = user?.email?.toLowerCase() ?? null;
+    const requestedUserId = asString(body.userId);
+    const requestedEmail = asString(body.email)?.toLowerCase() ?? null;
+
+    const trustedUserId =
+      sessionUserId && (!requestedUserId || requestedUserId === sessionUserId)
+        ? sessionUserId
+        : null;
+    const trustedEmail =
+      sessionEmail && (!requestedEmail || requestedEmail === sessionEmail)
+        ? sessionEmail
+        : null;
+
+    const siteHost =
+      asString(request.headers.get("x-forwarded-host")) ??
+      asString(request.headers.get("host"));
+
+    const result = await collectVisitorEvent(prisma, {
+      anonymousId,
+      eventType,
+      occurredAt: asString(body.occurredAt),
+      path: asString(body.path),
+      url: asString(body.url),
+      referrer: asString(body.referrer),
+      utmSource: asString(body.utmSource),
+      utmMedium: asString(body.utmMedium),
+      utmCampaign: asString(body.utmCampaign),
+      userId: trustedUserId,
+      email: trustedEmail,
+      dedupeKey: asString(body.dedupeKey),
+      metadata:
+        body.metadata && typeof body.metadata === "object" && !Array.isArray(body.metadata)
+          ? (body.metadata as Prisma.InputJsonValue)
+          : {},
+    }, { siteHost });
+
+    return NextResponse.json(result, { status: 202 });
+  } catch (error) {
+    console.error("POST /api/analytics/funnel/collect error:", error);
+    return NextResponse.json(
+      { error: "Failed to collect funnel event" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/analytics/funnel/enrich/[provider]/route.ts
+++ b/src/app/api/analytics/funnel/enrich/[provider]/route.ts
@@ -1,0 +1,53 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { getAuthenticatedUser } from "@/lib/session-user";
+import type { EnrichmentProvider } from "@/lib/analytics/types";
+import {
+  ingestVisitorEnrichmentSignals,
+  type VisitorEnrichmentSignalInput,
+} from "@/lib/analytics/visitor-funnel";
+
+const SUPPORTED_PROVIDERS = new Set<EnrichmentProvider>(["unify", "clay", "rb2b"]);
+
+interface EnrichRequestBody {
+  signals?: VisitorEnrichmentSignalInput[];
+}
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ provider: string }> },
+): Promise<NextResponse> {
+  try {
+    const session = await auth();
+    const user = getAuthenticatedUser(session);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (user.role !== "admin") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { provider: rawProvider } = await context.params;
+    const provider = rawProvider.trim().toLowerCase() as EnrichmentProvider;
+    if (!SUPPORTED_PROVIDERS.has(provider)) {
+      return NextResponse.json({ error: "Unsupported enrichment provider" }, { status: 400 });
+    }
+
+    const body = (await request.json().catch(() => ({}))) as EnrichRequestBody;
+    if (!Array.isArray(body.signals)) {
+      return NextResponse.json({ error: "signals must be an array" }, { status: 400 });
+    }
+
+    const result = await ingestVisitorEnrichmentSignals(prisma, provider, body.signals);
+    return NextResponse.json(result, { status: 202 });
+  } catch (error) {
+    console.error("POST /api/analytics/funnel/enrich/[provider] error:", error);
+    return NextResponse.json(
+      { error: "Failed to ingest enrichment signals" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -50,6 +50,11 @@ import {
 import { buildAnalyticsRouteMeta } from "@/lib/analytics/route-meta";
 import { computeAnalyticsKpis } from "@/lib/analytics/kpis";
 import { computeKpiDelta } from "@/lib/analytics/kpi-deltas";
+import {
+  buildVisitorFunnelData,
+  parseVisitorFunnelFilters,
+  syncVisitorFunnelArtifacts,
+} from "@/lib/analytics/visitor-funnel";
 import type {
   AnalyticsDashboardData,
   AnalyticsRecommendation,
@@ -96,6 +101,7 @@ type DomainKey =
   | "recommendations"
   | "distilledInsights"
   | "customerJourney"
+  | "visitorFunnel"
   | "demoAnalytics"
   | "processAnalytics";
 
@@ -229,6 +235,7 @@ const SECTION_DOMAINS: Record<string, DomainKey[]> = {
   "cj-overview": ["hubspot", "stripe", "googleWorkspace", "slack", "webflow", "googleAnalytics", "googleAds", "metaAds", "instagram", "redditAds", "pylon", "customerJourney"],
   "cj-touchpoints": ["hubspot", "stripe", "googleWorkspace", "slack", "webflow", "googleAnalytics", "googleAds", "metaAds", "instagram", "redditAds", "pylon", "customerJourney"],
   "cj-conversion": ["hubspot", "stripe", "googleWorkspace", "slack", "webflow", "googleAnalytics", "googleAds", "metaAds", "instagram", "redditAds", "pylon", "customerJourney"],
+  "cj-acquisition-funnel": ["hubspot", "stripe", "coda", "visitorFunnel"],
 
   "demo-analytics": [
     "hubspot", "googleWorkspace", "demoAnalytics",
@@ -661,6 +668,7 @@ type FetchEntry = {
     | "recommendations"
     | "distilledInsights"
     | "customerJourney"
+    | "visitorFunnel"
     | "demoAnalytics"
     | "processAnalytics"
   >;
@@ -1188,6 +1196,23 @@ export async function GET(request: Request) {
   
   if (domains.has("customerJourney")) {
     result.customerJourney = buildCustomerJourneyData(result);
+  }
+  if (domains.has("visitorFunnel")) {
+    await syncVisitorFunnelArtifacts({
+      prisma,
+      analyticsData: result,
+      stripeKey: creds.stripeKey ?? null,
+      from: fromDate,
+      to: toDate,
+    });
+    result.visitorFunnel = await buildVisitorFunnelData(prisma, {
+      from: fromDate,
+      to: toDate,
+      filters: parseVisitorFunnelFilters(url.searchParams),
+      closedWonCount: (result.hubspot?.deals ?? []).filter(
+        (deal) => deal.stageLabel.trim().toLowerCase() === "closed won",
+      ).length,
+    });
   }
   if (domains.has("recommendations")) {
     result.recommendations = buildRecommendations(result);

--- a/src/app/api/analytics/summary/route.ts
+++ b/src/app/api/analytics/summary/route.ts
@@ -154,6 +154,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       flowRisk: true,
       observability: true,
       customerJourney: true,
+      visitorFunnel: true,
       demoAnalytics: true,
       processAnalytics: true,
     };

--- a/src/app/api/analytics/visitor-funnel/records/route.ts
+++ b/src/app/api/analytics/visitor-funnel/records/route.ts
@@ -1,0 +1,52 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { parseAnalyticsTimeRange } from "@/lib/analytics/time-range";
+import { getAuthenticatedUser } from "@/lib/session-user";
+import {
+  listVisitorFunnelRecords,
+  parseVisitorFunnelFilters,
+} from "@/lib/analytics/visitor-funnel";
+
+function parsePositiveInt(value: string | null, fallback: number, max: number): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.min(parsed, max);
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth();
+    const user = getAuthenticatedUser(session);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (user.role !== "admin") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const range = parseAnalyticsTimeRange(request.nextUrl.searchParams);
+    const from = new Date(`${range.from}T00:00:00.000Z`);
+    const to = new Date(`${range.to}T23:59:59.999Z`);
+    const page = parsePositiveInt(request.nextUrl.searchParams.get("page"), 1, 10_000);
+    const pageSize = parsePositiveInt(request.nextUrl.searchParams.get("pageSize"), 25, 100);
+
+    const result = await listVisitorFunnelRecords(prisma, {
+      from,
+      to,
+      filters: parseVisitorFunnelFilters(request.nextUrl.searchParams),
+      page,
+      pageSize,
+    });
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("GET /api/analytics/visitor-funnel/records error:", error);
+    return NextResponse.json(
+      { error: "Failed to load visitor funnel records" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/analytics/analytics-section-page.tsx
+++ b/src/components/analytics/analytics-section-page.tsx
@@ -38,6 +38,7 @@ const DemoAnalyticsTab = dynamic(() => import("@/components/analytics/demo-analy
 const ProcessAnalyticsTab = dynamic(() => import("@/components/analytics/process-analytics-tab").then((m) => m.ProcessAnalyticsTab), { loading: () => <DashboardLoadingState message="Loading section..." className="h-48" /> });
 const CustomerJourneyDrillDown = dynamic(() => import("@/components/analytics/customer-journey-drill-down").then((m) => m.CustomerJourneyDrillDown), { loading: () => <DashboardLoadingState message="Loading section..." className="h-48" /> });
 const CustomerJourneyConversionTab = dynamic(() => import("@/components/analytics/customer-journey-conversion-tab").then((m) => m.CustomerJourneyConversionTab), { loading: () => <DashboardLoadingState message="Loading section..." className="h-48" /> });
+const VisitorFunnelTab = dynamic(() => import("@/components/analytics/visitor-funnel-tab").then((m) => m.VisitorFunnelTab), { loading: () => <DashboardLoadingState message="Loading section..." className="h-48" /> });
 const DemoSchedulingView = dynamic(() => import("@/components/analytics/demo-scheduling-view").then((m) => m.DemoSchedulingView), { loading: () => <DashboardLoadingState message="Loading section..." className="h-48" /> });
 const DemoAttributionView = dynamic(() => import("@/components/analytics/demo-attribution-view").then((m) => m.DemoAttributionView), { loading: () => <DashboardLoadingState message="Loading section..." className="h-48" /> });
 const ProcessBottlenecksView = dynamic(() => import("@/components/analytics/process-bottlenecks-view").then((m) => m.ProcessBottlenecksView), { loading: () => <DashboardLoadingState message="Loading section..." className="h-48" /> });
@@ -101,6 +102,7 @@ export type AnalyticsChildRenderKind =
   | "cs-slack"
   | "customerJourneyDrillDown"
   | "customerJourneyConversion"
+  | "visitorFunnel"
   | "demoScheduling"
   | "demoAttribution"
   | "processBottlenecks"
@@ -143,6 +145,7 @@ const CHILD_ID_TO_RENDER_KIND = {
   // Customer Journey
   "cj-touchpoints": "customerJourneyDrillDown",
   "cj-conversion": "customerJourneyConversion",
+  "cj-acquisition-funnel": "visitorFunnel",
   // Demo Analytics
   "demo-scheduling": "demoScheduling",
   "demo-attribution": "demoAttribution",
@@ -155,6 +158,7 @@ const CHILD_ID_TO_RENDER_KIND = {
 
 const DATA_DOMAIN_TO_RENDER_KIND = {
   customerJourney: "customerJourneyDrillDown",
+  visitorFunnel: "visitorFunnel",
   demoAnalytics: "demoScheduling",
   processAnalytics: "processBottlenecks",
 } as const satisfies Record<string, AnalyticsChildRenderKind>;
@@ -180,8 +184,8 @@ export function resolveAnalyticsChildRenderKind(input: {
   );
 }
 
-function sectionCacheKey(sectionId: string, rangeQuery: string): string {
-  return `${SECTION_CACHE_PREFIX}${sectionId}:${rangeQuery || "default"}`;
+function sectionCacheKey(sectionId: string, querySignature: string): string {
+  return `${SECTION_CACHE_PREFIX}${sectionId}:${querySignature || "default"}`;
 }
 
 function summarizePayload(payload: Record<string, unknown>) {
@@ -269,10 +273,10 @@ export function AnalyticsSectionPage({ sectionId }: AnalyticsSectionPageProps) {
   const fullRangeSuffix = rangeQuery ? `&${rangeQuery}` : "";
 
   const resource = useDashboardResource<SectionViewModel>({
-    cacheKey: sectionCacheKey(sectionId, rangeQuery),
+    cacheKey: sectionCacheKey(sectionId, searchParamsString),
     deps: [sectionId, rangeQuery, searchParamsString, child?.id],
     load: async ({ signal, refresh }) => {
-      const analyticsParams = new URLSearchParams(rangeQuery);
+      const analyticsParams = new URLSearchParams(searchParamsString);
       analyticsParams.set("section", sectionId);
       if (refresh) {
         analyticsParams.set("refresh", "true");
@@ -355,6 +359,7 @@ export function AnalyticsSectionPage({ sectionId }: AnalyticsSectionPageProps) {
     if (renderKind === "cs-slack") return <GenericSlackTab data={analyticsData} />;
     if (renderKind === "customerJourneyDrillDown") return <CustomerJourneyDrillDown data={analyticsData} />;
     if (renderKind === "customerJourneyConversion") return <CustomerJourneyConversionTab data={analyticsData} />;
+    if (renderKind === "visitorFunnel") return <VisitorFunnelTab data={analyticsData} />;
     if (renderKind === "demoScheduling") return <DemoSchedulingView data={analyticsData} />;
     if (renderKind === "demoAttribution") return <DemoAttributionView data={analyticsData} />;
     if (renderKind === "processBottlenecks") return <ProcessBottlenecksView data={analyticsData} />;

--- a/src/components/analytics/visitor-funnel-tab.tsx
+++ b/src/components/analytics/visitor-funnel-tab.tsx
@@ -1,0 +1,492 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useSession } from "next-auth/react";
+import {
+  CalendarRange,
+  DollarSign,
+  ExternalLink,
+  Filter,
+  FlaskConical,
+  PanelsTopLeft,
+  UserRound,
+  Users,
+} from "lucide-react";
+import type {
+  AnalyticsDashboardData,
+  VisitorFunnelBreakdownRow,
+  VisitorFunnelRecord,
+} from "@/lib/analytics/types";
+import { DrilldownPanel } from "./drilldown-panel";
+import { StatCard } from "./stat-card";
+
+interface RecordsResponse {
+  records: VisitorFunnelRecord[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+const STAGE_LABELS: Record<string, string> = {
+  visitors: "Visitors",
+  identified: "Identified",
+  demo_booked: "Demo Booked",
+  kanban_card_created: "Kanban Card Created",
+  trial_started: "Trials Started",
+  paid_customer: "Paid Customers",
+};
+
+const STAGE_ICONS = [
+  Users,
+  UserRound,
+  CalendarRange,
+  PanelsTopLeft,
+  FlaskConical,
+  DollarSign,
+] as const;
+
+function pct(value: number | null): string {
+  return value == null ? "—" : `${value.toFixed(1)}%`;
+}
+
+function formatStage(stage: string): string {
+  return STAGE_LABELS[stage] ?? stage.replaceAll("_", " ");
+}
+
+function formatMilestone(record: VisitorFunnelRecord, stage: string): string {
+  const milestone = record.milestones.find((entry) => entry.stage === stage);
+  if (!milestone?.occurredAt) return "—";
+  return new Date(milestone.occurredAt).toLocaleDateString();
+}
+
+function buildCsvRows(records: VisitorFunnelRecord[]): string[][] {
+  return records.map((record) => [
+    record.anonymousId,
+    record.firstTouchChannel ?? "",
+    record.firstTouchSource ?? "",
+    record.firstTouchCampaign ?? "",
+    record.deepestStage,
+    record.firstSeenAt,
+    record.lastSeenAt,
+    record.identities?.map((identity) => `${identity.type}:${identity.value}`).join(" | ") ?? "",
+  ]);
+}
+
+export function VisitorFunnelTab({ data }: { data: AnalyticsDashboardData | null }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { data: session } = useSession();
+  const sessionRole =
+    typeof (session?.user as { role?: unknown } | undefined)?.role === "string"
+      ? ((session?.user as { role: string }).role ?? null)
+      : null;
+  const funnel = data?.visitorFunnel;
+  const isAdmin = sessionRole === "admin";
+  const [recordsState, setRecordsState] = useState<{
+    href: string | null;
+    payload: RecordsResponse | null;
+    error: string | null;
+  }>({
+    href: null,
+    payload: null,
+    error: null,
+  });
+
+  const recordsHref = (() => {
+    const hrefValue = funnel?.recordsApi.href;
+    if (typeof window === "undefined" || !hrefValue) return null;
+    const href = new URL(hrefValue, window.location.origin);
+    href.searchParams.set("page", "1");
+    href.searchParams.set("pageSize", "10");
+    return `${href.pathname}${href.search}`;
+  })();
+
+  useEffect(() => {
+    if (!isAdmin || !recordsHref) return;
+
+    let active = true;
+    const controller = new AbortController();
+
+    void fetch(recordsHref, {
+      cache: "no-store",
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Preview request failed (${response.status})`);
+        }
+        const payload = (await response.json()) as RecordsResponse;
+        if (!active) return;
+        setRecordsState({
+          href: recordsHref,
+          payload,
+          error: null,
+        });
+      })
+      .catch((error) => {
+        if (!active || controller.signal.aborted) return;
+        setRecordsState({
+          href: recordsHref,
+          payload: null,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to load visitor preview.",
+        });
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [isAdmin, recordsHref]);
+
+  if (!funnel) {
+    return (
+      <div className="rounded-xl border border-border bg-card p-5 text-sm text-muted-foreground">
+        No visitor funnel data is available for the selected range.
+      </div>
+    );
+  }
+
+  const updateFilter = (key: string, value: string | null) => {
+    const next = new URLSearchParams(searchParams?.toString() ?? "");
+    if (!value || value === "all") {
+      next.delete(key);
+    } else {
+      next.set(key, value);
+    }
+    router.replace(`${pathname}${next.toString() ? `?${next.toString()}` : ""}`, { scroll: false });
+  };
+
+  const previewIsCurrent = Boolean(
+    isAdmin && recordsHref && recordsState.href === recordsHref
+  );
+  const previewRecords = previewIsCurrent ? recordsState.payload?.records ?? [] : [];
+  const previewTotal = previewIsCurrent ? recordsState.payload?.pagination.total ?? 0 : 0;
+  const previewError = previewIsCurrent ? recordsState.error : null;
+  const previewLoading = Boolean(isAdmin && recordsHref && !previewIsCurrent);
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl border border-border bg-card p-5">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h3 className="text-sm font-semibold text-foreground">Anonymous Visit to Customer Funnel</h3>
+            <p className="mt-1 max-w-2xl text-xs text-muted-foreground">
+              First-party visit cohorts joined to de-anonymization, demo, kanban, trial, and paid conversion milestones.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => updateFilter("quickFilter", "all")}
+              className={`rounded-md px-3 py-1.5 text-xs ${
+                funnel.filters.quickFilter === "all"
+                  ? "bg-foreground text-background"
+                  : "border border-border bg-background text-muted-foreground"
+              }`}
+            >
+              All Channels
+            </button>
+            <button
+              type="button"
+              onClick={() => updateFilter("quickFilter", "reddit")}
+              className={`rounded-md px-3 py-1.5 text-xs ${
+                funnel.filters.quickFilter === "reddit"
+                  ? "bg-[#ff4500] text-white"
+                  : "border border-border bg-background text-muted-foreground"
+              }`}
+            >
+              Reddit Only
+            </button>
+            <button
+              type="button"
+              onClick={() => updateFilter("knownOnly", funnel.filters.knownOnly ? null : "true")}
+              className={`rounded-md border px-3 py-1.5 text-xs ${
+                funnel.filters.knownOnly
+                  ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
+                  : "border-border bg-background text-muted-foreground"
+              }`}
+            >
+              Known Only
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <div className="inline-flex items-center gap-2 text-xs text-muted-foreground">
+            <Filter className="h-3.5 w-3.5" />
+            Filters
+          </div>
+          <select
+            value={funnel.filters.stage}
+            onChange={(event) => updateFilter("stage", event.target.value)}
+            className="rounded-md border border-border bg-background px-2 py-1.5 text-xs text-foreground"
+          >
+            <option value="all">All stages</option>
+            {funnel.stages.map((stage) => (
+              <option key={stage.stage} value={stage.stage}>
+                {stage.label}
+              </option>
+            ))}
+          </select>
+          <select
+            value={funnel.filters.channel}
+            onChange={(event) => updateFilter("channel", event.target.value)}
+            className="rounded-md border border-border bg-background px-2 py-1.5 text-xs text-foreground"
+          >
+            <option value="all">All channels</option>
+            {funnel.availableChannels.map((channel) => (
+              <option key={channel} value={channel}>
+                {channel}
+              </option>
+            ))}
+          </select>
+          <select
+            value={funnel.filters.source ?? "all"}
+            onChange={(event) => updateFilter("source", event.target.value)}
+            className="rounded-md border border-border bg-background px-2 py-1.5 text-xs text-foreground"
+          >
+            <option value="all">All sources</option>
+            {funnel.availableSources.map((source) => (
+              <option key={source} value={source}>
+                {source}
+              </option>
+            ))}
+          </select>
+          <select
+            value={funnel.filters.campaign ?? "all"}
+            onChange={(event) => updateFilter("campaign", event.target.value)}
+            className="rounded-md border border-border bg-background px-2 py-1.5 text-xs text-foreground"
+          >
+            <option value="all">All campaigns</option>
+            {funnel.availableCampaigns.map((campaign) => (
+              <option key={campaign} value={campaign}>
+                {campaign}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 xl:grid-cols-6">
+        {funnel.stages.map((stage, index) => {
+          const Icon = STAGE_ICONS[index] ?? Users;
+          return (
+            <StatCard
+              key={stage.stage}
+              label={stage.label}
+              value={stage.count}
+              subtitle={`Visitors: ${pct(stage.conversionFromVisitors)} · Prev: ${pct(stage.conversionFromPrevious)}`}
+              icon={Icon}
+            />
+          );
+        })}
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[1.4fr_1fr]">
+        <div className="rounded-xl border border-border bg-card p-5">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">Weekly Trend</h3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Cohort entry and milestone counts by ISO week.
+              </p>
+            </div>
+            <div className="text-right text-xs text-muted-foreground">
+              Closed-won reference: {funnel.secondaryMetrics.closedWonCount.toLocaleString()}
+            </div>
+          </div>
+
+          <div className="mt-4 overflow-x-auto">
+            <table className="min-w-full text-left text-xs">
+              <thead className="text-muted-foreground">
+                <tr>
+                  <th className="pb-2 pr-4 font-medium">Week</th>
+                  <th className="pb-2 pr-4 font-medium">Visitors</th>
+                  <th className="pb-2 pr-4 font-medium">Identified</th>
+                  <th className="pb-2 pr-4 font-medium">Demo</th>
+                  <th className="pb-2 pr-4 font-medium">Kanban</th>
+                  <th className="pb-2 pr-4 font-medium">Trial</th>
+                  <th className="pb-2 font-medium">Paid</th>
+                </tr>
+              </thead>
+              <tbody>
+                {funnel.trends.map((row) => (
+                  <tr key={row.week} className="border-t border-border">
+                    <td className="py-2 pr-4 text-foreground">{row.week}</td>
+                    <td className="py-2 pr-4">{row.visitors.toLocaleString()}</td>
+                    <td className="py-2 pr-4">{row.identified.toLocaleString()}</td>
+                    <td className="py-2 pr-4">{row.demo_booked.toLocaleString()}</td>
+                    <td className="py-2 pr-4">{row.kanban_card_created.toLocaleString()}</td>
+                    <td className="py-2 pr-4">{row.trial_started.toLocaleString()}</td>
+                    <td className="py-2">{row.paid_customer.toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-border bg-card p-5">
+          <h3 className="text-sm font-semibold text-foreground">Action Overlap</h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Visitors who completed multiple downstream actions in the range.
+          </p>
+          <div className="mt-4 space-y-2">
+            {funnel.overlaps.map((overlap) => (
+              <div key={overlap.key} className="flex items-center justify-between rounded-lg border border-border px-3 py-2 text-xs">
+                <span className="text-foreground">{overlap.key.replaceAll("_", " ").replace("+", " + ")}</span>
+                <span className="font-medium text-foreground">{overlap.count.toLocaleString()}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-3">
+        <BreakdownCard title="Channels" rows={funnel.channelBreakdown} />
+        <BreakdownCard title="Sources" rows={funnel.sourceBreakdown} />
+        <BreakdownCard title="Campaigns" rows={funnel.campaignBreakdown} />
+      </div>
+
+      <DrilldownPanel
+        title="Admin Record Preview"
+        subtitle="Top visitor rows with identity and milestone evidence."
+        statusLine={
+          isAdmin
+            ? previewLoading
+              ? "Loading admin preview…"
+              : `${previewTotal} total matching visitors`
+            : "Admin role required for row-level identity drill-down."
+        }
+        csvExport={
+          isAdmin && previewRecords.length > 0
+            ? {
+                filename: `visitor-funnel-preview-${new Date().toISOString().slice(0, 10)}.csv`,
+                headers: [
+                  "Anonymous ID",
+                  "Channel",
+                  "Source",
+                  "Campaign",
+                  "Deepest Stage",
+                  "First Seen",
+                  "Last Seen",
+                  "Identities",
+                ],
+                rows: () => buildCsvRows(previewRecords),
+              }
+            : undefined
+        }
+        isEmpty={!isAdmin || (!previewLoading && previewRecords.length === 0)}
+        emptyMessage={isAdmin ? previewError ?? "No matching visitor records." : "Admin access required."}
+      >
+        <div className="space-y-2">
+          {previewRecords.map((record) => (
+            <div key={record.visitorId} className="rounded-xl border border-border bg-background px-4 py-3">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="text-sm font-medium text-foreground">
+                    {record.firstTouchSource ?? "unknown source"} / {record.firstTouchChannel ?? "unknown channel"}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {record.anonymousId} · {new Date(record.firstSeenAt).toLocaleString()}
+                  </p>
+                </div>
+                <div className="text-right">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Deepest Stage</p>
+                  <p className="text-sm font-semibold text-foreground">{formatStage(record.deepestStage)}</p>
+                </div>
+              </div>
+
+              <div className="mt-3 grid gap-3 text-xs lg:grid-cols-3">
+                <div className="rounded-lg border border-border px-3 py-2">
+                  <p className="font-medium text-foreground">Milestones</p>
+                  <div className="mt-2 space-y-1 text-muted-foreground">
+                    <div>Demo: {formatMilestone(record, "demo_booked")}</div>
+                    <div>Kanban: {formatMilestone(record, "kanban_card_created")}</div>
+                    <div>Trial: {formatMilestone(record, "trial_started")}</div>
+                    <div>Paid: {formatMilestone(record, "paid_customer")}</div>
+                  </div>
+                </div>
+                <div className="rounded-lg border border-border px-3 py-2">
+                  <p className="font-medium text-foreground">Identity Links</p>
+                  <div className="mt-2 space-y-1 text-muted-foreground">
+                    {(record.identities ?? []).slice(0, 4).map((identity) => (
+                      <div key={`${identity.type}:${identity.value}`}>
+                        {identity.type}: {identity.value} ({identity.provenance})
+                      </div>
+                    ))}
+                    {(record.identities?.length ?? 0) === 0 ? <div>None</div> : null}
+                  </div>
+                </div>
+                <div className="rounded-lg border border-border px-3 py-2">
+                  <p className="font-medium text-foreground">Provider Evidence</p>
+                  <div className="mt-2 space-y-1 text-muted-foreground">
+                    {(record.providers ?? []).slice(0, 4).map((provider) => (
+                      <div key={provider.provider}>
+                        {provider.provider}: {provider.signalCount} signals{provider.accepted ? " accepted" : ""}
+                      </div>
+                    ))}
+                    {(record.providers?.length ?? 0) === 0 ? <div>None</div> : null}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {isAdmin && funnel.recordsApi.href ? (
+          <div className="mt-4 flex justify-end">
+            <a
+              href={funnel.recordsApi.href}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground"
+            >
+              Open records API
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          </div>
+        ) : null}
+      </DrilldownPanel>
+    </div>
+  );
+}
+
+function BreakdownCard({
+  title,
+  rows,
+}: {
+  title: string;
+  rows: VisitorFunnelBreakdownRow[];
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-5">
+      <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+      <p className="mt-1 text-xs text-muted-foreground">Top acquisition slices in the current filter context.</p>
+      <div className="mt-4 space-y-2">
+        {rows.map((row) => (
+          <div key={row.key} className="rounded-lg border border-border px-3 py-2">
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-sm font-medium text-foreground">{row.key}</p>
+              <p className="text-xs text-muted-foreground">{row.visitors.toLocaleString()} visitors</p>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Identified {row.identified} · Demo {row.demoBooked} · Kanban {row.kanbanCards} · Trial {row.trialsStarted} · Paid {row.paidCustomers}
+            </p>
+          </div>
+        ))}
+        {rows.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No breakdown rows in the selected range.</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/funnel-tracker.tsx
+++ b/src/components/layout/funnel-tracker.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import {
+  usePathname,
+  useSearchParams,
+} from "next/navigation";
+import { useSession } from "next-auth/react";
+import {
+  collectClientFunnelEvent,
+  getOrCreateAnonymousId,
+  getOrCreateBrowserSessionId,
+  markAuthTracked,
+  wasAuthTracked,
+} from "@/lib/tracking/visitor-funnel";
+
+export function FunnelTracker() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { data: session, status } = useSession();
+  const sessionUser = session?.user as
+    | { id?: string | null; email?: string | null }
+    | undefined;
+  const pageKeyRef = useRef<string | null>(null);
+  const sessionTrackedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    getOrCreateAnonymousId();
+    const sessionId = getOrCreateBrowserSessionId();
+    if (sessionTrackedRef.current === sessionId) return;
+    sessionTrackedRef.current = sessionId;
+
+    void collectClientFunnelEvent({
+      eventType: "SESSION_STARTED",
+      path: currentPath(pathname, searchParams),
+      dedupeKey: `session_started:${sessionId}`,
+    });
+  }, [pathname, searchParams]);
+
+  useEffect(() => {
+    const pageKey = currentPath(pathname, searchParams);
+    if (pageKeyRef.current === pageKey) return;
+    pageKeyRef.current = pageKey;
+
+    void collectClientFunnelEvent({
+      eventType: "PAGE_VIEW",
+      path: pageKey,
+      userId: typeof sessionUser?.id === "string" ? sessionUser.id : null,
+      email: typeof sessionUser?.email === "string" ? sessionUser.email : null,
+      dedupeKey: `page_view:${getOrCreateBrowserSessionId()}:${pageKey}`,
+    });
+  }, [pathname, searchParams, sessionUser?.email, sessionUser?.id]);
+
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    const userId = typeof sessionUser?.id === "string" ? sessionUser.id : null;
+    if (!userId || wasAuthTracked(userId)) return;
+
+    const email = typeof sessionUser?.email === "string" ? sessionUser.email : null;
+    markAuthTracked(userId);
+    void collectClientFunnelEvent({
+      eventType: "AUTH_COMPLETED",
+      path: currentPath(pathname, searchParams),
+      userId,
+      email,
+      dedupeKey: `auth_completed:${getOrCreateBrowserSessionId()}:${userId}`,
+    });
+  }, [pathname, searchParams, sessionUser?.email, sessionUser?.id, status]);
+
+  return null;
+}
+
+function currentPath(
+  pathname: string | null,
+  searchParams: { toString(): string } | null,
+): string {
+  const base = pathname || "/";
+  const query = searchParams?.toString();
+  return query ? `${base}?${query}` : base;
+}

--- a/src/components/layout/providers.tsx
+++ b/src/components/layout/providers.tsx
@@ -3,11 +3,13 @@
 import { SessionProvider } from "next-auth/react";
 import { ThemeProvider } from "next-themes";
 import type { ReactNode } from "react";
+import { FunnelTracker } from "@/components/layout/funnel-tracker";
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
     <SessionProvider>
       <ThemeProvider attribute="class" defaultTheme="light">
+        <FunnelTracker />
         {children}
       </ThemeProvider>
     </SessionProvider>

--- a/src/lib/analytics/response-shape.ts
+++ b/src/lib/analytics/response-shape.ts
@@ -45,6 +45,7 @@ export function createEmptyAnalyticsDashboardData(input: {
     funnelJourney: null,
     lifecycleFunnel: null,
     customerJourney: null,
+    visitorFunnel: null,
     demoAnalytics: null,
     processAnalytics: null,
     recommendations: [],

--- a/src/lib/analytics/section-registry.ts
+++ b/src/lib/analytics/section-registry.ts
@@ -36,7 +36,12 @@ export interface AnalyticsSubSection {
     | "semrush"
     | "pylon"
     | "product"
+    | "decisionDashboard"
+    | "flowMetrics"
+    | "flowRisk"
+    | "observability"
     | "customerJourney"
+    | "visitorFunnel"
     | "demoAnalytics"
     | "processAnalytics"
     | "financePlanning"
@@ -118,9 +123,15 @@ export const ANALYTICS_SUB_SECTIONS: AnalyticsSubSection[] = [
   { id: "cs-product", label: "Product", path: "/analytics/cs-product", parentId: "customer-success", dataDomain: "product" },
   { id: "cs-google-workspace", label: "Google Workspace", path: "/analytics/cs-google-workspace", parentId: "customer-success", dataDomain: "googleWorkspace" },
   { id: "cs-slack", label: "Slack", path: "/analytics/cs-slack", parentId: "customer-success", dataDomain: "slack" },
+  { id: "cs-decision-dashboard", label: "Decision Dashboard", path: "/analytics/cs-decision-dashboard", parentId: "customer-success", dataDomain: "decisionDashboard" },
+  { id: "cs-flow-metrics", label: "Flow Metrics", path: "/analytics/cs-flow-metrics", parentId: "customer-success", dataDomain: "flowMetrics" },
+  { id: "cs-flow-risk", label: "Flow Risk", path: "/analytics/cs-flow-risk", parentId: "customer-success", dataDomain: "flowRisk" },
+  { id: "cs-observability", label: "Observability", path: "/analytics/cs-observability", parentId: "customer-success", dataDomain: "observability" },
+
   { id: "cj-overview", label: "Journey Overview", path: "/analytics/cj-overview", parentId: "customer-journey", dataDomain: "customerJourney" },
   { id: "cj-touchpoints", label: "Touchpoints", path: "/analytics/cj-touchpoints", parentId: "customer-journey", dataDomain: "customerJourney" },
   { id: "cj-conversion", label: "Conversion Analysis", path: "/analytics/cj-conversion", parentId: "customer-journey", dataDomain: "customerJourney" },
+  { id: "cj-acquisition-funnel", label: "Acquisition Funnel", path: "/analytics/cj-acquisition-funnel", parentId: "customer-journey", dataDomain: "visitorFunnel" },
 
   { id: "demo-scheduling", label: "Scheduling", path: "/analytics/demo-scheduling", parentId: "demo-analytics", dataDomain: "demoAnalytics" },
   { id: "demo-attribution", label: "Attribution", path: "/analytics/demo-attribution", parentId: "demo-analytics", dataDomain: "demoAnalytics" },
@@ -183,6 +194,10 @@ export const LEGACY_ANALYTICS_ROUTE_REDIRECTS: Record<string, string> = {
   "google-workspace": "/analytics/sales-google-workspace",
   slack: "/analytics/sales-slack",
   semrush: "/analytics/ads-semrush",
+  "decision-dashboard": "/analytics/cs-decision-dashboard",
+  "flow-metrics": "/analytics/cs-flow-metrics",
+  "flow-risk": "/analytics/cs-flow-risk",
+  observability: "/analytics/cs-observability",
   "customer-journey": "/analytics/customer-journey",
   "demo-analytics": "/analytics/demo-analytics",
   "process-analytics": "/analytics/process-analytics",

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -159,6 +159,40 @@ export interface HubSpotData {
     };
     stageHistory?: Array<{ occurredAt: string; stageId: string; stageLabel: string }>;
   }>;
+  displayDeals?: Array<{
+    dealId: string;
+    dealName: string;
+    stageId: string;
+    stageLabel: string;
+    amount: number;
+    source: string;
+    ownerId: string | null;
+    repName?: string;
+    updatedAt: string | null;
+    createdAt: string | null;
+    closedAt?: string | null;
+    stripeCustomerId?: string | null;
+    pipelineId: string | null;
+    contactIds: string[];
+    primaryContactId: string | null;
+    primaryContactEmail: string | null;
+    primaryContactAnalytics?: {
+      createdAt?: string | null;
+      source: string | null;
+      sourceData1: string | null;
+      sourceData2: string | null;
+      firstSeenAt: string | null;
+      lastSeenAt: string | null;
+      firstUrl: string | null;
+      lastUrl: string | null;
+      numVisits: number | null;
+      numPageViews: number | null;
+      utmSource: string | null;
+      utmMedium: string | null;
+      utmCampaign: string | null;
+    };
+    stageHistory?: Array<{ occurredAt: string; stageId: string; stageLabel: string }>;
+  }>;
   _meta: AnalyticsTimestamp;
 }
 
@@ -1073,6 +1107,128 @@ export interface CustomerJourneyData {
 }
 
 // ══════════════════════════════════════════════════════════
+// VISITOR FUNNEL TYPES
+// ══════════════════════════════════════════════════════════
+
+export type EnrichmentProvider = "unify" | "clay" | "rb2b";
+
+export type VisitorFunnelStageId =
+  | "visitors"
+  | "identified"
+  | "demo_booked"
+  | "kanban_card_created"
+  | "trial_started"
+  | "paid_customer";
+
+export type VisitorLinkProvenance = "exact" | "inferred" | "backfilled";
+
+export interface VisitorMilestone {
+  stage: Exclude<VisitorFunnelStageId, "visitors">;
+  occurredAt: string | null;
+}
+
+export interface VisitorFunnelStageCount {
+  stage: VisitorFunnelStageId;
+  label: string;
+  count: number;
+  conversionFromVisitors: number | null;
+  conversionFromPrevious: number | null;
+}
+
+export interface VisitorFunnelTrendPoint {
+  week: string;
+  visitors: number;
+  identified: number;
+  demo_booked: number;
+  kanban_card_created: number;
+  trial_started: number;
+  paid_customer: number;
+}
+
+export interface VisitorFunnelBreakdownRow {
+  key: string;
+  visitors: number;
+  identified: number;
+  demoBooked: number;
+  kanbanCards: number;
+  trialsStarted: number;
+  paidCustomers: number;
+}
+
+export interface VisitorFunnelOverlap {
+  key: string;
+  count: number;
+}
+
+export interface VisitorFunnelIdentitySummary {
+  type: string;
+  value: string;
+  provider: string;
+  provenance: VisitorLinkProvenance;
+  confidence: number;
+}
+
+export interface VisitorFunnelProviderEvidence {
+  provider: string;
+  accepted: boolean;
+  signalCount: number;
+}
+
+export interface VisitorFunnelRecord {
+  visitorId: string;
+  anonymousId: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  firstTouchSource: string | null;
+  firstTouchChannel: string | null;
+  firstTouchCampaign: string | null;
+  firstTouchReferrer: string | null;
+  landingPath: string | null;
+  identified: boolean;
+  deepestStage: VisitorFunnelStageId;
+  milestones: VisitorMilestone[];
+  identities?: VisitorFunnelIdentitySummary[];
+  providers?: VisitorFunnelProviderEvidence[];
+}
+
+export interface VisitorFunnelFilters {
+  channel: string;
+  source: string | null;
+  campaign: string | null;
+  stage: VisitorFunnelStageId | "all";
+  knownOnly: boolean;
+  quickFilter: "all" | "reddit";
+}
+
+export interface VisitorFunnelData {
+  filters: VisitorFunnelFilters;
+  stages: VisitorFunnelStageCount[];
+  trends: VisitorFunnelTrendPoint[];
+  channelBreakdown: VisitorFunnelBreakdownRow[];
+  sourceBreakdown: VisitorFunnelBreakdownRow[];
+  campaignBreakdown: VisitorFunnelBreakdownRow[];
+  overlaps: VisitorFunnelOverlap[];
+  availableChannels: string[];
+  availableSources: string[];
+  availableCampaigns: string[];
+  totals: {
+    visitors: number;
+    identified: number;
+    demoBooked: number;
+    kanbanCards: number;
+    trialsStarted: number;
+    paidCustomers: number;
+  };
+  recordsApi: {
+    href: string;
+    adminOnly: boolean;
+  };
+  secondaryMetrics: {
+    closedWonCount: number;
+  };
+}
+
+// ══════════════════════════════════════════════════════════
 // DEMO ANALYTICS TYPES
 // ══════════════════════════════════════════════════════════
 
@@ -1374,6 +1530,7 @@ export interface AnalyticsDashboardData {
   funnelJourney: CrossFunnelData | null;
   lifecycleFunnel: LifecycleFunnelData | null;
   customerJourney: CustomerJourneyData | null;
+  visitorFunnel: VisitorFunnelData | null;
   demoAnalytics: DemoAnalyticsData | null;
   processAnalytics: ProcessAnalyticsData | null;
   recommendations: AnalyticsRecommendation[];

--- a/src/lib/analytics/visitor-funnel.test.ts
+++ b/src/lib/analytics/visitor-funnel.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { parseVisitorFunnelFilters } from "@/lib/analytics/visitor-funnel";
+
+describe("parseVisitorFunnelFilters", () => {
+  it("parses the reddit quick filter and normalized source filters", () => {
+    const params = new URLSearchParams({
+      channel: "all",
+      source: "Reddit",
+      campaign: "Launch-Week",
+      stage: "trial_started",
+      quickFilter: "reddit",
+      knownOnly: "true",
+    });
+
+    expect(parseVisitorFunnelFilters(params)).toEqual({
+      channel: "all",
+      source: "reddit",
+      campaign: "launch-week",
+      stage: "trial_started",
+      quickFilter: "reddit",
+      knownOnly: true,
+    });
+  });
+
+  it("falls back to safe defaults for unsupported values", () => {
+    const params = new URLSearchParams({
+      channel: "",
+      stage: "bogus_stage",
+      quickFilter: "linkedin",
+    });
+
+    expect(parseVisitorFunnelFilters(params)).toEqual({
+      channel: "all",
+      source: null,
+      campaign: null,
+      stage: "all",
+      quickFilter: "all",
+      knownOnly: false,
+    });
+  });
+});

--- a/src/lib/analytics/visitor-funnel.ts
+++ b/src/lib/analytics/visitor-funnel.ts
@@ -1,0 +1,1637 @@
+import { createHash } from "crypto";
+import {
+  EnrichmentProvider as PrismaEnrichmentProvider,
+  FunnelEventType,
+  FunnelIdentityType,
+  FunnelLinkProvenance,
+  type Prisma,
+  type PrismaClient,
+} from "@/generated/prisma/client";
+import { enrichStripeEmails } from "@/lib/analytics/stripe-email-enrichment";
+import type { PrismaClientType } from "@/lib/prisma";
+import type {
+  AnalyticsDashboardData,
+  EnrichmentProvider,
+  VisitorFunnelBreakdownRow,
+  VisitorFunnelData,
+  VisitorFunnelFilters,
+  VisitorFunnelOverlap,
+  VisitorFunnelProviderEvidence,
+  VisitorFunnelRecord,
+  VisitorFunnelStageCount,
+  VisitorFunnelStageId,
+  VisitorFunnelTrendPoint,
+  VisitorMilestone,
+  VisitorLinkProvenance,
+} from "@/lib/analytics/types";
+
+type FunnelPrismaClient = PrismaClientType;
+type PersistedVisitor = NonNullable<
+  Awaited<ReturnType<PrismaClient["funnelVisitor"]["findUnique"]>>
+>;
+type HubSpotDeal = NonNullable<
+  NonNullable<AnalyticsDashboardData["hubspot"]>["deals"]
+>[number];
+
+const STAGE_ORDER: VisitorFunnelStageId[] = [
+  "visitors",
+  "identified",
+  "demo_booked",
+  "kanban_card_created",
+  "trial_started",
+  "paid_customer",
+];
+
+const STAGE_LABELS: Record<VisitorFunnelStageId, string> = {
+  visitors: "Visitors",
+  identified: "Identified",
+  demo_booked: "Demo Booked",
+  kanban_card_created: "Kanban Card Created",
+  trial_started: "Trial Started",
+  paid_customer: "Paid Customer",
+};
+
+const DEMO_STAGES = new Set([
+  "Demo Scheduled",
+  "No-Show/Reschedule",
+  "Demo Follow-Up",
+  "Budgetary Quote Sent",
+  "Payment Link Sent",
+  "Free Trial",
+  "Freemium",
+  "Subscription",
+  "Closed Won",
+  "Active",
+]);
+
+const EMAIL_IDENTITY_TYPES = new Set<FunnelIdentityType>([
+  FunnelIdentityType.EMAIL,
+  FunnelIdentityType.CODA_EMAIL,
+]);
+
+type AttributionInfo = {
+  source: string | null;
+  channel: string | null;
+  campaign: string | null;
+  referrer: string | null;
+  path: string | null;
+  url: string | null;
+  siteHost: string | null;
+};
+
+type IdentityInput = {
+  type: FunnelIdentityType;
+  value: string;
+  provider: string;
+  provenance: FunnelLinkProvenance;
+  confidence: number;
+  userId?: string | null;
+  metadata?: Prisma.InputJsonValue | null;
+};
+
+type RawVisitorRecord = Awaited<
+  ReturnType<typeof loadVisitorsForRecords>
+>[number];
+
+type StripeStatusRecord = {
+  subscriptionStatus: "active" | "trialing" | "past_due" | "paused" | "canceled" | "none" | "unknown";
+  occurredAt: string | null;
+};
+
+export interface VisitorEventCollectorInput {
+  anonymousId: string;
+  eventType: FunnelEventType;
+  occurredAt?: string | null;
+  path?: string | null;
+  url?: string | null;
+  referrer?: string | null;
+  utmSource?: string | null;
+  utmMedium?: string | null;
+  utmCampaign?: string | null;
+  userId?: string | null;
+  email?: string | null;
+  dedupeKey?: string | null;
+  metadata?: Prisma.InputJsonValue | null;
+}
+
+export interface VisitorEnrichmentSignalInput {
+  signalKey?: string | null;
+  anonymousId?: string | null;
+  email?: string | null;
+  domain?: string | null;
+  fullName?: string | null;
+  companyName?: string | null;
+  confidence?: number | null;
+  occurredAt?: string | null;
+  provenance?: VisitorLinkProvenance | null;
+  metadata?: Prisma.InputJsonValue | null;
+  payload?: Prisma.InputJsonValue | null;
+}
+
+export interface VisitorRecordsQuery {
+  from: Date;
+  to: Date;
+  filters: VisitorFunnelFilters;
+  page: number;
+  pageSize: number;
+}
+
+export interface VisitorRecordsPage {
+  records: VisitorFunnelRecord[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+function trimOrNull(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeEmail(value: string | null | undefined): string | null {
+  const trimmed = trimOrNull(value);
+  return trimmed ? trimmed.toLowerCase() : null;
+}
+
+function normalizeIdentityValue(type: FunnelIdentityType, value: string): string {
+  if (type === FunnelIdentityType.EMAIL || type === FunnelIdentityType.CODA_EMAIL) {
+    return normalizeEmail(value) ?? value.trim().toLowerCase();
+  }
+  return value.trim();
+}
+
+function normalizeSource(value: string | null | undefined): string | null {
+  const source = trimOrNull(value);
+  return source ? source.toLowerCase() : null;
+}
+
+function normalizeCampaign(value: string | null | undefined): string | null {
+  const campaign = trimOrNull(value);
+  return campaign ? campaign.toLowerCase() : null;
+}
+
+function toIso(date: Date | string | null | undefined): string | null {
+  if (!date) return null;
+  const resolved = date instanceof Date ? date : new Date(date);
+  return Number.isNaN(resolved.getTime()) ? null : resolved.toISOString();
+}
+
+function safeDate(value: Date | string | null | undefined, fallback: Date): Date {
+  if (!value) return fallback;
+  const resolved = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(resolved.getTime()) ? fallback : resolved;
+}
+
+function safeOptionalDate(value: Date | string | null | undefined): Date | null {
+  if (!value) return null;
+  const resolved = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(resolved.getTime()) ? null : resolved;
+}
+
+function hostFromUrl(rawUrl: string | null | undefined): string | null {
+  const value = trimOrNull(rawUrl);
+  if (!value) return null;
+  try {
+    return new URL(value).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function pathFromUrl(rawUrl: string | null | undefined): string | null {
+  const value = trimOrNull(rawUrl);
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    return `${url.pathname}${url.search}`;
+  } catch {
+    return null;
+  }
+}
+
+function redditAttribution(input: {
+  source?: string | null;
+  referrer?: string | null;
+}): boolean {
+  const source = normalizeSource(input.source);
+  const referrer = trimOrNull(input.referrer)?.toLowerCase() ?? null;
+  return Boolean(
+    source?.startsWith("reddit") ||
+      source === "reddit.com" ||
+      referrer?.includes("reddit.com")
+  );
+}
+
+function mapMediumToChannel(
+  medium: string | null | undefined,
+  source: string | null,
+  referrer: string | null,
+): string | null {
+  const normalizedMedium = trimOrNull(medium)?.toLowerCase() ?? null;
+  if (redditAttribution({ source, referrer })) return "reddit";
+  if (normalizedMedium?.includes("email")) return "email";
+  if (
+    normalizedMedium?.includes("cpc") ||
+    normalizedMedium?.includes("ppc") ||
+    normalizedMedium?.includes("paid") ||
+    normalizedMedium?.includes("search")
+  ) {
+    return "paid-search";
+  }
+  if (
+    normalizedMedium?.includes("social") ||
+    normalizedMedium?.includes("community") ||
+    source === "facebook" ||
+    source === "instagram" ||
+    source === "linkedin"
+  ) {
+    return "paid-social";
+  }
+  if (source === "google" || source === "bing") return "organic-search";
+  if (referrer) return "referral";
+  return "direct";
+}
+
+function deriveAttribution(input: {
+  url?: string | null;
+  path?: string | null;
+  referrer?: string | null;
+  utmSource?: string | null;
+  utmMedium?: string | null;
+  utmCampaign?: string | null;
+  siteHost?: string | null;
+}): AttributionInfo {
+  const url = trimOrNull(input.url);
+  const referrer = trimOrNull(input.referrer);
+  const utmSource = normalizeSource(input.utmSource);
+  const source =
+    utmSource ??
+    hostFromUrl(referrer) ??
+    null;
+  const path = trimOrNull(input.path) ?? pathFromUrl(url);
+  return {
+    source,
+    channel: mapMediumToChannel(input.utmMedium, source, referrer),
+    campaign: normalizeCampaign(input.utmCampaign),
+    referrer,
+    path,
+    url,
+    siteHost: trimOrNull(input.siteHost) ?? hostFromUrl(url),
+  };
+}
+
+function stableHash(value: string): string {
+  return createHash("sha1").update(value).digest("hex").slice(0, 16);
+}
+
+function syntheticAnonymousId(identityType: FunnelIdentityType, value: string): string {
+  return `backfill:${identityType.toLowerCase()}:${stableHash(value)}`;
+}
+
+function providerSlug(provider: PrismaEnrichmentProvider | EnrichmentProvider | string): string {
+  const value = String(provider).trim().toLowerCase();
+  if (value === "unify") return "unify";
+  if (value === "clay") return "clay";
+  if (value === "rb2b") return "rb2b";
+  return value || "system";
+}
+
+function toPrismaEnrichmentProvider(
+  provider: string,
+): PrismaEnrichmentProvider | null {
+  const normalized = provider.trim().toLowerCase();
+  if (normalized === "unify") return PrismaEnrichmentProvider.UNIFY;
+  if (normalized === "clay") return PrismaEnrichmentProvider.CLAY;
+  if (normalized === "rb2b") return PrismaEnrichmentProvider.RB2B;
+  return null;
+}
+
+function toPrismaProvenance(value: VisitorLinkProvenance | null | undefined): FunnelLinkProvenance {
+  switch (value) {
+    case "inferred":
+      return FunnelLinkProvenance.INFERRED;
+    case "backfilled":
+      return FunnelLinkProvenance.BACKFILLED;
+    case "exact":
+    default:
+      return FunnelLinkProvenance.EXACT;
+  }
+}
+
+function fromPrismaProvenance(value: FunnelLinkProvenance): VisitorLinkProvenance {
+  switch (value) {
+    case FunnelLinkProvenance.INFERRED:
+      return "inferred";
+    case FunnelLinkProvenance.BACKFILLED:
+      return "backfilled";
+    case FunnelLinkProvenance.EXACT:
+    default:
+      return "exact";
+  }
+}
+
+function pct(numerator: number, denominator: number): number | null {
+  if (denominator <= 0) return null;
+  return Math.round((numerator / denominator) * 1000) / 10;
+}
+
+function stageRank(stage: VisitorFunnelStageId): number {
+  return STAGE_ORDER.indexOf(stage);
+}
+
+function isoWeekStart(dateInput: Date | string): string {
+  const date = new Date(dateInput);
+  const day = date.getUTCDay();
+  const diff = (day + 6) % 7;
+  date.setUTCDate(date.getUTCDate() - diff);
+  date.setUTCHours(0, 0, 0, 0);
+  return date.toISOString().slice(0, 10);
+}
+
+function buildWeekBuckets(from: Date, to: Date): string[] {
+  const buckets: string[] = [];
+  const cursor = new Date(from);
+  cursor.setUTCHours(0, 0, 0, 0);
+  const firstBucket = new Date(isoWeekStart(cursor));
+  for (let bucket = firstBucket; bucket <= to; bucket = new Date(bucket.getTime() + 7 * 24 * 60 * 60 * 1000)) {
+    buckets.push(bucket.toISOString().slice(0, 10));
+  }
+  return buckets;
+}
+
+function milestoneOccurredBy(
+  milestones: Map<VisitorFunnelStageId, string>,
+  stage: Exclude<VisitorFunnelStageId, "visitors" | "identified">,
+  cutoff: Date,
+): string | null {
+  const occurredAt = milestones.get(stage) ?? null;
+  if (!occurredAt) return null;
+  return new Date(occurredAt) <= cutoff ? occurredAt : null;
+}
+
+async function createFunnelEventIfMissing(
+  prisma: FunnelPrismaClient,
+  input: {
+    visitorId: string;
+    eventType: FunnelEventType;
+    occurredAt: Date;
+    source?: string | null;
+    channel?: string | null;
+    campaign?: string | null;
+    path?: string | null;
+    url?: string | null;
+    referrer?: string | null;
+    dedupeKey?: string | null;
+    metadata?: Prisma.InputJsonValue | null;
+  },
+): Promise<void> {
+  const dedupeKey = trimOrNull(input.dedupeKey);
+  if (dedupeKey) {
+    await prisma.funnelEvent.upsert({
+      where: { dedupeKey },
+      update: {
+        visitorId: input.visitorId,
+        eventType: input.eventType,
+        occurredAt: input.occurredAt,
+        source: input.source ?? null,
+        channel: input.channel ?? null,
+        campaign: input.campaign ?? null,
+        path: input.path ?? null,
+        url: input.url ?? null,
+        referrer: input.referrer ?? null,
+        metadata: input.metadata ?? {},
+      },
+      create: {
+        visitorId: input.visitorId,
+        eventType: input.eventType,
+        occurredAt: input.occurredAt,
+        source: input.source ?? null,
+        channel: input.channel ?? null,
+        campaign: input.campaign ?? null,
+        path: input.path ?? null,
+        url: input.url ?? null,
+        referrer: input.referrer ?? null,
+        dedupeKey,
+        metadata: input.metadata ?? {},
+      },
+    });
+    return;
+  }
+
+  await prisma.funnelEvent.create({
+    data: {
+      visitorId: input.visitorId,
+      eventType: input.eventType,
+      occurredAt: input.occurredAt,
+      source: input.source ?? null,
+      channel: input.channel ?? null,
+      campaign: input.campaign ?? null,
+      path: input.path ?? null,
+      url: input.url ?? null,
+      referrer: input.referrer ?? null,
+      metadata: input.metadata ?? {},
+    },
+  });
+}
+
+async function syncIdentityLinks(
+  prisma: FunnelPrismaClient,
+  visitorId: string,
+  identities: IdentityInput[],
+): Promise<void> {
+  for (const identity of identities) {
+    const normalizedValue = normalizeIdentityValue(identity.type, identity.value);
+    if (!normalizedValue) continue;
+
+    await prisma.funnelIdentityLink.upsert({
+      where: {
+        visitorId_identityType_identityValue: {
+          visitorId,
+          identityType: identity.type,
+          identityValue: normalizedValue,
+        },
+      },
+      update: {
+        provider: identity.provider,
+        provenance: identity.provenance,
+        confidence: identity.confidence,
+        metadata: identity.metadata ?? undefined,
+        userId: identity.userId ?? undefined,
+      },
+      create: {
+        visitorId,
+        identityType: identity.type,
+        identityValue: normalizedValue,
+        provider: identity.provider,
+        provenance: identity.provenance,
+        confidence: identity.confidence,
+        metadata: identity.metadata ?? undefined,
+        userId: identity.userId ?? undefined,
+      },
+    });
+  }
+}
+
+async function findVisitorByIdentity(
+  prisma: FunnelPrismaClient,
+  identities: Array<Pick<IdentityInput, "type" | "value">>,
+): Promise<Awaited<ReturnType<PrismaClient["funnelVisitor"]["findUnique"]>>> {
+  if (identities.length === 0) return null;
+  const candidates = identities
+    .map((identity) => ({
+      identityType: identity.type,
+      identityValue: normalizeIdentityValue(identity.type, identity.value),
+    }))
+    .filter((identity) => identity.identityValue.length > 0);
+
+  if (candidates.length === 0) return null;
+
+  const link = await prisma.funnelIdentityLink.findFirst({
+    where: {
+      OR: candidates,
+    },
+    include: {
+      visitor: true,
+    },
+    orderBy: [{ confidence: "desc" }, { updatedAt: "desc" }],
+  });
+
+  return link?.visitor ?? null;
+}
+
+async function createOrUpdateVisitor(
+  prisma: FunnelPrismaClient,
+  input: {
+    anonymousId: string;
+    occurredAt: Date;
+    attribution: AttributionInfo;
+  },
+): Promise<PersistedVisitor> {
+  const existing = await prisma.funnelVisitor.findUnique({
+    where: { anonymousId: input.anonymousId },
+  });
+
+  const attribution = input.attribution;
+
+  if (!existing) {
+    return prisma.funnelVisitor.create({
+      data: {
+        anonymousId: input.anonymousId,
+        siteHost: attribution.siteHost,
+        firstTouchSource: attribution.source,
+        firstTouchChannel: attribution.channel,
+        firstTouchCampaign: attribution.campaign,
+        firstTouchReferrer: attribution.referrer,
+        firstTouchLandingPath: attribution.path,
+        firstTouchLandingUrl: attribution.url,
+        lastTouchSource: attribution.source,
+        lastTouchChannel: attribution.channel,
+        lastTouchCampaign: attribution.campaign,
+        lastTouchReferrer: attribution.referrer,
+        lastTouchPath: attribution.path,
+        lastTouchUrl: attribution.url,
+        firstSeenAt: input.occurredAt,
+        lastSeenAt: input.occurredAt,
+      },
+    });
+  }
+
+  const update: Prisma.FunnelVisitorUpdateInput = {};
+  if (input.occurredAt <= existing.firstSeenAt) {
+    update.firstSeenAt = input.occurredAt;
+    update.firstTouchSource = attribution.source ?? existing.firstTouchSource;
+    update.firstTouchChannel = attribution.channel ?? existing.firstTouchChannel;
+    update.firstTouchCampaign = attribution.campaign ?? existing.firstTouchCampaign;
+    update.firstTouchReferrer = attribution.referrer ?? existing.firstTouchReferrer;
+    update.firstTouchLandingPath = attribution.path ?? existing.firstTouchLandingPath;
+    update.firstTouchLandingUrl = attribution.url ?? existing.firstTouchLandingUrl;
+  }
+  if (input.occurredAt >= existing.lastSeenAt) {
+    update.lastSeenAt = input.occurredAt;
+    update.lastTouchSource = attribution.source ?? existing.lastTouchSource;
+    update.lastTouchChannel = attribution.channel ?? existing.lastTouchChannel;
+    update.lastTouchCampaign = attribution.campaign ?? existing.lastTouchCampaign;
+    update.lastTouchReferrer = attribution.referrer ?? existing.lastTouchReferrer;
+    update.lastTouchPath = attribution.path ?? existing.lastTouchPath;
+    update.lastTouchUrl = attribution.url ?? existing.lastTouchUrl;
+    update.siteHost = attribution.siteHost ?? existing.siteHost;
+  }
+
+  if (Object.keys(update).length === 0) {
+    return existing;
+  }
+
+  return prisma.funnelVisitor.update({
+    where: { id: existing.id },
+    data: update,
+  });
+}
+
+async function ensureVisitorForKnownIdentity(
+  prisma: FunnelPrismaClient,
+  input: {
+    anonymousId?: string | null;
+    occurredAt: Date;
+    attribution: AttributionInfo;
+    identities: IdentityInput[];
+  },
+): Promise<PersistedVisitor> {
+  const anonymousId = trimOrNull(input.anonymousId);
+  if (anonymousId) {
+    const visitor = await createOrUpdateVisitor(prisma, {
+      anonymousId,
+      occurredAt: input.occurredAt,
+      attribution: input.attribution,
+    });
+    await syncIdentityLinks(prisma, visitor.id, input.identities);
+    return visitor;
+  }
+
+  const visitor =
+    (await findVisitorByIdentity(
+      prisma,
+      input.identities.map((identity) => ({ type: identity.type, value: identity.value })),
+    )) ??
+    (await createOrUpdateVisitor(prisma, {
+      anonymousId:
+        syntheticAnonymousId(input.identities[0]?.type ?? FunnelIdentityType.EMAIL, input.identities[0]?.value ?? stableHash(input.occurredAt.toISOString())),
+      occurredAt: input.occurredAt,
+      attribution: input.attribution,
+    }));
+
+  await syncIdentityLinks(prisma, visitor.id, input.identities);
+  return visitor;
+}
+
+function hubspotAttribution(deal: HubSpotDeal): AttributionInfo {
+  const analytics = deal.primaryContactAnalytics;
+  const source = normalizeSource(
+    analytics?.utmSource ?? analytics?.sourceData1 ?? analytics?.source ?? deal.source,
+  );
+  const campaign = normalizeCampaign(analytics?.utmCampaign);
+  const referrer = trimOrNull(analytics?.firstUrl);
+  return {
+    source,
+    channel: mapMediumToChannel(analytics?.utmMedium, source, referrer),
+    campaign,
+    referrer,
+    path: trimOrNull(analytics?.firstUrl),
+    url: trimOrNull(analytics?.firstUrl),
+    siteHost: hostFromUrl(analytics?.firstUrl),
+  };
+}
+
+function hubspotOccurredAt(deal: HubSpotDeal): Date {
+  return (
+    safeOptionalDate(deal.primaryContactAnalytics?.firstSeenAt) ??
+    safeOptionalDate(deal.createdAt) ??
+    safeOptionalDate(deal.updatedAt) ??
+    new Date()
+  );
+}
+
+async function syncHubSpotMilestones(
+  prisma: FunnelPrismaClient,
+  data: AnalyticsDashboardData,
+): Promise<void> {
+  const deals = data.hubspot?.deals ?? [];
+  for (const deal of deals) {
+    const identities: IdentityInput[] = [];
+    const email = normalizeEmail(deal.primaryContactEmail);
+    if (email) {
+      identities.push({
+        type: FunnelIdentityType.EMAIL,
+        value: email,
+        provider: "hubspot",
+        provenance: FunnelLinkProvenance.BACKFILLED,
+        confidence: 0.95,
+      });
+    }
+    if (deal.primaryContactId) {
+      identities.push({
+        type: FunnelIdentityType.HUBSPOT_CONTACT_ID,
+        value: deal.primaryContactId,
+        provider: "hubspot",
+        provenance: FunnelLinkProvenance.BACKFILLED,
+        confidence: 1,
+      });
+    }
+    identities.push({
+      type: FunnelIdentityType.HUBSPOT_DEAL_ID,
+      value: deal.dealId,
+      provider: "hubspot",
+      provenance: FunnelLinkProvenance.BACKFILLED,
+      confidence: 1,
+    });
+    if (deal.stripeCustomerId) {
+      identities.push({
+        type: FunnelIdentityType.STRIPE_CUSTOMER_ID,
+        value: deal.stripeCustomerId,
+        provider: "hubspot",
+        provenance: FunnelLinkProvenance.BACKFILLED,
+        confidence: 0.9,
+      });
+    }
+
+    if (identities.length === 0) continue;
+
+    const visitor = await ensureVisitorForKnownIdentity(prisma, {
+      occurredAt: hubspotOccurredAt(deal),
+      attribution: hubspotAttribution(deal),
+      identities,
+    });
+
+    const demoStage = deal.stageHistory?.find((stage) =>
+      stage.stageLabel.trim().toLowerCase() === "demo scheduled",
+    );
+    if (DEMO_STAGES.has(deal.stageLabel) || demoStage) {
+      const occurredAt =
+        safeOptionalDate(demoStage?.occurredAt) ??
+        safeOptionalDate(deal.updatedAt) ??
+        safeOptionalDate(deal.createdAt) ??
+        hubspotOccurredAt(deal);
+
+      await createFunnelEventIfMissing(prisma, {
+        visitorId: visitor.id,
+        eventType: FunnelEventType.DEMO_BOOKED,
+        occurredAt,
+        source: visitor.firstTouchSource,
+        channel: visitor.firstTouchChannel,
+        campaign: visitor.firstTouchCampaign,
+        dedupeKey: `demo_booked:${deal.dealId}`,
+        metadata: {
+          dealId: deal.dealId,
+          dealName: deal.dealName,
+          stageLabel: deal.stageLabel,
+        },
+      });
+    }
+  }
+}
+
+async function syncCodaMilestones(
+  prisma: FunnelPrismaClient,
+  data: AnalyticsDashboardData,
+): Promise<void> {
+  const submitters = data.coda?.recentSubmitters ?? data.codaKanban?.recentSubmitters ?? [];
+  for (const submitter of submitters) {
+    const email = normalizeEmail(submitter.email);
+    if (!email) continue;
+    const occurredAt =
+      safeOptionalDate(submitter.firstSubmittedAt) ??
+      safeOptionalDate(submitter.lastSubmittedAt) ??
+      new Date();
+    const visitor = await ensureVisitorForKnownIdentity(prisma, {
+      occurredAt,
+      attribution: {
+        source: "coda",
+        channel: "kanban-generator",
+        campaign: null,
+        referrer: null,
+        path: null,
+        url: null,
+        siteHost: null,
+      },
+      identities: [
+        {
+          type: FunnelIdentityType.CODA_EMAIL,
+          value: email,
+          provider: "coda",
+          provenance: FunnelLinkProvenance.BACKFILLED,
+          confidence: 0.95,
+        },
+        {
+          type: FunnelIdentityType.EMAIL,
+          value: email,
+          provider: "coda",
+          provenance: FunnelLinkProvenance.INFERRED,
+          confidence: 0.85,
+        },
+      ],
+    });
+
+    await createFunnelEventIfMissing(prisma, {
+      visitorId: visitor.id,
+      eventType: FunnelEventType.KANBAN_CARD_CREATED,
+      occurredAt,
+      source: visitor.firstTouchSource ?? "coda",
+      channel: visitor.firstTouchChannel ?? "kanban-generator",
+      campaign: visitor.firstTouchCampaign,
+      dedupeKey: `kanban_card_created:${email}`,
+      metadata: {
+        creator: submitter.creator,
+        cardsCreated: submitter.cardsCreated,
+      },
+    });
+  }
+}
+
+async function fetchStripeStatusByCustomerId(
+  apiKey: string,
+  customerId: string,
+): Promise<StripeStatusRecord | null> {
+  const url = new URL("https://api.stripe.com/v1/subscriptions");
+  url.searchParams.set("customer", customerId);
+  url.searchParams.set("status", "all");
+  url.searchParams.set("limit", "25");
+
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+    cache: "no-store",
+  });
+  if (!response.ok) return null;
+  const payload = (await response.json()) as {
+    data?: Array<{
+      status?: string | null;
+      created?: number | null;
+      trial_start?: number | null;
+      current_period_start?: number | null;
+    }>;
+  };
+
+  const subscriptions = payload.data ?? [];
+  if (subscriptions.length === 0) {
+    return { subscriptionStatus: "none", occurredAt: null };
+  }
+
+  const active = subscriptions.find((subscription) => subscription.status === "active");
+  if (active) {
+    const occurredAt = active.current_period_start ?? active.created ?? null;
+    return {
+      subscriptionStatus: "active",
+      occurredAt: occurredAt ? new Date(occurredAt * 1000).toISOString() : null,
+    };
+  }
+
+  const trialing = subscriptions.find((subscription) => subscription.status === "trialing");
+  if (trialing) {
+    const occurredAt = trialing.trial_start ?? trialing.created ?? null;
+    return {
+      subscriptionStatus: "trialing",
+      occurredAt: occurredAt ? new Date(occurredAt * 1000).toISOString() : null,
+    };
+  }
+
+  return {
+    subscriptionStatus: "unknown",
+    occurredAt: null,
+  };
+}
+
+async function syncStripeMilestones(
+  prisma: FunnelPrismaClient,
+  stripeKey: string | null,
+  from: Date,
+  to: Date,
+): Promise<void> {
+  if (!stripeKey) return;
+
+  const visitors = await prisma.funnelVisitor.findMany({
+    where: {
+      firstSeenAt: {
+        lte: to,
+      },
+    },
+    include: {
+      identityLinks: true,
+      events: {
+        where: {
+          eventType: {
+            in: [FunnelEventType.TRIAL_STARTED, FunnelEventType.PAID_CUSTOMER],
+          },
+        },
+      },
+    },
+    orderBy: {
+      firstSeenAt: "desc",
+    },
+  });
+
+  const emailInputs: Array<{ visitorId: string; email: string; firstSeenAt: Date; lastSeenAt: Date }> = [];
+  const customerInputs: Array<{ visitorId: string; customerId: string; firstSeenAt: Date; lastSeenAt: Date }> = [];
+
+  for (const visitor of visitors) {
+    const emailSet = new Set<string>();
+    const customerSet = new Set<string>();
+    for (const identity of visitor.identityLinks) {
+      if (EMAIL_IDENTITY_TYPES.has(identity.identityType)) {
+        const email = normalizeEmail(identity.identityValue);
+        if (email) emailSet.add(email);
+      }
+      if (identity.identityType === FunnelIdentityType.STRIPE_CUSTOMER_ID) {
+        const customerId = trimOrNull(identity.identityValue);
+        if (customerId) customerSet.add(customerId);
+      }
+    }
+
+    for (const email of emailSet) {
+      emailInputs.push({
+        visitorId: visitor.id,
+        email,
+        firstSeenAt: visitor.firstSeenAt,
+        lastSeenAt: visitor.lastSeenAt,
+      });
+    }
+    for (const customerId of customerSet) {
+      customerInputs.push({
+        visitorId: visitor.id,
+        customerId,
+        firstSeenAt: visitor.firstSeenAt,
+        lastSeenAt: visitor.lastSeenAt,
+      });
+    }
+  }
+
+  const emailMap = await enrichStripeEmails({
+    apiKey: stripeKey,
+    emails: [...new Set(emailInputs.map((entry) => entry.email))],
+    now: new Date(),
+    concurrency: 4,
+    timeoutMs: 3_500,
+  });
+
+  const customerStatusMap = new Map<string, StripeStatusRecord | null>();
+  for (const customerId of [...new Set(customerInputs.map((entry) => entry.customerId))]) {
+    customerStatusMap.set(customerId, await fetchStripeStatusByCustomerId(stripeKey, customerId));
+  }
+
+  const seenDedupeKeys = new Set<string>();
+
+  for (const entry of emailInputs) {
+    const enrichment = emailMap.get(entry.email);
+    if (!enrichment?.matched) continue;
+
+    if (enrichment.subscriptionStatus === "trialing") {
+      const dedupeKey = `trial_started:email:${entry.email}`;
+      if (!seenDedupeKeys.has(dedupeKey)) {
+        seenDedupeKeys.add(dedupeKey);
+        await createFunnelEventIfMissing(prisma, {
+          visitorId: entry.visitorId,
+          eventType: FunnelEventType.TRIAL_STARTED,
+          occurredAt: safeDate(enrichment.lastPaymentAt, entry.lastSeenAt),
+          dedupeKey,
+          metadata: {
+            email: entry.email,
+            approximate: true,
+            matchedBy: "email",
+          },
+        });
+      }
+    }
+
+    if (enrichment.subscriptionStatus === "active") {
+      const dedupeKey = `paid_customer:email:${entry.email}`;
+      if (!seenDedupeKeys.has(dedupeKey)) {
+        seenDedupeKeys.add(dedupeKey);
+        await createFunnelEventIfMissing(prisma, {
+          visitorId: entry.visitorId,
+          eventType: FunnelEventType.PAID_CUSTOMER,
+          occurredAt: safeDate(enrichment.lastPaymentAt, entry.lastSeenAt),
+          dedupeKey,
+          metadata: {
+            email: entry.email,
+            customerId: enrichment.customerId,
+            approximate: true,
+            matchedBy: "email",
+          },
+        });
+      }
+    }
+  }
+
+  for (const entry of customerInputs) {
+    const status = customerStatusMap.get(entry.customerId);
+    if (!status) continue;
+
+    if (status.subscriptionStatus === "trialing") {
+      await createFunnelEventIfMissing(prisma, {
+        visitorId: entry.visitorId,
+        eventType: FunnelEventType.TRIAL_STARTED,
+        occurredAt: safeDate(status.occurredAt, entry.lastSeenAt),
+        dedupeKey: `trial_started:customer:${entry.customerId}`,
+        metadata: {
+          customerId: entry.customerId,
+          approximate: status.occurredAt == null,
+          matchedBy: "customer_id",
+        },
+      });
+    }
+
+    if (status.subscriptionStatus === "active") {
+      await createFunnelEventIfMissing(prisma, {
+        visitorId: entry.visitorId,
+        eventType: FunnelEventType.PAID_CUSTOMER,
+        occurredAt: safeDate(status.occurredAt, entry.lastSeenAt),
+        dedupeKey: `paid_customer:customer:${entry.customerId}`,
+        metadata: {
+          customerId: entry.customerId,
+          approximate: status.occurredAt == null,
+          matchedBy: "customer_id",
+        },
+      });
+    }
+  }
+}
+
+function parseMilestones(
+  visitor: RawVisitorRecord,
+  cutoff: Date,
+): {
+  milestones: VisitorMilestone[];
+  deepestStage: VisitorFunnelStageId;
+  identified: boolean;
+} {
+  const eventMap = new Map<VisitorFunnelStageId, string>();
+
+  for (const event of visitor.events) {
+    const occurredAtIso = toIso(event.occurredAt);
+    if (!occurredAtIso) continue;
+    const occurredAt = new Date(occurredAtIso);
+    if (occurredAt > cutoff) continue;
+
+    switch (event.eventType) {
+      case FunnelEventType.DEMO_BOOKED:
+        eventMap.set("demo_booked", occurredAtIso);
+        break;
+      case FunnelEventType.KANBAN_CARD_CREATED:
+        eventMap.set("kanban_card_created", occurredAtIso);
+        break;
+      case FunnelEventType.TRIAL_STARTED:
+        eventMap.set("trial_started", occurredAtIso);
+        break;
+      case FunnelEventType.PAID_CUSTOMER:
+        eventMap.set("paid_customer", occurredAtIso);
+        break;
+      default:
+        break;
+    }
+  }
+
+  const identified = visitor.identityLinks.length > 0;
+  const milestones: VisitorMilestone[] = [];
+  if (identified) {
+    milestones.push({
+      stage: "identified",
+      occurredAt: visitor.identityLinks[0]?.updatedAt
+        ? new Date(visitor.identityLinks[0].updatedAt).toISOString()
+        : null,
+    });
+  }
+
+  for (const stage of STAGE_ORDER) {
+    if (stage === "visitors" || stage === "identified") continue;
+    const occurredAt = milestoneOccurredBy(eventMap, stage, cutoff);
+    if (!occurredAt) continue;
+    milestones.push({ stage, occurredAt });
+  }
+
+  let deepestStage: VisitorFunnelStageId = "visitors";
+  if (identified) deepestStage = "identified";
+  for (const milestone of milestones) {
+    if (stageRank(milestone.stage) > stageRank(deepestStage)) {
+      deepestStage = milestone.stage;
+    }
+  }
+
+  return { milestones, deepestStage, identified };
+}
+
+function buildRecord(
+  visitor: RawVisitorRecord,
+  cutoff: Date,
+): VisitorFunnelRecord {
+  const { milestones, deepestStage, identified } = parseMilestones(visitor, cutoff);
+
+  const providerAgg = new Map<string, VisitorFunnelProviderEvidence>();
+  for (const signal of visitor.enrichmentSignals) {
+    const provider = providerSlug(signal.provider);
+    const existing = providerAgg.get(provider) ?? {
+      provider,
+      accepted: false,
+      signalCount: 0,
+    };
+    existing.signalCount += 1;
+    existing.accepted = existing.accepted || signal.accepted;
+    providerAgg.set(provider, existing);
+  }
+
+  return {
+    visitorId: visitor.id,
+    anonymousId: visitor.anonymousId,
+    firstSeenAt: visitor.firstSeenAt.toISOString(),
+    lastSeenAt: visitor.lastSeenAt.toISOString(),
+    firstTouchSource: visitor.firstTouchSource ?? null,
+    firstTouchChannel: visitor.firstTouchChannel ?? null,
+    firstTouchCampaign: visitor.firstTouchCampaign ?? null,
+    firstTouchReferrer: visitor.firstTouchReferrer ?? null,
+    landingPath: visitor.firstTouchLandingPath ?? null,
+    identified,
+    deepestStage,
+    milestones,
+    identities: visitor.identityLinks.map((identity) => ({
+      type: identity.identityType,
+      value: identity.identityValue,
+      provider: identity.provider,
+      provenance: fromPrismaProvenance(identity.provenance),
+      confidence: identity.confidence,
+    })),
+    providers: [...providerAgg.values()].sort((a, b) => a.provider.localeCompare(b.provider)),
+  };
+}
+
+export function parseVisitorFunnelFilters(searchParams: URLSearchParams): VisitorFunnelFilters {
+  const channel = trimOrNull(searchParams.get("channel")) ?? "all";
+  const source = normalizeSource(searchParams.get("source"));
+  const campaign = normalizeCampaign(searchParams.get("campaign"));
+  const stageParam = trimOrNull(searchParams.get("stage")) ?? "all";
+  const quickFilter = trimOrNull(searchParams.get("quickFilter")) === "reddit" ? "reddit" : "all";
+  const knownOnly = searchParams.get("knownOnly") === "true";
+
+  const stage = STAGE_ORDER.includes(stageParam as VisitorFunnelStageId)
+    ? (stageParam as VisitorFunnelStageId)
+    : "all";
+
+  return {
+    channel,
+    source,
+    campaign,
+    stage,
+    knownOnly,
+    quickFilter,
+  };
+}
+
+async function loadVisitorRecords(
+  prisma: FunnelPrismaClient,
+  input: {
+    from: Date;
+    to: Date;
+    filters: VisitorFunnelFilters;
+  },
+): Promise<VisitorFunnelRecord[]> {
+  const where: Prisma.FunnelVisitorWhereInput = {
+    firstSeenAt: {
+      gte: input.from,
+      lte: input.to,
+    },
+  };
+
+  if (input.filters.channel !== "all") {
+    where.firstTouchChannel = input.filters.channel;
+  }
+  if (input.filters.source) {
+    where.firstTouchSource = input.filters.source;
+  }
+  if (input.filters.campaign) {
+    where.firstTouchCampaign = input.filters.campaign;
+  }
+  if (input.filters.quickFilter === "reddit") {
+    where.OR = [
+      { firstTouchChannel: "reddit" },
+      { firstTouchSource: { startsWith: "reddit" } },
+      { firstTouchReferrer: { contains: "reddit.com" } },
+    ];
+  }
+  if (input.filters.knownOnly) {
+    where.identityLinks = { some: {} };
+  }
+
+  const visitors = await loadVisitorsForRecords(prisma, where);
+
+  const records = visitors.map((visitor) => buildRecord(visitor, input.to));
+  if (input.filters.stage === "all") return records;
+  return records.filter((record) => record.deepestStage === input.filters.stage);
+}
+
+async function loadVisitorsForRecords(
+  prisma: FunnelPrismaClient,
+  where: Prisma.FunnelVisitorWhereInput,
+) {
+  return prisma.funnelVisitor.findMany({
+    where,
+    include: {
+      events: {
+        orderBy: { occurredAt: "asc" },
+      },
+      identityLinks: {
+        orderBy: [{ confidence: "desc" }, { updatedAt: "desc" }],
+      },
+      enrichmentSignals: {
+        orderBy: { createdAt: "desc" },
+      },
+    },
+    orderBy: { firstSeenAt: "desc" },
+  });
+}
+
+function collectBreakdown(
+  records: VisitorFunnelRecord[],
+  keySelector: (record: VisitorFunnelRecord) => string | null,
+): VisitorFunnelBreakdownRow[] {
+  const rows = new Map<string, VisitorFunnelBreakdownRow>();
+
+  for (const record of records) {
+    const key = keySelector(record) ?? "unknown";
+    const existing = rows.get(key) ?? {
+      key,
+      visitors: 0,
+      identified: 0,
+      demoBooked: 0,
+      kanbanCards: 0,
+      trialsStarted: 0,
+      paidCustomers: 0,
+    };
+
+    existing.visitors += 1;
+    if (record.identified) existing.identified += 1;
+    if (record.milestones.some((milestone) => milestone.stage === "demo_booked")) existing.demoBooked += 1;
+    if (record.milestones.some((milestone) => milestone.stage === "kanban_card_created")) existing.kanbanCards += 1;
+    if (record.milestones.some((milestone) => milestone.stage === "trial_started")) existing.trialsStarted += 1;
+    if (record.milestones.some((milestone) => milestone.stage === "paid_customer")) existing.paidCustomers += 1;
+    rows.set(key, existing);
+  }
+
+  return [...rows.values()]
+    .sort((a, b) => b.visitors - a.visitors || a.key.localeCompare(b.key))
+    .slice(0, 12);
+}
+
+function collectOverlap(records: VisitorFunnelRecord[]): VisitorFunnelOverlap[] {
+  const overlaps: VisitorFunnelOverlap[] = [];
+  const combinations: Array<[VisitorMilestone["stage"], VisitorMilestone["stage"]]> = [
+    ["demo_booked", "kanban_card_created"],
+    ["demo_booked", "trial_started"],
+    ["demo_booked", "paid_customer"],
+    ["kanban_card_created", "trial_started"],
+    ["kanban_card_created", "paid_customer"],
+    ["trial_started", "paid_customer"],
+  ];
+
+  for (const [left, right] of combinations) {
+    overlaps.push({
+      key: `${left}+${right}`,
+      count: records.filter((record) => {
+        const stageSet = new Set(record.milestones.map((milestone) => milestone.stage));
+        return stageSet.has(left) && stageSet.has(right);
+      }).length,
+    });
+  }
+
+  return overlaps;
+}
+
+function collectTrends(
+  records: VisitorFunnelRecord[],
+  from: Date,
+  to: Date,
+): VisitorFunnelTrendPoint[] {
+  const weeks = buildWeekBuckets(from, to);
+  const byWeek = new Map<string, VisitorFunnelTrendPoint>();
+
+  for (const week of weeks) {
+    byWeek.set(week, {
+      week,
+      visitors: 0,
+      identified: 0,
+      demo_booked: 0,
+      kanban_card_created: 0,
+      trial_started: 0,
+      paid_customer: 0,
+    });
+  }
+
+  for (const record of records) {
+    const visitorWeek = isoWeekStart(record.firstSeenAt);
+    const visitorBucket = byWeek.get(visitorWeek);
+    if (visitorBucket) {
+      visitorBucket.visitors += 1;
+    }
+
+    if (record.identified) {
+      const identifiedAt =
+        record.milestones.find((milestone) => milestone.stage === "identified")?.occurredAt ??
+        record.firstSeenAt;
+      const week = isoWeekStart(identifiedAt);
+      const identifiedBucket = byWeek.get(week);
+      if (identifiedBucket) {
+        identifiedBucket.identified += 1;
+      }
+    }
+
+    for (const milestone of record.milestones) {
+      if (milestone.stage === "identified" || !milestone.occurredAt) continue;
+      const week = isoWeekStart(milestone.occurredAt);
+      const bucket = byWeek.get(week);
+      if (bucket) {
+        switch (milestone.stage) {
+          case "demo_booked":
+            bucket.demo_booked += 1;
+            break;
+          case "kanban_card_created":
+            bucket.kanban_card_created += 1;
+            break;
+          case "trial_started":
+            bucket.trial_started += 1;
+            break;
+          case "paid_customer":
+            bucket.paid_customer += 1;
+            break;
+        }
+      }
+    }
+  }
+
+  return [...byWeek.values()];
+}
+
+export async function collectVisitorEvent(
+  prisma: FunnelPrismaClient,
+  input: VisitorEventCollectorInput,
+  requestMeta: { siteHost?: string | null } = {},
+): Promise<{ visitorId: string; anonymousId: string }> {
+  const occurredAt = safeDate(input.occurredAt, new Date());
+  const attribution = deriveAttribution({
+    path: input.path,
+    url: input.url,
+    referrer: input.referrer,
+    utmSource: input.utmSource,
+    utmMedium: input.utmMedium,
+    utmCampaign: input.utmCampaign,
+    siteHost: requestMeta.siteHost,
+  });
+
+  const identities: IdentityInput[] = [];
+  if (input.userId) {
+    identities.push({
+      type: FunnelIdentityType.USER_ID,
+      value: input.userId,
+      provider: "collector",
+      provenance: FunnelLinkProvenance.EXACT,
+      confidence: 1,
+      userId: input.userId,
+    });
+  }
+  if (input.email) {
+    identities.push({
+      type: FunnelIdentityType.EMAIL,
+      value: input.email,
+      provider: "collector",
+      provenance: FunnelLinkProvenance.EXACT,
+      confidence: 1,
+      userId: input.userId ?? null,
+    });
+  }
+
+  const visitor = await ensureVisitorForKnownIdentity(prisma, {
+    anonymousId: input.anonymousId,
+    occurredAt,
+    attribution,
+    identities,
+  });
+
+  await createFunnelEventIfMissing(prisma, {
+    visitorId: visitor.id,
+    eventType: input.eventType,
+    occurredAt,
+    source: attribution.source,
+    channel: attribution.channel,
+    campaign: attribution.campaign,
+    path: attribution.path,
+    url: attribution.url,
+    referrer: attribution.referrer,
+    dedupeKey: input.dedupeKey ?? null,
+    metadata: input.metadata ?? {},
+  });
+
+  return {
+    visitorId: visitor.id,
+    anonymousId: visitor.anonymousId,
+  };
+}
+
+export async function ingestVisitorEnrichmentSignals(
+  prisma: FunnelPrismaClient,
+  provider: EnrichmentProvider,
+  signals: VisitorEnrichmentSignalInput[],
+): Promise<{ accepted: number; stored: number }> {
+  const prismaProvider = toPrismaEnrichmentProvider(provider);
+  if (!prismaProvider) {
+    throw new Error(`Unsupported enrichment provider "${provider}"`);
+  }
+
+  let accepted = 0;
+
+  for (const signal of signals) {
+    const anonymousId = trimOrNull(signal.anonymousId);
+    const email = normalizeEmail(signal.email);
+    const domain = normalizeSource(signal.domain);
+    const confidence = Math.max(0, Math.min(1, signal.confidence ?? 0));
+    const occurrence = safeOptionalDate(signal.occurredAt) ?? new Date();
+
+    let visitor =
+      (anonymousId
+        ? await prisma.funnelVisitor.findUnique({ where: { anonymousId } })
+        : null) ??
+      (email
+        ? await findVisitorByIdentity(prisma, [
+            { type: FunnelIdentityType.EMAIL, value: email },
+            { type: FunnelIdentityType.CODA_EMAIL, value: email },
+          ])
+        : null);
+
+    const signalKey =
+      trimOrNull(signal.signalKey) ??
+      stableHash(JSON.stringify({
+        provider,
+        anonymousId,
+        email,
+        domain,
+        occurredAt: occurrence.toISOString(),
+      }));
+
+    const stored = await prisma.funnelEnrichmentSignal.upsert({
+      where: {
+        provider_signalKey: {
+          provider: prismaProvider,
+          signalKey,
+        },
+      },
+      update: {
+        visitorId: visitor?.id ?? null,
+        anonymousId,
+        email,
+        domain,
+        fullName: trimOrNull(signal.fullName),
+        companyName: trimOrNull(signal.companyName),
+        confidence,
+        occurredAt: occurrence,
+        accepted: false,
+        metadata: signal.metadata ?? {},
+        payload: signal.payload ?? signal.metadata ?? {},
+      },
+      create: {
+        provider: prismaProvider,
+        signalKey,
+        visitorId: visitor?.id ?? null,
+        anonymousId,
+        email,
+        domain,
+        fullName: trimOrNull(signal.fullName),
+        companyName: trimOrNull(signal.companyName),
+        confidence,
+        occurredAt: occurrence,
+        accepted: false,
+        metadata: signal.metadata ?? {},
+        payload: signal.payload ?? signal.metadata ?? {},
+      },
+    });
+
+    if (!visitor && email) {
+      visitor = await ensureVisitorForKnownIdentity(prisma, {
+        occurredAt: occurrence,
+        attribution: {
+          source: domain,
+          channel: domain ? "deanonymized" : null,
+          campaign: null,
+          referrer: null,
+          path: null,
+          url: null,
+          siteHost: null,
+        },
+        identities: [
+          {
+            type: FunnelIdentityType.EMAIL,
+            value: email,
+            provider,
+            provenance: toPrismaProvenance(signal.provenance ?? "backfilled"),
+            confidence: Math.max(confidence, 0.8),
+            metadata: signal.metadata ?? null,
+          },
+        ],
+      });
+    }
+
+    if (!visitor && anonymousId) {
+      visitor = await createOrUpdateVisitor(prisma, {
+        anonymousId,
+        occurredAt: occurrence,
+        attribution: {
+          source: stored.domain ?? null,
+          channel: stored.domain ? "deanonymized" : null,
+          campaign: null,
+          referrer: null,
+          path: null,
+          url: null,
+          siteHost: null,
+        },
+      });
+    }
+
+    const shouldAccept = confidence >= 0.8 && Boolean(visitor);
+    await prisma.funnelEnrichmentSignal.update({
+      where: { id: stored.id },
+      data: {
+        visitorId: visitor?.id ?? null,
+        accepted: shouldAccept,
+      },
+    });
+
+    if (shouldAccept) {
+      accepted += 1;
+    }
+
+    if (visitor && shouldAccept) {
+      const identities: IdentityInput[] = [];
+      if (email) {
+        identities.push({
+          type: FunnelIdentityType.EMAIL,
+          value: email,
+          provider,
+          provenance: toPrismaProvenance(signal.provenance ?? (anonymousId ? "exact" : "inferred")),
+          confidence,
+          metadata: signal.metadata ?? null,
+        });
+      }
+      await syncIdentityLinks(prisma, visitor.id, identities);
+    }
+  }
+
+  return {
+    accepted,
+    stored: signals.length,
+  };
+}
+
+export async function syncVisitorFunnelArtifacts(input: {
+  prisma: FunnelPrismaClient;
+  analyticsData: AnalyticsDashboardData;
+  stripeKey: string | null;
+  from: Date;
+  to: Date;
+}): Promise<void> {
+  await syncHubSpotMilestones(input.prisma, input.analyticsData);
+  await syncCodaMilestones(input.prisma, input.analyticsData);
+  await syncStripeMilestones(input.prisma, input.stripeKey, input.from, input.to);
+}
+
+export async function buildVisitorFunnelData(
+  prisma: FunnelPrismaClient,
+  input: {
+    from: Date;
+    to: Date;
+    filters: VisitorFunnelFilters;
+    closedWonCount?: number;
+  },
+): Promise<VisitorFunnelData> {
+  const records = await loadVisitorRecords(prisma, {
+    from: input.from,
+    to: input.to,
+    filters: input.filters,
+  });
+
+  const stages: VisitorFunnelStageCount[] = [];
+  let previousCount = 0;
+  const totals = {
+    visitors: records.length,
+    identified: records.filter((record) => record.identified).length,
+    demoBooked: records.filter((record) =>
+      record.milestones.some((milestone) => milestone.stage === "demo_booked"),
+    ).length,
+    kanbanCards: records.filter((record) =>
+      record.milestones.some((milestone) => milestone.stage === "kanban_card_created"),
+    ).length,
+    trialsStarted: records.filter((record) =>
+      record.milestones.some((milestone) => milestone.stage === "trial_started"),
+    ).length,
+    paidCustomers: records.filter((record) =>
+      record.milestones.some((milestone) => milestone.stage === "paid_customer"),
+    ).length,
+  };
+
+  const stageCounts: Record<VisitorFunnelStageId, number> = {
+    visitors: totals.visitors,
+    identified: totals.identified,
+    demo_booked: totals.demoBooked,
+    kanban_card_created: totals.kanbanCards,
+    trial_started: totals.trialsStarted,
+    paid_customer: totals.paidCustomers,
+  };
+
+  for (const stage of STAGE_ORDER) {
+    const count = stageCounts[stage];
+    stages.push({
+      stage,
+      label: STAGE_LABELS[stage],
+      count,
+      conversionFromVisitors: pct(count, totals.visitors),
+      conversionFromPrevious: previousCount > 0 ? pct(count, previousCount) : null,
+    });
+    previousCount = count;
+  }
+
+  const availableChannels = [...new Set(records.map((record) => record.firstTouchChannel).filter(Boolean) as string[])]
+    .sort();
+  const availableSources = [...new Set(records.map((record) => record.firstTouchSource).filter(Boolean) as string[])]
+    .sort();
+  const availableCampaigns = [...new Set(records.map((record) => record.firstTouchCampaign).filter(Boolean) as string[])]
+    .sort();
+
+  const filterParams = new URLSearchParams({
+    from: input.from.toISOString().slice(0, 10),
+    to: input.to.toISOString().slice(0, 10),
+    channel: input.filters.channel,
+    quickFilter: input.filters.quickFilter,
+  });
+  if (input.filters.source) filterParams.set("source", input.filters.source);
+  if (input.filters.campaign) filterParams.set("campaign", input.filters.campaign);
+  if (input.filters.stage !== "all") filterParams.set("stage", input.filters.stage);
+  if (input.filters.knownOnly) filterParams.set("knownOnly", "true");
+
+  return {
+    filters: input.filters,
+    stages,
+    trends: collectTrends(records, input.from, input.to),
+    channelBreakdown: collectBreakdown(records, (record) => record.firstTouchChannel),
+    sourceBreakdown: collectBreakdown(records, (record) => record.firstTouchSource),
+    campaignBreakdown: collectBreakdown(records, (record) => record.firstTouchCampaign),
+    overlaps: collectOverlap(records),
+    availableChannels,
+    availableSources,
+    availableCampaigns,
+    totals,
+    recordsApi: {
+      href: `/api/analytics/visitor-funnel/records?${filterParams.toString()}`,
+      adminOnly: true,
+    },
+    secondaryMetrics: {
+      closedWonCount: input.closedWonCount ?? 0,
+    },
+  };
+}
+
+export async function listVisitorFunnelRecords(
+  prisma: FunnelPrismaClient,
+  input: VisitorRecordsQuery,
+): Promise<VisitorRecordsPage> {
+  const allRecords = await loadVisitorRecords(prisma, {
+    from: input.from,
+    to: input.to,
+    filters: input.filters,
+  });
+
+  const startIndex = (input.page - 1) * input.pageSize;
+  const records = allRecords.slice(startIndex, startIndex + input.pageSize);
+
+  return {
+    records,
+    pagination: {
+      page: input.page,
+      pageSize: input.pageSize,
+      total: allRecords.length,
+      totalPages: Math.max(1, Math.ceil(allRecords.length / input.pageSize)),
+    },
+  };
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -19,16 +19,14 @@ const globalForPrisma = globalThis as unknown as {
   pgPool: Pool | undefined;
 };
 
-type PrismaClientType = ReturnType<typeof createPrismaClient>;
+export type PrismaClientType = ReturnType<typeof createPrismaClient>;
 
 function createPrismaClient(connectionString: string) {
-  const useSSL = connectionString.includes("sslmode=require") || process.env.DB_SSL === "true";
   const pool = new Pool({
     connectionString,
     max: maxPoolSize,
     idleTimeoutMillis,
     connectionTimeoutMillis,
-    ...(useSSL ? { ssl: { rejectUnauthorized: true } } : {}),
   });
 
   // Attach pool monitoring

--- a/src/lib/session-user.ts
+++ b/src/lib/session-user.ts
@@ -1,0 +1,34 @@
+export interface AuthenticatedUser {
+  id: string;
+  role?: string;
+  organizationId?: string | null;
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+}
+
+export function getAuthenticatedUser(
+  session: { user?: unknown } | null | undefined
+): AuthenticatedUser | null {
+  const rawUser = (session as { user?: unknown } | null | undefined)?.user;
+  if (!rawUser || typeof rawUser !== "object") {
+    return null;
+  }
+
+  const user = rawUser as Record<string, unknown>;
+  if (typeof user.id !== "string" || user.id.trim().length === 0) {
+    return null;
+  }
+
+  return {
+    id: user.id,
+    role: typeof user.role === "string" ? user.role : undefined,
+    organizationId:
+      typeof user.organizationId === "string" && user.organizationId.trim().length > 0
+        ? user.organizationId
+        : null,
+    name: typeof user.name === "string" ? user.name : null,
+    email: typeof user.email === "string" ? user.email : null,
+    image: typeof user.image === "string" ? user.image : null,
+  };
+}

--- a/src/lib/tracking/visitor-funnel.ts
+++ b/src/lib/tracking/visitor-funnel.ts
@@ -1,0 +1,145 @@
+"use client";
+
+const ANON_STORAGE_KEY = "wipguard:funnel:anonymous-id";
+const SESSION_STORAGE_KEY = "wipguard:funnel:session-id";
+const AUTH_TRACKED_PREFIX = "wipguard:funnel:auth-tracked:";
+const COOKIE_NAME = "wipguard_funnel_anon_id";
+
+export type ClientFunnelEventType =
+  | "PAGE_VIEW"
+  | "SESSION_STARTED"
+  | "AUTH_COMPLETED";
+
+type ClientCollectPayload = {
+  anonymousId: string;
+  eventType: ClientFunnelEventType;
+  occurredAt: string;
+  path: string;
+  url: string;
+  referrer: string | null;
+  utmSource: string | null;
+  utmMedium: string | null;
+  utmCampaign: string | null;
+  userId?: string | null;
+  email?: string | null;
+  dedupeKey?: string | null;
+  metadata?: Record<string, unknown>;
+};
+
+function readCookie(name: string): string | null {
+  if (typeof document === "undefined") return null;
+  const prefix = `${name}=`;
+  const parts = document.cookie.split(";");
+  for (const rawPart of parts) {
+    const part = rawPart.trim();
+    if (part.startsWith(prefix)) {
+      const value = decodeURIComponent(part.slice(prefix.length));
+      return value || null;
+    }
+  }
+  return null;
+}
+
+function writeCookie(name: string, value: string): void {
+  if (typeof document === "undefined") return;
+  document.cookie = `${name}=${encodeURIComponent(value)}; Path=/; Max-Age=${60 * 60 * 24 * 365}; SameSite=Lax`;
+}
+
+function createId(prefix: string): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `${prefix}_${crypto.randomUUID()}`;
+  }
+  return `${prefix}_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
+}
+
+export function getOrCreateAnonymousId(): string {
+  if (typeof window === "undefined") return createId("anon");
+
+  const stored = window.localStorage.getItem(ANON_STORAGE_KEY);
+  const cookieValue = readCookie(COOKIE_NAME);
+  const existing = stored || cookieValue;
+  if (existing) {
+    if (!stored) window.localStorage.setItem(ANON_STORAGE_KEY, existing);
+    if (!cookieValue) writeCookie(COOKIE_NAME, existing);
+    return existing;
+  }
+
+  const next = createId("anon");
+  window.localStorage.setItem(ANON_STORAGE_KEY, next);
+  writeCookie(COOKIE_NAME, next);
+  return next;
+}
+
+export function getOrCreateBrowserSessionId(): string {
+  if (typeof window === "undefined") return createId("session");
+  const existing = window.sessionStorage.getItem(SESSION_STORAGE_KEY);
+  if (existing) return existing;
+  const next = createId("session");
+  window.sessionStorage.setItem(SESSION_STORAGE_KEY, next);
+  return next;
+}
+
+function currentUtmParams(): {
+  utmSource: string | null;
+  utmMedium: string | null;
+  utmCampaign: string | null;
+} {
+  if (typeof window === "undefined") {
+    return { utmSource: null, utmMedium: null, utmCampaign: null };
+  }
+  const params = new URLSearchParams(window.location.search);
+  return {
+    utmSource: params.get("utm_source"),
+    utmMedium: params.get("utm_medium"),
+    utmCampaign: params.get("utm_campaign"),
+  };
+}
+
+export async function collectClientFunnelEvent(
+  input: Omit<ClientCollectPayload, "anonymousId" | "occurredAt" | "url" | "referrer" | "utmSource" | "utmMedium" | "utmCampaign"> & {
+    dedupeKey?: string | null;
+  },
+): Promise<void> {
+  if (typeof window === "undefined") return;
+
+  const anonymousId = getOrCreateAnonymousId();
+  const sessionId = getOrCreateBrowserSessionId();
+  const { utmSource, utmMedium, utmCampaign } = currentUtmParams();
+
+  const payload: ClientCollectPayload = {
+    anonymousId,
+    eventType: input.eventType,
+    occurredAt: new Date().toISOString(),
+    path: input.path,
+    url: window.location.href,
+    referrer: document.referrer || null,
+    utmSource,
+    utmMedium,
+    utmCampaign,
+    userId: input.userId ?? null,
+    email: input.email ?? null,
+    dedupeKey: input.dedupeKey ?? `${input.eventType.toLowerCase()}:${sessionId}:${input.path}`,
+    metadata: input.metadata,
+  };
+
+  try {
+    await fetch("/api/analytics/funnel/collect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      keepalive: true,
+    });
+  } catch {
+    // Best-effort analytics capture.
+  }
+}
+
+export function wasAuthTracked(userId: string): boolean {
+  if (typeof window === "undefined") return false;
+  return window.sessionStorage.getItem(`${AUTH_TRACKED_PREFIX}${userId}`) === "1";
+}
+
+export function markAuthTracked(userId: string): void {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.setItem(`${AUTH_TRACKED_PREFIX}${userId}`, "1");
+}


### PR DESCRIPTION
## Summary
- add a first-party visitor funnel for anonymous through paid-customer conversion tracking
- add normalized enrichment ingest for UNify, Clay, and RB2B
- materialize HubSpot, Coda, and Stripe milestones into the acquisition funnel
- add the cj-acquisition-funnel analytics UI and admin drill-down records API

## Testing
- npm run db:generate
- npx vitest run src/lib/analytics/visitor-funnel.test.ts
- npx tsc --noEmit --pretty false 2>&1 | rg "src/(app/api/analytics/funnel/collect/route.ts|app/api/analytics/funnel/enrich/[provider]/route.ts|app/api/analytics/visitor-funnel/records/route.ts|app/api/analytics/route.ts|app/api/analytics/summary/route.ts|components/layout/funnel-tracker.tsx|components/analytics/visitor-funnel-tab.tsx|components/analytics/analytics-section-page.tsx|lib/analytics/visitor-funnel.ts|lib/analytics/response-shape.ts|lib/analytics/section-registry.ts|lib/analytics/types.ts|lib/prisma.ts|lib/session-user.ts|lib/tracking/visitor-funnel.ts)"