### PR TITLE
Add provider health to visitor funnel analytics

### DIFF
--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -1397,6 +1397,8 @@ export async function GET(request: Request) {
       closedWonCount: (result.hubspot?.deals ?? []).filter(
         (deal) => deal.stageLabel.trim().toLowerCase() === "closed won",
       ).length,
+      includeOperationalMetadata:
+        ((session.user as { role?: string } | undefined)?.role ?? null) === "admin",
     });
   }
   if (domains.has("recommendations")) {

--- a/src/components/analytics/visitor-funnel-tab.tsx
+++ b/src/components/analytics/visitor-funnel-tab.tsx
@@ -5,6 +5,10 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import {
   CalendarRange,
+  CheckCircle2,
+  CircleAlert,
+  Clock3,
+  Link2,
   DollarSign,
   ExternalLink,
   Filter,
@@ -51,6 +55,11 @@ const STAGE_ICONS = [
 
 function pct(value: number | null): string {
   return value == null ? "—" : `${value.toFixed(1)}%`;
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return "—";
+  return new Date(value).toLocaleString();
 }
 
 function formatStage(stage: string): string {
@@ -355,6 +364,93 @@ export function VisitorFunnelTab({ data }: { data: AnalyticsDashboardData | null
         <BreakdownCard title="Sources" rows={funnel.sourceBreakdown} />
         <BreakdownCard title="Campaigns" rows={funnel.campaignBreakdown} />
       </div>
+
+      {isAdmin ? (
+        <div className="rounded-xl border border-border bg-card p-5">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">Provider Health</h3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Operational status for UNIFY scheduled pulls and Clay / RB2B push ingestion.
+              </p>
+            </div>
+            <div className="text-right text-xs text-muted-foreground">
+              Admin-only operational metadata
+            </div>
+          </div>
+
+          <div className="mt-4 grid gap-4 xl:grid-cols-3">
+            {funnel.enrichmentStatus.providers.map((provider) => {
+              const state = !provider.syncConfigured
+                ? { label: "Not Configured", cls: "bg-rose-500/10 text-rose-600", icon: CircleAlert }
+                : provider.stale
+                  ? { label: "Stale", cls: "bg-amber-500/10 text-amber-600", icon: Clock3 }
+                  : provider.totalSignals === 0
+                    ? { label: "Waiting", cls: "bg-amber-500/10 text-amber-600", icon: Clock3 }
+                    : { label: "Healthy", cls: "bg-emerald-500/10 text-emerald-600", icon: CheckCircle2 };
+              const StatusIcon = state.icon;
+
+              return (
+                <div key={provider.provider} className="rounded-xl border border-border bg-background px-4 py-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-foreground">{provider.label}</p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {provider.deliveryMode === "cron_pull" ? "Cron pull" : "Webhook push"}
+                      </p>
+                    </div>
+                    <span className={`inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-medium ${state.cls}`}>
+                      <StatusIcon className="h-3.5 w-3.5" />
+                      {state.label}
+                    </span>
+                  </div>
+
+                  <div className="mt-4 grid grid-cols-2 gap-3 text-xs">
+                    <div className="rounded-lg border border-border px-3 py-2">
+                      <p className="text-muted-foreground">Signals</p>
+                      <p className="mt-1 text-sm font-semibold text-foreground">
+                        {provider.acceptedSignals.toLocaleString()} / {provider.totalSignals.toLocaleString()}
+                      </p>
+                      <p className="mt-1 text-muted-foreground">Accepted {pct(provider.acceptedRate)}</p>
+                    </div>
+                    <div className="rounded-lg border border-border px-3 py-2">
+                      <p className="text-muted-foreground">Config</p>
+                      <p className="mt-1 text-sm font-semibold text-foreground">
+                        {provider.syncConfigured ? "Ready" : "Missing"}
+                      </p>
+                      <p className="mt-1 text-muted-foreground">
+                        Auth {provider.authConfigured ? "set" : "missing"}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="mt-4 space-y-2 rounded-lg border border-border px-3 py-3 text-xs text-muted-foreground">
+                    <div className="flex items-center justify-between gap-3">
+                      <span>Last signal</span>
+                      <span className="text-right text-foreground">{formatTimestamp(provider.lastSignalAt)}</span>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <span>Last accepted</span>
+                      <span className="text-right text-foreground">{formatTimestamp(provider.lastAcceptedAt)}</span>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <span>Endpoint</span>
+                      <code className="text-right text-[11px] text-foreground">{provider.endpointPath}</code>
+                    </div>
+                  </div>
+
+                  <p className="mt-3 text-xs text-muted-foreground">{provider.note}</p>
+
+                  <div className="mt-3 flex items-center gap-2 text-[11px] text-muted-foreground">
+                    <Link2 className="h-3.5 w-3.5" />
+                    {provider.syncEnabled ? "Enabled" : "Disabled"}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
 
       <DrilldownPanel
         title="Admin Record Preview"

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -1174,6 +1174,23 @@ export interface VisitorFunnelProviderEvidence {
   signalCount: number;
 }
 
+export interface VisitorFunnelEnrichmentProviderStatus {
+  provider: EnrichmentProvider;
+  label: string;
+  deliveryMode: "cron_pull" | "webhook_push";
+  endpointPath: string;
+  authConfigured: boolean;
+  syncConfigured: boolean;
+  syncEnabled: boolean;
+  totalSignals: number;
+  acceptedSignals: number;
+  acceptedRate: number | null;
+  lastSignalAt: string | null;
+  lastAcceptedAt: string | null;
+  stale: boolean;
+  note: string;
+}
+
 export interface VisitorFunnelRecord {
   visitorId: string;
   anonymousId: string;
@@ -1225,6 +1242,10 @@ export interface VisitorFunnelData {
   };
   secondaryMetrics: {
     closedWonCount: number;
+  };
+  enrichmentStatus: {
+    adminOnly: boolean;
+    providers: VisitorFunnelEnrichmentProviderStatus[];
   };
 }
 

--- a/src/lib/analytics/visitor-funnel-enrichment-status.test.ts
+++ b/src/lib/analytics/visitor-funnel-enrichment-status.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildVisitorFunnelEnrichmentStatus } from "@/lib/analytics/visitor-funnel";
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("buildVisitorFunnelEnrichmentStatus", () => {
+  it("summarizes provider health and configuration state", async () => {
+    process.env.VISITOR_FUNNEL_ENRICH_SECRET = "shared-secret";
+    process.env.UNIFY_DATA_API_KEY = "unify-key";
+    process.env.UNIFY_FUNNEL_OBJECT_NAME = "website_visitors";
+    process.env.UNIFY_FUNNEL_SYNC_ENABLED = "true";
+
+    const prisma = {
+      funnelEnrichmentSignal: {
+        count: async ({ where }: { where: { provider: string; accepted?: boolean } }) => {
+          if (where.provider === "UNIFY") return where.accepted ? 8 : 10;
+          if (where.provider === "CLAY") return where.accepted ? 2 : 3;
+          if (where.provider === "RB2B") return where.accepted ? 0 : 0;
+          return 0;
+        },
+        findFirst: async ({
+          where,
+        }: {
+          where: { provider: string; accepted?: boolean };
+          orderBy: Array<Record<string, "desc">>;
+          select: { occurredAt: boolean; createdAt: boolean };
+        }) => {
+          if (where.provider === "UNIFY" && where.accepted) {
+            return {
+              occurredAt: new Date("2026-03-08T12:00:00.000Z"),
+              createdAt: new Date("2026-03-08T12:00:00.000Z"),
+            };
+          }
+          if (where.provider === "UNIFY") {
+            return {
+              occurredAt: new Date("2026-03-08T12:15:00.000Z"),
+              createdAt: new Date("2026-03-08T12:15:00.000Z"),
+            };
+          }
+          if (where.provider === "CLAY" && where.accepted) {
+            return {
+              occurredAt: new Date("2026-03-05T18:00:00.000Z"),
+              createdAt: new Date("2026-03-05T18:00:00.000Z"),
+            };
+          }
+          if (where.provider === "CLAY") {
+            return {
+              occurredAt: new Date("2026-03-05T18:15:00.000Z"),
+              createdAt: new Date("2026-03-05T18:15:00.000Z"),
+            };
+          }
+          return null;
+        },
+      },
+    } as never;
+
+    const statuses = await buildVisitorFunnelEnrichmentStatus(
+      prisma,
+      new Date("2026-03-08T13:00:00.000Z"),
+    );
+
+    expect(statuses).toHaveLength(3);
+    expect(statuses[0]).toMatchObject({
+      provider: "unify",
+      deliveryMode: "cron_pull",
+      authConfigured: true,
+      syncConfigured: true,
+      syncEnabled: true,
+      totalSignals: 10,
+      acceptedSignals: 8,
+      acceptedRate: 80,
+      stale: false,
+    });
+    expect(statuses[1]).toMatchObject({
+      provider: "clay",
+      deliveryMode: "webhook_push",
+      authConfigured: true,
+      syncConfigured: true,
+      totalSignals: 3,
+      acceptedSignals: 2,
+      acceptedRate: 66.7,
+      stale: false,
+    });
+    expect(statuses[2]).toMatchObject({
+      provider: "rb2b",
+      deliveryMode: "webhook_push",
+      authConfigured: true,
+      syncConfigured: true,
+      totalSignals: 0,
+      acceptedSignals: 0,
+      acceptedRate: null,
+      lastSignalAt: null,
+      lastAcceptedAt: null,
+    });
+  });
+
+  it("marks stale or missing provider configuration correctly", async () => {
+    delete process.env.VISITOR_FUNNEL_ENRICH_SECRET;
+    delete process.env.UNIFY_DATA_API_KEY;
+    delete process.env.UNIFY_FUNNEL_OBJECT_NAME;
+    process.env.UNIFY_FUNNEL_SYNC_ENABLED = "false";
+
+    const prisma = {
+      funnelEnrichmentSignal: {
+        count: async () => 1,
+        findFirst: async () => ({
+          occurredAt: new Date("2026-02-20T12:00:00.000Z"),
+          createdAt: new Date("2026-02-20T12:00:00.000Z"),
+        }),
+      },
+    } as never;
+
+    const statuses = await buildVisitorFunnelEnrichmentStatus(
+      prisma,
+      new Date("2026-03-08T13:00:00.000Z"),
+    );
+
+    expect(statuses[0]).toMatchObject({
+      provider: "unify",
+      syncConfigured: false,
+      syncEnabled: false,
+      stale: false,
+    });
+    expect(statuses[1]).toMatchObject({
+      provider: "clay",
+      authConfigured: false,
+      syncConfigured: false,
+      stale: false,
+    });
+  });
+});

--- a/src/lib/analytics/visitor-funnel.ts
+++ b/src/lib/analytics/visitor-funnel.ts
@@ -14,6 +14,7 @@ import type {
   EnrichmentProvider,
   VisitorFunnelBreakdownRow,
   VisitorFunnelData,
+  VisitorFunnelEnrichmentProviderStatus,
   VisitorFunnelFilters,
   VisitorFunnelOverlap,
   VisitorFunnelProviderEvidence,
@@ -68,6 +69,13 @@ const EMAIL_IDENTITY_TYPES = new Set<FunnelIdentityType>([
   FunnelIdentityType.EMAIL,
   FunnelIdentityType.CODA_EMAIL,
 ]);
+
+const ENRICHMENT_PROVIDERS: EnrichmentProvider[] = ["unify", "clay", "rb2b"];
+const ENRICHMENT_PROVIDER_LABELS: Record<EnrichmentProvider, string> = {
+  unify: "UNIFY",
+  clay: "Clay",
+  rb2b: "RB2B",
+};
 
 type AttributionInfo = {
   source: string | null;
@@ -191,6 +199,14 @@ function safeOptionalDate(value: Date | string | null | undefined): Date | null 
   return Number.isNaN(resolved.getTime()) ? null : resolved;
 }
 
+function parseEnabledFlag(value: string | null | undefined, fallback: boolean): boolean {
+  const trimmed = trimOrNull(value)?.toLowerCase();
+  if (!trimmed) return fallback;
+  if (["1", "true", "yes", "on"].includes(trimmed)) return true;
+  if (["0", "false", "no", "off"].includes(trimmed)) return false;
+  return fallback;
+}
+
 function hostFromUrl(rawUrl: string | null | undefined): string | null {
   const value = trimOrNull(rawUrl);
   if (!value) return null;
@@ -307,6 +323,130 @@ function toPrismaEnrichmentProvider(
   if (normalized === "clay") return PrismaEnrichmentProvider.CLAY;
   if (normalized === "rb2b") return PrismaEnrichmentProvider.RB2B;
   return null;
+}
+
+function hasProviderAuthSecret(provider: EnrichmentProvider): boolean {
+  const globalSecret = trimOrNull(process.env.VISITOR_FUNNEL_ENRICH_SECRET);
+  const providerSecret = trimOrNull(
+    process.env[`${provider.toUpperCase()}_FUNNEL_ENRICH_SECRET`],
+  );
+  return Boolean(globalSecret || providerSecret);
+}
+
+function resolveUnifySyncConfig(): {
+  apiConfigured: boolean;
+  syncEnabled: boolean;
+  objectName: string | null;
+} {
+  const apiConfigured = Boolean(
+    trimOrNull(process.env.UNIFY_DATA_API_KEY) ??
+      trimOrNull(process.env.UNIFY_API_KEY),
+  ) && Boolean(trimOrNull(process.env.UNIFY_FUNNEL_OBJECT_NAME));
+  const syncEnabled = parseEnabledFlag(process.env.UNIFY_FUNNEL_SYNC_ENABLED, apiConfigured);
+
+  return {
+    apiConfigured,
+    syncEnabled,
+    objectName: trimOrNull(process.env.UNIFY_FUNNEL_OBJECT_NAME),
+  };
+}
+
+function enrichmentStatusNote(input: {
+  provider: EnrichmentProvider;
+  authConfigured: boolean;
+  syncConfigured: boolean;
+  syncEnabled: boolean;
+  objectName?: string | null;
+}): string {
+  if (input.provider === "unify") {
+    if (!input.syncEnabled) {
+      return input.authConfigured
+        ? "Push payloads to the v1 enrichment endpoint or enable scheduled Unify pulls."
+        : "Configure Unify pull env vars or an enrichment secret for push delivery.";
+    }
+
+    if (!input.syncConfigured) {
+      return "Missing UNIFY_DATA_API_KEY/UNIFY_API_KEY or UNIFY_FUNNEL_OBJECT_NAME.";
+    }
+
+    return `Scheduled pull enabled via /api/cron/sync${input.objectName ? ` for ${input.objectName}` : ""}.`;
+  }
+
+  return input.authConfigured
+    ? "Provider can post payloads to the versioned enrichment endpoint."
+    : "Set VISITOR_FUNNEL_ENRICH_SECRET or a provider-specific enrichment secret.";
+}
+
+export async function buildVisitorFunnelEnrichmentStatus(
+  prisma: FunnelPrismaClient,
+  now = new Date(),
+): Promise<VisitorFunnelEnrichmentProviderStatus[]> {
+  const unifyConfig = resolveUnifySyncConfig();
+
+  return Promise.all(
+    ENRICHMENT_PROVIDERS.map(async (provider) => {
+      const prismaProvider = toPrismaEnrichmentProvider(provider);
+      if (!prismaProvider) {
+        throw new Error(`Unsupported enrichment provider "${provider}"`);
+      }
+
+      const [totalSignals, acceptedSignals, lastSignal, lastAcceptedSignal] = await Promise.all([
+        prisma.funnelEnrichmentSignal.count({
+          where: { provider: prismaProvider },
+        }),
+        prisma.funnelEnrichmentSignal.count({
+          where: { provider: prismaProvider, accepted: true },
+        }),
+        prisma.funnelEnrichmentSignal.findFirst({
+          where: { provider: prismaProvider },
+          orderBy: [{ occurredAt: "desc" }, { createdAt: "desc" }],
+          select: { occurredAt: true, createdAt: true },
+        }),
+        prisma.funnelEnrichmentSignal.findFirst({
+          where: { provider: prismaProvider, accepted: true },
+          orderBy: [{ occurredAt: "desc" }, { createdAt: "desc" }],
+          select: { occurredAt: true, createdAt: true },
+        }),
+      ]);
+
+      const authConfigured = hasProviderAuthSecret(provider);
+      const syncConfigured =
+        provider === "unify" ? unifyConfig.apiConfigured : authConfigured;
+      const syncEnabled =
+        provider === "unify" ? unifyConfig.syncEnabled : authConfigured;
+      const lastSignalDate = lastSignal?.occurredAt ?? lastSignal?.createdAt ?? null;
+      const lastAcceptedDate =
+        lastAcceptedSignal?.occurredAt ?? lastAcceptedSignal?.createdAt ?? null;
+      const stale = Boolean(
+        syncConfigured &&
+          lastSignalDate &&
+          now.getTime() - lastSignalDate.getTime() > 7 * 24 * 60 * 60 * 1000,
+      );
+
+      return {
+        provider,
+        label: ENRICHMENT_PROVIDER_LABELS[provider],
+        deliveryMode: provider === "unify" ? "cron_pull" : "webhook_push",
+        endpointPath: `/api/v1/analytics/funnel/enrich/${provider}`,
+        authConfigured,
+        syncConfigured,
+        syncEnabled,
+        totalSignals,
+        acceptedSignals,
+        acceptedRate: pct(acceptedSignals, totalSignals),
+        lastSignalAt: toIso(lastSignalDate),
+        lastAcceptedAt: toIso(lastAcceptedDate),
+        stale,
+        note: enrichmentStatusNote({
+          provider,
+          authConfigured,
+          syncConfigured,
+          syncEnabled,
+          objectName: provider === "unify" ? unifyConfig.objectName : null,
+        }),
+      };
+    }),
+  );
 }
 
 function toPrismaProvenance(value: VisitorLinkProvenance | null | undefined): FunnelLinkProvenance {
@@ -1524,13 +1664,19 @@ export async function buildVisitorFunnelData(
     to: Date;
     filters: VisitorFunnelFilters;
     closedWonCount?: number;
+    includeOperationalMetadata?: boolean;
   },
 ): Promise<VisitorFunnelData> {
-  const records = await loadVisitorRecords(prisma, {
-    from: input.from,
-    to: input.to,
-    filters: input.filters,
-  });
+  const [records, enrichmentStatus] = await Promise.all([
+    loadVisitorRecords(prisma, {
+      from: input.from,
+      to: input.to,
+      filters: input.filters,
+    }),
+    input.includeOperationalMetadata === false
+      ? Promise.resolve([])
+      : buildVisitorFunnelEnrichmentStatus(prisma),
+  ]);
 
   const stages: VisitorFunnelStageCount[] = [];
   let previousCount = 0;
@@ -1608,6 +1754,10 @@ export async function buildVisitorFunnelData(
     },
     secondaryMetrics: {
       closedWonCount: input.closedWonCount ?? 0,
+    },
+    enrichmentStatus: {
+      adminOnly: true,
+      providers: enrichmentStatus,
     },
   };
 }


### PR DESCRIPTION
## Summary
- add admin-only provider health metadata to the visitor funnel analytics payload
- show UNIFY, Clay, and RB2B configuration and signal health in the acquisition funnel UI
- gate operational metadata to admin analytics responses only

## Testing
- npx vitest run src/lib/analytics/provider-enrichment-adapters.test.ts src/lib/analytics/provider-enrichment-sync.test.ts src/lib/analytics/visitor-funnel.test.ts src/lib/analytics/visitor-funnel-enrichment-status.test.ts src/app/api/v1/integrations/versioned-routes.test.ts
- scoped TypeScript check for the visitor funnel analytics files