### PR TITLE
Fix HubSpot main-pipeline analytics and cleanup

### DIFF
--- a/merge_deals.js
+++ b/merge_deals.js
@@ -1,103 +1,546 @@
-const dot = require('dotenv').config({ path: '.env.local' });
-const token = process.env.HUBSPOT_ACCESS_TOKEN;
+const dotenv = require("dotenv");
 
-const EXCLUDED_NAMES = new Set([
-  "",
-  "null",
-  "- Prospect",
-  "Zaybra Subscription",
-  "Growth via Payment Link",
-  "Arda Cloud +1 more via Payment Link",
-  "gh"
-]);
+const HUBSPOT_BASE = "https://api.hubapi.com";
+const MAIN_PIPELINE_ID = "default";
+const SUBSCRIPTION_PIPELINE_ID = "1390107368";
 
-async function mergeDeals() {
-  let allDeals = [];
-  let after = undefined;
-  
-  do {
-    const url = `https://api.hubapi.com/crm/v3/objects/deals?properties=dealname,amount,dealstage,pipeline&limit=100${after ? `&after=${after}` : ''}`;
-    const res = await fetch(url, {
-      headers: {
-        'Authorization': `Bearer ${token}`,
-        'Content-Type': 'application/json'
-      }
-    });
+const MANUAL_DEAL_MERGES = [
+  {
+    primaryObjectId: "79658864346",
+    objectIdToMerge: "138720011979",
+    reason: "Egg Collective closed-lost duplicate should resolve into the active closed-won deal.",
+    matchType: "manual",
+  },
+  {
+    primaryObjectId: "79676947156",
+    objectIdToMerge: "139322884826",
+    reason: "Lichen Precision closed-lost duplicate should resolve into the active closed-won deal.",
+    matchType: "manual",
+  },
+  {
+    primaryObjectId: "79675150072",
+    objectIdToMerge: "139080299207",
+    reason: "Super Pacific closed-lost duplicate should resolve into the active closed-won deal.",
+    matchType: "manual",
+  },
+  {
+    primaryObjectId: "79675150072",
+    objectIdToMerge: "304667726544",
+    reason: "Super Pacific duplicate should resolve into the active closed-won deal.",
+    matchType: "manual",
+  },
+];
 
-    if (!res.ok) {
-      console.error(await res.text());
-      break;
+const MANUAL_COMPANY_MERGES = [
+  {
+    primaryObjectId: "76096495311",
+    objectIdToMerge: "75923518183",
+    reason: "Super Pacific duplicate companies should consolidate into the company attached to the primary deal.",
+    matchType: "manual",
+  },
+];
+
+function normalizeText(value) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function normalizeCompanyName(value) {
+  return normalizeText(value)
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function toTimestamp(value) {
+  const time = Date.parse(String(value ?? ""));
+  return Number.isFinite(time) ? time : null;
+}
+
+function resolveCanonicalId(id, mergeMap) {
+  let current = id;
+  const seen = new Set();
+  while (mergeMap.has(current) && !seen.has(current)) {
+    seen.add(current);
+    current = mergeMap.get(current);
+  }
+  return current;
+}
+
+function isClosedWon(stageId) {
+  return normalizeText(stageId) === "closedwon";
+}
+
+function choosePrimaryDeal(deals) {
+  const sorted = [...deals].sort((a, b) => {
+    if (isClosedWon(a.stageId) !== isClosedWon(b.stageId)) {
+      return isClosedWon(a.stageId) ? -1 : 1;
     }
 
-    const data = await res.json();
-    allDeals = allDeals.concat(data.results);
-    after = data.paging?.next?.after;
-  } while (after);
+    const updatedDiff = (toTimestamp(b.updatedAt) ?? 0) - (toTimestamp(a.updatedAt) ?? 0);
+    if (updatedDiff !== 0) return updatedDiff;
 
-  console.log(`Fetched ${allDeals.length} deals.`);
-  
-  // Find duplicates by dealname
-  const nameMap = {};
-  for (const deal of allDeals) {
-    const name = deal.properties.dealname;
-    if (name && EXCLUDED_NAMES.has(name)) continue;
-    if (name === null && EXCLUDED_NAMES.has("null")) continue;
-    
-    // Also skip if the name is literally just empty or whitespace
-    if (typeof name !== 'string' || name.trim() === '') continue;
+    const createdA = toTimestamp(a.createdAt);
+    const createdB = toTimestamp(b.createdAt);
+    if (createdA !== null || createdB !== null) {
+      if (createdA === null) return 1;
+      if (createdB === null) return -1;
+      if (createdA !== createdB) return createdA - createdB;
+    }
 
-    if (!nameMap[name]) nameMap[name] = [];
-    nameMap[name].push(deal);
+    return String(a.id).localeCompare(String(b.id));
+  });
+  return sorted[0] ?? null;
+}
+
+function choosePrimaryCompany(companies, preferredCompanyId) {
+  if (preferredCompanyId) {
+    const preferred = companies.find((company) => company.id === preferredCompanyId);
+    if (preferred) return preferred;
   }
 
-  const duplicates = Object.entries(nameMap).filter(([name, deals]) => deals.length > 1);
-  console.log(`Found ${duplicates.length} duplicate names to merge.`);
-  
-  for (const [name, deals] of duplicates) {
-    console.log(`\nMerging duplicates for: "${name}"`);
-    
-    // Sort deals to prefer keeping the one with a non-zero amount or the most advanced stage or simply the oldest ID.
-    // Let's just use the first deal as primary, and merge the rest into it.
-    // Actually, sorting by amount descending so we keep the one with amount
-    deals.sort((a, b) => {
-        const amtA = parseFloat(a.properties.amount || "0");
-        const amtB = parseFloat(b.properties.amount || "0");
-        return amtB - amtA;
+  const sorted = [...companies].sort((a, b) => {
+    const aHasDomain = normalizeText(a.domain).length > 0;
+    const bHasDomain = normalizeText(b.domain).length > 0;
+    if (aHasDomain !== bHasDomain) return aHasDomain ? -1 : 1;
+
+    const createdA = toTimestamp(a.createdAt);
+    const createdB = toTimestamp(b.createdAt);
+    if (createdA !== null || createdB !== null) {
+      if (createdA === null) return 1;
+      if (createdB === null) return -1;
+      if (createdA !== createdB) return createdA - createdB;
+    }
+
+    return String(a.id).localeCompare(String(b.id));
+  });
+  return sorted[0] ?? null;
+}
+
+function collectCustomerSignals(deal, companiesById, contactsById) {
+  const companies = unique(deal.companyIds || [])
+    .map((companyId) => companiesById.get(companyId))
+    .filter(Boolean);
+  const contacts = unique(deal.contactIds || [])
+    .map((contactId) => contactsById.get(contactId))
+    .filter(Boolean);
+
+  return {
+    companies,
+    contacts,
+    domains: unique(companies.map((company) => normalizeText(company.domain))),
+    emails: unique(contacts.map((contact) => normalizeText(contact.email))),
+    companyNames: unique(companies.map((company) => normalizeCompanyName(company.name))),
+  };
+}
+
+function buildCustomerIndexes(mainDeals, companiesById, contactsById) {
+  const byDomain = new Map();
+  const byEmail = new Map();
+  const byCompanyName = new Map();
+
+  const addToIndex = (index, key, deal) => {
+    if (!key) return;
+    const existing = index.get(key) || [];
+    existing.push(deal);
+    index.set(key, existing);
+  };
+
+  for (const deal of mainDeals) {
+    const signals = collectCustomerSignals(deal, companiesById, contactsById);
+    for (const domain of signals.domains) addToIndex(byDomain, domain, deal);
+    for (const email of signals.emails) addToIndex(byEmail, email, deal);
+    for (const name of signals.companyNames) addToIndex(byCompanyName, name, deal);
+  }
+
+  return { byDomain, byEmail, byCompanyName };
+}
+
+function findMainDealMatch(subscriptionDeal, indexes, companiesById, contactsById) {
+  const signals = collectCustomerSignals(subscriptionDeal, companiesById, contactsById);
+
+  for (const domain of signals.domains) {
+    const matches = indexes.byDomain.get(domain) || [];
+    if (matches.length > 0) return { matchType: "company_domain", candidates: matches };
+  }
+
+  for (const email of signals.emails) {
+    const matches = indexes.byEmail.get(email) || [];
+    if (matches.length > 0) return { matchType: "contact_email", candidates: matches };
+  }
+
+  for (const name of signals.companyNames) {
+    const matches = indexes.byCompanyName.get(name) || [];
+    if (matches.length > 0) return { matchType: "company_name", candidates: matches };
+  }
+
+  return { matchType: "unmatched", candidates: [] };
+}
+
+function shouldMergeCompanies(matchType, primaryCompany, secondaryCompany) {
+  if (!primaryCompany || !secondaryCompany) return false;
+  if (primaryCompany.id === secondaryCompany.id) return false;
+
+  if (matchType === "company_domain") {
+    return normalizeText(primaryCompany.domain) !== "" &&
+      normalizeText(primaryCompany.domain) === normalizeText(secondaryCompany.domain);
+  }
+
+  if (matchType === "company_name") {
+    return normalizeCompanyName(primaryCompany.name) !== "" &&
+      normalizeCompanyName(primaryCompany.name) === normalizeCompanyName(secondaryCompany.name);
+  }
+
+  return matchType === "contact_email";
+}
+
+function isMainPipelineDeal(deal) {
+  return normalizeText(deal.pipelineId) === "" || deal.pipelineId === MAIN_PIPELINE_ID;
+}
+
+function buildCleanupPlan({ deals, companies, contacts }) {
+  const companiesById = new Map(companies.map((company) => [company.id, company]));
+  const contactsById = new Map(contacts.map((contact) => [contact.id, contact]));
+
+  const dealCanonicalMap = new Map();
+  const companyCanonicalMap = new Map();
+
+  const dealMerges = [];
+  const companyMerges = [];
+  const review = [];
+
+  const seenDealMerges = new Set();
+  const seenCompanyMerges = new Set();
+
+  const addDealMerge = (merge) => {
+    const secondaryId = resolveCanonicalId(merge.objectIdToMerge, dealCanonicalMap);
+    const primaryId = resolveCanonicalId(merge.primaryObjectId, dealCanonicalMap);
+    if (!secondaryId || !primaryId || secondaryId === primaryId) return;
+
+    const dedupeKey = `${primaryId}->${secondaryId}`;
+    if (seenDealMerges.has(dedupeKey)) return;
+
+    dealCanonicalMap.set(secondaryId, primaryId);
+    seenDealMerges.add(dedupeKey);
+    dealMerges.push({ ...merge, primaryObjectId: primaryId, objectIdToMerge: secondaryId });
+  };
+
+  const addCompanyMerge = (merge) => {
+    const secondaryId = resolveCanonicalId(merge.objectIdToMerge, companyCanonicalMap);
+    const primaryId = resolveCanonicalId(merge.primaryObjectId, companyCanonicalMap);
+    if (!secondaryId || !primaryId || secondaryId === primaryId) return;
+
+    const dedupeKey = `${primaryId}->${secondaryId}`;
+    if (seenCompanyMerges.has(dedupeKey)) return;
+
+    companyCanonicalMap.set(secondaryId, primaryId);
+    seenCompanyMerges.add(dedupeKey);
+    companyMerges.push({ ...merge, primaryObjectId: primaryId, objectIdToMerge: secondaryId });
+  };
+
+  for (const merge of MANUAL_DEAL_MERGES) addDealMerge(merge);
+  for (const merge of MANUAL_COMPANY_MERGES) addCompanyMerge(merge);
+
+  const manualSecondaryDealIds = new Set(MANUAL_DEAL_MERGES.map((merge) => merge.objectIdToMerge));
+  const mainDeals = deals.filter(
+    (deal) => isMainPipelineDeal(deal) && !manualSecondaryDealIds.has(deal.id),
+  );
+  const indexes = buildCustomerIndexes(mainDeals, companiesById, contactsById);
+
+  const subscriptionDeals = deals.filter((deal) => deal.pipelineId === SUBSCRIPTION_PIPELINE_ID);
+  for (const subscriptionDeal of subscriptionDeals) {
+    const match = findMainDealMatch(subscriptionDeal, indexes, companiesById, contactsById);
+    if (match.candidates.length === 0) {
+      const signals = collectCustomerSignals(subscriptionDeal, companiesById, contactsById);
+      review.push({
+        dealId: subscriptionDeal.id,
+        dealName: subscriptionDeal.name,
+        reason: "No main-pipeline customer match found for subscription deal.",
+        companyNames: signals.companies.map((company) => company.name),
+        domains: signals.domains.filter(Boolean),
+        emails: signals.emails.filter(Boolean),
+      });
+      continue;
+    }
+
+    const canonicalCandidates = unique(
+      match.candidates.map((candidate) => resolveCanonicalId(candidate.id, dealCanonicalMap)),
+    )
+      .map((dealId) => deals.find((candidate) => candidate.id === dealId))
+      .filter(Boolean);
+
+    const primaryDeal = choosePrimaryDeal(canonicalCandidates);
+    if (!primaryDeal || primaryDeal.id === subscriptionDeal.id) continue;
+
+    addDealMerge({
+      primaryObjectId: primaryDeal.id,
+      objectIdToMerge: subscriptionDeal.id,
+      reason: `Subscription-pipeline deal matched to main-pipeline customer via ${match.matchType}.`,
+      matchType: match.matchType,
     });
 
-    const primaryObjectId = deals[0].id;
-    console.log(`  Primary Deal ID: ${primaryObjectId}`);
+    const primarySignals = collectCustomerSignals(primaryDeal, companiesById, contactsById);
+    const secondarySignals = collectCustomerSignals(subscriptionDeal, companiesById, contactsById);
+    const primaryCompany = choosePrimaryCompany(primarySignals.companies, primaryDeal.companyIds?.[0] ?? null);
+    const secondaryCompany = choosePrimaryCompany(secondarySignals.companies, subscriptionDeal.companyIds?.[0] ?? null);
 
-    for (let i = 1; i < deals.length; i++) {
-        const objectIdToMerge = deals[i].id;
-        console.log(`  Merging Deal ID: ${objectIdToMerge} into ${primaryObjectId}`);
-        
-        try {
-            const res = await fetch('https://api.hubapi.com/crm/v3/objects/deals/merge', {
-                method: 'POST',
-                headers: {
-                    'Authorization': `Bearer ${token}`,
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({
-                    primaryObjectId,
-                    objectIdToMerge
-                })
-            });
+    if (shouldMergeCompanies(match.matchType, primaryCompany, secondaryCompany)) {
+      addCompanyMerge({
+        primaryObjectId: primaryCompany.id,
+        objectIdToMerge: secondaryCompany.id,
+        reason: `Company merge required after subscription-pipeline match via ${match.matchType}.`,
+        matchType: match.matchType,
+      });
+    }
+  }
 
-            if (!res.ok) {
-                console.error(`  Failed to merge: ${await res.text()}`);
-            } else {
-                console.log(`  Successfully merged ${objectIdToMerge} into ${primaryObjectId}`);
-            }
-        } catch (e) {
-            console.error(`  Error during merge:`, e);
-        }
-        
-        // Sleep to avoid rate limits
-        await new Promise(resolve => setTimeout(resolve, 500));
+  return {
+    dealMerges,
+    companyMerges,
+    review,
+    summary: {
+      mainPipelineId: MAIN_PIPELINE_ID,
+      excludedSubscriptionPipelineId: SUBSCRIPTION_PIPELINE_ID,
+      manualDealMerges: MANUAL_DEAL_MERGES.length,
+      manualCompanyMerges: MANUAL_COMPANY_MERGES.length,
+      plannedDealMerges: dealMerges.length,
+      plannedCompanyMerges: companyMerges.length,
+      reviewCount: review.length,
+    },
+  };
+}
+
+async function hubspotFetchJson(token, url, init = {}) {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      ...(init.headers || {}),
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`${response.status} ${await response.text().catch(() => "HubSpot request failed")}`);
+  }
+
+  return response.json();
+}
+
+async function fetchAllObjects(token, objectType, properties) {
+  const results = [];
+  let after;
+
+  for (;;) {
+    const url = new URL(`${HUBSPOT_BASE}/crm/v3/objects/${objectType}`);
+    url.searchParams.set("limit", "100");
+    url.searchParams.set("properties", properties);
+    if (after) url.searchParams.set("after", after);
+
+    const payload = await hubspotFetchJson(token, url.toString());
+    results.push(...(payload.results || []));
+    after = payload.paging?.next?.after;
+    if (!after) break;
+  }
+
+  return results;
+}
+
+async function fetchDealAssociations(token, dealIds, pathSegment) {
+  const associations = new Map();
+  const batchSize = 100;
+
+  for (let index = 0; index < dealIds.length; index += batchSize) {
+    const batch = dealIds.slice(index, index + batchSize);
+    const payload = await hubspotFetchJson(
+      token,
+      `${HUBSPOT_BASE}/crm/v4/associations/deal/${pathSegment}/batch/read`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          inputs: batch.map((id) => ({ id })),
+        }),
+      },
+    );
+
+    for (const row of payload.results || []) {
+      const fromId = String(row.from?.id ?? "");
+      const targetIds = unique(
+        (row.to || [])
+          .map((target) => String(target.toObjectId ?? ""))
+          .filter(Boolean),
+      );
+      if (fromId) associations.set(fromId, targetIds);
+    }
+  }
+
+  for (const dealId of dealIds) {
+    if (!associations.has(dealId)) associations.set(dealId, []);
+  }
+
+  return associations;
+}
+
+async function loadHubSpotCleanupData(token) {
+  const [dealRows, companyRows, contactRows] = await Promise.all([
+    fetchAllObjects(token, "deals", "dealname,dealstage,amount,pipeline,createdate,hs_lastmodifieddate"),
+    fetchAllObjects(token, "companies", "name,domain,createdate,hs_lastmodifieddate"),
+    fetchAllObjects(token, "contacts", "firstname,lastname,email,createdate,lastmodifieddate"),
+  ]);
+
+  const dealIds = dealRows.map((deal) => String(deal.id)).filter(Boolean);
+  const [dealCompanies, dealContacts] = await Promise.all([
+    fetchDealAssociations(token, dealIds, "company"),
+    fetchDealAssociations(token, dealIds, "contact"),
+  ]);
+
+  return {
+    deals: dealRows.map((deal) => ({
+      id: String(deal.id ?? ""),
+      name: String(deal.properties?.dealname ?? ""),
+      stageId: String(deal.properties?.dealstage ?? ""),
+      pipelineId: String(deal.properties?.pipeline ?? ""),
+      amount: Number(deal.properties?.amount ?? 0),
+      createdAt: deal.properties?.createdate ?? null,
+      updatedAt: deal.properties?.hs_lastmodifieddate ?? null,
+      companyIds: dealCompanies.get(String(deal.id ?? "")) || [],
+      contactIds: dealContacts.get(String(deal.id ?? "")) || [],
+    })),
+    companies: companyRows.map((company) => ({
+      id: String(company.id ?? ""),
+      name: String(company.properties?.name ?? ""),
+      domain: company.properties?.domain ?? null,
+      createdAt: company.properties?.createdate ?? null,
+      updatedAt: company.properties?.hs_lastmodifieddate ?? null,
+    })),
+    contacts: contactRows.map((contact) => ({
+      id: String(contact.id ?? ""),
+      firstName: contact.properties?.firstname ?? "",
+      lastName: contact.properties?.lastname ?? "",
+      email: contact.properties?.email ?? null,
+      createdAt: contact.properties?.createdate ?? null,
+      updatedAt: contact.properties?.lastmodifieddate ?? null,
+    })),
+  };
+}
+
+async function mergeHubSpotObjects(token, objectType, merges) {
+  for (const merge of merges) {
+    const response = await fetch(`${HUBSPOT_BASE}/crm/v3/objects/${objectType}/merge`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        primaryObjectId: merge.primaryObjectId,
+        objectIdToMerge: merge.objectIdToMerge,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to merge ${objectType} ${merge.objectIdToMerge} -> ${merge.primaryObjectId}: ${await response.text().catch(() => "merge failed")}`,
+      );
     }
   }
 }
 
-mergeDeals();
+async function applyCleanupPlan(token, plan) {
+  await mergeHubSpotObjects(token, "deals", plan.dealMerges);
+  await mergeHubSpotObjects(token, "companies", plan.companyMerges);
+}
+
+function parseArgs(argv) {
+  const args = new Set(argv.slice(2));
+  return {
+    apply: args.has("--apply"),
+    json: args.has("--json"),
+  };
+}
+
+function loadHubSpotAccessToken() {
+  dotenv.config({ path: ".env.local" });
+  const token = process.env.HUBSPOT_ACCESS_TOKEN;
+  if (!token) {
+    throw new Error("HUBSPOT_ACCESS_TOKEN is required in .env.local");
+  }
+  return token;
+}
+
+function printPlan(plan, asJson) {
+  if (asJson) {
+    console.log(JSON.stringify(plan, null, 2));
+    return;
+  }
+
+  console.log(`Main pipeline: ${plan.summary.mainPipelineId}`);
+  console.log(`Excluded subscription pipeline: ${plan.summary.excludedSubscriptionPipelineId}`);
+  console.log(`Planned deal merges: ${plan.summary.plannedDealMerges}`);
+  console.log(`Planned company merges: ${plan.summary.plannedCompanyMerges}`);
+  console.log(`Needs review: ${plan.summary.reviewCount}`);
+
+  if (plan.dealMerges.length > 0) {
+    console.log("\nDeal merges:");
+    for (const merge of plan.dealMerges) {
+      console.log(`- ${merge.objectIdToMerge} -> ${merge.primaryObjectId} [${merge.matchType}] ${merge.reason}`);
+    }
+  }
+
+  if (plan.companyMerges.length > 0) {
+    console.log("\nCompany merges:");
+    for (const merge of plan.companyMerges) {
+      console.log(`- ${merge.objectIdToMerge} -> ${merge.primaryObjectId} [${merge.matchType}] ${merge.reason}`);
+    }
+  }
+
+  if (plan.review.length > 0) {
+    console.log("\nReview queue:");
+    for (const item of plan.review.slice(0, 25)) {
+      console.log(`- ${item.dealId} ${item.dealName} :: ${item.reason}`);
+    }
+    if (plan.review.length > 25) {
+      console.log(`... ${plan.review.length - 25} additional review items omitted`);
+    }
+  }
+}
+
+async function executeCli(argv = process.argv) {
+  const token = loadHubSpotAccessToken();
+  const options = parseArgs(argv);
+  const data = await loadHubSpotCleanupData(token);
+  const plan = buildCleanupPlan(data);
+
+  if (!options.apply) {
+    printPlan(plan, options.json);
+    return plan;
+  }
+
+  await applyCleanupPlan(token, plan);
+  printPlan(plan, options.json);
+  return plan;
+}
+
+if (require.main === module) {
+  executeCli().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  MAIN_PIPELINE_ID,
+  SUBSCRIPTION_PIPELINE_ID,
+  MANUAL_DEAL_MERGES,
+  MANUAL_COMPANY_MERGES,
+  normalizeCompanyName,
+  choosePrimaryDeal,
+  choosePrimaryCompany,
+  buildCleanupPlan,
+  loadHubSpotCleanupData,
+  applyCleanupPlan,
+  executeCli,
+};

--- a/src/components/analytics/sales-hubspot-tab.tsx
+++ b/src/components/analytics/sales-hubspot-tab.tsx
@@ -33,7 +33,7 @@ export function SalesHubspotTab({ data }: SalesHubspotTabProps) {
   }
 
   const funnel = hs.funnel;
-  const deals = hs.deals ?? [];
+  const deals = hs.displayDeals ?? hs.deals ?? [];
 
   /* ── Alerts ──────────────────────────────────────── */
 
@@ -69,11 +69,17 @@ export function SalesHubspotTab({ data }: SalesHubspotTabProps) {
     .filter((s) => !["Closed Lost", "Unlikely", "Churn"].includes(s.label))
     .sort((a, b) => {
       const order = [
-        "Prospect", "Lead", "Demo Scheduled", "No-Show/Reschedule",
+        "Prospect", "Approached", "Lead", "Demo Scheduled", "No-Show/Reschedule",
         "Demo Follow-Up", "Budgetary Quote Sent", "Payment Link Sent",
-        "Free Trial", "Freemium", "Subscription", "Closed Won",
+        "Free Trial", "Freemium", "Interested in a pilot", "Ping Later",
+        "On Hold", "Internal+Friends and Family", "Closed Won",
       ];
-      return order.indexOf(a.label) - order.indexOf(b.label);
+      const aIndex = order.indexOf(a.label);
+      const bIndex = order.indexOf(b.label);
+      if (aIndex === -1 && bIndex === -1) return a.label.localeCompare(b.label);
+      if (aIndex === -1) return 1;
+      if (bIndex === -1) return -1;
+      return aIndex - bIndex;
     });
   const maxStageCount = Math.max(...salesStages.map((s) => s.count), 1);
 
@@ -96,7 +102,6 @@ export function SalesHubspotTab({ data }: SalesHubspotTabProps) {
     { key: "updatedAt", label: "Last Updated", render: (row) => row.updatedAt ? new Date(row.updatedAt).toLocaleDateString() : "—" },
   ];
   const dealRows: DealRow[] = deals
-    .sort((a, b) => b.amount - a.amount)
     .slice(0, 25)
     .map((d) => ({
       dealName: d.dealName,
@@ -269,7 +274,7 @@ export function SalesHubspotTab({ data }: SalesHubspotTabProps) {
 
       {/* ── Deal Details ──────────────────────────── */}
       {dealRows.length > 0 && (
-        <SectionCard title="Deal Details" subtitle={`Deals touched in range (showing top ${dealRows.length} by value)`}>
+        <SectionCard title="Deal Details" subtitle={`Main-pipeline deals last updated in range (showing ${dealRows.length})`}>
           <DataTable columns={dealColumns} rows={dealRows} emptyMessage="No deals found" />
         </SectionCard>
       )}

--- a/src/components/analytics/sub-dashboards/hubspot-sales-dashboard.tsx
+++ b/src/components/analytics/sub-dashboards/hubspot-sales-dashboard.tsx
@@ -59,7 +59,7 @@ export function HubspotSalesDashboard({ data }: HubspotSalesDashboardProps) {
     );
   }
 
-  const { funnel, deals } = hubspot;
+  const { funnel } = hubspot;
 
   /* ── Funnel stages for HorizontalFunnel ─── */
   const funnelStages = funnel.stages.map((stage) => ({
@@ -77,7 +77,7 @@ export function HubspotSalesDashboard({ data }: HubspotSalesDashboardProps) {
   const totalSourceDeals = funnel.dealsBySource.reduce((sum, s) => sum + s.count, 0);
 
   /* ── Top deals ─── */
-  const topDeals = (deals ?? []).slice(0, 10);
+  const topDeals = (hubspot.displayDeals ?? hubspot.deals ?? []).slice(0, 10);
   const repRows = hubspot.repScoreboard ?? [];
 
   return (
@@ -159,7 +159,7 @@ export function HubspotSalesDashboard({ data }: HubspotSalesDashboardProps) {
             )}
           </DashboardSectionCard>
 
-          <DashboardSectionCard title="Top Deals">
+          <DashboardSectionCard title="Recent Deals">
             {topDeals.length === 0 ? (
               <p className="py-4 text-center text-xs text-muted-foreground">No deal data available</p>
             ) : (

--- a/src/lib/__tests__/analytics-fetchers-hubspot.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-hubspot.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchHubSpotData } from "@/lib/analytics/fetchers";
 
 function jsonResponse(payload: unknown, status = 200): Response {
@@ -8,106 +8,186 @@ function jsonResponse(payload: unknown, status = 200): Response {
   });
 }
 
-describe("analytics hubspot fetcher", () => {
-  it("uses limit=50 when requesting propertiesWithHistory", async () => {
-    const fetchMock = vi.fn();
+function createPipelineResponse() {
+  return {
+    results: [
+      {
+        id: "default",
+        label: " Deals pipeline",
+        stages: [
+          { id: "presentationscheduled", label: "Demo Scheduled", displayOrder: 0 },
+          { id: "1955958510", label: "No-Show/Reschedule Demo", displayOrder: 1 },
+          { id: "decisionmakerboughtin", label: "Demo Follow-Up", displayOrder: 2 },
+          { id: "contractsent", label: "Ping Later", displayOrder: 3 },
+          { id: "closedwon", label: "Closed Won", displayOrder: 4 },
+          { id: "closedlost", label: "Closed Lost", displayOrder: 5 },
+          { id: "1499784890", label: "Churn", displayOrder: 6 },
+          { id: "1499784891", label: "Unlikely", displayOrder: 7 },
+        ],
+      },
+      {
+        id: "1390107368",
+        label: "Zaybra Subscriptions",
+        stages: [{ id: "2239936224", label: "Subscriptions", displayOrder: 0 }],
+      },
+    ],
+  };
+}
 
-    fetchMock
-      // Active deals
-      .mockResolvedValueOnce(jsonResponse({ results: [] }))
-      // Archived deals
-      .mockResolvedValueOnce(jsonResponse({ results: [] }))
-      // Contacts endpoint (best-effort)
-      .mockResolvedValueOnce(jsonResponse({ total: 0 }));
+function createHubSpotFetchMock(input: {
+  activeDeals?: unknown[];
+  archivedDeals?: unknown[];
+  totalContacts?: number;
+  owners?: unknown[];
+}) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const parsed = new URL(url);
 
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    if (parsed.pathname === "/crm/v3/pipelines/deals") {
+      return jsonResponse(createPipelineResponse());
+    }
 
-    await fetchHubSpotData("hs-token");
+    if (parsed.pathname === "/crm/v3/objects/deals") {
+      const archived = parsed.searchParams.get("archived") === "true";
+      return jsonResponse({
+        results: archived ? input.archivedDeals ?? [] : input.activeDeals ?? [],
+      });
+    }
 
-    const firstUrl = String(fetchMock.mock.calls[0]?.[0] ?? "");
-    expect(firstUrl).toContain("propertiesWithHistory=dealstage");
-    expect(firstUrl).toContain("limit=50");
+    if (parsed.pathname === "/crm/v3/owners/") {
+      return jsonResponse({ results: input.owners ?? [] });
+    }
+
+    if (parsed.pathname === "/crm/v3/objects/contacts" && parsed.searchParams.get("limit") === "1") {
+      return jsonResponse({ total: input.totalContacts ?? 0 });
+    }
+
+    if (parsed.pathname === "/crm/v4/associations/deal/contact/batch/read") {
+      return jsonResponse({ results: [] });
+    }
+
+    if (parsed.pathname === "/crm/v3/objects/contacts/batch/read") {
+      return jsonResponse({ results: [] });
+    }
+
+    throw new Error(`Unexpected fetch: ${parsed.pathname} ${init?.method ?? "GET"}`);
   });
+}
 
-  it("paginates active+archived, dedupes by id, and emits diagnostics", async () => {
-    const fetchMock = vi.fn();
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
-    // Active page 1
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({
-        results: [
-          { id: "1", properties: { dealstage: "presentationscheduled", amount: "10", dealname: "A" } },
-          { id: "2", properties: { dealstage: "closedwon", amount: "20", dealname: "B" } },
-        ],
-        paging: { next: { after: "p2" } },
-      })
-    );
-    // Active page 2
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({
-        results: [{ id: "3", properties: { dealstage: "closedlost", amount: "5", dealname: "C" } }],
-      })
-    );
-
-    // Archived page 1 includes an overlap id=2 (should dedupe)
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({
-        results: [
-          { id: "2", properties: { dealstage: "closedwon", amount: "20", dealname: "B" } },
-          { id: "4", properties: { dealstage: "1499784891", amount: "7", dealname: "D" } },
-        ],
-      })
-    );
-
-    // Contacts endpoint (best-effort)
-    fetchMock.mockResolvedValueOnce(jsonResponse({ total: 999 }));
-
+describe("analytics hubspot fetcher", () => {
+  it("loads live pipeline metadata and still requests history pages with limit=50", async () => {
+    const fetchMock = createHubSpotFetchMock({});
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
     const data = await fetchHubSpotData("hs-token");
-    expect(data.funnel.totalDeals).toBe(4);
-    expect(data._meta.diagnostics?.archivedIncluded).toBe(true);
-    const pagesFetched = data._meta.diagnostics?.pagesFetched as Record<string, number> | undefined;
-    expect(pagesFetched?.active).toBe(2);
-    expect(pagesFetched?.archived).toBe(1);
-  });
 
-  it("computes activity-in-range metrics from stage history", async () => {
-    const fetchMock = vi.fn();
-
-    // Active deals: one deal with stage history entering demo + won in range.
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({
-        results: [
-          {
-            id: "10",
-            properties: {
-              dealstage: "closedwon",
-              amount: "100",
-              dealname: "Deal 10",
-              hubspot_owner_id: "o1",
-              hs_analytics_source: "Ads",
-            },
-            propertiesWithHistory: {
-              dealstage: [
-                { value: "presentationscheduled", timestamp: "2026-02-10T12:00:00.000Z" },
-                { value: "closedwon", timestamp: "2026-02-11T12:00:00.000Z" },
-              ],
-            },
-          },
-        ],
-      })
+    const dealsRequest = fetchMock.mock.calls.find(([url]) =>
+      String(url).includes("/crm/v3/objects/deals"),
     );
 
-    // Archived deals empty
-    fetchMock.mockResolvedValueOnce(jsonResponse({ results: [] }));
+    expect(String(dealsRequest?.[0] ?? "")).toContain("propertiesWithHistory=dealstage");
+    expect(String(dealsRequest?.[0] ?? "")).toContain("limit=50");
+    expect(data.pipelineStageLabelsSource).toBe("api");
+    expect(data.pipelineDetected).toEqual({ pipelineId: "default", dealCount: 0 });
+  });
 
-    // Owners endpoint can fail or return empty; not required for counts
-    fetchMock.mockResolvedValueOnce(jsonResponse({ results: [] }));
+  it("filters non-default pipelines and resolves contractsent to Ping Later from live metadata", async () => {
+    const fetchMock = createHubSpotFetchMock({
+      activeDeals: [
+        {
+          id: "deal-default",
+          properties: {
+            pipeline: "default",
+            dealstage: "contractsent",
+            amount: "20",
+            dealname: "Main Pipeline Deal",
+            hs_lastmodifieddate: "2026-03-04T12:00:00.000Z",
+            createdate: "2026-03-01T12:00:00.000Z",
+          },
+          propertiesWithHistory: {
+            dealstage: [{ value: "contractsent", timestamp: "2026-03-04T12:00:00.000Z" }],
+          },
+        },
+        {
+          id: "deal-subscription",
+          properties: {
+            pipeline: "1390107368",
+            dealstage: "2239936224",
+            amount: "99",
+            dealname: "Zaybra Subscription",
+            hs_lastmodifieddate: "2026-03-04T12:30:00.000Z",
+            createdate: "2026-03-01T12:30:00.000Z",
+          },
+          propertiesWithHistory: {
+            dealstage: [{ value: "2239936224", timestamp: "2026-03-04T12:30:00.000Z" }],
+          },
+        },
+      ],
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
-    // Contacts endpoint
-    fetchMock.mockResolvedValueOnce(jsonResponse({ total: 0 }));
+    const data = await fetchHubSpotData("hs-token");
 
+    expect(data.deals?.map((deal) => deal.dealId)).toEqual(["deal-default"]);
+    expect(data.deals?.[0]?.stageLabel).toBe("Ping Later");
+    expect(data.pipelineStages?.find((stage) => stage.stageId === "contractsent")?.label).toBe("Ping Later");
+    expect(data.funnel.activeSubscriptions).toBe(0);
+  });
+
+  it("keeps funnel metrics activity-based but builds display deals from last-modified recency", async () => {
+    const fetchMock = createHubSpotFetchMock({
+      activeDeals: [
+        {
+          id: "deal-history",
+          properties: {
+            pipeline: "default",
+            dealstage: "closedwon",
+            amount: "100",
+            dealname: "History Deal",
+            hs_lastmodifieddate: "2026-01-15T12:00:00.000Z",
+            createdate: "2026-01-01T12:00:00.000Z",
+          },
+          propertiesWithHistory: {
+            dealstage: [
+              { value: "presentationscheduled", timestamp: "2026-02-10T12:00:00.000Z" },
+              { value: "closedwon", timestamp: "2026-02-11T12:00:00.000Z" },
+            ],
+          },
+        },
+        {
+          id: "deal-recent-b",
+          properties: {
+            pipeline: "default",
+            dealstage: "presentationscheduled",
+            amount: "50",
+            dealname: "Recent Deal B",
+            hs_lastmodifieddate: "2026-02-15T12:00:00.000Z",
+            createdate: "2026-02-01T12:00:00.000Z",
+          },
+          propertiesWithHistory: {
+            dealstage: [{ value: "presentationscheduled", timestamp: "2026-01-15T12:00:00.000Z" }],
+          },
+        },
+        {
+          id: "deal-recent-c",
+          properties: {
+            pipeline: "default",
+            dealstage: "closedlost",
+            amount: "75",
+            dealname: "Recent Deal C",
+            hs_lastmodifieddate: "2026-02-20T12:00:00.000Z",
+            createdate: "2026-02-05T12:00:00.000Z",
+          },
+          propertiesWithHistory: {
+            dealstage: [{ value: "closedlost", timestamp: "2026-01-20T12:00:00.000Z" }],
+          },
+        },
+      ],
+    });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
     const fromDate = new Date("2026-02-01T00:00:00.000Z");
@@ -118,8 +198,14 @@ describe("analytics hubspot fetcher", () => {
     expect(data.funnel.totalDeals).toBe(1);
     expect(data.funnel.demoScheduled).toBe(1);
     expect(data.funnel.closedWon).toBe(1);
-    expect(data.funnel.winRate).toBe(100);
-    expect(data.repScoreboard?.[0]?.ownerName).toBeTruthy();
-    expect(data.repScoreboard?.[0]?.wonCount).toBe(1);
+    expect(data.deals?.map((deal) => deal.dealId)).toEqual([
+      "deal-recent-c",
+      "deal-recent-b",
+      "deal-history",
+    ]);
+    expect(data.displayDeals?.map((deal) => deal.dealId)).toEqual([
+      "deal-recent-c",
+      "deal-recent-b",
+    ]);
   });
 });

--- a/src/lib/__tests__/hubspot-cleanup.test.ts
+++ b/src/lib/__tests__/hubspot-cleanup.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import mergeDealsModule from "../../../merge_deals.js";
+
+const {
+  MAIN_PIPELINE_ID,
+  SUBSCRIPTION_PIPELINE_ID,
+  buildCleanupPlan,
+} = mergeDealsModule;
+
+describe("HubSpot cleanup planner", () => {
+  it("builds the confirmed customer merges and only auto-merges subscription deals on customer match", () => {
+    const plan = buildCleanupPlan({
+      deals: [
+        {
+          id: "79658864346",
+          name: "Egg Collective - Sales",
+          stageId: "closedwon",
+          pipelineId: MAIN_PIPELINE_ID,
+          createdAt: "2025-05-09T19:27:53.295Z",
+          updatedAt: "2026-03-04T15:59:33.802Z",
+          companyIds: ["135151484655"],
+          contactIds: ["egg-main"],
+        },
+        {
+          id: "138720011979",
+          name: "Egg Collective",
+          stageId: "closedlost",
+          pipelineId: MAIN_PIPELINE_ID,
+          createdAt: "2025-08-09T18:35:07.264Z",
+          updatedAt: "2026-03-04T15:59:33.801Z",
+          companyIds: ["135151484655"],
+          contactIds: ["egg-dup"],
+        },
+        {
+          id: "79676947156",
+          name: "Lichen Precision - Sales",
+          stageId: "closedwon",
+          pipelineId: MAIN_PIPELINE_ID,
+          createdAt: "2025-05-09T19:21:16.160Z",
+          updatedAt: "2026-02-24T10:31:45.083Z",
+          companyIds: ["79299898053"],
+          contactIds: ["lichen-main"],
+        },
+        {
+          id: "139322884826",
+          name: "Lichen Precision",
+          stageId: "closedlost",
+          pipelineId: MAIN_PIPELINE_ID,
+          createdAt: "2025-08-09T18:35:06.462Z",
+          updatedAt: "2026-02-19T19:46:33.423Z",
+          companyIds: ["79299898053"],
+          contactIds: ["lichen-main"],
+        },
+        {
+          id: "79675150072",
+          name: "Super Pacific - Sales",
+          stageId: "closedwon",
+          pipelineId: MAIN_PIPELINE_ID,
+          createdAt: "2025-05-09T19:21:48.243Z",
+          updatedAt: "2026-02-27T18:01:33.650Z",
+          companyIds: ["76096495311"],
+          contactIds: ["super-main"],
+        },
+        {
+          id: "139080299207",
+          name: "Super Pacific",
+          stageId: "closedlost",
+          pipelineId: MAIN_PIPELINE_ID,
+          createdAt: "2025-08-09T18:35:07.065Z",
+          updatedAt: "2026-02-27T18:01:35.108Z",
+          companyIds: ["76096495311"],
+          contactIds: ["super-secondary-a"],
+        },
+        {
+          id: "304667726544",
+          name: "Super Pacific",
+          stageId: "closedlost",
+          pipelineId: MAIN_PIPELINE_ID,
+          createdAt: "2025-08-09T18:35:06.375Z",
+          updatedAt: "2026-02-24T05:25:52.197Z",
+          companyIds: ["75923518183"],
+          contactIds: ["super-secondary-b"],
+        },
+        {
+          id: "main-domain",
+          name: "Oakley Fire - Sales",
+          stageId: "closedwon",
+          pipelineId: MAIN_PIPELINE_ID,
+          createdAt: "2025-10-01T10:00:00.000Z",
+          updatedAt: "2026-03-01T10:00:00.000Z",
+          companyIds: ["company-domain-main"],
+          contactIds: ["contact-domain-main"],
+        },
+        {
+          id: "main-email",
+          name: "Email Match - Sales",
+          stageId: "presentationscheduled",
+          pipelineId: MAIN_PIPELINE_ID,
+          createdAt: "2025-10-02T10:00:00.000Z",
+          updatedAt: "2026-03-02T10:00:00.000Z",
+          companyIds: ["company-email-main"],
+          contactIds: ["contact-email-main"],
+        },
+        {
+          id: "main-name",
+          name: "Same Name Co - Sales",
+          stageId: "closedlost",
+          pipelineId: MAIN_PIPELINE_ID,
+          createdAt: "2025-10-03T10:00:00.000Z",
+          updatedAt: "2026-03-03T10:00:00.000Z",
+          companyIds: ["company-name-main"],
+          contactIds: ["contact-name-main"],
+        },
+        {
+          id: "sub-domain",
+          name: "Zaybra Subscription",
+          stageId: "2239936224",
+          pipelineId: SUBSCRIPTION_PIPELINE_ID,
+          createdAt: "2026-02-01T10:00:00.000Z",
+          updatedAt: "2026-03-04T10:00:00.000Z",
+          companyIds: ["company-domain-sub"],
+          contactIds: ["contact-domain-sub"],
+        },
+        {
+          id: "sub-email",
+          name: "Zaybra Subscription",
+          stageId: "2239936224",
+          pipelineId: SUBSCRIPTION_PIPELINE_ID,
+          createdAt: "2026-02-02T10:00:00.000Z",
+          updatedAt: "2026-03-04T11:00:00.000Z",
+          companyIds: ["company-email-sub"],
+          contactIds: ["contact-email-main"],
+        },
+        {
+          id: "sub-name",
+          name: "Zaybra Subscription",
+          stageId: "2239936224",
+          pipelineId: SUBSCRIPTION_PIPELINE_ID,
+          createdAt: "2026-02-03T10:00:00.000Z",
+          updatedAt: "2026-03-04T12:00:00.000Z",
+          companyIds: ["company-name-sub"],
+          contactIds: ["contact-name-sub"],
+        },
+        {
+          id: "sub-unmatched",
+          name: "Zaybra Subscription",
+          stageId: "2239936224",
+          pipelineId: SUBSCRIPTION_PIPELINE_ID,
+          createdAt: "2026-02-04T10:00:00.000Z",
+          updatedAt: "2026-03-04T13:00:00.000Z",
+          companyIds: ["company-unmatched"],
+          contactIds: ["contact-unmatched"],
+        },
+      ],
+      companies: [
+        { id: "135151484655", name: "Egg Collective", domain: "eggcollective.com", createdAt: null, updatedAt: null },
+        { id: "79299898053", name: "Lichen Precision", domain: "lichenprecision.com", createdAt: null, updatedAt: null },
+        { id: "76096495311", name: "Super Pacific USA", domain: "superpacificusa.com", createdAt: null, updatedAt: null },
+        { id: "75923518183", name: "Super Pacific USA", domain: "superpacificusa.com", createdAt: null, updatedAt: null },
+        { id: "company-domain-main", name: "Oakley Fire", domain: "oakleyfire.com", createdAt: null, updatedAt: null },
+        { id: "company-domain-sub", name: "Oakley Fire", domain: "oakleyfire.com", createdAt: null, updatedAt: null },
+        { id: "company-email-main", name: "Email Match Company", domain: null, createdAt: null, updatedAt: null },
+        { id: "company-email-sub", name: "Email Match Company Duplicate", domain: null, createdAt: null, updatedAt: null },
+        { id: "company-name-main", name: "Same Name Co", domain: null, createdAt: null, updatedAt: null },
+        { id: "company-name-sub", name: "Same Name Co", domain: null, createdAt: null, updatedAt: null },
+        { id: "company-unmatched", name: "Completely Different Co", domain: "different.example", createdAt: null, updatedAt: null },
+      ],
+      contacts: [
+        { id: "egg-main", email: "hello@eggcollective.com" },
+        { id: "egg-dup", email: "sales@eggcollective.com" },
+        { id: "lichen-main", email: "hello@lichenprecision.com" },
+        { id: "super-main", email: "jessica@superpacificusa.com" },
+        { id: "super-secondary-a", email: "alt@superpacificusa.com" },
+        { id: "super-secondary-b", email: "ops@superpacificusa.com" },
+        { id: "contact-domain-main", email: "jacob@oakleyfire.com" },
+        { id: "contact-domain-sub", email: "jacob@oakleyfire.com" },
+        { id: "contact-email-main", email: "owner@email-match.example" },
+        { id: "contact-name-main", email: "owner@same-name.example" },
+        { id: "contact-name-sub", email: "other@same-name.example" },
+        { id: "contact-unmatched", email: "nobody@different.example" },
+      ],
+    });
+
+    expect(plan.dealMerges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ primaryObjectId: "79658864346", objectIdToMerge: "138720011979", matchType: "manual" }),
+        expect.objectContaining({ primaryObjectId: "79676947156", objectIdToMerge: "139322884826", matchType: "manual" }),
+        expect.objectContaining({ primaryObjectId: "79675150072", objectIdToMerge: "139080299207", matchType: "manual" }),
+        expect.objectContaining({ primaryObjectId: "79675150072", objectIdToMerge: "304667726544", matchType: "manual" }),
+        expect.objectContaining({ primaryObjectId: "main-domain", objectIdToMerge: "sub-domain", matchType: "company_domain" }),
+        expect.objectContaining({ primaryObjectId: "main-email", objectIdToMerge: "sub-email", matchType: "contact_email" }),
+        expect.objectContaining({ primaryObjectId: "main-name", objectIdToMerge: "sub-name", matchType: "company_name" }),
+      ]),
+    );
+
+    expect(plan.companyMerges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ primaryObjectId: "76096495311", objectIdToMerge: "75923518183", matchType: "manual" }),
+        expect.objectContaining({ primaryObjectId: "company-domain-main", objectIdToMerge: "company-domain-sub", matchType: "company_domain" }),
+        expect.objectContaining({ primaryObjectId: "company-email-main", objectIdToMerge: "company-email-sub", matchType: "contact_email" }),
+        expect.objectContaining({ primaryObjectId: "company-name-main", objectIdToMerge: "company-name-sub", matchType: "company_name" }),
+      ]),
+    );
+
+    expect(plan.review).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          dealId: "sub-unmatched",
+          dealName: "Zaybra Subscription",
+        }),
+      ]),
+    );
+  });
+});

--- a/src/lib/__tests__/hubspot-deals-sync.test.ts
+++ b/src/lib/__tests__/hubspot-deals-sync.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DealStage, IntegrationConnectionStatus, IntegrationProvider } from "@/generated/prisma/client";
+import { prisma } from "@/lib/prisma";
+import { mapHubSpotStageToDealStage, syncDealsFromHubSpot } from "@/lib/deals/hubspot-sync";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    integrationConnection: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    dealCompany: {
+      upsert: vi.fn(),
+    },
+    dealContact: {
+      upsert: vi.fn(),
+    },
+    user: {
+      findMany: vi.fn(),
+    },
+    deal: {
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+    },
+    dealStageHistory: {
+      create: vi.fn(),
+    },
+    dealMeeting: {
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/integrations/token-crypto", () => ({
+  protectIntegrationSecret: vi.fn((value: string) => value),
+  unprotectIntegrationSecret: vi.fn((value: string) =>
+    typeof value === "string" && value.startsWith("plainv1.") ? value.slice("plainv1.".length) : value,
+  ),
+}));
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("HubSpot local deal sync", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    vi.mocked(prisma.integrationConnection.findUnique).mockResolvedValue({
+      id: "conn-1",
+      userId: "user-1",
+      provider: IntegrationProvider.HUBSPOT,
+      status: IntegrationConnectionStatus.CONNECTED,
+      providerAccountId: "hubspot-account",
+      accountLabel: "HubSpot",
+      scopes: [],
+      accessToken: "plainv1.hs-token",
+      refreshToken: "plainv1.refresh-token",
+      tokenType: "bearer",
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      connectedAt: new Date(),
+      lastSyncedAt: null,
+      lastError: null,
+      metadata: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as never);
+
+    vi.mocked(prisma.user.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.deal.findUnique).mockResolvedValue(null as never);
+    vi.mocked(prisma.deal.upsert).mockImplementation(async (args: {
+      where: { hubspotDealId: string };
+      create: { stage: DealStage };
+    }) => ({
+      id: `local-${args.where.hubspotDealId}`,
+      stage: args.create.stage,
+    }) as never);
+    vi.mocked(prisma.dealStageHistory.create).mockResolvedValue({} as never);
+    vi.mocked(prisma.dealCompany.upsert).mockResolvedValue({ id: "company-1" } as never);
+    vi.mocked(prisma.dealContact.upsert).mockResolvedValue({ id: "contact-1" } as never);
+    vi.mocked(prisma.dealMeeting.upsert).mockResolvedValue({ id: "meeting-1" } as never);
+  });
+
+  it("maps the current main-pipeline stages to internal deal stages", () => {
+    expect(mapHubSpotStageToDealStage("1499838171")).toBe(DealStage.LEAD);
+    expect(mapHubSpotStageToDealStage("1955958510")).toBe(DealStage.QUALIFIED);
+    expect(mapHubSpotStageToDealStage("1955580622")).toBe(DealStage.PROPOSAL);
+    expect(mapHubSpotStageToDealStage("contractsent")).toBe(DealStage.NEGOTIATION);
+    expect(mapHubSpotStageToDealStage("1499784890")).toBe(DealStage.CLOSED_LOST);
+  });
+
+  it("skips non-default pipelines during local deal sync", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      const parsed = new URL(url);
+
+      if (parsed.pathname === "/crm/v3/objects/deals") {
+        return jsonResponse({
+          results: [
+            {
+              id: "deal-proposal",
+              properties: {
+                dealname: "Proposal Deal",
+                dealstage: "1955580622",
+                pipeline: "default",
+                amount: "1000",
+                createdate: "2026-03-01T12:00:00.000Z",
+                hs_lastmodifieddate: "2026-03-03T12:00:00.000Z",
+              },
+            },
+            {
+              id: "deal-qualified",
+              properties: {
+                dealname: "Qualified Deal",
+                dealstage: "1955958510",
+                pipeline: "default",
+                amount: "2000",
+                createdate: "2026-03-01T12:30:00.000Z",
+                hs_lastmodifieddate: "2026-03-03T12:30:00.000Z",
+              },
+            },
+            {
+              id: "deal-ping-later",
+              properties: {
+                dealname: "Ping Later Deal",
+                dealstage: "contractsent",
+                pipeline: "default",
+                amount: "3000",
+                createdate: "2026-03-01T13:00:00.000Z",
+                hs_lastmodifieddate: "2026-03-03T13:00:00.000Z",
+              },
+            },
+            {
+              id: "deal-subscription",
+              properties: {
+                dealname: "Zaybra Subscription",
+                dealstage: "2239936224",
+                pipeline: "1390107368",
+                amount: "99",
+                createdate: "2026-03-01T13:30:00.000Z",
+                hs_lastmodifieddate: "2026-03-03T13:30:00.000Z",
+              },
+            },
+          ],
+        });
+      }
+
+      if (
+        parsed.pathname === "/crm/v3/objects/contacts" ||
+        parsed.pathname === "/crm/v3/objects/companies" ||
+        parsed.pathname === "/crm/v3/objects/meetings"
+      ) {
+        return jsonResponse({ results: [] });
+      }
+
+      if (parsed.pathname === "/crm/v3/owners") {
+        return jsonResponse({ results: [] });
+      }
+
+      if (parsed.pathname.includes("/associations/")) {
+        return jsonResponse({ results: [] });
+      }
+
+      throw new Error(`Unexpected fetch: ${parsed.pathname}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const result = await syncDealsFromHubSpot("user-1");
+
+    expect(result.deals).toBe(3);
+    expect(vi.mocked(prisma.deal.upsert).mock.calls).toHaveLength(3);
+    expect(
+      vi.mocked(prisma.deal.upsert).mock.calls.map((call) => call[0].create.stage),
+    ).toEqual([
+      DealStage.PROPOSAL,
+      DealStage.QUALIFIED,
+      DealStage.NEGOTIATION,
+    ]);
+
+    const calls = fetchMock.mock.calls.map(([url]) => String(url));
+    expect(calls.some((url) => url.includes("/crm/v3/objects/deals/deal-subscription/associations/"))).toBe(false);
+    expect(calls.some((url) => url.includes("properties=dealname%2Cdealstage%2Camount%2Cclosedate%2Ccreatedate%2Chs_analytics_source%2Chubspot_owner_id%2Chs_lastmodifieddate%2Cpipeline"))).toBe(true);
+  });
+});

--- a/src/lib/analytics/fetchers.ts
+++ b/src/lib/analytics/fetchers.ts
@@ -30,23 +30,82 @@ function makeMeta(source: "live" | "cached" = "live"): AnalyticsTimestamp {
 // HUBSPOT FETCHER
 // ═══════════════════════════════════════════════════════════
 
-const HUBSPOT_STAGE_MAP: Record<string, string> = {
-  appointmentscheduled: "Prospect",
-  qualifiedtobuy: "Lead",
-  presentationscheduled: "Demo Scheduled",
-  "1955958510": "No-Show/Reschedule",
-  decisionmakerboughtin: "Demo Follow-Up",
-  "176498593": "Budgetary Quote Sent",
-  "176498594": "Payment Link Sent",
-  "1524801846": "Free Trial",
-  "1499784891": "Closed Lost",
-  "1722537990": "Freemium",
-  contractsent: "Subscription",
-  closedwon: "Closed Won",
-  closedlost: "Closed Lost",
-  "1499784892": "Ping Later",
-  "1574807548": "Churn",
-  "1916862197": "On Hold",
+const HUBSPOT_MAIN_PIPELINE_ID = "default";
+const HUBSPOT_SUBSCRIPTION_PIPELINE_ID = "1390107368";
+
+const HUBSPOT_MAIN_PIPELINE_FALLBACK_STAGES = [
+  { id: "appointmentscheduled", label: "Prospect", displayOrder: 0 },
+  { id: "1499838171", label: "Approached", displayOrder: 1 },
+  { id: "qualifiedtobuy", label: "Lead", displayOrder: 2 },
+  { id: "presentationscheduled", label: "Demo Scheduled", displayOrder: 3 },
+  { id: "1955958510", label: "No-Show/Reschedule", displayOrder: 4 },
+  { id: "decisionmakerboughtin", label: "Demo Follow-Up", displayOrder: 5 },
+  { id: "1955580622", label: "Budgetary Quote Sent", displayOrder: 6 },
+  { id: "1559099077", label: "Payment Link Sent", displayOrder: 7 },
+  { id: "1499827945", label: "Free Trial", displayOrder: 8 },
+  { id: "1731122907", label: "Freemium", displayOrder: 9 },
+  { id: "closedwon", label: "Closed Won", displayOrder: 10 },
+  { id: "contractsent", label: "Ping Later", displayOrder: 11 },
+  { id: "closedlost", label: "Closed Lost", displayOrder: 12 },
+  { id: "1499784890", label: "Churn", displayOrder: 13 },
+  { id: "1499784891", label: "Unlikely", displayOrder: 14 },
+  { id: "1499827944", label: "On Hold", displayOrder: 15 },
+  { id: "1718686448", label: "Internal+Friends and Family", displayOrder: 16 },
+  { id: "2025131723", label: "Interested in a pilot", displayOrder: 17 },
+] as const;
+
+const HUBSPOT_STAGE_LABEL_CANONICALIZATION: Record<string, string> = {
+  "prospect": "Prospect",
+  "approached": "Approached",
+  "lead": "Lead",
+  "demo scheduled": "Demo Scheduled",
+  "no-show/reschedule demo": "No-Show/Reschedule",
+  "no-show/reschedule": "No-Show/Reschedule",
+  "demo follow-up": "Demo Follow-Up",
+  "budgetary quote sent": "Budgetary Quote Sent",
+  "payment link sent": "Payment Link Sent",
+  "free trial": "Free Trial",
+  "freemium": "Freemium",
+  "closed won": "Closed Won",
+  "ping later": "Ping Later",
+  "closed lost": "Closed Lost",
+  "churn": "Churn",
+  "unlikely": "Unlikely",
+  "on hold": "On Hold",
+  "internal+friends and family": "Internal+Friends and Family",
+  "interested in a pilot": "Interested in a pilot",
+};
+
+const HUBSPOT_STAGE_FALLBACK_LABEL_BY_ID = Object.fromEntries(
+  HUBSPOT_MAIN_PIPELINE_FALLBACK_STAGES.map((stage) => [stage.id, stage.label]),
+) as Record<string, string>;
+
+type HubSpotPipelineStage = {
+  id: string;
+  label: string;
+  archived: boolean;
+  displayOrder: number;
+};
+
+type HubSpotPipeline = {
+  id: string;
+  label: string;
+  archived: boolean;
+  stages: HubSpotPipelineStage[];
+};
+
+type HubSpotPipelinesResponse = {
+  results?: Array<{
+    id?: string;
+    label?: string;
+    archived?: boolean;
+    stages?: Array<{
+      id?: string;
+      label?: string;
+      archived?: boolean;
+      displayOrder?: number;
+    }>;
+  }>;
 };
 
 type HubSpotDealObject = {
@@ -72,6 +131,81 @@ type HubSpotStageEvent = {
   source: string;
   dealName: string;
 };
+
+function normalizeHubSpotStageLabel(label: string): string {
+  const trimmed = label.trim();
+  if (!trimmed) return trimmed;
+  const canonical = HUBSPOT_STAGE_LABEL_CANONICALIZATION[trimmed.toLowerCase()];
+  return canonical ?? trimmed;
+}
+
+function buildFallbackPipelines(): HubSpotPipeline[] {
+  return [
+    {
+      id: HUBSPOT_MAIN_PIPELINE_ID,
+      label: "Deals pipeline",
+      archived: false,
+      stages: HUBSPOT_MAIN_PIPELINE_FALLBACK_STAGES.map((stage) => ({
+        id: stage.id,
+        label: stage.label,
+        archived: false,
+        displayOrder: stage.displayOrder,
+      })),
+    },
+  ];
+}
+
+function isMainHubSpotPipeline(pipelineId: string | null | undefined): boolean {
+  const normalized = pipelineId?.trim();
+  return !normalized || normalized === HUBSPOT_MAIN_PIPELINE_ID;
+}
+
+function compareHubSpotDealsByRecency(
+  a: { dealId: string; updatedAt: string | null; createdAt: string | null },
+  b: { dealId: string; updatedAt: string | null; createdAt: string | null },
+): number {
+  const updatedDiff = (Date.parse(b.updatedAt || "") || 0) - (Date.parse(a.updatedAt || "") || 0);
+  if (updatedDiff !== 0) return updatedDiff;
+  const createdDiff = (Date.parse(b.createdAt || "") || 0) - (Date.parse(a.createdAt || "") || 0);
+  if (createdDiff !== 0) return createdDiff;
+  return a.dealId.localeCompare(b.dealId);
+}
+
+function resolveHubSpotStageLabel(stageId: string, stageLabelById: Map<string, string>): string {
+  return stageLabelById.get(stageId) ?? HUBSPOT_STAGE_FALLBACK_LABEL_BY_ID[stageId] ?? normalizeHubSpotStageLabel(stageId);
+}
+
+function buildOrderedHubSpotStages(
+  stageAgg: Record<string, { count: number; value: number }>,
+  pipeline: HubSpotPipeline | null,
+): DealStage[] {
+  const ordered: DealStage[] = [];
+  const seen = new Set<string>();
+
+  for (const stage of pipeline?.stages ?? []) {
+    const entry = stageAgg[stage.id];
+    if (!entry) continue;
+    ordered.push({
+      stageId: stage.id,
+      label: stage.label,
+      count: entry.count,
+      value: entry.value,
+    });
+    seen.add(stage.id);
+  }
+
+  for (const [stageId, entry] of Object.entries(stageAgg)) {
+    if (seen.has(stageId)) continue;
+    ordered.push({
+      stageId,
+      label: HUBSPOT_STAGE_FALLBACK_LABEL_BY_ID[stageId] ?? normalizeHubSpotStageLabel(stageId),
+      count: entry.count,
+      value: entry.value,
+    });
+  }
+
+  return ordered;
+}
 
 async function fetchAllHubSpotDeals(input: {
   baseUrl: string;
@@ -119,6 +253,62 @@ async function fetchAllHubSpotDeals(input: {
   }
 
   return { deals, pagesFetched, lastAfter: after ?? null };
+}
+
+async function fetchHubSpotDealPipelines(input: {
+  baseUrl: string;
+  headers: Record<string, string>;
+}): Promise<{ pipelines: HubSpotPipeline[]; source: "api" | "fallback" }> {
+  const fallback = buildFallbackPipelines();
+
+  try {
+    const res = await fetch(`${input.baseUrl}/crm/v3/pipelines/deals`, {
+      headers: input.headers,
+      cache: "no-store",
+    });
+    if (!res.ok) {
+      return { pipelines: fallback, source: "fallback" };
+    }
+
+    const data = (await res.json().catch(() => null)) as HubSpotPipelinesResponse | null;
+    const pipelines = (data?.results ?? [])
+      .map((pipeline) => {
+        const id = String(pipeline.id ?? "").trim();
+        if (!id) return null;
+
+        const stages = (pipeline.stages ?? [])
+          .map((stage, index) => {
+            const stageId = String(stage.id ?? "").trim();
+            if (!stageId) return null;
+            return {
+              id: stageId,
+              label: normalizeHubSpotStageLabel(String(stage.label ?? stageId)),
+              archived: Boolean(stage.archived),
+              displayOrder: typeof stage.displayOrder === "number" ? stage.displayOrder : index,
+            } satisfies HubSpotPipelineStage;
+          })
+          .filter(Boolean) as HubSpotPipelineStage[];
+
+        stages.sort((a, b) => a.displayOrder - b.displayOrder);
+
+        return {
+          id,
+          label: String(pipeline.label ?? id).trim() || id,
+          archived: Boolean(pipeline.archived),
+          stages,
+        } satisfies HubSpotPipeline;
+      })
+      .filter(Boolean) as HubSpotPipeline[];
+
+    const hasMainPipeline = pipelines.some((pipeline) => pipeline.id === HUBSPOT_MAIN_PIPELINE_ID);
+    if (!hasMainPipeline) {
+      return { pipelines: fallback, source: "fallback" };
+    }
+
+    return { pipelines, source: "api" };
+  } catch {
+    return { pipelines: fallback, source: "fallback" };
+  }
 }
 
 function parseHubSpotTimestamp(value: string | number | undefined): number | null {
@@ -264,7 +454,8 @@ export async function fetchHubSpotData(
     "dealstage,amount,dealname,closedate,createdate,hs_analytics_source,num_associated_contacts,hubspot_owner_id,hs_lastmodifieddate,stripe_customer_id,stripe_customer,pipeline";
   const historyKey = "dealstage";
 
-  const [activeDealsResult, archivedDealsResult] = await Promise.all([
+  const [pipelineResult, activeDealsResult, archivedDealsResult] = await Promise.all([
+    fetchHubSpotDealPipelines({ baseUrl, headers }),
     fetchAllHubSpotDeals({
       baseUrl,
       headers,
@@ -283,6 +474,11 @@ export async function fetchHubSpotData(
     }),
   ]);
 
+  const mainPipeline = pipelineResult.pipelines.find((pipeline) => pipeline.id === HUBSPOT_MAIN_PIPELINE_ID) ?? null;
+  const stageLabelById = new Map(
+    (mainPipeline?.stages ?? []).map((stage) => [stage.id, stage.label]),
+  );
+
   const allDealsById = new Map<string, HubSpotDealObject>();
   for (const deal of [...activeDealsResult.deals, ...archivedDealsResult.deals]) {
     const id = String(deal.id ?? "").trim();
@@ -290,19 +486,23 @@ export async function fetchHubSpotData(
     allDealsById.set(id, deal);
   }
   const allDeals = [...allDealsById.values()];
-  const dealsFetched = allDeals.length;
+  const allMainPipelineDeals = allDeals.filter((deal) =>
+    isMainHubSpotPipeline(deal.properties?.pipeline ?? null),
+  );
+  const activeDeals = activeDealsResult.deals.filter((deal) =>
+    isMainHubSpotPipeline(deal.properties?.pipeline ?? null),
+  );
+  const dealsFetched = allMainPipelineDeals.length;
 
   // Aggregate by stage
   const stageAgg: Record<string, { count: number; value: number }> = {};
   const sourceAgg: Record<string, { count: number; value: number; closedWon: number; followUpNeeded: number; churned: number }> = {};
-  const repAgg: Record<string, { count: number; value: number; closedWon: number; closedWonValue: number }> = {};
 
   let notActivatedCount = 0;
 
-  const activeDeals = activeDealsResult.deals;
   const shouldLoadOwners =
     useActivityInRange ||
-    allDeals.some((deal) => Boolean(deal.properties?.hubspot_owner_id));
+    allMainPipelineDeals.some((deal) => Boolean(deal.properties?.hubspot_owner_id));
 
   const ownerNameById = new Map<string, string>();
   let ownerLookupDiagnostics: { ownersFetched: number; source: string } | null = null;
@@ -325,11 +525,9 @@ export async function fetchHubSpotData(
     const props = deal.properties || {};
 
     const stage = props.dealstage || "unknown";
-    const mappedLabel = HUBSPOT_STAGE_MAP[stage] || stage;
+    const mappedLabel = resolveHubSpotStageLabel(stage, stageLabelById);
     const amount = parseFloat(props.amount) || 0;
     const source = props.hs_analytics_source || "Unknown";
-    const ownerId = props.hubspot_owner_id;
-    const repName = resolveOwnerName(ownerId);
 
     if (!stageAgg[stage]) stageAgg[stage] = { count: 0, value: 0 };
     stageAgg[stage].count++;
@@ -355,24 +553,9 @@ export async function fetchHubSpotData(
         notActivatedCount++;
       }
     }
-
-    if (!repAgg[repName]) repAgg[repName] = { count: 0, value: 0, closedWon: 0, closedWonValue: 0 };
-    repAgg[repName].count++;
-    repAgg[repName].value += amount;
-    if (stage === "closedwon") {
-      repAgg[repName].closedWon++;
-      repAgg[repName].closedWonValue += amount;
-    }
   }
 
-  const stages: DealStage[] = Object.entries(stageAgg).map(([id, data]) => ({
-    stageId: id,
-    label: HUBSPOT_STAGE_MAP[id] || id,
-    count: data.count,
-    value: data.value,
-  }));
-
-  const deals = activeDeals.map((deal) => {
+  const deals = allMainPipelineDeals.map((deal) => {
     const props = deal.properties || {};
     const stageId = props.dealstage || "unknown";
     const ownerId = props.hubspot_owner_id || null;
@@ -380,7 +563,7 @@ export async function fetchHubSpotData(
       dealId: String((deal as { id?: string }).id ?? ""),
       dealName: props.dealname || "Untitled deal",
       stageId,
-      stageLabel: HUBSPOT_STAGE_MAP[stageId] || stageId,
+      stageLabel: resolveHubSpotStageLabel(stageId, stageLabelById),
       amount: parseFloat(props.amount) || 0,
       source: props.hs_analytics_source || "Unknown",
       ownerId,
@@ -399,13 +582,12 @@ export async function fetchHubSpotData(
   const STAGE_CLOSED_WON = "closedwon";
   const STAGE_CLOSED_LOST = "closedlost";
   const STAGE_UNLIKELY = "1499784891";
-  const STAGE_CHURN = "1574807548";
-  const STAGE_SUBSCRIPTION = "contractsent";
+  const STAGE_CHURN = "1499784890";
   const STAGE_NO_SHOW = "1955958510";
   const STAGE_DEMO_SCHEDULED = "presentationscheduled";
   const STAGE_DEMO_FOLLOW_UP = "decisionmakerboughtin";
 
-  let funnelStages = stages;
+  let funnelStages = buildOrderedHubSpotStages(stageAgg, mainPipeline);
   let dealsBySource = Object.entries(sourceAgg).map(([source, data]) => ({
     source,
     count: data.count,
@@ -416,7 +598,7 @@ export async function fetchHubSpotData(
   let closedLost = stageAgg[STAGE_CLOSED_LOST]?.count || 0;
   let unlikely = stageAgg[STAGE_UNLIKELY]?.count || 0;
   let churn = stageAgg[STAGE_CHURN]?.count || 0;
-  let subscriptions = stageAgg[STAGE_SUBSCRIPTION]?.count || 0;
+  let subscriptions = 0;
   let noShows = stageAgg[STAGE_NO_SHOW]?.count || 0;
   let demoScheduled = stageAgg[STAGE_DEMO_SCHEDULED]?.count || 0;
   let demoFollowUp = stageAgg[STAGE_DEMO_FOLLOW_UP]?.count || 0;
@@ -432,7 +614,7 @@ export async function fetchHubSpotData(
     const eventsInRange: HubSpotStageEvent[] = [];
     const hadWonBeforeChurnInRange = new Set<string>();
 
-    for (const deal of allDeals) {
+    for (const deal of allMainPipelineDeals) {
       const events = extractHubSpotStageEvents(deal);
       if (events.length === 0) continue;
 
@@ -467,18 +649,13 @@ export async function fetchHubSpotData(
     closedLost = stageEntryAgg[STAGE_CLOSED_LOST]?.count || 0;
     unlikely = stageEntryAgg[STAGE_UNLIKELY]?.count || 0;
     churn = stageEntryAgg[STAGE_CHURN]?.count || 0;
-    subscriptions = stageEntryAgg[STAGE_SUBSCRIPTION]?.count || 0;
+    subscriptions = 0;
     noShows = stageEntryAgg[STAGE_NO_SHOW]?.count || 0;
     demoScheduled = stageEntryAgg[STAGE_DEMO_SCHEDULED]?.count || 0;
     demoFollowUp = stageEntryAgg[STAGE_DEMO_FOLLOW_UP]?.count || 0;
     wonValue = stageEntryAgg[STAGE_CLOSED_WON]?.value || 0;
 
-    funnelStages = Object.entries(stageEntryAgg).map(([id, data]) => ({
-      stageId: id,
-      label: HUBSPOT_STAGE_MAP[id] || id,
-      count: data.count,
-      value: data.value,
-    }));
+    funnelStages = buildOrderedHubSpotStages(stageEntryAgg, mainPipeline);
 
     const sourceAggTouched: Record<string, { count: number; value: number }> = {};
     for (const touched of touchedDeals.values()) {
@@ -590,12 +767,20 @@ export async function fetchHubSpotData(
       })
       .sort((a, b) => b.totalPipeline - a.totalPipeline);
 
-    // Reduce deal list to touched deals (keeps UI payload aligned to selected range).
-    const touchedIds = new Set(touchedDeals.keys());
-    const filteredDeals = deals.filter((d) => touchedIds.has(d.dealId));
-    deals.length = 0;
-    deals.push(...filteredDeals);
+  }
 
+  deals.sort(compareHubSpotDealsByRecency);
+
+  let displayDeals = [...deals];
+  if (useActivityInRange && rangeFrom && rangeTo) {
+    const fromMs = rangeFrom.getTime();
+    const toMs = rangeTo.getTime();
+    displayDeals = deals
+      .filter((deal) => {
+        const updatedAtMs = Date.parse(deal.updatedAt || "");
+        return Number.isFinite(updatedAtMs) && updatedAtMs >= fromMs && updatedAtMs <= toMs;
+      })
+      .sort(compareHubSpotDealsByRecency);
   }
 
   const winRate = closedWon + closedLost > 0 ? (closedWon / (closedWon + closedLost)) * 100 : 0;
@@ -646,6 +831,9 @@ export async function fetchHubSpotData(
     },
     activeDealsRaw: activeDealsResult.deals.length,
     archivedDealsRaw: archivedDealsResult.deals.length,
+    includedPipelineId: HUBSPOT_MAIN_PIPELINE_ID,
+    excludedPipelineIds: [HUBSPOT_SUBSCRIPTION_PIPELINE_ID],
+    excludedDeals: allDeals.length - allMainPipelineDeals.length,
     lastAfter: {
       active: activeDealsResult.lastAfter,
       archived: archivedDealsResult.lastAfter,
@@ -683,8 +871,18 @@ export async function fetchHubSpotData(
       recentContacts,
       bySource: [],
     },
+    pipelineDetected: {
+      pipelineId: HUBSPOT_MAIN_PIPELINE_ID,
+      dealCount: deals.length,
+    },
+    pipelineStageLabelsSource: pipelineResult.source,
+    pipelineStages: (mainPipeline?.stages ?? []).map((stage) => ({
+      stageId: stage.id,
+      label: stage.label,
+    })),
     repScoreboard,
     deals,
+    displayDeals,
     _meta: meta,
   };
 }

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -159,6 +159,40 @@ export interface HubSpotData {
     };
     stageHistory?: Array<{ occurredAt: string; stageId: string; stageLabel: string }>;
   }>;
+  displayDeals?: Array<{
+    dealId: string;
+    dealName: string;
+    stageId: string;
+    stageLabel: string;
+    amount: number;
+    source: string;
+    ownerId: string | null;
+    repName?: string;
+    updatedAt: string | null;
+    createdAt: string | null;
+    closedAt?: string | null;
+    stripeCustomerId?: string | null;
+    pipelineId: string | null;
+    contactIds: string[];
+    primaryContactId: string | null;
+    primaryContactEmail: string | null;
+    primaryContactAnalytics?: {
+      createdAt?: string | null;
+      source: string | null;
+      sourceData1: string | null;
+      sourceData2: string | null;
+      firstSeenAt: string | null;
+      lastSeenAt: string | null;
+      firstUrl: string | null;
+      lastUrl: string | null;
+      numVisits: number | null;
+      numPageViews: number | null;
+      utmSource: string | null;
+      utmMedium: string | null;
+      utmCampaign: string | null;
+    };
+    stageHistory?: Array<{ occurredAt: string; stageId: string; stageLabel: string }>;
+  }>;
   _meta: AnalyticsTimestamp;
 }
 

--- a/src/lib/deals/hubspot-sync.ts
+++ b/src/lib/deals/hubspot-sync.ts
@@ -13,21 +13,29 @@ import {
 
 const HUBSPOT_BASE = "https://api.hubapi.com";
 const HUBSPOT_TOKEN_ENDPOINT = "https://api.hubapi.com/oauth/v1/token";
+const HUBSPOT_MAIN_PIPELINE_ID = "default";
 
 // ── Stage & source mapping ──────────────────────────────────
 
 const HUBSPOT_STAGE_TO_DEAL: Record<string, DealStage> = {
   appointmentscheduled: DealStage.LEAD,
+  "1499838171": DealStage.LEAD, // Approached
   qualifiedtobuy: DealStage.LEAD,
   presentationscheduled: DealStage.QUALIFIED,
+  "1955958510": DealStage.QUALIFIED, // No-Show/Reschedule Demo
   decisionmakerboughtin: DealStage.QUALIFIED,
-  "176498593": DealStage.PROPOSAL, // Budgetary Quote Sent
-  "176498594": DealStage.PROPOSAL, // Payment Link Sent
-  "1524801846": DealStage.NEGOTIATION, // Free Trial
-  contractsent: DealStage.NEGOTIATION,
+  "1955580622": DealStage.PROPOSAL, // Budgetary quote sent
+  "1559099077": DealStage.PROPOSAL, // Payment Link Sent
+  "1499827945": DealStage.NEGOTIATION, // Free Trial
+  "1731122907": DealStage.NEGOTIATION, // Freemium
+  contractsent: DealStage.NEGOTIATION, // Ping Later
   closedwon: DealStage.CLOSED_WON,
   closedlost: DealStage.CLOSED_LOST,
-  "1499784891": DealStage.CLOSED_LOST,
+  "1499784890": DealStage.CLOSED_LOST, // Churn
+  "1499784891": DealStage.CLOSED_LOST, // Unlikely
+  "1499827944": DealStage.NEGOTIATION, // On Hold
+  "1718686448": DealStage.NEGOTIATION, // Internal+Friends and Family
+  "2025131723": DealStage.NEGOTIATION, // Interested in a pilot
 };
 
 const HUBSPOT_SOURCE_TO_DEAL: Record<string, DealSource> = {
@@ -42,7 +50,7 @@ const HUBSPOT_SOURCE_TO_DEAL: Record<string, DealSource> = {
   EMAIL_MARKETING: DealSource.OUTBOUND,
 };
 
-function mapStage(hubspotStage: string): DealStage {
+export function mapHubSpotStageToDealStage(hubspotStage: string): DealStage {
   return HUBSPOT_STAGE_TO_DEAL[hubspotStage] ?? DealStage.LEAD;
 }
 
@@ -216,7 +224,7 @@ export async function syncDealsFromHubSpot(userId: string): Promise<SyncResult> 
 
   // 1. Fetch all entities from HubSpot
   const [hsDeals, hsContacts, hsCompanies, hsMeetings, ownerMap] = await Promise.all([
-    fetchAllPaginated(accessToken, "deals", "dealname,dealstage,amount,closedate,createdate,hs_analytics_source,hubspot_owner_id,hs_lastmodifieddate"),
+    fetchAllPaginated(accessToken, "deals", "dealname,dealstage,amount,closedate,createdate,hs_analytics_source,hubspot_owner_id,hs_lastmodifieddate,pipeline"),
     fetchAllPaginated(accessToken, "contacts", "firstname,lastname,email,phone,jobtitle"),
     fetchAllPaginated(accessToken, "companies", "name,domain,industry"),
     fetchAllPaginated(accessToken, "meetings", "hs_meeting_title,hs_meeting_start_time,hs_meeting_end_time,hs_meeting_location,hs_meeting_outcome,hs_meeting_external_url"),
@@ -296,10 +304,13 @@ export async function syncDealsFromHubSpot(userId: string): Promise<SyncResult> 
 
   // 5. Upsert deals (with company + contact associations)
   for (const hd of hsDeals) {
+    const pipelineId = hd.properties.pipeline?.trim() || null;
+    if (pipelineId && pipelineId !== HUBSPOT_MAIN_PIPELINE_ID) continue;
+
     const name = hd.properties.dealname?.trim();
     if (!name) continue;
 
-    const stage = mapStage(hd.properties.dealstage || "");
+    const stage = mapHubSpotStageToDealStage(hd.properties.dealstage || "");
     const source = mapSource(hd.properties.hs_analytics_source);
     const amount = parseFloat(hd.properties.amount) || 0;
     const closeDate = hd.properties.closedate ? new Date(hd.properties.closedate) : null;


### PR DESCRIPTION
## Summary
- switch HubSpot analytics and local sync to the live main deals pipeline only
- sort HubSpot deal tables by last-modified recency and expose a display list for in-range views
- replace the naive deal-name merge script with a safe dry-run/apply cleanup planner and add HubSpot coverage

## Testing
- npx vitest run src/lib/__tests__/analytics-fetchers-hubspot.test.ts src/lib/__tests__/hubspot-deals-sync.test.ts src/lib/__tests__/hubspot-cleanup.test.ts src/lib/__tests__/analytics-demo-analytics.test.ts src/lib/__tests__/analytics-process-analytics.test.ts src/lib/__tests__/analytics-customer-journey.test.ts src/lib/__tests__/analytics-customer-journey-conversion.test.ts src/lib/__tests__/analytics-funnel-lifecycle.test.ts src/lib/__tests__/hubspot-sync.test.ts src/lib/__tests__/hubspot-bidirectional-sync.test.ts src/lib/__tests__/hubspot-stage-checklist.test.ts src/lib/__tests__/hubspot-customer-signals.test.ts
- npx eslint merge_deals.js src/components/analytics/sales-hubspot-tab.tsx src/components/analytics/sub-dashboards/hubspot-sales-dashboard.tsx src/lib/analytics/fetchers.ts src/lib/analytics/types.ts src/lib/deals/hubspot-sync.ts src/lib/__tests__/analytics-fetchers-hubspot.test.ts src/lib/__tests__/hubspot-deals-sync.test.ts src/lib/__tests__/hubspot-cleanup.test.ts --no-warn-ignored