### PR TITLE
Fix funnel visitor race condition and restore /tasks route

### DIFF
--- a/src/app/(dashboard)/tasks/page.tsx
+++ b/src/app/(dashboard)/tasks/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from "next/navigation";
+import { KanbanBoard } from "@/components/board/kanban-board";
+import { auth } from "@/lib/auth";
+
+export default async function TasksPage() {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  return <KanbanBoard />;
+}

--- a/src/lib/analytics/visitor-funnel-collector.test.ts
+++ b/src/lib/analytics/visitor-funnel-collector.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { FunnelEventType } from "@/lib/analytics/prisma-funnel-enums";
+import { collectVisitorEvent } from "@/lib/analytics/visitor-funnel";
+
+describe("collectVisitorEvent", () => {
+  it("upserts the visitor instead of racing through a create path", async () => {
+    const visitorRecord = {
+      id: "visitor-1",
+      anonymousId: "anon-1",
+      siteHost: "localhost",
+      firstTouchSource: null,
+      firstTouchChannel: "direct",
+      firstTouchCampaign: null,
+      firstTouchReferrer: null,
+      firstTouchLandingPath: "/tasks",
+      firstTouchLandingUrl: "http://localhost:3000/tasks",
+      lastTouchSource: null,
+      lastTouchChannel: "direct",
+      lastTouchCampaign: null,
+      lastTouchReferrer: null,
+      lastTouchPath: "/tasks",
+      lastTouchUrl: "http://localhost:3000/tasks",
+      firstSeenAt: new Date("2026-03-08T00:00:00.000Z"),
+      lastSeenAt: new Date("2026-03-08T00:00:00.000Z"),
+      createdAt: new Date("2026-03-08T00:00:00.000Z"),
+      updatedAt: new Date("2026-03-08T00:00:00.000Z"),
+    };
+
+    const prisma = {
+      funnelVisitor: {
+        upsert: vi.fn(async () => visitorRecord),
+        create: vi.fn(() => {
+          throw new Error("create should not be used for visitor writes");
+        }),
+        update: vi.fn(async ({ data }: { data: Partial<typeof visitorRecord> }) => ({
+          ...visitorRecord,
+          ...data,
+        })),
+      },
+      funnelIdentityLink: {
+        upsert: vi.fn(),
+      },
+      funnelEvent: {
+        upsert: vi.fn(async () => ({})),
+        create: vi.fn(async () => ({})),
+      },
+    } as const;
+
+    const [first, second] = await Promise.all([
+      collectVisitorEvent(
+        prisma as never,
+        {
+          anonymousId: "anon-1",
+          eventType: FunnelEventType.PAGE_VIEW,
+          path: "/tasks",
+          url: "http://localhost:3000/tasks",
+          dedupeKey: "page_view:anon-1:/tasks",
+        },
+        { siteHost: "localhost" },
+      ),
+      collectVisitorEvent(
+        prisma as never,
+        {
+          anonymousId: "anon-1",
+          eventType: FunnelEventType.AUTH_COMPLETED,
+          path: "/tasks",
+          url: "http://localhost:3000/tasks",
+          dedupeKey: "auth_completed:anon-1",
+        },
+        { siteHost: "localhost" },
+      ),
+    ]);
+
+    expect(prisma.funnelVisitor.upsert).toHaveBeenCalledTimes(2);
+    expect(prisma.funnelVisitor.create).not.toHaveBeenCalled();
+    expect(first).toEqual({ visitorId: "visitor-1", anonymousId: "anon-1" });
+    expect(second).toEqual({ visitorId: "visitor-1", anonymousId: "anon-1" });
+  });
+});

--- a/src/lib/analytics/visitor-funnel.ts
+++ b/src/lib/analytics/visitor-funnel.ts
@@ -654,34 +654,29 @@ async function createOrUpdateVisitor(
     attribution: AttributionInfo;
   },
 ): Promise<PersistedVisitor> {
-  const existing = await prisma.funnelVisitor.findUnique({
-    where: { anonymousId: input.anonymousId },
-  });
-
   const attribution = input.attribution;
-
-  if (!existing) {
-    return prisma.funnelVisitor.create({
-      data: {
-        anonymousId: input.anonymousId,
-        siteHost: attribution.siteHost,
-        firstTouchSource: attribution.source,
-        firstTouchChannel: attribution.channel,
-        firstTouchCampaign: attribution.campaign,
-        firstTouchReferrer: attribution.referrer,
-        firstTouchLandingPath: attribution.path,
-        firstTouchLandingUrl: attribution.url,
-        lastTouchSource: attribution.source,
-        lastTouchChannel: attribution.channel,
-        lastTouchCampaign: attribution.campaign,
-        lastTouchReferrer: attribution.referrer,
-        lastTouchPath: attribution.path,
-        lastTouchUrl: attribution.url,
-        firstSeenAt: input.occurredAt,
-        lastSeenAt: input.occurredAt,
-      },
-    });
-  }
+  const existing = await prisma.funnelVisitor.upsert({
+    where: { anonymousId: input.anonymousId },
+    update: {},
+    create: {
+      anonymousId: input.anonymousId,
+      siteHost: attribution.siteHost,
+      firstTouchSource: attribution.source,
+      firstTouchChannel: attribution.channel,
+      firstTouchCampaign: attribution.campaign,
+      firstTouchReferrer: attribution.referrer,
+      firstTouchLandingPath: attribution.path,
+      firstTouchLandingUrl: attribution.url,
+      lastTouchSource: attribution.source,
+      lastTouchChannel: attribution.channel,
+      lastTouchCampaign: attribution.campaign,
+      lastTouchReferrer: attribution.referrer,
+      lastTouchPath: attribution.path,
+      lastTouchUrl: attribution.url,
+      firstSeenAt: input.occurredAt,
+      lastSeenAt: input.occurredAt,
+    },
+  });
 
   const update: Prisma.FunnelVisitorUpdateInput = {};
   if (input.occurredAt <= existing.firstSeenAt) {


### PR DESCRIPTION
## Summary
- Replace racy `findUnique` + `create` with atomic `upsert` in `createOrUpdateVisitor` so concurrent tracker events stop colliding on `anonymousId`
- Restore the protected `/tasks` page that renders KanbanBoard for the E2E auth/board/settings spec flow
- Add regression test for the visitor upsert path

## Context
Clean follow-up to #442 (now closed). The enum import fixes from #442 already landed in #441; this PR carries forward only the unique changes that weren't yet on main.

## Test plan
- [x] `npx vitest run src/lib/analytics/visitor-funnel-collector.test.ts` passes
- [x] `npm run build` succeeds (tasks route appears as dynamic)
- [ ] CI validates full build against migrated test database

🤖 Generated with [Claude Code](https://claude.com/claude-code)