### PR TITLE
feat(dashboard): executive summary overview

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,5 +1,5 @@
-import { PersonalizedDashboard } from "@/components/dashboard/personalized-dashboard";
+import { ExecutiveOverviewDashboard } from "@/components/dashboard/executive-overview-dashboard";
 
 export default function DashboardPage() {
-  return <PersonalizedDashboard />;
+  return <ExecutiveOverviewDashboard />;
 }

--- a/src/app/api/dashboard/overview/route.ts
+++ b/src/app/api/dashboard/overview/route.ts
@@ -1,0 +1,370 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { getAuthenticatedUser } from "@/lib/session-user";
+import { getCredentials } from "@/lib/analytics/credentials";
+import { resolveIntegrationOwnerUserId } from "@/lib/integrations/ownership";
+import { readLatestSuccessfulSnapshot, type SnapshotResult } from "@/lib/analytics/snapshots";
+import {
+  ANALYTICS_PRIMARY_SECTIONS,
+  ANALYTICS_SUB_SECTIONS,
+  type AnalyticsSubSection,
+} from "@/lib/analytics/section-registry";
+import { deriveDomainSectionStatus } from "@/lib/analytics/summary-health";
+import type {
+  StripeData,
+  MercuryData,
+  GAData,
+  HubSpotData,
+  GoogleAdsData,
+  MetaAdsData,
+  RedditAdsData,
+  PylonData,
+  ProductSuccessData,
+} from "@/lib/analytics/types";
+import type {
+  ExecutiveOverviewPayload,
+  OverviewFinance,
+  OverviewTraffic,
+  OverviewSales,
+  OverviewCustomerSuccess,
+  OverviewAdSpend,
+  OverviewSectionHealth,
+} from "@/lib/dashboard/executive-overview-types";
+
+/* ── Helper: build 30-day snapshot query input ───────────── */
+
+function snapshotInput(userId: string, providerKey: string) {
+  const now = new Date();
+  const from = new Date(now);
+  from.setUTCDate(from.getUTCDate() - 30);
+  from.setUTCHours(0, 0, 0, 0);
+  const to = new Date(now);
+  to.setUTCHours(23, 59, 59, 999);
+  return {
+    userId,
+    providerKey,
+    rangePreset: "30d" as const,
+    fromDate: from,
+    toDate: to,
+  };
+}
+
+/* ── Domain extractors ───────────────────────────────────── */
+
+function extractFinance(
+  creds: Awaited<ReturnType<typeof getCredentials>>,
+  stripeSnap: StripeData | null,
+  mercurySnap: MercuryData | null
+): OverviewFinance {
+  const stripeConnected = Boolean(creds.stripeKey);
+  const mercuryConnected = Boolean(creds.mercuryKey);
+  return {
+    connected: stripeConnected || mercuryConnected,
+    mrr: stripeSnap?.revenue?.mrr ?? 0,
+    mrrChange: stripeSnap?.revenue?.mrrChange ?? 0,
+    totalRevenue30d: stripeSnap?.revenue?.totalRevenue30d ?? 0,
+    totalRevenuePrev30d: stripeSnap?.revenue?.totalRevenuePrev30d ?? 0,
+    revenueGrowth: stripeSnap?.revenue?.revenueGrowth ?? 0,
+    activeSubscriptions: stripeSnap?.subscriptions?.active ?? 0,
+    churnRate: stripeSnap?.subscriptions?.churnRate ?? 0,
+    revenueTrend: stripeSnap?.revenueTrend ?? [],
+    totalBalance: mercurySnap?.cashFlow?.totalBalance ?? 0,
+    burnRate: mercurySnap?.cashFlow?.burnRate ?? 0,
+    runway: mercurySnap?.cashFlow?.runway ?? 0,
+  };
+}
+
+function extractTraffic(
+  creds: Awaited<ReturnType<typeof getCredentials>>,
+  gaSnap: GAData | null
+): OverviewTraffic {
+  const connected = Boolean(
+    creds.gaPropertyId &&
+      ((creds.gaClientEmail && creds.gaPrivateKey) ||
+        (process.env.GA_REFRESH_TOKEN &&
+          process.env.GOOGLE_CLIENT_ID &&
+          process.env.GOOGLE_CLIENT_SECRET))
+  );
+  return {
+    connected,
+    sessions30d: gaSnap?.sessions30d ?? 0,
+    sessionsPrev30d: gaSnap?.sessionsPrev30d ?? 0,
+    users30d: gaSnap?.users30d ?? 0,
+    bounceRate: gaSnap?.bounceRate ?? 0,
+    topChannels: (gaSnap?.trafficByChannel ?? []).slice(0, 5).map((ch) => ({
+      channel: ch.channel,
+      sessions: ch.sessions,
+    })),
+    dailyTrend: gaSnap?.dailyTrend ?? [],
+  };
+}
+
+function extractSales(
+  creds: Awaited<ReturnType<typeof getCredentials>>,
+  hubspotSnap: HubSpotData | null
+): OverviewSales {
+  const connected = Boolean(creds.hubspotToken);
+  const funnel = hubspotSnap?.funnel;
+  const stages = funnel?.stages ?? [];
+  const pipelineValue = stages.reduce((sum, s) => sum + s.value, 0);
+  return {
+    connected,
+    totalDeals: funnel?.totalDeals ?? 0,
+    pipelineValue,
+    closedWon: funnel?.closedWon ?? 0,
+    closedWonValue: stages.find((s) => s.label.toLowerCase().includes("closed won"))?.value ?? 0,
+    winRate: funnel?.winRate ?? 0,
+    avgDealSize: funnel?.avgDealSize ?? 0,
+    stages,
+  };
+}
+
+function extractCustomerSuccess(
+  creds: Awaited<ReturnType<typeof getCredentials>>,
+  pylonSnap: PylonData | null,
+  productSnap: ProductSuccessData | null
+): OverviewCustomerSuccess {
+  const pylonConnected = Boolean(creds.pylonApiKey);
+  return {
+    connected: pylonConnected || productSnap !== null,
+    openConversations: pylonSnap?.openConversations ?? 0,
+    urgentConversations: pylonSnap?.urgentConversations ?? 0,
+    avgFirstResponseMinutes: pylonSnap?.avgFirstResponseMinutes ?? null,
+    csat: pylonSnap?.csat ?? null,
+    resolvedInRange: pylonSnap?.resolvedInRange ?? 0,
+    completedTasks: productSnap?.completedTasksInRange ?? 0,
+    throughputRate: productSnap?.throughputRate ?? null,
+  };
+}
+
+function extractAdSpend(
+  creds: Awaited<ReturnType<typeof getCredentials>>,
+  googleAdsSnap: GoogleAdsData | null,
+  metaAdsSnap: MetaAdsData | null,
+  redditAdsSnap: RedditAdsData | null
+): OverviewAdSpend {
+  const googleConnected = Boolean(
+    creds.googleAdsDevToken && creds.googleAdsCustomerId && creds.googleAdsRefreshToken
+  );
+  const metaConnected = Boolean(creds.metaAccessToken && creds.metaAdAccountId);
+  const redditConnected = Boolean(
+    creds.redditClientId && creds.redditClientSecret && creds.redditRefreshToken && creds.redditAdAccountId
+  );
+
+  const totalSpend =
+    (googleAdsSnap?.totalSpend30d ?? 0) +
+    (metaAdsSnap?.totalSpend30d ?? 0) +
+    (redditAdsSnap?.totalSpend30d ?? 0);
+  const totalImpressions =
+    (googleAdsSnap?.totalImpressions ?? 0) +
+    (metaAdsSnap?.totalImpressions ?? 0) +
+    (redditAdsSnap?.totalImpressions ?? 0);
+  const totalClicks =
+    (googleAdsSnap?.totalClicks ?? 0) +
+    (metaAdsSnap?.totalClicks ?? 0) +
+    (redditAdsSnap?.totalClicks ?? 0);
+  const totalConversions =
+    (googleAdsSnap?.totalConversions ?? 0) +
+    (metaAdsSnap?.totalConversions ?? 0) +
+    (redditAdsSnap?.totalConversions ?? 0);
+
+  return {
+    connected: googleConnected || metaConnected || redditConnected,
+    totalSpend30d: totalSpend,
+    totalImpressions,
+    totalClicks,
+    totalConversions,
+    blendedCtr: totalImpressions > 0 ? (totalClicks / totalImpressions) * 100 : 0,
+    blendedCpa: totalConversions > 0 ? totalSpend / totalConversions : 0,
+  };
+}
+
+/* ── Section health builder ──────────────────────────────── */
+
+function buildSectionHealth(
+  creds: Awaited<ReturnType<typeof getCredentials>>,
+  snapshotStatuses: Map<string, { success: boolean; stale: boolean }>
+): OverviewSectionHealth[] {
+  const domainConnected: Record<AnalyticsSubSection["dataDomain"], boolean> = {
+    hubspot: Boolean(creds.hubspotToken),
+    salesPerformance: Boolean(creds.hubspotToken),
+    stripe: Boolean(creds.stripeKey),
+    mercury: Boolean(creds.mercuryKey),
+    googleWorkspace: Boolean(creds.googleWorkspaceAccessToken),
+    slack: Boolean(creds.slackAccessToken),
+    googleAnalytics: Boolean(
+      creds.gaPropertyId &&
+        ((creds.gaClientEmail && creds.gaPrivateKey) ||
+          (process.env.GA_REFRESH_TOKEN &&
+            process.env.GOOGLE_CLIENT_ID &&
+            process.env.GOOGLE_CLIENT_SECRET))
+    ),
+    googleAds: Boolean(
+      creds.googleAdsDevToken &&
+        creds.googleAdsCustomerId &&
+        creds.googleAdsRefreshToken &&
+        creds.googleAdsClientId &&
+        creds.googleAdsClientSecret
+    ),
+    metaAds: Boolean(creds.metaAccessToken && creds.metaAdAccountId),
+    metaPage: Boolean(creds.metaAccessToken),
+    redditAds: Boolean(
+      creds.redditClientId &&
+        creds.redditClientSecret &&
+        creds.redditRefreshToken &&
+        creds.redditAdAccountId
+    ),
+    webflow: Boolean(creds.webflowApiToken && creds.webflowSiteId),
+    coda: Boolean(creds.codaApiToken && creds.codaDocId),
+    semrush: Boolean(creds.semrushApiToken && creds.semrushDomain),
+    pylon: Boolean(creds.pylonApiKey),
+    financePlanning: Boolean(creds.stripeKey || creds.mercuryKey),
+    financeForecast: Boolean(creds.stripeKey || creds.mercuryKey),
+    financePnl: Boolean(creds.stripeKey || creds.mercuryKey),
+    financeUnitEconomics: Boolean(creds.stripeKey),
+    product: true,
+    customerJourney: true,
+    visitorFunnel: true,
+    demoAnalytics: true,
+    processAnalytics: true,
+  };
+
+  const domainSnapshotKey: Partial<Record<AnalyticsSubSection["dataDomain"], string>> = {
+    hubspot: "hubspot",
+    salesPerformance: "salesPerformance",
+    stripe: "stripe",
+    mercury: "mercury",
+    googleWorkspace: "googleWorkspace",
+    slack: "slack",
+    googleAnalytics: "googleAnalytics",
+    googleAds: "googleAds",
+    metaAds: "metaAds",
+    metaPage: "metaPage",
+    redditAds: "redditAds",
+    webflow: "webflow",
+    coda: "coda",
+    semrush: "semrush",
+    pylon: "pylon",
+  };
+
+  return ANALYTICS_PRIMARY_SECTIONS.map((primary) => {
+    const children = ANALYTICS_SUB_SECTIONS.filter((c) => c.parentId === primary.id);
+    const childStatuses = children.map((child) => {
+      const configured = domainConnected[child.dataDomain];
+      const snapshotKey = domainSnapshotKey[child.dataDomain];
+      const snap = snapshotKey ? snapshotStatuses.get(snapshotKey) : null;
+      return deriveDomainSectionStatus({
+        configured,
+        requiresSnapshot: Boolean(snapshotKey),
+        snapshotStatus: snap ? (snap.success ? "SUCCESS" : "ERROR") : null,
+        snapshotStale: snap?.stale ?? false,
+      });
+    });
+
+    let status: OverviewSectionHealth["status"] = "missing";
+    if (childStatuses.every((s) => s === "connected")) status = "connected";
+    else if (childStatuses.some((s) => s === "degraded")) status = "degraded";
+    else if (childStatuses.some((s) => s === "connected")) status = "partial";
+
+    return {
+      id: primary.id,
+      label: primary.label,
+      href: primary.path,
+      status,
+    };
+  });
+}
+
+/* ── Route handler ───────────────────────────────────────── */
+
+export async function GET(): Promise<NextResponse> {
+  try {
+    const session = await auth();
+    const user = getAuthenticatedUser(session);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const ownerUserId = resolveIntegrationOwnerUserId(user.id);
+    const creds = await getCredentials(ownerUserId);
+
+    // Read all 30d snapshots in parallel
+    const [
+      stripeResult,
+      mercuryResult,
+      gaResult,
+      hubspotResult,
+      googleAdsResult,
+      metaAdsResult,
+      redditAdsResult,
+      pylonResult,
+      productResult,
+    ] = await Promise.all([
+      readLatestSuccessfulSnapshot<StripeData>(snapshotInput(ownerUserId, "stripe")),
+      readLatestSuccessfulSnapshot<MercuryData>(snapshotInput(ownerUserId, "mercury")),
+      readLatestSuccessfulSnapshot<GAData>(snapshotInput(ownerUserId, "googleAnalytics")),
+      readLatestSuccessfulSnapshot<HubSpotData>(snapshotInput(ownerUserId, "hubspot")),
+      readLatestSuccessfulSnapshot<GoogleAdsData>(snapshotInput(ownerUserId, "googleAds")),
+      readLatestSuccessfulSnapshot<MetaAdsData>(snapshotInput(ownerUserId, "metaAds")),
+      readLatestSuccessfulSnapshot<RedditAdsData>(snapshotInput(ownerUserId, "redditAds")),
+      readLatestSuccessfulSnapshot<PylonData>(snapshotInput(ownerUserId, "pylon")),
+      readLatestSuccessfulSnapshot<ProductSuccessData>(snapshotInput(ownerUserId, "product")),
+    ]);
+
+    // Build snapshot-status map for section health
+    const snapshotStatuses = new Map<string, { success: boolean; stale: boolean }>();
+    const snapResults: [string, SnapshotResult<unknown>][] = [
+      ["stripe", stripeResult],
+      ["mercury", mercuryResult],
+      ["googleAnalytics", gaResult],
+      ["hubspot", hubspotResult],
+      ["googleAds", googleAdsResult],
+      ["metaAds", metaAdsResult],
+      ["redditAds", redditAdsResult],
+      ["pylon", pylonResult],
+      ["product", productResult],
+    ];
+    for (const [key, result] of snapResults) {
+      if (result.fromSnapshot) {
+        snapshotStatuses.set(key, {
+          success: result.status === "SUCCESS",
+          stale: result.stale,
+        });
+      }
+    }
+
+    const isPartial = snapResults.some(
+      ([, result]) => result.fromSnapshot && (result.stale || result.status !== "SUCCESS")
+    );
+
+    const payload: ExecutiveOverviewPayload = {
+      generatedAt: new Date().toISOString(),
+      meta: {
+        servedAt: new Date().toISOString(),
+        isPartial,
+      },
+      finance: extractFinance(creds, stripeResult.payload, mercuryResult.payload),
+      traffic: extractTraffic(creds, gaResult.payload),
+      sales: extractSales(creds, hubspotResult.payload),
+      customerSuccess: extractCustomerSuccess(creds, pylonResult.payload, productResult.payload),
+      adSpend: extractAdSpend(
+        creds,
+        googleAdsResult.payload,
+        metaAdsResult.payload,
+        redditAdsResult.payload
+      ),
+      sections: buildSectionHealth(creds, snapshotStatuses),
+    };
+
+    return NextResponse.json(payload, {
+      headers: {
+        "Cache-Control": "private, max-age=30, stale-while-revalidate=120",
+      },
+    });
+  } catch (error) {
+    console.error("GET /api/dashboard/overview error:", error);
+    return NextResponse.json({ error: "Failed to fetch executive overview" }, { status: 500 });
+  }
+}

--- a/src/components/dashboard/executive-overview-dashboard.tsx
+++ b/src/components/dashboard/executive-overview-dashboard.tsx
@@ -1,0 +1,613 @@
+"use client";
+
+import { useMemo } from "react";
+import Link from "next/link";
+import {
+  DollarSign,
+  TrendingUp,
+  BarChart3,
+  Users,
+  Megaphone,
+  HeadphonesIcon,
+  RefreshCw,
+  ArrowRight,
+  Settings,
+  Activity,
+} from "lucide-react";
+import { DashboardLoadingState } from "@/components/dashboard/dashboard-loading-state";
+import { DashboardErrorBanner } from "@/components/dashboard/dashboard-error-banner";
+import { DashboardStaleBanner } from "@/components/dashboard/dashboard-stale-banner";
+import { useDashboardResource } from "@/components/dashboard/use-dashboard-resource";
+import { AreaTrend } from "@/components/charts/area-trend";
+import { HorizontalFunnel } from "@/components/charts/horizontal-funnel";
+import { SparkLine } from "@/components/charts/spark-line";
+import { getChartColor } from "@/components/charts/chart-theme";
+import { fmt$, fmtN, fmtPct, ChangeIndicator, SectionCard } from "@/components/analytics/dashboard-primitives";
+import type { ExecutiveOverviewPayload } from "@/lib/dashboard/executive-overview-types";
+import { isExecutiveOverviewPayload } from "@/lib/dashboard/executive-overview-types";
+
+const CACHE_KEY = "dashboard:overview:v1";
+
+/* ── KPI card ────────────────────────────────────────────── */
+
+function KpiCard({
+  label,
+  value,
+  icon,
+  change,
+  sparkData,
+}: {
+  label: string;
+  value: string;
+  icon: React.ReactNode;
+  change?: { current: number; previous: number; invert?: boolean };
+  sparkData?: number[];
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-4 shadow-sm transition-shadow hover:shadow-md">
+      <div className="flex items-center gap-2 text-muted-foreground">
+        {icon}
+        <span className="text-xs font-medium">{label}</span>
+      </div>
+      <div className="mt-2 flex items-end justify-between gap-2">
+        <p className="text-2xl font-bold tabular-nums text-foreground">{value}</p>
+        <div className="flex items-center gap-2">
+          {sparkData && sparkData.length >= 2 && (
+            <SparkLine data={sparkData} width={56} height={24} />
+          )}
+          {change && (
+            <ChangeIndicator
+              current={change.current}
+              previous={change.previous}
+              invertColors={change.invert}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── Disconnected placeholder ────────────────────────────── */
+
+function DisconnectedSection({ domain, settingsHref }: { domain: string; settingsHref?: string }) {
+  return (
+    <div className="flex h-48 flex-col items-center justify-center rounded-lg border border-dashed border-border/60 bg-secondary/20 text-center">
+      <Settings className="mb-3 h-8 w-8 text-muted-foreground/50" />
+      <p className="text-sm font-medium text-muted-foreground">Connect {domain}</p>
+      <p className="mt-1 text-xs text-muted-foreground/70">
+        Set up your integration to see {domain.toLowerCase()} metrics here.
+      </p>
+      {settingsHref && (
+        <Link
+          href={settingsHref}
+          className="mt-3 inline-flex items-center gap-1 rounded-md border border-border bg-secondary/40 px-3 py-1.5 text-xs text-foreground hover:bg-secondary/60"
+        >
+          Integration settings <ArrowRight className="h-3 w-3" />
+        </Link>
+      )}
+    </div>
+  );
+}
+
+/* ── Section link footer ─────────────────────────────────── */
+
+function SectionFooter({ href, label }: { href: string; label: string }) {
+  return (
+    <Link
+      href={href}
+      className="mt-4 inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+    >
+      {label} <ArrowRight className="h-3 w-3" />
+    </Link>
+  );
+}
+
+/* ── Status badge ────────────────────────────────────────── */
+
+const STATUS_STYLES: Record<string, string> = {
+  connected: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 border-emerald-500/20",
+  partial: "bg-amber-500/15 text-amber-600 dark:text-amber-400 border-amber-500/20",
+  degraded: "bg-red-500/15 text-red-600 dark:text-red-400 border-red-500/20",
+  missing: "bg-secondary text-muted-foreground border-border",
+};
+
+function StatusBadge({
+  label,
+  status,
+  href,
+}: {
+  label: string;
+  status: string;
+  href: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors hover:opacity-80 ${STATUS_STYLES[status] ?? STATUS_STYLES.missing}`}
+    >
+      <span
+        className={`h-1.5 w-1.5 rounded-full ${
+          status === "connected"
+            ? "bg-emerald-500"
+            : status === "partial"
+              ? "bg-amber-500"
+              : status === "degraded"
+                ? "bg-red-500"
+                : "bg-muted-foreground/40"
+        }`}
+      />
+      {label}
+    </Link>
+  );
+}
+
+/* ── Finance section ─────────────────────────────────────── */
+
+function FinanceSection({ data }: { data: ExecutiveOverviewPayload["finance"] }) {
+  if (!data.connected) {
+    return (
+      <SectionCard title="Finance" subtitle="Revenue, cash, and runway">
+        <DisconnectedSection domain="Stripe / Mercury" settingsHref="/settings/integrations" />
+      </SectionCard>
+    );
+  }
+
+  const trendData = data.revenueTrend.map((t) => ({
+    month: t.month,
+    revenue: t.revenue,
+  }));
+
+  return (
+    <SectionCard title="Finance" subtitle="Revenue, cash, and runway">
+      <div className="space-y-5">
+        {/* KPIs row */}
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <div>
+            <p className="text-xs text-muted-foreground">MRR</p>
+            <p className="text-lg font-bold tabular-nums">{fmt$(data.mrr)}</p>
+            <ChangeIndicator current={data.mrr} previous={data.mrr - data.mrrChange} />
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Subscriptions</p>
+            <p className="text-lg font-bold tabular-nums">{fmtN(data.activeSubscriptions)}</p>
+            <p className="text-xs text-muted-foreground">{fmtPct(data.churnRate)} churn</p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Cash Balance</p>
+            <p className="text-lg font-bold tabular-nums">{fmt$(data.totalBalance)}</p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Runway</p>
+            <p className="text-lg font-bold tabular-nums">
+              {data.runway > 0 ? `${Math.round(data.runway)}mo` : "N/A"}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {data.burnRate > 0 ? `${fmt$(data.burnRate)}/mo burn` : ""}
+            </p>
+          </div>
+        </div>
+
+        {/* Revenue trend chart */}
+        {trendData.length >= 2 && (
+          <AreaTrend
+            data={trendData}
+            xKey="month"
+            yKeys={["revenue"]}
+            height={180}
+            yFormatter={(v) => fmt$(v)}
+          />
+        )}
+
+        <SectionFooter href="/analytics/finance" label="View full finance dashboard" />
+      </div>
+    </SectionCard>
+  );
+}
+
+/* ── Traffic section ─────────────────────────────────────── */
+
+function TrafficSection({ data }: { data: ExecutiveOverviewPayload["traffic"] }) {
+  if (!data.connected) {
+    return (
+      <SectionCard title="Traffic & Marketing" subtitle="Web sessions and channels">
+        <DisconnectedSection domain="Google Analytics" settingsHref="/settings/integrations" />
+      </SectionCard>
+    );
+  }
+
+  const trendData = data.dailyTrend.map((t) => ({
+    date: t.date,
+    sessions: t.sessions,
+  }));
+
+  return (
+    <SectionCard title="Traffic & Marketing" subtitle="Web sessions and channels">
+      <div className="space-y-5">
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+          <div>
+            <p className="text-xs text-muted-foreground">Sessions (30d)</p>
+            <p className="text-lg font-bold tabular-nums">{fmtN(data.sessions30d)}</p>
+            <ChangeIndicator current={data.sessions30d} previous={data.sessionsPrev30d} />
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Users (30d)</p>
+            <p className="text-lg font-bold tabular-nums">{fmtN(data.users30d)}</p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Bounce Rate</p>
+            <p className="text-lg font-bold tabular-nums">{fmtPct(data.bounceRate)}</p>
+          </div>
+        </div>
+
+        {/* Daily sessions chart */}
+        {trendData.length >= 2 && (
+          <AreaTrend
+            data={trendData}
+            xKey="date"
+            yKeys={["sessions"]}
+            height={180}
+            yFormatter={(v) => fmtN(v)}
+            xFormatter={(d) => {
+              const parts = d.split("-");
+              return parts.length >= 3 ? `${parts[1]}/${parts[2]}` : d;
+            }}
+          />
+        )}
+
+        {/* Top channels */}
+        {data.topChannels.length > 0 && (
+          <div>
+            <p className="mb-2 text-xs font-medium text-muted-foreground">Top Channels</p>
+            <div className="space-y-1.5">
+              {data.topChannels.map((ch) => (
+                <div key={ch.channel} className="flex items-center justify-between text-sm">
+                  <span className="truncate text-foreground">{ch.channel}</span>
+                  <span className="tabular-nums text-muted-foreground">{fmtN(ch.sessions)}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <SectionFooter href="/analytics/ads-traffic" label="View full traffic dashboard" />
+      </div>
+    </SectionCard>
+  );
+}
+
+/* ── Sales section ───────────────────────────────────────── */
+
+function SalesSection({ data }: { data: ExecutiveOverviewPayload["sales"] }) {
+  if (!data.connected) {
+    return (
+      <SectionCard title="Sales Pipeline" subtitle="Deal flow and conversion">
+        <DisconnectedSection domain="HubSpot" settingsHref="/settings/integrations" />
+      </SectionCard>
+    );
+  }
+
+  const funnelStages = data.stages.slice(0, 8).map((stage, i) => ({
+    label: stage.label,
+    value: stage.count,
+    color: getChartColor(i),
+  }));
+
+  return (
+    <SectionCard title="Sales Pipeline" subtitle="Deal flow and conversion">
+      <div className="space-y-5">
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <div>
+            <p className="text-xs text-muted-foreground">Pipeline Value</p>
+            <p className="text-lg font-bold tabular-nums">{fmt$(data.pipelineValue)}</p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Total Deals</p>
+            <p className="text-lg font-bold tabular-nums">{fmtN(data.totalDeals)}</p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Win Rate</p>
+            <p className="text-lg font-bold tabular-nums">{fmtPct(data.winRate)}</p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Avg Deal Size</p>
+            <p className="text-lg font-bold tabular-nums">{fmt$(data.avgDealSize)}</p>
+          </div>
+        </div>
+
+        {/* Pipeline funnel */}
+        {funnelStages.length > 0 && (
+          <HorizontalFunnel
+            stages={funnelStages}
+            height={Math.min(280, funnelStages.length * 40 + 40)}
+            valueFormatter={(v) => fmtN(v)}
+          />
+        )}
+
+        <SectionFooter href="/analytics/sales-pipeline" label="View full sales dashboard" />
+      </div>
+    </SectionCard>
+  );
+}
+
+/* ── Customer Success section ────────────────────────────── */
+
+function CustomerSuccessSection({ data }: { data: ExecutiveOverviewPayload["customerSuccess"] }) {
+  if (!data.connected) {
+    return (
+      <SectionCard title="Customer Success" subtitle="Support and product adoption">
+        <DisconnectedSection domain="Pylon" settingsHref="/settings/integrations" />
+      </SectionCard>
+    );
+  }
+
+  return (
+    <SectionCard title="Customer Success" subtitle="Support and product adoption">
+      <div className="space-y-5">
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+          <div>
+            <p className="text-xs text-muted-foreground">Open Conversations</p>
+            <p className="text-lg font-bold tabular-nums">{fmtN(data.openConversations)}</p>
+            {data.urgentConversations > 0 && (
+              <p className="text-xs font-medium text-red-500">{data.urgentConversations} urgent</p>
+            )}
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Avg Response Time</p>
+            <p className="text-lg font-bold tabular-nums">
+              {data.avgFirstResponseMinutes !== null
+                ? data.avgFirstResponseMinutes < 60
+                  ? `${Math.round(data.avgFirstResponseMinutes)}m`
+                  : `${(data.avgFirstResponseMinutes / 60).toFixed(1)}h`
+                : "N/A"}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">CSAT</p>
+            <p className="text-lg font-bold tabular-nums">
+              {data.csat !== null ? fmtPct(data.csat) : "N/A"}
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div className="rounded-lg border border-border/60 p-3">
+            <p className="text-xs text-muted-foreground">Resolved (Range)</p>
+            <p className="text-xl font-bold tabular-nums">{fmtN(data.resolvedInRange)}</p>
+          </div>
+          <div className="rounded-lg border border-border/60 p-3">
+            <p className="text-xs text-muted-foreground">Tasks Completed</p>
+            <p className="text-xl font-bold tabular-nums">{fmtN(data.completedTasks)}</p>
+            {data.throughputRate !== null && (
+              <p className="text-xs text-muted-foreground">{fmtPct(data.throughputRate)} throughput</p>
+            )}
+          </div>
+        </div>
+
+        <SectionFooter href="/analytics/customer-success" label="View full CS dashboard" />
+      </div>
+    </SectionCard>
+  );
+}
+
+/* ── Main component ──────────────────────────────────────── */
+
+export function ExecutiveOverviewDashboard() {
+  const resource = useDashboardResource<ExecutiveOverviewPayload>({
+    cacheKey: CACHE_KEY,
+    deps: [],
+    load: async ({ signal, refresh }) => {
+      const response = await fetch("/api/dashboard/overview", {
+        signal,
+        cache: refresh ? "no-store" : "default",
+      });
+
+      if (!response.ok) {
+        throw new Error(`Dashboard request failed (${response.status})`);
+      }
+
+      const payload = (await response.json()) as unknown;
+      if (!isExecutiveOverviewPayload(payload)) {
+        throw new Error("Dashboard response payload is invalid");
+      }
+      return payload;
+    },
+    getLastUpdatedAt: (payload) => payload.meta?.servedAt ?? payload.generatedAt,
+    mapError: (error) => {
+      if (error instanceof Error && error.message.trim().length > 0) return error.message;
+      return "Could not load executive overview.";
+    },
+  });
+
+  const data = resource.data;
+
+  const revenueTrendSpark = useMemo(() => {
+    if (!data?.finance.revenueTrend) return [];
+    return data.finance.revenueTrend.map((t) => t.revenue);
+  }, [data]);
+
+  const sessionsTrendSpark = useMemo(() => {
+    if (!data?.traffic.dailyTrend) return [];
+    // Last 14 days for a clean sparkline
+    return data.traffic.dailyTrend.slice(-14).map((t) => t.sessions);
+  }, [data]);
+
+  /* ── Loading state ──────────────────────────────────── */
+
+  if (resource.loading && !data) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">Dashboard</h1>
+        <DashboardLoadingState />
+      </div>
+    );
+  }
+
+  /* ── Error-only state (no cached data) ──────────────── */
+
+  if (!data && resource.error) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">Dashboard</h1>
+        <DashboardErrorBanner
+          message={resource.error}
+          onRetry={resource.refresh}
+          settingsHref="/settings/integrations"
+        />
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">Dashboard</h1>
+          {resource.lastUpdatedAt && (
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Updated {new Date(resource.lastUpdatedAt).toLocaleString()}
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={resource.refresh}
+          disabled={resource.refreshing}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-3 py-1.5 text-xs font-medium text-foreground shadow-sm hover:bg-secondary/60 disabled:opacity-50"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${resource.refreshing ? "animate-spin" : ""}`} />
+          {resource.refreshing ? "Refreshing..." : "Refresh"}
+        </button>
+      </div>
+
+      {/* Stale banner */}
+      {resource.stale && (
+        <DashboardStaleBanner
+          lastUpdatedAt={resource.lastUpdatedAt}
+          onRefresh={resource.refresh}
+          refreshing={resource.refreshing}
+        />
+      )}
+
+      {/* Error banner (with stale cached data) */}
+      {resource.error && !resource.stale && (
+        <DashboardErrorBanner message={resource.error} onRetry={resource.refresh} />
+      )}
+
+      {/* KPI strip */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        <KpiCard
+          label="MRR"
+          value={data.finance.connected ? fmt$(data.finance.mrr) : "--"}
+          icon={<DollarSign className="h-4 w-4" />}
+          change={
+            data.finance.connected
+              ? { current: data.finance.mrr, previous: data.finance.mrr - data.finance.mrrChange }
+              : undefined
+          }
+          sparkData={revenueTrendSpark.length >= 2 ? revenueTrendSpark : undefined}
+        />
+        <KpiCard
+          label="Revenue (30d)"
+          value={data.finance.connected ? fmt$(data.finance.totalRevenue30d) : "--"}
+          icon={<TrendingUp className="h-4 w-4" />}
+          change={
+            data.finance.connected
+              ? { current: data.finance.totalRevenue30d, previous: data.finance.totalRevenuePrev30d }
+              : undefined
+          }
+        />
+        <KpiCard
+          label="Sessions (30d)"
+          value={data.traffic.connected ? fmtN(data.traffic.sessions30d) : "--"}
+          icon={<BarChart3 className="h-4 w-4" />}
+          change={
+            data.traffic.connected
+              ? { current: data.traffic.sessions30d, previous: data.traffic.sessionsPrev30d }
+              : undefined
+          }
+          sparkData={sessionsTrendSpark.length >= 2 ? sessionsTrendSpark : undefined}
+        />
+        <KpiCard
+          label="Pipeline"
+          value={data.sales.connected ? fmt$(data.sales.pipelineValue) : "--"}
+          icon={<Users className="h-4 w-4" />}
+        />
+        <KpiCard
+          label="Open Support"
+          value={data.customerSuccess.connected ? fmtN(data.customerSuccess.openConversations) : "--"}
+          icon={<HeadphonesIcon className="h-4 w-4" />}
+        />
+        <KpiCard
+          label="Ad Spend (30d)"
+          value={data.adSpend.connected ? fmt$(data.adSpend.totalSpend30d) : "--"}
+          icon={<Megaphone className="h-4 w-4" />}
+        />
+      </div>
+
+      {/* Two-column domain sections */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <FinanceSection data={data.finance} />
+        <TrafficSection data={data.traffic} />
+        <SalesSection data={data.sales} />
+        <CustomerSuccessSection data={data.customerSuccess} />
+      </div>
+
+      {/* Ad Spend summary (single row) */}
+      {data.adSpend.connected && (
+        <SectionCard title="Ad Spend Overview" subtitle="Blended metrics across all ad platforms">
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+            <div>
+              <p className="text-xs text-muted-foreground">Total Spend</p>
+              <p className="text-lg font-bold tabular-nums">{fmt$(data.adSpend.totalSpend30d)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Impressions</p>
+              <p className="text-lg font-bold tabular-nums">{fmtN(data.adSpend.totalImpressions)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Clicks</p>
+              <p className="text-lg font-bold tabular-nums">{fmtN(data.adSpend.totalClicks)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Conversions</p>
+              <p className="text-lg font-bold tabular-nums">{fmtN(data.adSpend.totalConversions)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Blended CTR</p>
+              <p className="text-lg font-bold tabular-nums">{fmtPct(data.adSpend.blendedCtr)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Blended CPA</p>
+              <p className="text-lg font-bold tabular-nums">{fmt$(data.adSpend.blendedCpa)}</p>
+            </div>
+          </div>
+          <SectionFooter href="/analytics/ads-traffic" label="View full ad performance" />
+        </SectionCard>
+      )}
+
+      {/* Integration health strip */}
+      {data.sections.length > 0 && (
+        <div className="rounded-xl border border-border bg-card p-4">
+          <div className="mb-3 flex items-center gap-2">
+            <Activity className="h-4 w-4 text-muted-foreground" />
+            <span className="text-xs font-medium text-muted-foreground">Integration Health</span>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {data.sections.map((section) => (
+              <StatusBadge
+                key={section.id}
+                label={section.label}
+                status={section.status}
+                href={section.href}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/analytics/credentials.ts
+++ b/src/lib/analytics/credentials.ts
@@ -526,11 +526,12 @@ export async function getCredentials(userId?: string): Promise<AnalyticsCredenti
     });
 
     // Owner fallback: when the configured owner has no connections yet
-    // (migration hasn't run), fetch from any connected user.
+    // (migration hasn't run), fetch from any connected user.  We order by
+    // connectedAt desc and deduplicate in JS to avoid a Prisma/PostgreSQL
+    // DISTINCT ON + ORDER BY constraint conflict.
     if (connections.length === 0 && isConfiguredIntegrationOwner(userId)) {
-      connections = await prisma.integrationConnection.findMany({
+      const allConnected = await prisma.integrationConnection.findMany({
         where: { status: IntegrationConnectionStatus.CONNECTED },
-        distinct: ["provider"],
         orderBy: { connectedAt: "desc" },
         select: {
           userId: true,
@@ -546,6 +547,13 @@ export async function getCredentials(userId?: string): Promise<AnalyticsCredenti
           lastSyncedAt: true,
           lastError: true,
         },
+      });
+      // Keep only the most recently connected row per provider.
+      const seen = new Set<IntegrationProvider>();
+      connections = allConnected.filter((c) => {
+        if (seen.has(c.provider)) return false;
+        seen.add(c.provider);
+        return true;
       });
     }
 

--- a/src/lib/dashboard/executive-overview-types.ts
+++ b/src/lib/dashboard/executive-overview-types.ts
@@ -1,0 +1,107 @@
+// ─── Executive Overview Dashboard Types ──────────────────
+// Payload served by /api/dashboard/overview and consumed by
+// the ExecutiveOverviewDashboard component.
+
+import type { SectionStatus } from "@/lib/analytics/summary-health";
+import type { RevenueTrend, DealStage } from "@/lib/analytics/types";
+
+/* ── Per-domain section payloads ─────────────────────────── */
+
+export interface OverviewFinance {
+  connected: boolean;
+  mrr: number;
+  mrrChange: number;
+  totalRevenue30d: number;
+  totalRevenuePrev30d: number;
+  revenueGrowth: number;
+  activeSubscriptions: number;
+  churnRate: number;
+  revenueTrend: RevenueTrend[];
+  totalBalance: number;
+  burnRate: number;
+  runway: number;
+}
+
+export interface OverviewTraffic {
+  connected: boolean;
+  sessions30d: number;
+  sessionsPrev30d: number;
+  users30d: number;
+  bounceRate: number;
+  topChannels: { channel: string; sessions: number }[];
+  dailyTrend: { date: string; sessions: number }[];
+}
+
+export interface OverviewSales {
+  connected: boolean;
+  totalDeals: number;
+  pipelineValue: number;
+  closedWon: number;
+  closedWonValue: number;
+  winRate: number;
+  avgDealSize: number;
+  stages: DealStage[];
+}
+
+export interface OverviewCustomerSuccess {
+  connected: boolean;
+  openConversations: number;
+  urgentConversations: number;
+  avgFirstResponseMinutes: number | null;
+  csat: number | null;
+  resolvedInRange: number;
+  completedTasks: number;
+  throughputRate: number | null;
+}
+
+export interface OverviewAdSpend {
+  connected: boolean;
+  totalSpend30d: number;
+  totalImpressions: number;
+  totalClicks: number;
+  totalConversions: number;
+  blendedCtr: number;
+  blendedCpa: number;
+}
+
+export interface OverviewSectionHealth {
+  id: string;
+  label: string;
+  href: string;
+  status: SectionStatus;
+}
+
+/* ── Top-level payload ───────────────────────────────────── */
+
+export interface ExecutiveOverviewPayload {
+  generatedAt: string;
+  meta: {
+    servedAt: string;
+    isPartial: boolean;
+  };
+  finance: OverviewFinance;
+  traffic: OverviewTraffic;
+  sales: OverviewSales;
+  customerSuccess: OverviewCustomerSuccess;
+  adSpend: OverviewAdSpend;
+  sections: OverviewSectionHealth[];
+}
+
+/* ── Type guard ──────────────────────────────────────────── */
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isExecutiveOverviewPayload(value: unknown): value is ExecutiveOverviewPayload {
+  if (!isRecord(value)) return false;
+  if (typeof value.generatedAt !== "string") return false;
+  if (!isRecord(value.meta)) return false;
+  if (!isRecord(value.finance)) return false;
+  if (!isRecord(value.traffic)) return false;
+  if (!isRecord(value.sales)) return false;
+  if (!isRecord(value.customerSuccess)) return false;
+  if (!isRecord(value.adSpend)) return false;
+  if (!Array.isArray(value.sections)) return false;
+  return true;
+}


### PR DESCRIPTION
## Summary
- Replaces the task-focused `PersonalizedDashboard` on `/dashboard` with a new `ExecutiveOverviewDashboard` that aggregates top-line KPIs from all connected integrations
- Adds a lightweight `/api/dashboard/overview` route that reads from existing cached analytics snapshots (Stripe, Mercury, GA, HubSpot, Google/Meta/Reddit Ads, Pylon)
- New responsive layout: 6-card KPI strip → 2-column domain sections (Finance, Traffic, Sales, Customer Success) → Ad Spend row → integration health strip

## Test plan
- [x] `npx tsc --noEmit` — no new type errors (only pre-existing Prisma/OutboxClient issues)
- [x] `npx vitest run 'dashboard'` — all 40 tests pass across 8 test files
- [ ] Manual: navigate to `/dashboard`, verify sections render with data or empty states
- [ ] Manual: verify responsive layout at mobile / tablet / desktop widths
- [ ] Manual: verify section links navigate to sub-dashboards (`/analytics`, `/deals`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)