### PR TITLE
Add provider-specific funnel enrichment ingest

### DIFF
--- a/src/app/api/analytics/funnel/enrich/[provider]/route.ts
+++ b/src/app/api/analytics/funnel/enrich/[provider]/route.ts
@@ -1,10 +1,16 @@
 export const dynamic = "force-dynamic";
 
+import { timingSafeEqual } from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { getAuthenticatedUser } from "@/lib/session-user";
 import type { EnrichmentProvider } from "@/lib/analytics/types";
+import {
+  isUnifyPullRequest,
+  normalizeNativeProviderSignals,
+  pullUnifySignalsFromApi,
+} from "@/lib/analytics/provider-enrichment-adapters";
 import {
   ingestVisitorEnrichmentSignals,
   type VisitorEnrichmentSignalInput,
@@ -16,6 +22,50 @@ interface EnrichRequestBody {
   signals?: VisitorEnrichmentSignalInput[];
 }
 
+function trimOrNull(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+function safeEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  if (leftBuffer.length !== rightBuffer.length) return false;
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function extractRequestSecret(request: NextRequest): string | null {
+  const authorization = trimOrNull(request.headers.get("authorization"));
+  if (authorization?.toLowerCase().startsWith("bearer ")) {
+    return trimOrNull(authorization.slice(7));
+  }
+
+  return (
+    trimOrNull(request.headers.get("x-webhook-secret")) ??
+    trimOrNull(request.nextUrl.searchParams.get("token")) ??
+    trimOrNull(request.nextUrl.searchParams.get("secret"))
+  );
+}
+
+function providerSecrets(provider: EnrichmentProvider): string[] {
+  const specificEnvName = `${provider.toUpperCase()}_FUNNEL_ENRICH_SECRET`;
+  return [
+    process.env.VISITOR_FUNNEL_ENRICH_SECRET,
+    process.env[specificEnvName],
+  ]
+    .map((value) => trimOrNull(value))
+    .filter((value): value is string => Boolean(value));
+}
+
+function authorizeRequest(request: NextRequest, provider: EnrichmentProvider, role: string | undefined): boolean {
+  if (role === "admin") return true;
+
+  const suppliedSecret = extractRequestSecret(request);
+  if (!suppliedSecret) return false;
+
+  return providerSecrets(provider).some((expected) => safeEqual(expected, suppliedSecret));
+}
+
 export async function POST(
   request: NextRequest,
   context: { params: Promise<{ provider: string }> },
@@ -23,26 +73,75 @@ export async function POST(
   try {
     const session = await auth();
     const user = getAuthenticatedUser(session);
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-    if (user.role !== "admin") {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
 
     const { provider: rawProvider } = await context.params;
     const provider = rawProvider.trim().toLowerCase() as EnrichmentProvider;
     if (!SUPPORTED_PROVIDERS.has(provider)) {
       return NextResponse.json({ error: "Unsupported enrichment provider" }, { status: 400 });
     }
-
-    const body = (await request.json().catch(() => ({}))) as EnrichRequestBody;
-    if (!Array.isArray(body.signals)) {
-      return NextResponse.json({ error: "signals must be an array" }, { status: 400 });
+    if (!authorizeRequest(request, provider, user?.role)) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const result = await ingestVisitorEnrichmentSignals(prisma, provider, body.signals);
-    return NextResponse.json(result, { status: 202 });
+    const rawBody = await request.text();
+    let body: Record<string, unknown> = {};
+    if (rawBody.length > 0) {
+      try {
+        body = JSON.parse(rawBody) as Record<string, unknown>;
+      } catch {
+        return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+      }
+    }
+
+    let signals: VisitorEnrichmentSignalInput[] = [];
+    let mode: "normalized" | "native" | "pull" = "normalized";
+
+    if (Array.isArray((body as EnrichRequestBody).signals)) {
+      signals = (body as EnrichRequestBody).signals ?? [];
+    } else if (provider === "unify" && isUnifyPullRequest(body)) {
+      mode = "pull";
+      const apiKey =
+        trimOrNull(typeof body.apiKey === "string" ? body.apiKey : null) ??
+        trimOrNull(process.env.UNIFY_DATA_API_KEY) ??
+        trimOrNull(process.env.UNIFY_API_KEY);
+      const objectName =
+        trimOrNull(typeof body.objectName === "string" ? body.objectName : null) ??
+        trimOrNull(process.env.UNIFY_FUNNEL_OBJECT_NAME);
+      if (!apiKey || !objectName) {
+        return NextResponse.json(
+          { error: "Unify pull requires apiKey and objectName" },
+          { status: 400 },
+        );
+      }
+
+      signals = await pullUnifySignalsFromApi({
+        apiKey,
+        objectName,
+        updatedAfter: trimOrNull(typeof body.updatedAfter === "string" ? body.updatedAfter : null),
+        maxRecords: typeof body.maxRecords === "number" ? body.maxRecords : null,
+      });
+    } else {
+      mode = "native";
+      signals = normalizeNativeProviderSignals(provider, body);
+    }
+
+    if (signals.length === 0) {
+      return NextResponse.json(
+        { error: "No enrichment signals found in request payload" },
+        { status: 400 },
+      );
+    }
+
+    const result = await ingestVisitorEnrichmentSignals(prisma, provider, signals);
+    return NextResponse.json(
+      {
+        ...result,
+        mode,
+        provider,
+        received: signals.length,
+      },
+      { status: 202 },
+    );
   } catch (error) {
     console.error("POST /api/analytics/funnel/enrich/[provider] error:", error);
     return NextResponse.json(

--- a/src/lib/analytics/provider-enrichment-adapters.test.ts
+++ b/src/lib/analytics/provider-enrichment-adapters.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  isUnifyPullRequest,
+  normalizeNativeProviderSignals,
+  pullUnifySignalsFromApi,
+} from "@/lib/analytics/provider-enrichment-adapters";
+
+describe("normalizeNativeProviderSignals", () => {
+  it("normalizes RB2B webhook payloads", () => {
+    const signals = normalizeNativeProviderSignals("rb2b", {
+      "Business Email": "Prospect@Example.com",
+      "First Name": "Ada",
+      "Last Name": "Lovelace",
+      "Company Name": "Example Co",
+      Website: "https://example.com",
+      "Captured URL": "https://wipguard.ai/pricing",
+      Referrer: "https://www.reddit.com/r/startups",
+      "Seen At": "2026-03-08T12:00:00.000Z",
+      is_repeat_visit: true,
+    });
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]).toMatchObject({
+      email: "prospect@example.com",
+      fullName: "Ada Lovelace",
+      companyName: "Example Co",
+      domain: "example.com",
+      confidence: 0.95,
+      provenance: "inferred",
+      occurredAt: "2026-03-08T12:00:00.000Z",
+    });
+    expect(signals[0]?.metadata).toMatchObject({
+      referrer: "https://www.reddit.com/r/startups",
+      capturedUrl: "https://wipguard.ai/pricing",
+      isRepeatVisit: true,
+    });
+  });
+
+  it("normalizes Clay HTTP API payloads with flexible aliases", () => {
+    const signals = normalizeNativeProviderSignals("clay", {
+      rows: [
+        {
+          rowId: "row-123",
+          workEmail: "sales@example.com",
+          companyDomain: "example.com",
+          fullName: "Grace Hopper",
+          companyName: "Example",
+          confidence: 87,
+          capturedUrl: "https://wipguard.ai/demo",
+          referrerUrl: "https://www.reddit.com/r/revops",
+          occurredAt: "2026-03-07T18:25:00.000Z",
+        },
+      ],
+    });
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]).toMatchObject({
+      signalKey: "row-123",
+      email: "sales@example.com",
+      domain: "example.com",
+      fullName: "Grace Hopper",
+      companyName: "Example",
+      confidence: 0.87,
+      occurredAt: "2026-03-07T18:25:00.000Z",
+    });
+    expect(signals[0]?.metadata).toMatchObject({
+      capturedUrl: "https://wipguard.ai/demo",
+      referrer: "https://www.reddit.com/r/revops",
+    });
+  });
+
+  it("normalizes Unify Data API records", () => {
+    const signals = normalizeNativeProviderSignals("unify", {
+      data: [
+        {
+          id: "rec_123",
+          object: "website_visitors",
+          created_at: "2026-03-06T10:00:00.000Z",
+          updated_at: "2026-03-08T10:00:00.000Z",
+          attributes: {
+            anonymous_id: "anon-42",
+            email: "founder@example.com",
+            first_name: "Linus",
+            last_name: "Torvalds",
+            company_name: "Example Labs",
+            website: "https://example.com",
+            confidence_score: 0.91,
+            seen_at: "2026-03-08T09:55:00.000Z",
+          },
+        },
+      ],
+    });
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]).toMatchObject({
+      signalKey: "rec_123",
+      anonymousId: "anon-42",
+      email: "founder@example.com",
+      fullName: "Linus Torvalds",
+      companyName: "Example Labs",
+      domain: "example.com",
+      confidence: 0.91,
+      provenance: "exact",
+      occurredAt: "2026-03-08T09:55:00.000Z",
+    });
+  });
+});
+
+describe("Unify pull helpers", () => {
+  it("detects pull-mode requests", () => {
+    expect(isUnifyPullRequest({ mode: "pull" })).toBe(true);
+    expect(isUnifyPullRequest({ mode: "native" })).toBe(false);
+  });
+
+  it("pulls and filters Unify records from the Data API", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: "old",
+            updated_at: "2026-03-01T00:00:00.000Z",
+            attributes: {
+              email: "old@example.com",
+              website: "https://old.example.com",
+            },
+          },
+          {
+            id: "new",
+            updated_at: "2026-03-08T00:00:00.000Z",
+            attributes: {
+              email: "new@example.com",
+              website: "https://new.example.com",
+              seen_at: "2026-03-08T00:00:00.000Z",
+            },
+          },
+        ],
+      }),
+    });
+
+    const signals = await pullUnifySignalsFromApi({
+      apiKey: "unify-key",
+      objectName: "website_visitors",
+      updatedAfter: "2026-03-05T00:00:00.000Z",
+      maxRecords: 1,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.signalKey).toBe("new");
+    expect(signals[0]?.email).toBe("new@example.com");
+  });
+});

--- a/src/lib/analytics/provider-enrichment-adapters.ts
+++ b/src/lib/analytics/provider-enrichment-adapters.ts
@@ -1,0 +1,491 @@
+import type { Prisma } from "@/generated/prisma/client";
+import type { EnrichmentProvider } from "@/lib/analytics/types";
+import type { VisitorEnrichmentSignalInput } from "@/lib/analytics/visitor-funnel";
+
+type JsonObject = Record<string, unknown>;
+
+export interface UnifyPullRequest {
+  mode: "pull";
+  apiKey?: string | null;
+  objectName?: string | null;
+  updatedAfter?: string | null;
+  maxRecords?: number | null;
+}
+
+interface NormalizeContext {
+  provider: EnrichmentProvider;
+  payload: unknown;
+}
+
+function asObject(value: unknown): JsonObject | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as JsonObject;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeLookupKey(value: string): string {
+  return value.replace(/[^a-z0-9]/gi, "").toLowerCase();
+}
+
+function getChildValue(source: unknown, segment: string): unknown {
+  const record = asObject(source);
+  if (!record) return null;
+
+  const target = normalizeLookupKey(segment);
+  for (const [key, value] of Object.entries(record)) {
+    if (normalizeLookupKey(key) === target) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function getPathValue(source: unknown, path: string): unknown {
+  const segments = path.split(".").map((segment) => segment.trim()).filter(Boolean);
+  let current: unknown = source;
+  for (const segment of segments) {
+    current = getChildValue(current, segment);
+    if (current == null) return null;
+  }
+  return current;
+}
+
+function pickValue(source: unknown, candidates: string[]): unknown {
+  for (const candidate of candidates) {
+    const value = getPathValue(source, candidate);
+    if (value == null) continue;
+    if (typeof value === "string" && value.trim().length === 0) continue;
+    return value;
+  }
+  return null;
+}
+
+function pickString(source: unknown, candidates: string[]): string | null {
+  const value = pickValue(source, candidates);
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return null;
+}
+
+function pickNumber(source: unknown, candidates: string[]): number | null {
+  const value = pickValue(source, candidates);
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const normalized = trimmed.endsWith("%")
+      ? Number.parseFloat(trimmed.slice(0, -1)) / 100
+      : Number.parseFloat(trimmed);
+    return Number.isFinite(normalized) ? normalized : null;
+  }
+  return null;
+}
+
+function pickBoolean(source: unknown, candidates: string[]): boolean | null {
+  const value = pickValue(source, candidates);
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes", "y"].includes(normalized)) return true;
+    if (["false", "0", "no", "n"].includes(normalized)) return false;
+  }
+  return null;
+}
+
+function trimOrNull(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeEmail(value: string | null | undefined): string | null {
+  const trimmed = trimOrNull(value);
+  return trimmed ? trimmed.toLowerCase() : null;
+}
+
+function clampConfidence(value: number | null | undefined, fallback: number): number {
+  const candidate = value ?? fallback;
+  if (!Number.isFinite(candidate)) return fallback;
+  if (candidate > 1) {
+    return Math.max(0, Math.min(1, candidate / 100));
+  }
+  return Math.max(0, Math.min(1, candidate));
+}
+
+function domainFromUrl(rawUrl: string | null | undefined): string | null {
+  const value = trimOrNull(rawUrl);
+  if (!value) return null;
+  try {
+    return new URL(value).hostname.toLowerCase();
+  } catch {
+    return value.replace(/^https?:\/\//i, "").replace(/^www\./i, "").split("/")[0]?.toLowerCase() ?? null;
+  }
+}
+
+function fullNameFromParts(firstName: string | null, lastName: string | null): string | null {
+  const combined = [trimOrNull(firstName), trimOrNull(lastName)].filter(Boolean).join(" ");
+  return combined.length > 0 ? combined : null;
+}
+
+function unwrapRecords(payload: unknown): JsonObject[] {
+  const record = asObject(payload);
+  if (!record) return [];
+
+  const listCandidates = [
+    record,
+    pickValue(record, ["signals", "rows", "records", "data", "results", "items", "lead_list"]),
+    pickValue(record, ["body.rows", "body.records", "body.data", "body.results", "body.items"]),
+  ];
+
+  for (const candidate of listCandidates) {
+    const values = asArray(candidate)
+      .map((entry) => asObject(entry))
+      .filter((entry): entry is JsonObject => entry !== null);
+    if (values.length > 0) return values;
+  }
+
+  return [record];
+}
+
+function buildMetadata(record: JsonObject, extras: JsonObject): Prisma.InputJsonValue {
+  return {
+    ...extras,
+    raw: record as Prisma.InputJsonValue,
+  } as Prisma.InputJsonObject;
+}
+
+function normalizeRb2bRecords(payload: unknown): VisitorEnrichmentSignalInput[] {
+  const records = unwrapRecords(payload);
+
+  return records
+    .map((record) => {
+      const firstName = pickString(record, ["First Name", "first_name"]);
+      const lastName = pickString(record, ["Last Name", "last_name"]);
+      const fullName =
+        pickString(record, ["Full Name", "full_name", "Name", "name"]) ??
+        fullNameFromParts(firstName, lastName);
+      const website = pickString(record, ["Website", "website"]);
+      const capturedUrl = pickString(record, ["Captured URL", "captured_url", "url", "page_url"]);
+      const referrer = pickString(record, ["Referrer", "referrer"]);
+      const email =
+        normalizeEmail(
+          pickString(record, [
+            "Business Email",
+            "business_email",
+            "email",
+            "Personal Email",
+            "personal_email",
+          ]),
+        );
+      const anonymousId = pickString(record, [
+        "Anonymous ID",
+        "anonymous_id",
+        "Visitor ID",
+        "visitor_id",
+      ]);
+      const occurredAt = pickString(record, ["Seen At", "seen_at", "timestamp"]);
+      const confidence = clampConfidence(
+        pickNumber(record, ["Confidence", "confidence", "Match Score", "match_score"]),
+        0.95,
+      );
+
+      return {
+        signalKey: pickString(record, ["id", "event_id", "signal_id"]),
+        anonymousId,
+        email,
+        domain:
+          trimOrNull(pickString(record, ["Domain", "domain"])) ??
+          domainFromUrl(website) ??
+          domainFromUrl(capturedUrl),
+        fullName,
+        companyName: pickString(record, ["Company Name", "company_name"]),
+        confidence,
+        occurredAt,
+        provenance: anonymousId ? "exact" : "inferred",
+        metadata: buildMetadata(record, {
+          title: pickString(record, ["Title", "title"]),
+          website,
+          referrer,
+          capturedUrl,
+          linkedinUrl: pickString(record, ["LinkedIn URL", "linkedin_url"]),
+          tags: pickString(record, ["Tags", "tags"]),
+          isRepeatVisit: pickBoolean(record, ["is_repeat_visit", "Is Repeat Visit"]),
+        }),
+        payload: record as Prisma.InputJsonValue,
+      } satisfies VisitorEnrichmentSignalInput;
+    })
+    .filter((signal) => Boolean(signal.email || signal.anonymousId || signal.domain));
+}
+
+function normalizeClayRecords(payload: unknown): VisitorEnrichmentSignalInput[] {
+  const records = unwrapRecords(payload);
+
+  return records
+    .map((record) => {
+      const firstName = pickString(record, [
+        "first_name",
+        "firstName",
+        "person.first_name",
+        "person.firstName",
+        "contact.first_name",
+      ]);
+      const lastName = pickString(record, [
+        "last_name",
+        "lastName",
+        "person.last_name",
+        "person.lastName",
+        "contact.last_name",
+      ]);
+      const fullName =
+        pickString(record, [
+          "full_name",
+          "fullName",
+          "name",
+          "person.full_name",
+          "person.fullName",
+          "contact.name",
+        ]) ?? fullNameFromParts(firstName, lastName);
+      const website = pickString(record, [
+        "website",
+        "company_website",
+        "companyWebsite",
+        "company.website",
+      ]);
+      const capturedUrl = pickString(record, [
+        "captured_url",
+        "capturedUrl",
+        "page_url",
+        "pageUrl",
+        "landing_page",
+        "landingPage",
+        "url",
+      ]);
+      const referrer = pickString(record, ["referrer", "referrer_url", "referrerUrl"]);
+
+      return {
+        signalKey: pickString(record, ["signal_key", "signalKey", "record_id", "recordId", "row_id", "rowId", "id"]),
+        anonymousId: pickString(record, ["anonymous_id", "anonymousId", "visitor_id", "visitorId"]),
+        email: normalizeEmail(
+          pickString(record, [
+            "email",
+            "business_email",
+            "businessEmail",
+            "work_email",
+            "workEmail",
+            "person.email",
+            "contact.email",
+          ]),
+        ),
+        domain:
+          trimOrNull(
+            pickString(record, [
+              "domain",
+              "company_domain",
+              "companyDomain",
+              "website_domain",
+              "websiteDomain",
+              "company.domain",
+            ]),
+          ) ??
+          domainFromUrl(website) ??
+          domainFromUrl(capturedUrl),
+        fullName,
+        companyName: pickString(record, [
+          "company_name",
+          "companyName",
+          "company",
+          "account_name",
+          "accountName",
+          "organization",
+        ]),
+        confidence: clampConfidence(
+          pickNumber(record, ["confidence", "match_score", "matchScore", "score"]),
+          0.9,
+        ),
+        occurredAt: pickString(record, [
+          "occurred_at",
+          "occurredAt",
+          "seen_at",
+          "seenAt",
+          "timestamp",
+          "last_seen_at",
+          "lastSeenAt",
+          "updated_at",
+          "updatedAt",
+        ]),
+        provenance: pickString(record, ["provenance"]) === "backfilled" ? "backfilled" : "inferred",
+        metadata: buildMetadata(record, {
+          firstName,
+          lastName,
+          title: pickString(record, ["title", "job_title", "jobTitle"]),
+          website,
+          referrer,
+          capturedUrl,
+          linkedinUrl: pickString(record, ["linkedin_url", "linkedinUrl", "person.linkedin_url"]),
+        }),
+        payload: record as Prisma.InputJsonValue,
+      } satisfies VisitorEnrichmentSignalInput;
+    })
+    .filter((signal) => Boolean(signal.email || signal.anonymousId || signal.domain));
+}
+
+function normalizeUnifyRecords(payload: unknown): VisitorEnrichmentSignalInput[] {
+  const records = unwrapRecords(payload);
+
+  return records
+    .map((record) => {
+      const attributes = asObject(record.attributes) ?? record;
+      const firstName = pickString(attributes, ["first_name", "firstName"]);
+      const lastName = pickString(attributes, ["last_name", "lastName"]);
+      const fullName =
+        pickString(attributes, ["full_name", "fullName", "name"]) ??
+        fullNameFromParts(firstName, lastName);
+      const website = pickString(attributes, ["website", "company_website", "companyWebsite"]);
+
+      return {
+        signalKey:
+          pickString(record, ["id"]) ??
+          pickString(attributes, ["record_id", "recordId", "signal_id", "signalId"]),
+        anonymousId: pickString(attributes, [
+          "anonymous_id",
+          "anonymousId",
+          "visitor_id",
+          "visitorId",
+          "device_id",
+          "deviceId",
+        ]),
+        email: normalizeEmail(
+          pickString(attributes, [
+            "email",
+            "work_email",
+            "workEmail",
+            "business_email",
+            "businessEmail",
+          ]),
+        ),
+        domain:
+          trimOrNull(
+            pickString(attributes, [
+              "domain",
+              "company_domain",
+              "companyDomain",
+              "website_domain",
+              "websiteDomain",
+            ]),
+          ) ?? domainFromUrl(website),
+        fullName,
+        companyName: pickString(attributes, [
+          "company_name",
+          "companyName",
+          "account_name",
+          "accountName",
+          "organization_name",
+          "organizationName",
+        ]),
+        confidence: clampConfidence(
+          pickNumber(attributes, ["confidence", "confidence_score", "confidenceScore", "score"]),
+          0.9,
+        ),
+        occurredAt:
+          pickString(attributes, ["seen_at", "seenAt", "last_seen_at", "lastSeenAt"]) ??
+          pickString(record, ["updated_at", "created_at"]),
+        provenance: pickString(attributes, ["anonymous_id", "anonymousId"]) ? "exact" : "inferred",
+        metadata: buildMetadata(record, {
+          object: pickString(record, ["object"]),
+          recordId: pickString(record, ["id"]),
+          createdAt: pickString(record, ["created_at"]),
+          updatedAt: pickString(record, ["updated_at"]),
+          website,
+          linkedinUrl: pickString(attributes, ["linkedin_url", "linkedinUrl"]),
+          title: pickString(attributes, ["title", "job_title", "jobTitle"]),
+        }),
+        payload: record as Prisma.InputJsonValue,
+      } satisfies VisitorEnrichmentSignalInput;
+    })
+    .filter((signal) => Boolean(signal.email || signal.anonymousId || signal.domain));
+}
+
+export function isUnifyPullRequest(value: unknown): value is UnifyPullRequest {
+  const record = asObject(value);
+  return Boolean(record && pickString(record, ["mode"])?.toLowerCase() === "pull");
+}
+
+export function normalizeNativeProviderSignals(
+  provider: EnrichmentProvider,
+  payload: unknown,
+): VisitorEnrichmentSignalInput[] {
+  switch (provider) {
+    case "rb2b":
+      return normalizeRb2bRecords(payload);
+    case "clay":
+      return normalizeClayRecords(payload);
+    case "unify":
+      return normalizeUnifyRecords(payload);
+    default:
+      return [];
+  }
+}
+
+function safeOptionalDate(value: string | null | undefined): Date | null {
+  const trimmed = trimOrNull(value);
+  if (!trimmed) return null;
+  const parsed = new Date(trimmed);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export async function pullUnifySignalsFromApi(input: {
+  apiKey: string;
+  objectName: string;
+  updatedAfter?: string | null;
+  maxRecords?: number | null;
+  fetchImpl?: typeof fetch;
+}): Promise<VisitorEnrichmentSignalInput[]> {
+  const apiKey = trimOrNull(input.apiKey);
+  const objectName = trimOrNull(input.objectName);
+  if (!apiKey || !objectName) {
+    throw new Error("Unify pull requires apiKey and objectName");
+  }
+
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const response = await fetchImpl(
+    `https://api.unifygtm.com/data/v1/objects/${encodeURIComponent(objectName)}/records`,
+    {
+      headers: {
+        "x-api-key": apiKey,
+      },
+      cache: "no-store",
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Unify pull failed with status ${response.status}`);
+  }
+
+  const payload = (await response.json()) as { data?: unknown[] };
+  const signals = normalizeUnifyRecords(payload);
+  const updatedAfter = safeOptionalDate(input.updatedAfter ?? null);
+  const maxRecords = Math.max(1, Math.min(5000, input.maxRecords ?? 500));
+
+  return signals
+    .filter((signal) => {
+      if (!updatedAfter) return true;
+      const occurredAt = safeOptionalDate(signal.occurredAt ?? null);
+      return occurredAt ? occurredAt >= updatedAfter : true;
+    })
+    .slice(0, maxRecords);
+}
+
+export function summarizeProviderPayload(input: NormalizeContext): string {
+  if (isUnifyPullRequest(input.payload)) return "unify-pull";
+  const records = normalizeNativeProviderSignals(input.provider, input.payload);
+  return `${input.provider}:${records.length}`;
+}


### PR DESCRIPTION
## Summary
- add native payload normalization for RB2B webhooks and Clay HTTP API pushes
- add a Unify Data API pull mode on the existing funnel enrichment endpoint
- allow server-to-server ingest auth via bearer/header/query secrets for provider webhooks
- add adapter tests covering RB2B, Clay, and Unify normalization

## Testing
- npx vitest run src/lib/analytics/provider-enrichment-adapters.test.ts src/lib/analytics/visitor-funnel.test.ts
- scoped TypeScript check for the provider ingest files