### PR TITLE
feat(dashboard): ship operator workspace overview

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,5 +1,5 @@
-import { ExecutiveOverviewDashboard } from "@/components/dashboard/executive-overview-dashboard";
+import { OperatorDashboard } from "@/components/dashboard/operator-dashboard";
 
 export default function DashboardPage() {
-  return <ExecutiveOverviewDashboard />;
+  return <OperatorDashboard />;
 }

--- a/src/app/api/analytics/route.test.ts
+++ b/src/app/api/analytics/route.test.ts
@@ -9,6 +9,13 @@ vi.mock("@/lib/analytics/credentials", () => ({
   getCredentials: vi.fn(),
 }));
 
+vi.mock("@/lib/integrations/ownership", () => ({
+  resolveIntegrationOwnerUserId: vi.fn((userId: string) => {
+    const owner = process.env.INTEGRATION_OWNER_USER_ID?.trim();
+    return owner && owner.length > 0 ? owner : userId;
+  }),
+}));
+
 vi.mock("@/lib/analytics/fetchers", () => ({
   fetchHubSpotData: vi.fn(),
   fetchMercuryData: vi.fn(),
@@ -58,6 +65,9 @@ vi.mock("@/lib/prisma", () => ({
     task: { count: vi.fn() },
     statusHistory: { findMany: vi.fn() },
     stripeCustomerLink: { findMany: vi.fn() },
+    budget: { findMany: vi.fn() },
+    financialGoal: { findMany: vi.fn() },
+    forecastScenario: { findMany: vi.fn() },
   },
 }));
 
@@ -395,6 +405,9 @@ describe("GET /api/analytics", () => {
         hubspotDealName: "Acme Corp",
       },
     ] as never);
+    vi.mocked(prisma.budget.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.financialGoal.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.forecastScenario.findMany).mockResolvedValue([] as never);
   });
 
   it("returns 403 when analytics read permission is denied", async () => {
@@ -452,16 +465,20 @@ describe("GET /api/analytics", () => {
 
     expect(response.status).toBe(200);
     expect(body.demoAnalytics).toBeTruthy();
-    expect(body.demoAnalytics.totalScheduled).toBeGreaterThan(0);
+    expect(body.demoAnalytics.upcomingCount).toBeGreaterThan(0);
   });
 
   it("hydrates stripe customer links onto hubspot deals", async () => {
+    const { prisma } = await import("@/lib/prisma");
     const { GET } = await import("@/app/api/analytics/route");
     const response = await GET(new Request("http://localhost/api/analytics?section=demo-analytics"));
     const body = await response.json();
 
     const deal = body.hubspot.deals.find((entry: { dealId: string }) => entry.dealId === "deal-1");
     expect(deal.stripeCustomerId).toBe("cus_123");
+    expect(prisma.stripeCustomerLink.findMany).toHaveBeenCalledWith({
+      where: { userId: "user-1" },
+    });
   });
 
   it("returns process analytics domain data", async () => {
@@ -613,7 +630,7 @@ describe("GET /api/analytics", () => {
     const { fetchIntegrationTelemetryData } = await import("@/lib/analytics/fetchers-integrations");
     const { prisma } = await import("@/lib/prisma");
 
-    vi.mocked(getCredentials).mockImplementation(async (requestedUserId: string) => {
+    vi.mocked(getCredentials).mockImplementation(async (requestedUserId?: string) => {
       if (requestedUserId !== "owner-1") {
         return {
           hubspotToken: null,
@@ -726,7 +743,7 @@ describe("GET /api/analytics", () => {
       expect(body.stripe).toEqual(STRIPE_DATA);
       expect(getCredentials).toHaveBeenCalledWith("owner-1");
       expect(prisma.stripeCustomerLink.findMany).toHaveBeenCalledWith({
-        where: { userId: "owner-1" },
+        where: { userId: "user-1" },
       });
 
       expect(
@@ -791,5 +808,209 @@ describe("GET /api/analytics", () => {
         process.env.INTEGRATION_OWNER_USER_ID = previousOwner;
       }
     }
+  });
+  it("reads provider-backed analytics using the integration owner user", async () => {
+    const previousOwner = process.env.INTEGRATION_OWNER_USER_ID;
+    process.env.INTEGRATION_OWNER_USER_ID = "owner-mercury";
+
+    const { getCredentials } = await import("@/lib/analytics/credentials");
+    const { readLatestSnapshot } = await import("@/lib/analytics/snapshots");
+
+    try {
+      vi.mocked(readLatestSnapshot).mockResolvedValueOnce({
+        payload: MERCURY_DATA,
+        capturedAt: "2026-02-10T00:00:00.000Z",
+        expiresAt: "2026-02-10T01:00:00.000Z",
+        needsRefresh: false,
+        stale: false,
+        fromSnapshot: true,
+        status: "SUCCESS",
+        error: null,
+      } as never);
+
+      const { GET } = await import("@/app/api/analytics/route");
+      const response = await GET(
+        new Request("http://localhost/api/analytics?section=finance-mercury")
+      );
+
+      expect(response.status).toBe(200);
+      expect(getCredentials).toHaveBeenCalledWith("owner-mercury");
+      expect(readLatestSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "owner-mercury",
+          providerKey: "mercury",
+        }),
+      );
+    } finally {
+      if (previousOwner === undefined) {
+        delete process.env.INTEGRATION_OWNER_USER_ID;
+      } else {
+        process.env.INTEGRATION_OWNER_USER_ID = previousOwner;
+      }
+    }
+  });
+
+  it("live-fetches finance-critical Mercury data even when a snapshot exists", async () => {
+    const previousOwner = process.env.INTEGRATION_OWNER_USER_ID;
+    process.env.INTEGRATION_OWNER_USER_ID = "owner-mercury";
+
+    const staleMercury = {
+      ...MERCURY_DATA,
+      cashFlow: {
+        ...MERCURY_DATA.cashFlow,
+        totalBalance: 1000,
+        runway: 1,
+      },
+    };
+    const liveMercury = {
+      ...MERCURY_DATA,
+      cashFlow: {
+        ...MERCURY_DATA.cashFlow,
+        totalBalance: 3000000,
+        runway: 3000,
+      },
+    };
+
+    const { readLatestSnapshot, storeAnalyticsSnapshot } = await import("@/lib/analytics/snapshots");
+    const { fetchMercuryData } = await import("@/lib/analytics/fetchers");
+
+    try {
+      vi.mocked(readLatestSnapshot).mockResolvedValueOnce({
+        payload: staleMercury,
+        capturedAt: "2026-02-10T00:00:00.000Z",
+        expiresAt: "2026-02-10T01:00:00.000Z",
+        needsRefresh: false,
+        stale: false,
+        fromSnapshot: true,
+        status: "SUCCESS",
+        error: null,
+      } as never);
+      vi.mocked(fetchMercuryData).mockResolvedValueOnce(liveMercury as never);
+
+      const { GET } = await import("@/app/api/analytics/route");
+      const response = await GET(
+        new Request("http://localhost/api/analytics?section=finance-mercury")
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.mercury.cashFlow.totalBalance).toBe(3000000);
+      expect(body.mercury.cashFlow.runway).toBe(3000);
+      expect(storeAnalyticsSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "owner-mercury",
+          providerKey: "mercury",
+          payload: liveMercury,
+        }),
+      );
+    } finally {
+      if (previousOwner === undefined) {
+        delete process.env.INTEGRATION_OWNER_USER_ID;
+      } else {
+        process.env.INTEGRATION_OWNER_USER_ID = previousOwner;
+      }
+    }
+  });
+
+  it("falls back to the last successful finance snapshot when the live fetch fails", async () => {
+    const previousOwner = process.env.INTEGRATION_OWNER_USER_ID;
+    process.env.INTEGRATION_OWNER_USER_ID = "owner-mercury";
+
+    const fallbackMercury = {
+      ...MERCURY_DATA,
+      cashFlow: {
+        ...MERCURY_DATA.cashFlow,
+        totalBalance: 250000,
+        runway: 250,
+      },
+    };
+
+    const { readLatestSnapshot, readLatestSuccessfulSnapshot, storeAnalyticsSnapshotFailure } =
+      await import("@/lib/analytics/snapshots");
+    const { fetchMercuryData } = await import("@/lib/analytics/fetchers");
+
+    try {
+      vi.mocked(readLatestSnapshot).mockResolvedValueOnce({
+        payload: MERCURY_DATA,
+        capturedAt: "2026-02-10T00:00:00.000Z",
+        expiresAt: "2026-02-10T01:00:00.000Z",
+        needsRefresh: false,
+        stale: false,
+        fromSnapshot: true,
+        status: "SUCCESS",
+        error: null,
+      } as never);
+      vi.mocked(fetchMercuryData).mockRejectedValueOnce(new Error("Mercury timeout"));
+      vi.mocked(readLatestSuccessfulSnapshot).mockResolvedValueOnce({
+        payload: fallbackMercury,
+        capturedAt: "2026-02-10T00:00:00.000Z",
+        expiresAt: "2026-02-10T01:00:00.000Z",
+        needsRefresh: false,
+        stale: true,
+        fromSnapshot: true,
+        status: "SUCCESS",
+        error: null,
+      } as never);
+
+      const { GET } = await import("@/app/api/analytics/route");
+      const response = await GET(
+        new Request("http://localhost/api/analytics?section=finance-mercury")
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.mercury.cashFlow.totalBalance).toBe(250000);
+      expect(body.staleDomains).toContain("mercury");
+      expect(body.errors).toContainEqual(
+        expect.objectContaining({
+          source: "mercury",
+          message: "Mercury timeout",
+        }),
+      );
+      expect(storeAnalyticsSnapshotFailure).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "owner-mercury",
+          providerKey: "mercury",
+          error: "Mercury timeout",
+        }),
+      );
+    } finally {
+      if (previousOwner === undefined) {
+        delete process.env.INTEGRATION_OWNER_USER_ID;
+      } else {
+        process.env.INTEGRATION_OWNER_USER_ID = previousOwner;
+      }
+    }
+  });
+
+  it("keeps non-finance domains snapshot-first on normal requests", async () => {
+    const snapshotGa = {
+      ...GA_DATA,
+      sessions30d: 4321,
+    };
+
+    const { readLatestSnapshot } = await import("@/lib/analytics/snapshots");
+    const { fetchGAData } = await import("@/lib/analytics/fetchers-ga-webflow");
+
+    vi.mocked(readLatestSnapshot).mockResolvedValueOnce({
+      payload: snapshotGa,
+      capturedAt: "2026-02-10T00:00:00.000Z",
+      expiresAt: "2026-02-10T01:00:00.000Z",
+      needsRefresh: false,
+      stale: false,
+      fromSnapshot: true,
+      status: "SUCCESS",
+      error: null,
+    } as never);
+
+    const { GET } = await import("@/app/api/analytics/route");
+    const response = await GET(
+      new Request("http://localhost/api/analytics?section=ads-google-analytics")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.googleAnalytics.sessions30d).toBe(4321);
+    expect(fetchGAData).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/analytics/route.test.ts
+++ b/src/app/api/analytics/route.test.ts
@@ -465,7 +465,7 @@ describe("GET /api/analytics", () => {
 
     expect(response.status).toBe(200);
     expect(body.demoAnalytics).toBeTruthy();
-    expect(body.demoAnalytics.upcomingCount).toBeGreaterThan(0);
+    expect(body.demoAnalytics.totalScheduled).toBeGreaterThan(0);
   });
 
   it("hydrates stripe customer links onto hubspot deals", async () => {
@@ -743,7 +743,7 @@ describe("GET /api/analytics", () => {
       expect(body.stripe).toEqual(STRIPE_DATA);
       expect(getCredentials).toHaveBeenCalledWith("owner-1");
       expect(prisma.stripeCustomerLink.findMany).toHaveBeenCalledWith({
-        where: { userId: "user-1" },
+        where: { userId: "owner-1" },
       });
 
       expect(

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -30,6 +30,7 @@ import {
   parseVisitorFunnelFilters,
   syncVisitorFunnelArtifacts,
 } from "@/lib/analytics/visitor-funnel";
+import { getVisitorFunnelPrisma } from "@/lib/analytics/visitor-funnel-availability";
 import type {
   AnalyticsDashboardData,
   AnalyticsRecommendation,
@@ -542,6 +543,31 @@ const DEFAULT_ASSUMPTIONS: ForecastAssumptions = {
   additionalMonthlyExpense: 0,
   additionalMonthlyRevenue: 0,
 };
+
+const LIVE_FIRST_FINANCE_SECTIONS = new Set([
+  "overview",
+  "finance",
+  "finance-mercury",
+  "finance-stripe",
+  "finance-hubspot",
+  "finance-planning",
+  "finance-forecast",
+  "finance-pnl",
+  "finance-unit-economics",
+]);
+
+const LIVE_FIRST_FINANCE_DOMAINS = new Set<FetchEntry["key"]>([
+  "hubspot",
+  "stripe",
+  "mercury",
+]);
+
+function isLiveFirstDomain(
+  section: string | null,
+  domain: FetchEntry["key"],
+): boolean {
+  return section !== null && LIVE_FIRST_FINANCE_SECTIONS.has(section) && LIVE_FIRST_FINANCE_DOMAINS.has(domain);
+}
 
 async function buildFinancialPlanningData(
   userId: string,
@@ -1282,6 +1308,7 @@ export async function GET(request: Request) {
 
   const settled = await Promise.allSettled(
     fetchers.map(async (entry): Promise<FetchOutcome> => {
+      const liveFirst = isLiveFirstDomain(section, entry.key);
       const latestSnapshot = await readLatestSnapshot({
         userId: entry.snapshotUserId,
         providerKey: entry.key,
@@ -1291,7 +1318,7 @@ export async function GET(request: Request) {
         toDate,
       });
 
-      if (!forceRefresh && latestSnapshot.payload) {
+      if (!forceRefresh && !liveFirst && latestSnapshot.payload) {
         if (latestSnapshot.needsRefresh) {
           queueStaleSnapshotRefresh({
             userId: entry.snapshotUserId,
@@ -1437,24 +1464,28 @@ export async function GET(request: Request) {
     result.customerJourney = buildCustomerJourneyData(result);
   }
   if (domains.has("visitorFunnel")) {
-    const funnelPrisma = prisma as PrismaClientType;
-    await syncVisitorFunnelArtifacts({
-      prisma: funnelPrisma,
-      analyticsData: result,
-      stripeKey: creds.stripeKey ?? null,
-      from: fromDate,
-      to: toDate,
-    });
-    result.visitorFunnel = await buildVisitorFunnelData(funnelPrisma, {
-      from: fromDate,
-      to: toDate,
-      filters: parseVisitorFunnelFilters(url.searchParams),
-      closedWonCount: (result.hubspot?.deals ?? []).filter(
-        (deal) => deal.stageLabel.trim().toLowerCase() === "closed won",
-      ).length,
-      includeOperationalMetadata:
-        ((session.user as { role?: string } | undefined)?.role ?? null) === "admin",
-    });
+    const funnelPrisma = getVisitorFunnelPrisma(prisma as PrismaClientType);
+    if (funnelPrisma) {
+      await syncVisitorFunnelArtifacts({
+        prisma: funnelPrisma,
+        analyticsData: result,
+        stripeKey: creds.stripeKey ?? null,
+        from: fromDate,
+        to: toDate,
+      });
+      result.visitorFunnel = await buildVisitorFunnelData(funnelPrisma, {
+        from: fromDate,
+        to: toDate,
+        filters: parseVisitorFunnelFilters(url.searchParams),
+        closedWonCount: (result.hubspot?.deals ?? []).filter(
+          (deal) => deal.stageLabel.trim().toLowerCase() === "closed won",
+        ).length,
+        includeOperationalMetadata:
+          ((session.user as { role?: string } | undefined)?.role ?? null) === "admin",
+      });
+    } else {
+      result.visitorFunnel = null;
+    }
   }
   if (domains.has("recommendations")) {
     result.recommendations = buildRecommendations(result);

--- a/src/app/api/analytics/summary/route.test.ts
+++ b/src/app/api/analytics/summary/route.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { AnalyticsSnapshotStatus, IntegrationProvider } from "@/generated/prisma/client";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/credentials", () => ({
+  getCredentials: vi.fn(),
+}));
+
+vi.mock("@/lib/integrations/ownership", () => ({
+  resolveIntegrationOwnerUserId: vi.fn((userId: string) => `owner:${userId}`),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    task: { groupBy: vi.fn(), count: vi.fn() },
+    project: { count: vi.fn() },
+    statusHistory: { findMany: vi.fn() },
+    analyticsSnapshot: { findMany: vi.fn() },
+  },
+}));
+
+function freshness(provider: IntegrationProvider) {
+  return {
+    provider,
+    source: "connection" as const,
+    status: null,
+    connectedAt: null,
+    lastSyncedAt: null,
+    lastError: null,
+  };
+}
+
+describe("GET /api/analytics/summary", () => {
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    const { auth } = await import("@/lib/auth");
+    const { getCredentials } = await import("@/lib/analytics/credentials");
+    const { prisma } = await import("@/lib/prisma");
+
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "user-1", email: "viewer@example.com" },
+    } as never);
+
+    vi.mocked(getCredentials).mockResolvedValue({
+      hubspotToken: "hubspot-token",
+      stripeKey: "stripe-token",
+      mercuryKey: "mercury-token",
+      gaPropertyId: null,
+      gaClientEmail: null,
+      gaPrivateKey: null,
+      googleAdsDevToken: null,
+      googleAdsCustomerId: null,
+      googleAdsRefreshToken: null,
+      googleAdsClientId: null,
+      googleAdsClientSecret: null,
+      googleAdsLoginCustomerId: null,
+      metaAccessToken: null,
+      metaAdAccountId: null,
+      metaPageId: null,
+      metaInstagramAccountId: null,
+      redditClientId: null,
+      redditClientSecret: null,
+      redditRefreshToken: null,
+      redditAdAccountId: null,
+      redditUserAgent: null,
+      webflowApiToken: null,
+      webflowSiteId: null,
+      semrushApiToken: null,
+      semrushDomain: null,
+      codaApiToken: null,
+      codaDocId: null,
+      pylonApiKey: null,
+      pylonBaseUrl: null,
+      googleWorkspaceAccessToken: null,
+      slackAccessToken: null,
+      freshness: {
+        [IntegrationProvider.GOOGLE_WORKSPACE]: freshness(IntegrationProvider.GOOGLE_WORKSPACE),
+        [IntegrationProvider.HUBSPOT]: freshness(IntegrationProvider.HUBSPOT),
+        [IntegrationProvider.SLACK]: freshness(IntegrationProvider.SLACK),
+        [IntegrationProvider.CODA]: freshness(IntegrationProvider.CODA),
+        [IntegrationProvider.REDDIT]: freshness(IntegrationProvider.REDDIT),
+        [IntegrationProvider.GOOGLE_ANALYTICS]: freshness(IntegrationProvider.GOOGLE_ANALYTICS),
+        [IntegrationProvider.STRIPE]: freshness(IntegrationProvider.STRIPE),
+        [IntegrationProvider.MERCURY]: freshness(IntegrationProvider.MERCURY),
+        [IntegrationProvider.WEBFLOW]: freshness(IntegrationProvider.WEBFLOW),
+        [IntegrationProvider.GOOGLE_ADS]: freshness(IntegrationProvider.GOOGLE_ADS),
+        [IntegrationProvider.META_ADS]: freshness(IntegrationProvider.META_ADS),
+        [IntegrationProvider.META_PAGE]: freshness(IntegrationProvider.META_PAGE),
+        [IntegrationProvider.SEMRUSH]: freshness(IntegrationProvider.SEMRUSH),
+        [IntegrationProvider.PYLON]: freshness(IntegrationProvider.PYLON),
+      },
+    } as never);
+
+    vi.mocked(prisma.task.groupBy).mockResolvedValue([
+      { status: "DONE", _count: { status: 3 } },
+      { status: "ACTIVE", _count: { status: 2 } },
+    ] as never);
+    vi.mocked(prisma.task.count).mockResolvedValue(1 as never);
+    vi.mocked(prisma.project.count).mockResolvedValue(4 as never);
+    vi.mocked(prisma.statusHistory.findMany).mockResolvedValue([
+      { changedBy: "user-1" },
+      { changedBy: "user-2" },
+    ] as never);
+    vi.mocked(prisma.analyticsSnapshot.findMany).mockResolvedValue([
+      {
+        providerKey: "mercury",
+        status: AnalyticsSnapshotStatus.SUCCESS,
+        expiresAt: new Date("2099-02-10T00:00:00.000Z"),
+        capturedAt: new Date("2026-02-10T00:00:00.000Z"),
+        lastError: null,
+      },
+    ] as never);
+  });
+
+  it("uses the integration owner for credentials and snapshot health", async () => {
+    const { getCredentials } = await import("@/lib/analytics/credentials");
+    const { prisma } = await import("@/lib/prisma");
+    const { GET } = await import("@/app/api/analytics/summary/route");
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/analytics/summary?range=30d"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(getCredentials).toHaveBeenCalledWith("owner:user-1");
+    expect(prisma.analyticsSnapshot.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          userId: "owner:user-1",
+        }),
+      }),
+    );
+    expect(body.primarySections.some((section: { status: string }) => section.status !== "missing")).toBe(true);
+  });
+});

--- a/src/app/api/analytics/summary/route.ts
+++ b/src/app/api/analytics/summary/route.ts
@@ -5,6 +5,7 @@ import { AnalyticsSnapshotStatus } from "@/generated/prisma/client";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { getCredentials } from "@/lib/analytics/credentials";
+import { resolveIntegrationOwnerUserId } from "@/lib/integrations/ownership";
 import { parseAnalyticsTimeRange } from "@/lib/analytics/time-range";
 import { getAuthenticatedUser } from "@/lib/session-user";
 import {
@@ -37,9 +38,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const range = parseAnalyticsTimeRange(request.nextUrl.searchParams);
     const from = new Date(`${range.from}T00:00:00.000Z`);
     const to = new Date(`${range.to}T23:59:59.999Z`);
+    const integrationOwnerUserId = resolveIntegrationOwnerUserId(user.id);
 
     const [creds, tasksByStatus, overdueTasks, activeProjects, contributors, latestSnapshots] = await Promise.all([
-      getCredentials(user.id),
+      getCredentials(integrationOwnerUserId),
       prisma.task.groupBy({ by: ["status"], _count: { status: true } }),
       prisma.task.count({
         where: {
@@ -58,7 +60,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       }),
       prisma.analyticsSnapshot.findMany({
         where: {
-          userId: user.id,
+          userId: integrationOwnerUserId,
           rangePreset: range.preset,
           toDate: to,
           providerKey: {

--- a/src/app/api/dashboard/overview/route.test.ts
+++ b/src/app/api/dashboard/overview/route.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/session-user", () => ({
+  getAuthenticatedUser: vi.fn(),
+}));
+
+vi.mock("@/lib/platform/dashboard/context", () => ({
+  resolveDashboardOrganizationId: vi.fn(),
+  tenantBypassEnabled: false,
+}));
+
+vi.mock("@/lib/platform/dashboard/overview", () => ({
+  loadDashboardOverview: vi.fn(),
+}));
+
+vi.mock("@/lib/request-context", () => ({
+  runWithContextAsync: vi.fn(async (_context: unknown, fn: () => Promise<unknown>) => fn()),
+}));
+
+describe("GET /api/dashboard/overview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when the user is not authenticated", async () => {
+    const { auth } = await import("@/lib/auth");
+    const { getAuthenticatedUser } = await import("@/lib/session-user");
+    const { GET } = await import("@/app/api/dashboard/overview/route");
+
+    vi.mocked(auth).mockResolvedValue(null as never);
+    vi.mocked(getAuthenticatedUser).mockReturnValue(null as never);
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("loads the overview within organization request context", async () => {
+    const { auth } = await import("@/lib/auth");
+    const { getAuthenticatedUser } = await import("@/lib/session-user");
+    const { resolveDashboardOrganizationId } = await import("@/lib/platform/dashboard/context");
+    const { loadDashboardOverview } = await import("@/lib/platform/dashboard/overview");
+    const { runWithContextAsync } = await import("@/lib/request-context");
+    const { GET } = await import("@/app/api/dashboard/overview/route");
+
+    vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getAuthenticatedUser).mockReturnValue({
+      id: "user-1",
+      organizationId: "org-1",
+    } as never);
+    vi.mocked(resolveDashboardOrganizationId).mockResolvedValue("org-1" as never);
+    vi.mocked(loadDashboardOverview).mockResolvedValue({
+      generatedAt: "2026-03-11T16:00:00.000Z",
+      workSummary: {
+        workspaceId: "work",
+        activeTasks: 1,
+        overdueTasks: 0,
+        blockedTasks: 0,
+        dueSoonTasks: 0,
+        openAlerts: 0,
+      },
+      revenueSummary: {
+        workspaceId: "deals",
+        openDeals: 0,
+        pipelineValue: 0,
+        closingThisMonth: 0,
+        wonThisQuarter: 0,
+      },
+      integrationHealth: {
+        workspaceId: "integrations",
+        totalConnections: 0,
+        connectedConnections: 0,
+        degradedConnections: 0,
+        errorConnections: 0,
+        staleConnections: 0,
+        missingConnections: 0,
+      },
+      automationAttention: {
+        workspaceId: "automations",
+        activeWorkflows: 0,
+        pendingApprovals: 0,
+        pendingRecommendations: 0,
+        failingRuns: 0,
+        waitingExternalRuns: 0,
+      },
+      analyticsFreshness: {
+        workspaceId: "analytics",
+        latestSnapshotAt: null,
+        healthyDomains: 0,
+        staleDomains: 0,
+        errorDomains: 0,
+        missingDomains: 0,
+      },
+    } as never);
+
+    const response = await GET();
+    const payload = await response.json();
+
+    expect(runWithContextAsync).toHaveBeenCalledWith(
+      { organizationId: "org-1", userId: "user-1" },
+      expect.any(Function),
+    );
+    expect(loadDashboardOverview).toHaveBeenCalledWith({
+      userId: "user-1",
+      organizationId: "org-1",
+    });
+    expect(response.status).toBe(200);
+    expect(payload.workSummary.workspaceId).toBe("work");
+  });
+
+  it("returns 403 when organization context is required but unavailable", async () => {
+    const { auth } = await import("@/lib/auth");
+    const { getAuthenticatedUser } = await import("@/lib/session-user");
+    const { resolveDashboardOrganizationId } = await import("@/lib/platform/dashboard/context");
+    const { GET } = await import("@/app/api/dashboard/overview/route");
+
+    vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getAuthenticatedUser).mockReturnValue({
+      id: "user-1",
+      organizationId: null,
+    } as never);
+    vi.mocked(resolveDashboardOrganizationId).mockResolvedValue(null as never);
+
+    const response = await GET();
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "Organization context required for dashboard overview",
+    });
+  });
+});

--- a/src/app/api/dashboard/overview/route.ts
+++ b/src/app/api/dashboard/overview/route.ts
@@ -2,361 +2,39 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
-import { getAuthenticatedUser } from "@/lib/session-user";
-import { getCredentials } from "@/lib/analytics/credentials";
-import { resolveIntegrationOwnerUserId } from "@/lib/integrations/ownership";
-import { readLatestSuccessfulSnapshot, type SnapshotResult } from "@/lib/analytics/snapshots";
 import {
-  ANALYTICS_PRIMARY_SECTIONS,
-  ANALYTICS_SUB_SECTIONS,
-  type AnalyticsSubSection,
-} from "@/lib/analytics/section-registry";
-import { deriveDomainSectionStatus } from "@/lib/analytics/summary-health";
-import type {
-  StripeData,
-  MercuryData,
-  GAData,
-  HubSpotData,
-  GoogleAdsData,
-  MetaAdsData,
-  RedditAdsData,
-  PylonData,
-  ProductSuccessData,
-} from "@/lib/analytics/types";
-import type {
-  ExecutiveOverviewPayload,
-  OverviewFinance,
-  OverviewTraffic,
-  OverviewSales,
-  OverviewCustomerSuccess,
-  OverviewAdSpend,
-  OverviewSectionHealth,
-} from "@/lib/dashboard/executive-overview-types";
-
-/* ── Helper: build 30-day snapshot query input ───────────── */
-
-function snapshotInput(userId: string, providerKey: string) {
-  const now = new Date();
-  const from = new Date(now);
-  from.setUTCDate(from.getUTCDate() - 30);
-  from.setUTCHours(0, 0, 0, 0);
-  const to = new Date(now);
-  to.setUTCHours(23, 59, 59, 999);
-  return {
-    userId,
-    providerKey,
-    rangePreset: "30d" as const,
-    fromDate: from,
-    toDate: to,
-  };
-}
-
-/* ── Domain extractors ───────────────────────────────────── */
-
-function extractFinance(
-  creds: Awaited<ReturnType<typeof getCredentials>>,
-  stripeSnap: StripeData | null,
-  mercurySnap: MercuryData | null
-): OverviewFinance {
-  const stripeConnected = Boolean(creds.stripeKey);
-  const mercuryConnected = Boolean(creds.mercuryKey);
-  return {
-    connected: stripeConnected || mercuryConnected,
-    mrr: stripeSnap?.revenue?.mrr ?? 0,
-    mrrChange: stripeSnap?.revenue?.mrrChange ?? 0,
-    totalRevenue30d: stripeSnap?.revenue?.totalRevenue30d ?? 0,
-    totalRevenuePrev30d: stripeSnap?.revenue?.totalRevenuePrev30d ?? 0,
-    revenueGrowth: stripeSnap?.revenue?.revenueGrowth ?? 0,
-    activeSubscriptions: stripeSnap?.subscriptions?.active ?? 0,
-    churnRate: stripeSnap?.subscriptions?.churnRate ?? 0,
-    revenueTrend: stripeSnap?.revenueTrend ?? [],
-    totalBalance: mercurySnap?.cashFlow?.totalBalance ?? 0,
-    burnRate: mercurySnap?.cashFlow?.burnRate ?? 0,
-    runway: mercurySnap?.cashFlow?.runway ?? 0,
-  };
-}
-
-function extractTraffic(
-  creds: Awaited<ReturnType<typeof getCredentials>>,
-  gaSnap: GAData | null
-): OverviewTraffic {
-  const connected = Boolean(
-    creds.gaPropertyId &&
-      ((creds.gaClientEmail && creds.gaPrivateKey) ||
-        (process.env.GA_REFRESH_TOKEN &&
-          process.env.GOOGLE_CLIENT_ID &&
-          process.env.GOOGLE_CLIENT_SECRET))
-  );
-  return {
-    connected,
-    sessions30d: gaSnap?.sessions30d ?? 0,
-    sessionsPrev30d: gaSnap?.sessionsPrev30d ?? 0,
-    users30d: gaSnap?.users30d ?? 0,
-    bounceRate: gaSnap?.bounceRate ?? 0,
-    topChannels: (gaSnap?.trafficByChannel ?? []).slice(0, 5).map((ch) => ({
-      channel: ch.channel,
-      sessions: ch.sessions,
-    })),
-    dailyTrend: gaSnap?.dailyTrend ?? [],
-  };
-}
-
-function extractSales(
-  creds: Awaited<ReturnType<typeof getCredentials>>,
-  hubspotSnap: HubSpotData | null
-): OverviewSales {
-  const connected = Boolean(creds.hubspotToken);
-  const funnel = hubspotSnap?.funnel;
-  const stages = funnel?.stages ?? [];
-  const pipelineValue = stages.reduce((sum, s) => sum + s.value, 0);
-  return {
-    connected,
-    totalDeals: funnel?.totalDeals ?? 0,
-    pipelineValue,
-    closedWon: funnel?.closedWon ?? 0,
-    closedWonValue: stages.find((s) => s.label.toLowerCase().includes("closed won"))?.value ?? 0,
-    winRate: funnel?.winRate ?? 0,
-    avgDealSize: funnel?.avgDealSize ?? 0,
-    stages,
-  };
-}
-
-function extractCustomerSuccess(
-  creds: Awaited<ReturnType<typeof getCredentials>>,
-  pylonSnap: PylonData | null,
-  productSnap: ProductSuccessData | null
-): OverviewCustomerSuccess {
-  const pylonConnected = Boolean(creds.pylonApiKey);
-  return {
-    connected: pylonConnected || productSnap !== null,
-    openConversations: pylonSnap?.openConversations ?? 0,
-    urgentConversations: pylonSnap?.urgentConversations ?? 0,
-    avgFirstResponseMinutes: pylonSnap?.avgFirstResponseMinutes ?? null,
-    csat: pylonSnap?.csat ?? null,
-    resolvedInRange: pylonSnap?.resolvedInRange ?? 0,
-    completedTasks: productSnap?.completedTasksInRange ?? 0,
-    throughputRate: productSnap?.throughputRate ?? null,
-  };
-}
-
-function extractAdSpend(
-  creds: Awaited<ReturnType<typeof getCredentials>>,
-  googleAdsSnap: GoogleAdsData | null,
-  metaAdsSnap: MetaAdsData | null,
-  redditAdsSnap: RedditAdsData | null
-): OverviewAdSpend {
-  const googleConnected = Boolean(
-    creds.googleAdsDevToken && creds.googleAdsCustomerId && creds.googleAdsRefreshToken
-  );
-  const metaConnected = Boolean(creds.metaAccessToken && creds.metaAdAccountId);
-  const redditConnected = Boolean(
-    creds.redditClientId && creds.redditClientSecret && creds.redditRefreshToken && creds.redditAdAccountId
-  );
-
-  const totalSpend =
-    (googleAdsSnap?.totalSpend30d ?? 0) +
-    (metaAdsSnap?.totalSpend30d ?? 0) +
-    (redditAdsSnap?.totalSpend30d ?? 0);
-  const totalImpressions =
-    (googleAdsSnap?.totalImpressions ?? 0) +
-    (metaAdsSnap?.totalImpressions ?? 0) +
-    (redditAdsSnap?.totalImpressions ?? 0);
-  const totalClicks =
-    (googleAdsSnap?.totalClicks ?? 0) +
-    (metaAdsSnap?.totalClicks ?? 0) +
-    (redditAdsSnap?.totalClicks ?? 0);
-  const totalConversions =
-    (googleAdsSnap?.totalConversions ?? 0) +
-    (metaAdsSnap?.totalConversions ?? 0) +
-    (redditAdsSnap?.totalConversions ?? 0);
-
-  return {
-    connected: googleConnected || metaConnected || redditConnected,
-    totalSpend30d: totalSpend,
-    totalImpressions,
-    totalClicks,
-    totalConversions,
-    blendedCtr: totalImpressions > 0 ? (totalClicks / totalImpressions) * 100 : 0,
-    blendedCpa: totalConversions > 0 ? totalSpend / totalConversions : 0,
-  };
-}
-
-/* ── Section health builder ──────────────────────────────── */
-
-function buildSectionHealth(
-  creds: Awaited<ReturnType<typeof getCredentials>>,
-  snapshotStatuses: Map<string, { success: boolean; stale: boolean }>
-): OverviewSectionHealth[] {
-  const domainConnected: Record<AnalyticsSubSection["dataDomain"], boolean> = {
-    hubspot: Boolean(creds.hubspotToken),
-    salesPerformance: Boolean(creds.hubspotToken),
-    stripe: Boolean(creds.stripeKey),
-    mercury: Boolean(creds.mercuryKey),
-    googleWorkspace: Boolean(creds.googleWorkspaceAccessToken),
-    slack: Boolean(creds.slackAccessToken),
-    googleAnalytics: Boolean(
-      creds.gaPropertyId &&
-        ((creds.gaClientEmail && creds.gaPrivateKey) ||
-          (process.env.GA_REFRESH_TOKEN &&
-            process.env.GOOGLE_CLIENT_ID &&
-            process.env.GOOGLE_CLIENT_SECRET))
-    ),
-    googleAds: Boolean(
-      creds.googleAdsDevToken &&
-        creds.googleAdsCustomerId &&
-        creds.googleAdsRefreshToken &&
-        creds.googleAdsClientId &&
-        creds.googleAdsClientSecret
-    ),
-    metaAds: Boolean(creds.metaAccessToken && creds.metaAdAccountId),
-    metaPage: Boolean(creds.metaAccessToken),
-    redditAds: Boolean(
-      creds.redditClientId &&
-        creds.redditClientSecret &&
-        creds.redditRefreshToken &&
-        creds.redditAdAccountId
-    ),
-    webflow: Boolean(creds.webflowApiToken && creds.webflowSiteId),
-    coda: Boolean(creds.codaApiToken && creds.codaDocId),
-    semrush: Boolean(creds.semrushApiToken && creds.semrushDomain),
-    pylon: Boolean(creds.pylonApiKey),
-    financePlanning: Boolean(creds.stripeKey || creds.mercuryKey),
-    financeForecast: Boolean(creds.stripeKey || creds.mercuryKey),
-    financePnl: Boolean(creds.stripeKey || creds.mercuryKey),
-    financeUnitEconomics: Boolean(creds.stripeKey),
-    product: true,
-    customerJourney: true,
-    visitorFunnel: true,
-    demoAnalytics: true,
-    processAnalytics: true,
-  };
-
-  const domainSnapshotKey: Partial<Record<AnalyticsSubSection["dataDomain"], string>> = {
-    hubspot: "hubspot",
-    salesPerformance: "salesPerformance",
-    stripe: "stripe",
-    mercury: "mercury",
-    googleWorkspace: "googleWorkspace",
-    slack: "slack",
-    googleAnalytics: "googleAnalytics",
-    googleAds: "googleAds",
-    metaAds: "metaAds",
-    metaPage: "metaPage",
-    redditAds: "redditAds",
-    webflow: "webflow",
-    coda: "coda",
-    semrush: "semrush",
-    pylon: "pylon",
-  };
-
-  return ANALYTICS_PRIMARY_SECTIONS.map((primary) => {
-    const children = ANALYTICS_SUB_SECTIONS.filter((c) => c.parentId === primary.id);
-    const childStatuses = children.map((child) => {
-      const configured = domainConnected[child.dataDomain];
-      const snapshotKey = domainSnapshotKey[child.dataDomain];
-      const snap = snapshotKey ? snapshotStatuses.get(snapshotKey) : null;
-      return deriveDomainSectionStatus({
-        configured,
-        requiresSnapshot: Boolean(snapshotKey),
-        snapshotStatus: snap ? (snap.success ? "SUCCESS" : "ERROR") : null,
-        snapshotStale: snap?.stale ?? false,
-      });
-    });
-
-    let status: OverviewSectionHealth["status"] = "missing";
-    if (childStatuses.every((s) => s === "connected")) status = "connected";
-    else if (childStatuses.some((s) => s === "degraded")) status = "degraded";
-    else if (childStatuses.some((s) => s === "connected")) status = "partial";
-
-    return {
-      id: primary.id,
-      label: primary.label,
-      href: primary.path,
-      status,
-    };
-  });
-}
-
-/* ── Route handler ───────────────────────────────────────── */
+  resolveDashboardOrganizationId,
+  tenantBypassEnabled,
+} from "@/lib/platform/dashboard/context";
+import { loadDashboardOverview } from "@/lib/platform/dashboard/overview";
+import { runWithContextAsync } from "@/lib/request-context";
+import { getAuthenticatedUser } from "@/lib/session-user";
 
 export async function GET(): Promise<NextResponse> {
   try {
     const session = await auth();
-    const user = getAuthenticatedUser(session);
-    if (!user) {
+    const sessionUser = getAuthenticatedUser(session);
+    if (!sessionUser) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const ownerUserId = resolveIntegrationOwnerUserId(user.id);
-    const creds = await getCredentials(ownerUserId);
-
-    // Read all 30d snapshots in parallel
-    const [
-      stripeResult,
-      mercuryResult,
-      gaResult,
-      hubspotResult,
-      googleAdsResult,
-      metaAdsResult,
-      redditAdsResult,
-      pylonResult,
-      productResult,
-    ] = await Promise.all([
-      readLatestSuccessfulSnapshot<StripeData>(snapshotInput(ownerUserId, "stripe")),
-      readLatestSuccessfulSnapshot<MercuryData>(snapshotInput(ownerUserId, "mercury")),
-      readLatestSuccessfulSnapshot<GAData>(snapshotInput(ownerUserId, "googleAnalytics")),
-      readLatestSuccessfulSnapshot<HubSpotData>(snapshotInput(ownerUserId, "hubspot")),
-      readLatestSuccessfulSnapshot<GoogleAdsData>(snapshotInput(ownerUserId, "googleAds")),
-      readLatestSuccessfulSnapshot<MetaAdsData>(snapshotInput(ownerUserId, "metaAds")),
-      readLatestSuccessfulSnapshot<RedditAdsData>(snapshotInput(ownerUserId, "redditAds")),
-      readLatestSuccessfulSnapshot<PylonData>(snapshotInput(ownerUserId, "pylon")),
-      readLatestSuccessfulSnapshot<ProductSuccessData>(snapshotInput(ownerUserId, "product")),
-    ]);
-
-    // Build snapshot-status map for section health
-    const snapshotStatuses = new Map<string, { success: boolean; stale: boolean }>();
-    const snapResults: [string, SnapshotResult<unknown>][] = [
-      ["stripe", stripeResult],
-      ["mercury", mercuryResult],
-      ["googleAnalytics", gaResult],
-      ["hubspot", hubspotResult],
-      ["googleAds", googleAdsResult],
-      ["metaAds", metaAdsResult],
-      ["redditAds", redditAdsResult],
-      ["pylon", pylonResult],
-      ["product", productResult],
-    ];
-    for (const [key, result] of snapResults) {
-      if (result.fromSnapshot) {
-        snapshotStatuses.set(key, {
-          success: result.status === "SUCCESS",
-          stale: result.stale,
-        });
-      }
+    const organizationId = await resolveDashboardOrganizationId(session, sessionUser.id);
+    if (!organizationId && !tenantBypassEnabled) {
+      return NextResponse.json(
+        { error: "Organization context required for dashboard overview" },
+        { status: 403 },
+      );
     }
 
-    const isPartial = snapResults.some(
-      ([, result]) => result.fromSnapshot && (result.stale || result.status !== "SUCCESS")
-    );
+    const loadOverview = () =>
+      loadDashboardOverview({
+        userId: sessionUser.id,
+        organizationId,
+      });
 
-    const payload: ExecutiveOverviewPayload = {
-      generatedAt: new Date().toISOString(),
-      meta: {
-        servedAt: new Date().toISOString(),
-        isPartial,
-      },
-      finance: extractFinance(creds, stripeResult.payload, mercuryResult.payload),
-      traffic: extractTraffic(creds, gaResult.payload),
-      sales: extractSales(creds, hubspotResult.payload),
-      customerSuccess: extractCustomerSuccess(creds, pylonResult.payload, productResult.payload),
-      adSpend: extractAdSpend(
-        creds,
-        googleAdsResult.payload,
-        metaAdsResult.payload,
-        redditAdsResult.payload
-      ),
-      sections: buildSectionHealth(creds, snapshotStatuses),
-    };
+    const payload = organizationId
+      ? await runWithContextAsync({ organizationId, userId: sessionUser.id }, loadOverview)
+      : await loadOverview();
 
     return NextResponse.json(payload, {
       headers: {
@@ -365,6 +43,9 @@ export async function GET(): Promise<NextResponse> {
     });
   } catch (error) {
     console.error("GET /api/dashboard/overview error:", error);
-    return NextResponse.json({ error: "Failed to fetch executive overview" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Failed to load dashboard overview" },
+      { status: 500 },
+    );
   }
 }

--- a/src/app/api/dashboard/personalized/route.ts
+++ b/src/app/api/dashboard/personalized/route.ts
@@ -2,57 +2,13 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
-import { prisma } from "@/lib/prisma";
-import { buildDailyCountSeriesUtc } from "@/lib/dashboard-trends";
+import {
+  resolveDashboardOrganizationId,
+  tenantBypassEnabled,
+} from "@/lib/platform/dashboard/context";
 import { runWithContextAsync } from "@/lib/request-context";
 import { getAuthenticatedUser } from "@/lib/session-user";
-
-const USER_SELECT = {
-  id: true,
-  name: true,
-  email: true,
-  image: true,
-} as const;
-
-const PRIORITY_WEIGHT: Record<string, number> = {
-  P0: 8,
-  P1: 5,
-  P2: 3,
-  P3: 1,
-};
-
-const tenantBypassEnabled =
-  process.env.PRISMA_TENANT_BYPASS === "true" || process.env.NODE_ENV === "development";
-
-async function resolveDashboardOrganizationId(
-  session: unknown,
-  userId: string,
-): Promise<string | null> {
-  const sessionUser = getAuthenticatedUser(session as { user?: unknown } | null | undefined);
-  if (sessionUser?.organizationId) {
-    return sessionUser.organizationId;
-  }
-
-  try {
-    return (
-      (
-        await prisma.user.findUnique({
-          where: { id: userId },
-          select: { organizationId: true },
-        })
-      )?.organizationId ?? null
-    );
-  } catch {
-    return null;
-  }
-}
-
-function daysOverdue(value: Date | null): number {
-  if (!value) return 0;
-  const diff = Date.now() - value.getTime();
-  if (diff <= 0) return 0;
-  return Math.floor(diff / (1000 * 60 * 60 * 24));
-}
+import { loadPersonalizedDashboard } from "@/lib/work/dashboard/personalized";
 
 export async function GET(): Promise<NextResponse> {
   try {
@@ -70,212 +26,16 @@ export async function GET(): Promise<NextResponse> {
       );
     }
 
-    const loadDashboard = async () => {
+    const loadDashboard = async () => loadPersonalizedDashboard(sessionUser.id);
+    const payload = organizationId
+      ? await runWithContextAsync({ organizationId, userId: sessionUser.id }, loadDashboard)
+      : await loadDashboard();
 
-      const now = new Date();
-      const todayUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-      const completedTrendStartUtc = new Date(todayUtc.getTime() - 13 * 24 * 60 * 60 * 1000);
-      const completedTrendEndExclusiveUtc = new Date(todayUtc.getTime() + 24 * 60 * 60 * 1000);
-      const in7d = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
-      const fiveDaysAgo = new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000);
-      const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
-
-      const [
-        myActive,
-        myBlocked,
-        myOverdue,
-        myDueSoon,
-        myCompletedWeek,
-        completedTimestamps,
-        staleTeam,
-        blockedTeam,
-        overdueTeam,
-        activeProjects,
-        statusCounts,
-      ] = await Promise.all([
-      prisma.task.findMany({
-        where: {
-          responsible: { some: { id: sessionUser.id } },
-          status: { in: ["WORKING_ON_TODAY", "ACTIVE", "QUEUED"] },
-        },
-        include: {
-          project: { select: { id: true, name: true } },
-          responsible: { select: USER_SELECT },
-          dependedBy: { select: { id: true } },
-        },
-        orderBy: [{ dueDate: "asc" }, { updatedAt: "asc" }],
-        take: 20,
-      }),
-      prisma.task.findMany({
-        where: {
-          responsible: { some: { id: sessionUser.id } },
-          status: "NOT_DONE",
-        },
-        include: {
-          project: { select: { id: true, name: true } },
-          responsible: { select: USER_SELECT },
-          dependedBy: { select: { id: true } },
-        },
-        orderBy: { updatedAt: "asc" },
-        take: 20,
-      }),
-      prisma.task.findMany({
-        where: {
-          responsible: { some: { id: sessionUser.id } },
-          status: { notIn: ["DONE"] },
-          dueDate: { lt: now },
-        },
-        include: {
-          project: { select: { id: true, name: true } },
-          responsible: { select: USER_SELECT },
-          dependedBy: { select: { id: true } },
-        },
-        orderBy: { dueDate: "asc" },
-        take: 20,
-      }),
-      prisma.task.findMany({
-        where: {
-          responsible: { some: { id: sessionUser.id } },
-          status: { notIn: ["DONE"] },
-          dueDate: { gte: now, lte: in7d },
-        },
-        include: {
-          project: { select: { id: true, name: true } },
-          responsible: { select: USER_SELECT },
-          dependedBy: { select: { id: true } },
-        },
-        orderBy: { dueDate: "asc" },
-        take: 20,
-      }),
-      prisma.task.count({
-        where: {
-          responsible: { some: { id: sessionUser.id } },
-          status: "DONE",
-          updatedAt: { gte: sevenDaysAgo },
-        },
-      }),
-      prisma.task.findMany({
-        where: {
-          responsible: { some: { id: sessionUser.id } },
-          status: "DONE",
-          updatedAt: { gte: completedTrendStartUtc, lt: completedTrendEndExclusiveUtc },
-        },
-        select: { updatedAt: true },
-      }),
-      prisma.task.count({
-        where: {
-          status: { in: ["ACTIVE", "WORKING_ON_TODAY", "QUEUED"] },
-          updatedAt: { lt: fiveDaysAgo },
-        },
-      }),
-      prisma.task.count({
-        where: {
-          status: "NOT_DONE",
-        },
-      }),
-      prisma.task.count({
-        where: {
-          status: { notIn: ["DONE"] },
-          dueDate: { lt: now },
-        },
-      }),
-      prisma.project.findMany({
-        where: { status: "ACTIVE" },
-        include: {
-          department: { select: { id: true, name: true, color: true } },
-          tasks: { select: { status: true } },
-        },
-        orderBy: { updatedAt: "desc" },
-        take: 8,
-      }),
-      prisma.task.groupBy({
-        by: ["status"],
-        _count: { status: true },
-      }),
-    ]);
-
-      const completedByDay = buildDailyCountSeriesUtc({
-        now,
-        days: 14,
-        timestamps: completedTimestamps.map((row) => row.updatedAt),
-      });
-
-      const taskMap = new Map<string, (typeof myActive)[number]>();
-      for (const task of [...myOverdue, ...myBlocked, ...myDueSoon, ...myActive]) {
-        if (!taskMap.has(task.id)) taskMap.set(task.id, task);
-      }
-
-      const recommendations = Array.from(taskMap.values())
-        .map((task) => {
-          const priorityWeight = PRIORITY_WEIGHT[task.priority] ?? 1;
-          const overdueScore = daysOverdue(task.dueDate) * 2;
-          const blockedBonus = task.status === "NOT_DONE" ? 5 : 0;
-          const dependencyBonus = (task.dependedBy?.length ?? 0) * 2;
-          return {
-            ...task,
-            recommendationScore: priorityWeight + overdueScore + blockedBonus + dependencyBonus,
-          };
-        })
-        .sort((a, b) => b.recommendationScore - a.recommendationScore)
-        .slice(0, 12);
-
-      const projectSummaries = activeProjects.map((project) => {
-        const total = project.tasks.length;
-        const done = project.tasks.filter((task) => task.status === "DONE").length;
-        return {
-          id: project.id,
-          name: project.name,
-          department: project.department,
-          totalTasks: total,
-          doneTasks: done,
-          progress: total > 0 ? Math.round((done / total) * 100) : 0,
-        };
-      });
-
-      const taskStatusOverview: Record<string, number> = {};
-      for (const status of statusCounts) {
-        taskStatusOverview[status.status] = status._count.status;
-      }
-
-      return NextResponse.json(
-        {
-          meta: {
-            servedAt: new Date().toISOString(),
-            isPartial: false,
-          },
-          generatedAt: now.toISOString(),
-          personal: {
-            myActive,
-            myBlocked,
-            myOverdue,
-            myDueSoon,
-            myCompletedWeek,
-            completedByDay,
-            recommendations,
-          },
-          team: {
-            staleTasks: staleTeam,
-            blockedTasks: blockedTeam,
-            overdueTasks: overdueTeam,
-            taskStatusOverview,
-          },
-          projects: {
-            active: projectSummaries,
-          },
-        },
-        {
-          headers: {
-            "Cache-Control": "private, max-age=30, stale-while-revalidate=120",
-          },
-        },
-      );
-    };
-
-    if (organizationId) {
-      return runWithContextAsync({ organizationId, userId: sessionUser.id }, loadDashboard);
-    }
-
-    return loadDashboard();
+    return NextResponse.json(payload, {
+      headers: {
+        "Cache-Control": "private, max-age=30, stale-while-revalidate=120",
+      },
+    });
   } catch (error) {
     console.error("GET /api/dashboard/personalized error:", error);
     return NextResponse.json(

--- a/src/components/analytics/ai-insights-page.tsx
+++ b/src/components/analytics/ai-insights-page.tsx
@@ -38,7 +38,7 @@ export function AiInsightsPage() {
 
       const response = await fetch(`/api/analytics?${params.toString()}`, {
         signal,
-        cache: refresh ? "no-store" : "default",
+        cache: "no-store",
       });
       if (!response.ok) {
         throw new Error(`Analytics overview request failed (${response.status})`);
@@ -46,7 +46,7 @@ export function AiInsightsPage() {
       return (await response.json()) as AnalyticsDashboardData;
     },
     getLastUpdatedAt: (payload) =>
-      payload.meta?.servedAt ?? payload.lastFullRefresh ?? payload.generatedAt ?? null,
+      payload.meta?.servedAt ?? payload.lastFullRefresh ?? null,
     mapError: (error) =>
       error instanceof Error && error.message ? error.message : "Could not load insights.",
   });
@@ -72,7 +72,6 @@ export function AiInsightsPage() {
     createTaskFromInsight,
     creatingTaskForId,
     sortAndFilter,
-    dismissedIds,
   } = useInsightPreferences();
 
   useEffect(() => {
@@ -80,11 +79,11 @@ export function AiInsightsPage() {
     populateConnectionStatus(data.freshness, data);
   }, [data]);
 
-  const allInsights = data?.aiInsights?.global ?? [];
+  const allInsights = useMemo(() => data?.aiInsights?.global ?? [], [data?.aiInsights?.global]);
 
   const dismissedCount = useMemo(
     () => allInsights.filter((i) => isDismissed(i.id)).length,
-    [allInsights, isDismissed, dismissedIds]
+    [allInsights, isDismissed]
   );
 
   const filtered = useMemo(() => {
@@ -109,7 +108,7 @@ export function AiInsightsPage() {
         : b.confidence - a.confidence;
 
     return [...pinned, ...unpinned.sort(sortFn)];
-  }, [allInsights, severityFilter, sectionFilter, sortMode, sortAndFilter, showDismissed, isPinned, dismissedIds]);
+  }, [allInsights, severityFilter, sectionFilter, sortMode, sortAndFilter, showDismissed, isPinned]);
 
   const totalInsights = filtered.length;
   const pageCount = Math.max(1, Math.ceil(totalInsights / pageSize));

--- a/src/components/analytics/analytics-section-page.test.tsx
+++ b/src/components/analytics/analytics-section-page.test.tsx
@@ -48,6 +48,7 @@ describe("AnalyticsSectionPage", () => {
       expect(screen.getByText("Google Ads data is unavailable")).toBeTruthy();
     });
 
+    expect(vi.mocked(fetch).mock.calls[0]?.[1]).toMatchObject({ cache: "no-store" });
     expect(screen.getByText("Google Ads API quota exceeded")).toBeTruthy();
     expect(screen.getByText("Manage integration connection status in Settings")).toBeTruthy();
   });

--- a/src/components/analytics/analytics-section-page.tsx
+++ b/src/components/analytics/analytics-section-page.tsx
@@ -284,7 +284,7 @@ export function AnalyticsSectionPage({ sectionId }: AnalyticsSectionPageProps) {
 
       const response = await fetch(`/api/analytics?${analyticsParams.toString()}`, {
         signal,
-        cache: refresh ? "no-store" : "default",
+        cache: "no-store",
       });
       if (!response.ok) {
         throw new Error(`Analytics section request failed (${response.status})`);

--- a/src/components/analytics/analytics-summary-page.test.tsx
+++ b/src/components/analytics/analytics-summary-page.test.tsx
@@ -77,6 +77,11 @@ describe("AnalyticsSummaryPage", () => {
       expect(screen.getByText("Analytics Overview")).toBeTruthy();
     });
 
+    const fetchMock = vi.mocked(fetch);
+    expect(fetchMock).toHaveBeenCalled();
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ cache: "no-store" });
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({ cache: "no-store" });
+
     expect(
       screen.queryByText("Showing cached analytics while background refresh completes or retries.")
     ).toBeNull();

--- a/src/components/analytics/analytics-summary-page.tsx
+++ b/src/components/analytics/analytics-summary-page.tsx
@@ -109,11 +109,11 @@ export function AnalyticsSummaryPage() {
       const [summarySettled, overviewSettled] = await Promise.allSettled([
         fetch(`/api/analytics/summary${summaryParams.toString() ? `?${summaryParams.toString()}` : ""}`, {
           signal,
-          cache: refresh ? "no-store" : "default",
+          cache: "no-store",
         }),
         fetch(`/api/analytics?${overviewParams.toString()}`, {
           signal,
-          cache: refresh ? "no-store" : "default",
+          cache: "no-store",
         }),
       ]);
 

--- a/src/components/analytics/customer-journey-page.tsx
+++ b/src/components/analytics/customer-journey-page.tsx
@@ -4,8 +4,6 @@ import { useEffect, useState } from "react";
 import { HorizontalFunnel } from "@/components/charts";
 import { StatCard } from "./stat-card";
 import { DashboardSectionCard } from "./dashboard-section-card";
-import { AiInsightsPanel } from "./ai-insights-panel";
-import { AnalyticsTimeRangeControls } from "@/components/analytics/time-range-controls";
 import type {
   AnalyticsDashboardData,
   LifecycleStageId,
@@ -32,14 +30,17 @@ export function CustomerJourneyPage() {
     cacheKey: "analytics:overview:v1",
     deps: [],
     load: async ({ signal }) => {
-      const response = await fetch("/api/analytics?section=overview", { signal });
+      const response = await fetch("/api/analytics?section=overview", {
+        signal,
+        cache: "no-store",
+      });
       if (!response.ok) {
         throw new Error(`Analytics overview request failed (${response.status})`);
       }
       return (await response.json()) as AnalyticsDashboardData;
     },
     getLastUpdatedAt: (payload) =>
-      payload.meta?.servedAt ?? payload.lastFullRefresh ?? payload.generatedAt ?? null,
+      payload.meta?.servedAt ?? payload.lastFullRefresh ?? null,
     mapError: (error) =>
       error instanceof Error && error.message ? error.message : "Could not load journey data.",
   });

--- a/src/components/dashboard/operator-dashboard.test.tsx
+++ b/src/components/dashboard/operator-dashboard.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OperatorDashboard } from "@/components/dashboard/operator-dashboard";
+
+vi.mock("@/components/dashboard/personalized-dashboard", () => ({
+  PersonalizedDashboard: ({ title }: { title?: string }) => (
+    <div>{title ?? "Personalized Dashboard"}</div>
+  ),
+}));
+
+describe("OperatorDashboard", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders platform overview cards from the overview API", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            generatedAt: "2026-03-11T16:00:00.000Z",
+            workSummary: {
+              workspaceId: "work",
+              activeTasks: 4,
+              overdueTasks: 2,
+              blockedTasks: 1,
+              dueSoonTasks: 3,
+              openAlerts: 2,
+            },
+            revenueSummary: {
+              workspaceId: "deals",
+              openDeals: 6,
+              pipelineValue: 42500,
+              closingThisMonth: 3,
+              wonThisQuarter: 2,
+            },
+            integrationHealth: {
+              workspaceId: "integrations",
+              totalConnections: 8,
+              connectedConnections: 6,
+              degradedConnections: 2,
+              errorConnections: 1,
+              staleConnections: 1,
+              missingConnections: 2,
+            },
+            automationAttention: {
+              workspaceId: "automations",
+              activeWorkflows: 5,
+              pendingApprovals: 1,
+              pendingRecommendations: 2,
+              failingRuns: 1,
+              waitingExternalRuns: 1,
+            },
+            analyticsFreshness: {
+              workspaceId: "analytics",
+              latestSnapshotAt: "2026-03-11T15:55:00.000Z",
+              healthyDomains: 5,
+              staleDomains: 1,
+              errorDomains: 1,
+              missingDomains: 2,
+            },
+          }),
+        ),
+      ),
+    );
+
+    render(<OperatorDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Operator Cockpit")).toBeTruthy();
+    });
+
+    expect(screen.getByText("4 active tasks in motion")).toBeTruthy();
+    expect(screen.getByText("6 open deals worth $42,500")).toBeTruthy();
+    expect(screen.getByText("6/8 providers connected")).toBeTruthy();
+    expect(screen.getByText("5 active workflows running")).toBeTruthy();
+    expect(screen.getByText("5 healthy analytics domains")).toBeTruthy();
+    expect(screen.getByText("My Work")).toBeTruthy();
+  });
+});

--- a/src/components/dashboard/operator-dashboard.tsx
+++ b/src/components/dashboard/operator-dashboard.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo } from "react";
+import { ArrowRight, RefreshCw } from "lucide-react";
+import { DashboardEmptyState } from "@/components/dashboard/dashboard-empty-state";
+import { DashboardErrorBanner } from "@/components/dashboard/dashboard-error-banner";
+import { DashboardLoadingState } from "@/components/dashboard/dashboard-loading-state";
+import { DashboardStaleBanner } from "@/components/dashboard/dashboard-stale-banner";
+import { PersonalizedDashboard } from "@/components/dashboard/personalized-dashboard";
+import { WorkspaceBadge } from "@/components/dashboard/workspace-badge";
+import { useDashboardResource } from "@/components/dashboard/use-dashboard-resource";
+import type { DashboardOverviewPayload } from "@/lib/platform/dashboard/overview";
+import { getWorkspaceById, type WorkspaceId } from "@/lib/platform/workspaces";
+
+const OPERATOR_DASHBOARD_CACHE_KEY = "dashboard:overview:v1";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isDashboardOverviewPayload(value: unknown): value is DashboardOverviewPayload {
+  if (!isRecord(value)) return false;
+  return (
+    isRecord(value.workSummary) &&
+    isRecord(value.revenueSummary) &&
+    isRecord(value.integrationHealth) &&
+    isRecord(value.automationAttention) &&
+    isRecord(value.analyticsFreshness) &&
+    typeof value.generatedAt === "string"
+  );
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function OverviewCard({
+  workspaceId,
+  title,
+  href,
+  primary,
+  secondary,
+  tertiary,
+}: {
+  workspaceId: WorkspaceId;
+  title: string;
+  href: string;
+  primary: string;
+  secondary: string;
+  tertiary: string;
+}) {
+  return (
+    <Link
+      href={href}
+      data-workspace-id={workspaceId}
+      className="group rounded-xl border border-border bg-card p-4 transition-colors hover:border-primary/30 hover:bg-secondary/20"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-2">
+          <WorkspaceBadge workspaceId={workspaceId} />
+          <div>
+            <h2 className="text-base font-semibold text-foreground">{title}</h2>
+            <p className="mt-1 text-sm text-foreground">{primary}</p>
+          </div>
+        </div>
+        <ArrowRight className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+      </div>
+      <div className="mt-4 space-y-1 text-xs text-muted-foreground">
+        <p>{secondary}</p>
+        <p>{tertiary}</p>
+      </div>
+    </Link>
+  );
+}
+
+export function OperatorDashboard() {
+  const resource = useDashboardResource<DashboardOverviewPayload>({
+    cacheKey: OPERATOR_DASHBOARD_CACHE_KEY,
+    deps: [],
+    load: async ({ signal, refresh }) => {
+      const response = await fetch("/api/dashboard/overview", {
+        signal,
+        cache: refresh ? "no-store" : "default",
+      });
+
+      if (!response.ok) {
+        throw new Error(`Overview request failed (${response.status})`);
+      }
+
+      const payload = (await response.json()) as unknown;
+      if (!isDashboardOverviewPayload(payload)) {
+        throw new Error("Dashboard overview payload is invalid");
+      }
+
+      return payload;
+    },
+    getLastUpdatedAt: (payload) => payload.generatedAt,
+    mapError: (error) => {
+      if (error instanceof Error && error.message.trim().length > 0) return error.message;
+      return "Could not load operator overview.";
+    },
+  });
+
+  const cards = useMemo(() => {
+    if (!resource.data) return [];
+
+    const work = getWorkspaceById(resource.data.workSummary.workspaceId);
+    const deals = getWorkspaceById(resource.data.revenueSummary.workspaceId);
+    const integrations = getWorkspaceById(resource.data.integrationHealth.workspaceId);
+    const automations = getWorkspaceById(resource.data.automationAttention.workspaceId);
+    const analytics = getWorkspaceById(resource.data.analyticsFreshness.workspaceId);
+
+    return [
+      {
+        workspaceId: resource.data.workSummary.workspaceId,
+        title: work?.label ?? "Work",
+        href: work?.href ?? "/tasks",
+        primary: `${resource.data.workSummary.activeTasks} active tasks in motion`,
+        secondary: `${resource.data.workSummary.overdueTasks} overdue, ${resource.data.workSummary.blockedTasks} blocked`,
+        tertiary: `${resource.data.workSummary.openAlerts} open customer alerts, ${resource.data.workSummary.dueSoonTasks} due soon`,
+      },
+      {
+        workspaceId: resource.data.revenueSummary.workspaceId,
+        title: deals?.label ?? "Deals",
+        href: deals?.href ?? "/deals",
+        primary: `${resource.data.revenueSummary.openDeals} open deals worth ${formatCurrency(resource.data.revenueSummary.pipelineValue)}`,
+        secondary: `${resource.data.revenueSummary.closingThisMonth} expected to close this month`,
+        tertiary: `${resource.data.revenueSummary.wonThisQuarter} wins closed this quarter`,
+      },
+      {
+        workspaceId: resource.data.integrationHealth.workspaceId,
+        title: integrations?.label ?? "Integrations",
+        href: integrations?.href ?? "/integrations",
+        primary: `${resource.data.integrationHealth.connectedConnections}/${resource.data.integrationHealth.totalConnections} providers connected`,
+        secondary: `${resource.data.integrationHealth.degradedConnections} degraded, ${resource.data.integrationHealth.errorConnections} in error`,
+        tertiary: `${resource.data.integrationHealth.missingConnections} missing and ${resource.data.integrationHealth.staleConnections} stale`,
+      },
+      {
+        workspaceId: resource.data.automationAttention.workspaceId,
+        title: automations?.label ?? "Automations",
+        href: automations?.href ?? "/automations",
+        primary: `${resource.data.automationAttention.activeWorkflows} active workflows running`,
+        secondary: `${resource.data.automationAttention.pendingApprovals} approvals and ${resource.data.automationAttention.pendingRecommendations} recommendations pending`,
+        tertiary: `${resource.data.automationAttention.failingRuns} failing runs, ${resource.data.automationAttention.waitingExternalRuns} waiting on external work`,
+      },
+      {
+        workspaceId: resource.data.analyticsFreshness.workspaceId,
+        title: analytics?.label ?? "Analytics",
+        href: analytics?.href ?? "/analytics",
+        primary: `${resource.data.analyticsFreshness.healthyDomains} healthy analytics domains`,
+        secondary: `${resource.data.analyticsFreshness.staleDomains} stale, ${resource.data.analyticsFreshness.errorDomains} errored`,
+        tertiary: `${resource.data.analyticsFreshness.missingDomains} missing snapshots`,
+      },
+    ];
+  }, [resource.data]);
+
+  return (
+    <div className="flex h-full flex-col overflow-auto">
+      <div className="space-y-4 px-4 py-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="text-xl font-semibold text-foreground">Operator Cockpit</h1>
+            <p className="text-xs text-muted-foreground">
+              Platform-wide GTM signals across work, revenue, integrations, automations, and analytics.
+            </p>
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              Last updated:{" "}
+              {resource.lastUpdatedAt ? new Date(resource.lastUpdatedAt).toLocaleString() : "Unknown"}
+              {resource.fromCache ? " (cache warm start)" : ""}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={resource.refresh}
+            disabled={resource.refreshing}
+            className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground disabled:opacity-70"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+            {resource.refreshing ? "Refreshing..." : "Refresh overview"}
+          </button>
+        </div>
+
+        {resource.stale ? (
+          <DashboardStaleBanner
+            lastUpdatedAt={resource.lastUpdatedAt}
+            onRefresh={resource.refresh}
+            refreshing={resource.refreshing}
+          />
+        ) : null}
+
+        {resource.error ? (
+          <DashboardErrorBanner message={resource.error} onRetry={resource.refresh} />
+        ) : null}
+
+        {resource.loading && !resource.data ? (
+          <DashboardLoadingState message="Loading operator overview..." className="h-32" />
+        ) : null}
+
+        {!resource.loading && !resource.data ? (
+          <DashboardEmptyState
+            title="Operator overview unavailable"
+            message={resource.error ?? "No operator overview data was returned."}
+            actionLabel="Refresh now"
+            onAction={resource.refresh}
+          />
+        ) : null}
+
+        {cards.length > 0 ? (
+          <section className="grid grid-cols-1 gap-3 lg:grid-cols-2 xl:grid-cols-3" aria-label="Operator overview cards">
+            {cards.map((card) => (
+              <OverviewCard key={card.workspaceId} {...card} />
+            ))}
+          </section>
+        ) : null}
+      </div>
+
+      <PersonalizedDashboard
+        title="My Work"
+        description="Your personal queue, recommendations, and team flow signals."
+      />
+    </div>
+  );
+}

--- a/src/components/dashboard/personalized-dashboard.tsx
+++ b/src/components/dashboard/personalized-dashboard.tsx
@@ -11,48 +11,7 @@ import { DonutChart } from "@/components/charts/donut-chart";
 import { StackedBarChart } from "@/components/charts/stacked-bar-chart";
 import { SparkLine } from "@/components/charts/spark-line";
 import { getChartColor } from "@/components/charts/chart-theme";
-
-interface DashboardTask {
-  id: string;
-  title: string;
-  status: string;
-  priority: string;
-  dueDate: string | null;
-  project: { id: string; name: string } | null;
-  recommendationScore?: number;
-}
-
-interface PersonalizedDashboardPayload {
-  generatedAt: string;
-  meta?: {
-    servedAt: string;
-    isPartial: boolean;
-  };
-  personal: {
-    myActive: DashboardTask[];
-    myBlocked: DashboardTask[];
-    myOverdue: DashboardTask[];
-    myDueSoon: DashboardTask[];
-    myCompletedWeek: number;
-    completedByDay?: Array<{ date: string; count: number }>;
-    recommendations: DashboardTask[];
-  };
-  team: {
-    staleTasks: number;
-    blockedTasks: number;
-    overdueTasks: number;
-    taskStatusOverview: Record<string, number>;
-  };
-  projects: {
-    active: Array<{
-      id: string;
-      name: string;
-      progress: number;
-      doneTasks: number;
-      totalTasks: number;
-    }>;
-  };
-}
+import type { PersonalizedDashboardPayload } from "@/lib/work/dashboard/personalized";
 
 const PERSONALIZED_DASHBOARD_CACHE_KEY = "dashboard:personalized:v2";
 
@@ -95,7 +54,7 @@ function isPersonalizedDashboardPayload(value: unknown): value is PersonalizedDa
   );
 }
 
-function relativeDate(date: string | null): string {
+function relativeDate(date: string | Date | null): string {
   if (!date) return "No due date";
   const target = new Date(date).getTime();
   const diffDays = Math.ceil((target - Date.now()) / (1000 * 60 * 60 * 24));
@@ -112,7 +71,7 @@ function TaskList({
   maxItems = 8,
 }: {
   title: string;
-  items: DashboardTask[];
+  items: PersonalizedDashboardPayload["personal"]["myActive"];
   empty: string;
   maxItems?: number;
 }) {
@@ -149,7 +108,15 @@ function TaskList({
   );
 }
 
-export function PersonalizedDashboard() {
+interface PersonalizedDashboardProps {
+  title?: string;
+  description?: string;
+}
+
+export function PersonalizedDashboard({
+  title = "Dashboard",
+  description = "Your workload, trends, and team signals.",
+}: PersonalizedDashboardProps) {
   const focusRef = useRef<HTMLDivElement | null>(null);
   const [focusKey, setFocusKey] = useState<"blocked" | "overdue" | "dueSoon" | "active">("blocked");
 
@@ -254,7 +221,7 @@ export function PersonalizedDashboard() {
     return (
       <div className="p-4">
         <DashboardEmptyState
-          title="Dashboard unavailable"
+          title={`${title} unavailable`}
           message={resource.error ?? "No personalized dashboard data was returned."}
           actionLabel="Refresh now"
           onAction={resource.refresh}
@@ -267,8 +234,8 @@ export function PersonalizedDashboard() {
     <div className="space-y-4 px-4 py-4">
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div>
-          <h1 className="text-xl font-semibold text-foreground">Dashboard</h1>
-          <p className="text-xs text-muted-foreground">Your workload, trends, and team signals.</p>
+          <h1 className="text-xl font-semibold text-foreground">{title}</h1>
+          <p className="text-xs text-muted-foreground">{description}</p>
           <p className="mt-1 text-[11px] text-muted-foreground">
             Last updated: {resource.lastUpdatedAt ? new Date(resource.lastUpdatedAt).toLocaleString() : "Unknown"}
             {resource.fromCache ? " (cache warm start)" : ""}

--- a/src/components/dashboard/workspace-badge.tsx
+++ b/src/components/dashboard/workspace-badge.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { clsx } from "clsx";
+import { getWorkspaceLabel, type WorkspaceId } from "@/lib/platform/workspaces";
+
+const BADGE_STYLES: Record<WorkspaceId, string> = {
+  dashboard: "bg-slate-100 text-slate-700",
+  work: "bg-amber-100 text-amber-800",
+  deals: "bg-emerald-100 text-emerald-800",
+  analytics: "bg-sky-100 text-sky-800",
+  integrations: "bg-violet-100 text-violet-800",
+  automations: "bg-rose-100 text-rose-800",
+};
+
+export function WorkspaceBadge({ workspaceId }: { workspaceId: WorkspaceId }) {
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium uppercase tracking-[0.12em]",
+        BADGE_STYLES[workspaceId],
+      )}
+    >
+      {getWorkspaceLabel(workspaceId)}
+    </span>
+  );
+}

--- a/src/lib/platform/dashboard/context.ts
+++ b/src/lib/platform/dashboard/context.ts
@@ -1,0 +1,28 @@
+import { prisma } from "@/lib/prisma";
+import { getAuthenticatedUser } from "@/lib/session-user";
+
+export const tenantBypassEnabled =
+  process.env.PRISMA_TENANT_BYPASS === "true" || process.env.NODE_ENV === "development";
+
+export async function resolveDashboardOrganizationId(
+  session: unknown,
+  userId: string,
+): Promise<string | null> {
+  const sessionUser = getAuthenticatedUser(session as { user?: unknown } | null | undefined);
+  if (sessionUser?.organizationId) {
+    return sessionUser.organizationId;
+  }
+
+  try {
+    return (
+      (
+        await prisma.user.findUnique({
+          where: { id: userId },
+          select: { organizationId: true },
+        })
+      )?.organizationId ?? null
+    );
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/platform/dashboard/overview.test.ts
+++ b/src/lib/platform/dashboard/overview.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AnalyticsSnapshotStatus,
+  DealStage,
+  IntegrationConnectionStatus,
+} from "@/generated/prisma/client";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    task: { count: vi.fn() },
+    customerSuccessAlertRecord: { count: vi.fn() },
+    deal: { count: vi.fn(), aggregate: vi.fn() },
+    workflowDefinition: { count: vi.fn() },
+    workflowApproval: { count: vi.fn() },
+    automationRecommendation: { count: vi.fn() },
+    workflowRun: { count: vi.fn() },
+    integrationConnection: { findMany: vi.fn() },
+    analyticsSnapshot: { groupBy: vi.fn(), findMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/integrations/ownership", () => ({
+  resolveIntegrationOwnerUserId: vi.fn((userId: string) => `owner:${userId}`),
+}));
+
+vi.mock("@/lib/integrations/catalog", () => ({
+  listIntegrationDefinitions: vi.fn(() => [
+    { provider: "HUBSPOT" },
+    { provider: "SLACK" },
+    { provider: "GOOGLE_ANALYTICS" },
+  ]),
+}));
+
+vi.mock("@/lib/analytics/provider-health", () => ({
+  snapshotKeysForIntegrationProvider: vi.fn((provider: string) => {
+    if (provider === "GOOGLE_ANALYTICS") return ["googleAnalytics"];
+    if (provider === "HUBSPOT") return ["hubspot"];
+    return ["slack"];
+  }),
+}));
+
+vi.mock("@/lib/analytics/credentials", () => ({
+  getCredentials: vi.fn(async () => ({ hubspotToken: "hubspot-token" })),
+  hasIntegrationCredential: vi.fn((provider: string, credentials: Record<string, unknown>) => {
+    if (provider === "HUBSPOT") return Boolean(credentials.hubspotToken);
+    return false;
+  }),
+}));
+
+describe("loadDashboardOverview", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("summarizes work, revenue, integrations, automations, and analytics freshness", async () => {
+    const { prisma } = await import("@/lib/prisma");
+    const { loadDashboardOverview } = await import("@/lib/platform/dashboard/overview");
+
+    vi.mocked(prisma.task.count)
+      .mockResolvedValueOnce(4 as never)
+      .mockResolvedValueOnce(2 as never)
+      .mockResolvedValueOnce(1 as never)
+      .mockResolvedValueOnce(3 as never);
+    vi.mocked(prisma.customerSuccessAlertRecord.count).mockResolvedValue(2 as never);
+    vi.mocked(prisma.deal.count)
+      .mockResolvedValueOnce(6 as never)
+      .mockResolvedValueOnce(3 as never)
+      .mockResolvedValueOnce(2 as never);
+    vi.mocked(prisma.deal.aggregate).mockResolvedValue({ _sum: { amount: 42500 } } as never);
+    vi.mocked(prisma.workflowDefinition.count).mockResolvedValue(5 as never);
+    vi.mocked(prisma.workflowApproval.count).mockResolvedValue(1 as never);
+    vi.mocked(prisma.automationRecommendation.count).mockResolvedValue(2 as never);
+    vi.mocked(prisma.workflowRun.count)
+      .mockResolvedValueOnce(1 as never)
+      .mockResolvedValueOnce(1 as never);
+    vi.mocked(prisma.integrationConnection.findMany).mockResolvedValue([
+      {
+        provider: "SLACK",
+        status: IntegrationConnectionStatus.ERROR,
+        lastSyncedAt: new Date("2026-03-11T09:00:00.000Z"),
+      },
+    ] as never);
+    vi.mocked(prisma.analyticsSnapshot.groupBy).mockResolvedValue([
+      { providerKey: "hubspot", _max: { capturedAt: new Date("2026-03-11T15:00:00.000Z") } },
+      { providerKey: "slack", _max: { capturedAt: new Date("2026-03-11T14:00:00.000Z") } },
+    ] as never);
+    vi.mocked(prisma.analyticsSnapshot.findMany).mockResolvedValue([
+      {
+        providerKey: "hubspot",
+        status: AnalyticsSnapshotStatus.SUCCESS,
+        capturedAt: new Date("2026-03-11T15:00:00.000Z"),
+        expiresAt: new Date("2099-03-11T17:00:00.000Z"),
+      },
+      {
+        providerKey: "slack",
+        status: AnalyticsSnapshotStatus.ERROR,
+        capturedAt: new Date("2026-03-11T14:00:00.000Z"),
+        expiresAt: new Date("2026-03-11T16:00:00.000Z"),
+      },
+    ] as never);
+
+    const payload = await loadDashboardOverview({
+      userId: "user-1",
+      organizationId: "org-1",
+    });
+
+    expect(payload.workSummary).toMatchObject({
+      workspaceId: "work",
+      activeTasks: 4,
+      overdueTasks: 2,
+      blockedTasks: 1,
+      dueSoonTasks: 3,
+      openAlerts: 2,
+    });
+    expect(payload.revenueSummary).toMatchObject({
+      workspaceId: "deals",
+      openDeals: 6,
+      pipelineValue: 42500,
+      closingThisMonth: 3,
+      wonThisQuarter: 2,
+    });
+    expect(payload.integrationHealth).toMatchObject({
+      workspaceId: "integrations",
+      totalConnections: 3,
+      connectedConnections: 1,
+      degradedConnections: 1,
+      errorConnections: 1,
+      staleConnections: 0,
+      missingConnections: 1,
+    });
+    expect(payload.automationAttention).toMatchObject({
+      workspaceId: "automations",
+      activeWorkflows: 5,
+      pendingApprovals: 1,
+      pendingRecommendations: 2,
+      failingRuns: 1,
+      waitingExternalRuns: 1,
+    });
+    expect(payload.analyticsFreshness).toMatchObject({
+      workspaceId: "analytics",
+      healthyDomains: 1,
+      errorDomains: 1,
+      missingDomains: 1,
+    });
+  });
+
+  it("queries open and won deal stages using revenue-specific filters", async () => {
+    const { prisma } = await import("@/lib/prisma");
+    const { loadDashboardOverview } = await import("@/lib/platform/dashboard/overview");
+
+    vi.mocked(prisma.task.count).mockResolvedValue(0 as never);
+    vi.mocked(prisma.customerSuccessAlertRecord.count).mockResolvedValue(0 as never);
+    vi.mocked(prisma.deal.count).mockResolvedValue(0 as never);
+    vi.mocked(prisma.deal.aggregate).mockResolvedValue({ _sum: { amount: 0 } } as never);
+    vi.mocked(prisma.workflowDefinition.count).mockResolvedValue(0 as never);
+    vi.mocked(prisma.workflowApproval.count).mockResolvedValue(0 as never);
+    vi.mocked(prisma.automationRecommendation.count).mockResolvedValue(0 as never);
+    vi.mocked(prisma.workflowRun.count).mockResolvedValue(0 as never);
+    vi.mocked(prisma.integrationConnection.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.analyticsSnapshot.groupBy).mockResolvedValue([] as never);
+    vi.mocked(prisma.analyticsSnapshot.findMany).mockResolvedValue([] as never);
+
+    await loadDashboardOverview({ userId: "user-1", organizationId: "org-1" });
+
+    const dealCountCalls = vi.mocked(prisma.deal.count).mock.calls;
+    expect(dealCountCalls[0]?.[0]?.where?.stage).toEqual({
+      notIn: [DealStage.CLOSED_WON, DealStage.CLOSED_LOST],
+    });
+    expect(dealCountCalls[2]?.[0]?.where?.stage).toBe(DealStage.CLOSED_WON);
+  });
+});

--- a/src/lib/platform/dashboard/overview.ts
+++ b/src/lib/platform/dashboard/overview.ts
@@ -1,0 +1,381 @@
+import {
+  AnalyticsSnapshotStatus,
+  AutomationRecommendationStatus,
+  DealStage,
+  IntegrationConnectionStatus,
+  WorkflowApprovalStatus,
+  WorkflowRunStatus,
+  WorkflowScope,
+  WorkflowStatus,
+} from "@/generated/prisma/client";
+import { getCredentials, hasIntegrationCredential } from "@/lib/analytics/credentials";
+import { snapshotKeysForIntegrationProvider } from "@/lib/analytics/provider-health";
+import { listIntegrationDefinitions } from "@/lib/integrations/catalog";
+import { resolveIntegrationOwnerUserId } from "@/lib/integrations/ownership";
+import type { WorkspaceId } from "@/lib/platform/workspaces";
+import { prisma } from "@/lib/prisma";
+
+export interface DashboardOverviewPayload {
+  generatedAt: string;
+  workSummary: {
+    workspaceId: WorkspaceId;
+    activeTasks: number;
+    overdueTasks: number;
+    blockedTasks: number;
+    dueSoonTasks: number;
+    openAlerts: number;
+  };
+  revenueSummary: {
+    workspaceId: WorkspaceId;
+    openDeals: number;
+    pipelineValue: number;
+    closingThisMonth: number;
+    wonThisQuarter: number;
+  };
+  integrationHealth: {
+    workspaceId: WorkspaceId;
+    totalConnections: number;
+    connectedConnections: number;
+    degradedConnections: number;
+    errorConnections: number;
+    staleConnections: number;
+    missingConnections: number;
+  };
+  automationAttention: {
+    workspaceId: WorkspaceId;
+    activeWorkflows: number;
+    pendingApprovals: number;
+    pendingRecommendations: number;
+    failingRuns: number;
+    waitingExternalRuns: number;
+  };
+  analyticsFreshness: {
+    workspaceId: WorkspaceId;
+    latestSnapshotAt: string | null;
+    healthyDomains: number;
+    staleDomains: number;
+    errorDomains: number;
+    missingDomains: number;
+  };
+}
+
+interface LoadDashboardOverviewInput {
+  userId: string;
+  organizationId: string | null;
+}
+
+function startOfUtcMonth(now: Date): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+}
+
+function startOfNextUtcMonth(now: Date): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+}
+
+function startOfUtcQuarter(now: Date): Date {
+  const quarterMonth = Math.floor(now.getUTCMonth() / 3) * 3;
+  return new Date(Date.UTC(now.getUTCFullYear(), quarterMonth, 1));
+}
+
+function startOfNextUtcQuarter(now: Date): Date {
+  const quarterMonth = Math.floor(now.getUTCMonth() / 3) * 3;
+  return new Date(Date.UTC(now.getUTCFullYear(), quarterMonth + 3, 1));
+}
+
+export async function loadDashboardOverview(
+  input: LoadDashboardOverviewInput,
+): Promise<DashboardOverviewPayload> {
+  const now = new Date();
+  const in7d = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+  const staleSyncThreshold = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const monthStart = startOfUtcMonth(now);
+  const nextMonthStart = startOfNextUtcMonth(now);
+  const quarterStart = startOfUtcQuarter(now);
+  const nextQuarterStart = startOfNextUtcQuarter(now);
+  const organizationFilter = input.organizationId ? { organizationId: input.organizationId } : {};
+  const ownerUserId = resolveIntegrationOwnerUserId(input.userId);
+  const workflowVisibilityFilter = {
+    OR: [{ ownerId: input.userId }, { scope: WorkflowScope.SHARED }],
+  };
+  const integrationDefinitions = listIntegrationDefinitions();
+  const expectedSnapshotKeys = Array.from(
+    new Set(
+      integrationDefinitions.flatMap((definition) =>
+        snapshotKeysForIntegrationProvider(definition.provider),
+      ),
+    ),
+  );
+
+  const [
+    activeTasks,
+    overdueTasks,
+    blockedTasks,
+    dueSoonTasks,
+    openAlerts,
+    openDeals,
+    pipelineAggregate,
+    closingThisMonth,
+    wonThisQuarter,
+    activeWorkflows,
+    pendingApprovals,
+    pendingRecommendations,
+    failingRuns,
+    waitingExternalRuns,
+    connections,
+    credentials,
+    latestRows,
+  ] = await Promise.all([
+    prisma.task.count({
+      where: {
+        ...organizationFilter,
+        status: { in: ["WORKING_ON_TODAY", "ACTIVE", "QUEUED"] },
+      },
+    }),
+    prisma.task.count({
+      where: {
+        ...organizationFilter,
+        status: { notIn: ["DONE"] },
+        dueDate: { lt: now },
+      },
+    }),
+    prisma.task.count({
+      where: {
+        ...organizationFilter,
+        status: "NOT_DONE",
+      },
+    }),
+    prisma.task.count({
+      where: {
+        ...organizationFilter,
+        status: { notIn: ["DONE"] },
+        dueDate: { gte: now, lte: in7d },
+      },
+    }),
+    prisma.customerSuccessAlertRecord.count({
+      where: {
+        ...organizationFilter,
+        status: "OPEN",
+      },
+    }),
+    prisma.deal.count({
+      where: {
+        ...organizationFilter,
+        stage: { notIn: [DealStage.CLOSED_WON, DealStage.CLOSED_LOST] },
+      },
+    }),
+    prisma.deal.aggregate({
+      _sum: { amount: true },
+      where: {
+        ...organizationFilter,
+        stage: { notIn: [DealStage.CLOSED_WON, DealStage.CLOSED_LOST] },
+      },
+    }),
+    prisma.deal.count({
+      where: {
+        ...organizationFilter,
+        stage: { notIn: [DealStage.CLOSED_WON, DealStage.CLOSED_LOST] },
+        expectedCloseDate: { gte: monthStart, lt: nextMonthStart },
+      },
+    }),
+    prisma.deal.count({
+      where: {
+        ...organizationFilter,
+        stage: DealStage.CLOSED_WON,
+        closedAt: { gte: quarterStart, lt: nextQuarterStart },
+      },
+    }),
+    prisma.workflowDefinition.count({
+      where: {
+        ...workflowVisibilityFilter,
+        status: WorkflowStatus.ACTIVE,
+      },
+    }),
+    prisma.workflowApproval.count({
+      where: {
+        status: WorkflowApprovalStatus.PENDING,
+        run: {
+          workflow: workflowVisibilityFilter,
+        },
+      },
+    }),
+    prisma.automationRecommendation.count({
+      where: {
+        status: AutomationRecommendationStatus.PENDING_APPROVAL,
+        workflow: workflowVisibilityFilter,
+      },
+    }),
+    prisma.workflowRun.count({
+      where: {
+        status: WorkflowRunStatus.FAILED,
+        workflow: workflowVisibilityFilter,
+      },
+    }),
+    prisma.workflowRun.count({
+      where: {
+        status: WorkflowRunStatus.WAITING_EXTERNAL,
+        workflow: workflowVisibilityFilter,
+      },
+    }),
+    prisma.integrationConnection.findMany({
+      where: { userId: ownerUserId },
+      select: {
+        provider: true,
+        status: true,
+        lastSyncedAt: true,
+      },
+    }),
+    getCredentials(ownerUserId),
+    expectedSnapshotKeys.length === 0
+      ? Promise.resolve([])
+      : prisma.analyticsSnapshot.groupBy({
+          by: ["providerKey"],
+          where: {
+            userId: ownerUserId,
+            providerKey: { in: expectedSnapshotKeys },
+          },
+          _max: { capturedAt: true },
+        }),
+  ]);
+
+  const latestSnapshotSelectors = latestRows
+    .map((row) =>
+      row._max.capturedAt
+        ? { providerKey: row.providerKey, capturedAt: row._max.capturedAt }
+        : null,
+    )
+    .filter(Boolean) as Array<{ providerKey: string; capturedAt: Date }>;
+
+  const latestSnapshots =
+    latestSnapshotSelectors.length === 0
+      ? []
+      : await prisma.analyticsSnapshot.findMany({
+          where: {
+            userId: ownerUserId,
+            OR: latestSnapshotSelectors,
+          },
+          select: {
+            providerKey: true,
+            status: true,
+            capturedAt: true,
+            expiresAt: true,
+          },
+        });
+
+  const latestSnapshotByKey = new Map(
+    latestSnapshots.map((snapshot) => [snapshot.providerKey, snapshot]),
+  );
+
+  let latestSnapshotAt: string | null = null;
+  let healthyDomains = 0;
+  let staleDomains = 0;
+  let errorDomains = 0;
+  let missingDomains = 0;
+
+  for (const providerKey of expectedSnapshotKeys) {
+    const snapshot = latestSnapshotByKey.get(providerKey);
+    if (!snapshot) {
+      missingDomains += 1;
+      continue;
+    }
+
+    if (!latestSnapshotAt || snapshot.capturedAt.toISOString() > latestSnapshotAt) {
+      latestSnapshotAt = snapshot.capturedAt.toISOString();
+    }
+
+    if (snapshot.status === AnalyticsSnapshotStatus.ERROR) {
+      errorDomains += 1;
+      continue;
+    }
+
+    if (snapshot.expiresAt.getTime() <= now.getTime()) {
+      staleDomains += 1;
+      continue;
+    }
+
+    healthyDomains += 1;
+  }
+
+  const connectionsByProvider = new Map(
+    connections.map((connection) => [connection.provider, connection]),
+  );
+
+  let connectedConnections = 0;
+  let errorConnections = 0;
+  let staleConnections = 0;
+  let missingConnections = 0;
+
+  for (const definition of integrationDefinitions) {
+    const connection = connectionsByProvider.get(definition.provider);
+    const hasCredential = hasIntegrationCredential(definition.provider, credentials);
+    const isError = connection?.status === IntegrationConnectionStatus.ERROR;
+    const isConnected =
+      connection?.status === IntegrationConnectionStatus.CONNECTED || hasCredential;
+
+    if (isConnected) {
+      connectedConnections += 1;
+    }
+
+    if (isError) {
+      errorConnections += 1;
+      continue;
+    }
+
+    if (connection && isConnected) {
+      if (
+        !connection.lastSyncedAt ||
+        connection.lastSyncedAt.getTime() < staleSyncThreshold.getTime()
+      ) {
+        staleConnections += 1;
+      }
+      continue;
+    }
+
+    if (!isConnected) {
+      missingConnections += 1;
+    }
+  }
+
+  return {
+    generatedAt: now.toISOString(),
+    workSummary: {
+      workspaceId: "work",
+      activeTasks,
+      overdueTasks,
+      blockedTasks,
+      dueSoonTasks,
+      openAlerts,
+    },
+    revenueSummary: {
+      workspaceId: "deals",
+      openDeals,
+      pipelineValue: pipelineAggregate._sum.amount ?? 0,
+      closingThisMonth,
+      wonThisQuarter,
+    },
+    integrationHealth: {
+      workspaceId: "integrations",
+      totalConnections: integrationDefinitions.length,
+      connectedConnections,
+      degradedConnections: errorConnections + staleConnections,
+      errorConnections,
+      staleConnections,
+      missingConnections,
+    },
+    automationAttention: {
+      workspaceId: "automations",
+      activeWorkflows,
+      pendingApprovals,
+      pendingRecommendations,
+      failingRuns,
+      waitingExternalRuns,
+    },
+    analyticsFreshness: {
+      workspaceId: "analytics",
+      latestSnapshotAt,
+      healthyDomains,
+      staleDomains,
+      errorDomains,
+      missingDomains,
+    },
+  };
+}

--- a/src/lib/work/dashboard/personalized.ts
+++ b/src/lib/work/dashboard/personalized.ts
@@ -1,0 +1,259 @@
+import { buildDailyCountSeriesUtc } from "@/lib/dashboard-trends";
+import { prisma } from "@/lib/prisma";
+
+const USER_SELECT = {
+  id: true,
+  name: true,
+  email: true,
+  image: true,
+} as const;
+
+const PRIORITY_WEIGHT: Record<string, number> = {
+  P0: 8,
+  P1: 5,
+  P2: 3,
+  P3: 1,
+};
+
+export interface DashboardTask {
+  id: string;
+  title: string;
+  status: string;
+  priority: string;
+  dueDate: string | Date | null;
+  project: { id: string; name: string } | null;
+  recommendationScore?: number;
+}
+
+export interface PersonalizedDashboardPayload {
+  generatedAt: string;
+  meta?: {
+    servedAt: string;
+    isPartial: boolean;
+  };
+  personal: {
+    myActive: DashboardTask[];
+    myBlocked: DashboardTask[];
+    myOverdue: DashboardTask[];
+    myDueSoon: DashboardTask[];
+    myCompletedWeek: number;
+    completedByDay?: Array<{ date: string; count: number }>;
+    recommendations: DashboardTask[];
+  };
+  team: {
+    staleTasks: number;
+    blockedTasks: number;
+    overdueTasks: number;
+    taskStatusOverview: Record<string, number>;
+  };
+  projects: {
+    active: Array<{
+      id: string;
+      name: string;
+      progress: number;
+      doneTasks: number;
+      totalTasks: number;
+    }>;
+  };
+}
+
+function daysOverdue(value: Date | null): number {
+  if (!value) return 0;
+  const diff = Date.now() - value.getTime();
+  if (diff <= 0) return 0;
+  return Math.floor(diff / (1000 * 60 * 60 * 24));
+}
+
+export async function loadPersonalizedDashboard(
+  userId: string,
+): Promise<PersonalizedDashboardPayload> {
+  const now = new Date();
+  const todayUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const completedTrendStartUtc = new Date(todayUtc.getTime() - 13 * 24 * 60 * 60 * 1000);
+  const completedTrendEndExclusiveUtc = new Date(todayUtc.getTime() + 24 * 60 * 60 * 1000);
+  const in7d = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+  const fiveDaysAgo = new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000);
+  const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+  const [
+    myActive,
+    myBlocked,
+    myOverdue,
+    myDueSoon,
+    myCompletedWeek,
+    completedTimestamps,
+    staleTeam,
+    blockedTeam,
+    overdueTeam,
+    activeProjects,
+    statusCounts,
+  ] = await Promise.all([
+    prisma.task.findMany({
+      where: {
+        responsible: { some: { id: userId } },
+        status: { in: ["WORKING_ON_TODAY", "ACTIVE", "QUEUED"] },
+      },
+      include: {
+        project: { select: { id: true, name: true } },
+        responsible: { select: USER_SELECT },
+        dependedBy: { select: { id: true } },
+      },
+      orderBy: [{ dueDate: "asc" }, { updatedAt: "asc" }],
+      take: 20,
+    }),
+    prisma.task.findMany({
+      where: {
+        responsible: { some: { id: userId } },
+        status: "NOT_DONE",
+      },
+      include: {
+        project: { select: { id: true, name: true } },
+        responsible: { select: USER_SELECT },
+        dependedBy: { select: { id: true } },
+      },
+      orderBy: { updatedAt: "asc" },
+      take: 20,
+    }),
+    prisma.task.findMany({
+      where: {
+        responsible: { some: { id: userId } },
+        status: { notIn: ["DONE"] },
+        dueDate: { lt: now },
+      },
+      include: {
+        project: { select: { id: true, name: true } },
+        responsible: { select: USER_SELECT },
+        dependedBy: { select: { id: true } },
+      },
+      orderBy: { dueDate: "asc" },
+      take: 20,
+    }),
+    prisma.task.findMany({
+      where: {
+        responsible: { some: { id: userId } },
+        status: { notIn: ["DONE"] },
+        dueDate: { gte: now, lte: in7d },
+      },
+      include: {
+        project: { select: { id: true, name: true } },
+        responsible: { select: USER_SELECT },
+        dependedBy: { select: { id: true } },
+      },
+      orderBy: { dueDate: "asc" },
+      take: 20,
+    }),
+    prisma.task.count({
+      where: {
+        responsible: { some: { id: userId } },
+        status: "DONE",
+        updatedAt: { gte: sevenDaysAgo },
+      },
+    }),
+    prisma.task.findMany({
+      where: {
+        responsible: { some: { id: userId } },
+        status: "DONE",
+        updatedAt: { gte: completedTrendStartUtc, lt: completedTrendEndExclusiveUtc },
+      },
+      select: { updatedAt: true },
+    }),
+    prisma.task.count({
+      where: {
+        status: { in: ["ACTIVE", "WORKING_ON_TODAY", "QUEUED"] },
+        updatedAt: { lt: fiveDaysAgo },
+      },
+    }),
+    prisma.task.count({
+      where: {
+        status: "NOT_DONE",
+      },
+    }),
+    prisma.task.count({
+      where: {
+        status: { notIn: ["DONE"] },
+        dueDate: { lt: now },
+      },
+    }),
+    prisma.project.findMany({
+      where: { status: "ACTIVE" },
+      include: {
+        department: { select: { id: true, name: true, color: true } },
+        tasks: { select: { status: true } },
+      },
+      orderBy: { updatedAt: "desc" },
+      take: 8,
+    }),
+    prisma.task.groupBy({
+      by: ["status"],
+      _count: { status: true },
+    }),
+  ]);
+
+  const completedByDay = buildDailyCountSeriesUtc({
+    now,
+    days: 14,
+    timestamps: completedTimestamps.map((row) => row.updatedAt),
+  });
+
+  const taskMap = new Map<string, (typeof myActive)[number]>();
+  for (const task of [...myOverdue, ...myBlocked, ...myDueSoon, ...myActive]) {
+    if (!taskMap.has(task.id)) taskMap.set(task.id, task);
+  }
+
+  const recommendations = Array.from(taskMap.values())
+    .map((task) => {
+      const priorityWeight = PRIORITY_WEIGHT[task.priority] ?? 1;
+      const overdueScore = daysOverdue(task.dueDate) * 2;
+      const blockedBonus = task.status === "NOT_DONE" ? 5 : 0;
+      const dependencyBonus = (task.dependedBy?.length ?? 0) * 2;
+      return {
+        ...task,
+        recommendationScore: priorityWeight + overdueScore + blockedBonus + dependencyBonus,
+      };
+    })
+    .sort((a, b) => b.recommendationScore - a.recommendationScore)
+    .slice(0, 12);
+
+  const projectSummaries = activeProjects.map((project) => {
+    const total = project.tasks.length;
+    const done = project.tasks.filter((task) => task.status === "DONE").length;
+    return {
+      id: project.id,
+      name: project.name,
+      totalTasks: total,
+      doneTasks: done,
+      progress: total > 0 ? Math.round((done / total) * 100) : 0,
+    };
+  });
+
+  const taskStatusOverview: Record<string, number> = {};
+  for (const status of statusCounts) {
+    taskStatusOverview[status.status] = status._count.status;
+  }
+
+  return {
+    meta: {
+      servedAt: new Date().toISOString(),
+      isPartial: false,
+    },
+    generatedAt: now.toISOString(),
+    personal: {
+      myActive,
+      myBlocked,
+      myOverdue,
+      myDueSoon,
+      myCompletedWeek,
+      completedByDay,
+      recommendations,
+    },
+    team: {
+      staleTasks: staleTeam,
+      blockedTasks: blockedTeam,
+      overdueTasks: overdueTeam,
+      taskStatusOverview,
+    },
+    projects: {
+      active: projectSummaries,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- replace the executive overview landing page with the operator workspace overview
- add platform dashboard overview loaders and operator dashboard UI
- carry forward the stale integration-backed analytics refresh changes needed on top of current main

## Validation
- npm test -- src/lib/platform/dashboard/overview.test.ts src/components/dashboard/operator-dashboard.test.tsx src/app/api/dashboard/overview/route.test.ts src/app/api/analytics/route.test.ts src/app/api/analytics/summary/route.test.ts src/components/analytics/analytics-section-page.test.tsx src/components/analytics/analytics-summary-page.test.tsx
- npm run build

## Notes
- build passes on Next.js 16.1.6
- existing compile warning remains: attempted import error for getVisitorFunnelPrisma from visitor-funnel-availability
