### PR TITLE
Fix stale integration-backed analytics refresh

### DIFF
--- a/src/app/api/analytics/route.test.ts
+++ b/src/app/api/analytics/route.test.ts
@@ -9,6 +9,13 @@ vi.mock("@/lib/analytics/credentials", () => ({
   getCredentials: vi.fn(),
 }));
 
+vi.mock("@/lib/integrations/ownership", () => ({
+  resolveIntegrationOwnerUserId: vi.fn((userId: string) => {
+    const owner = process.env.INTEGRATION_OWNER_USER_ID?.trim();
+    return owner && owner.length > 0 ? owner : userId;
+  }),
+}));
+
 vi.mock("@/lib/analytics/fetchers", () => ({
   fetchHubSpotData: vi.fn(),
   fetchMercuryData: vi.fn(),
@@ -58,6 +65,9 @@ vi.mock("@/lib/prisma", () => ({
     task: { count: vi.fn() },
     statusHistory: { findMany: vi.fn() },
     stripeCustomerLink: { findMany: vi.fn() },
+    budget: { findMany: vi.fn() },
+    financialGoal: { findMany: vi.fn() },
+    forecastScenario: { findMany: vi.fn() },
   },
 }));
 
@@ -395,6 +405,9 @@ describe("GET /api/analytics", () => {
         hubspotDealName: "Acme Corp",
       },
     ] as never);
+    vi.mocked(prisma.budget.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.financialGoal.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.forecastScenario.findMany).mockResolvedValue([] as never);
   });
 
   it("returns 403 when analytics read permission is denied", async () => {
@@ -452,16 +465,20 @@ describe("GET /api/analytics", () => {
 
     expect(response.status).toBe(200);
     expect(body.demoAnalytics).toBeTruthy();
-    expect(body.demoAnalytics.totalScheduled).toBeGreaterThan(0);
+    expect(body.demoAnalytics.upcomingCount).toBeGreaterThan(0);
   });
 
   it("hydrates stripe customer links onto hubspot deals", async () => {
+    const { prisma } = await import("@/lib/prisma");
     const { GET } = await import("@/app/api/analytics/route");
     const response = await GET(new Request("http://localhost/api/analytics?section=demo-analytics"));
     const body = await response.json();
 
     const deal = body.hubspot.deals.find((entry: { dealId: string }) => entry.dealId === "deal-1");
     expect(deal.stripeCustomerId).toBe("cus_123");
+    expect(prisma.stripeCustomerLink.findMany).toHaveBeenCalledWith({
+      where: { userId: "user-1" },
+    });
   });
 
   it("returns process analytics domain data", async () => {
@@ -613,7 +630,7 @@ describe("GET /api/analytics", () => {
     const { fetchIntegrationTelemetryData } = await import("@/lib/analytics/fetchers-integrations");
     const { prisma } = await import("@/lib/prisma");
 
-    vi.mocked(getCredentials).mockImplementation(async (requestedUserId: string) => {
+    vi.mocked(getCredentials).mockImplementation(async (requestedUserId?: string) => {
       if (requestedUserId !== "owner-1") {
         return {
           hubspotToken: null,
@@ -726,7 +743,7 @@ describe("GET /api/analytics", () => {
       expect(body.stripe).toEqual(STRIPE_DATA);
       expect(getCredentials).toHaveBeenCalledWith("owner-1");
       expect(prisma.stripeCustomerLink.findMany).toHaveBeenCalledWith({
-        where: { userId: "owner-1" },
+        where: { userId: "user-1" },
       });
 
       expect(
@@ -791,5 +808,209 @@ describe("GET /api/analytics", () => {
         process.env.INTEGRATION_OWNER_USER_ID = previousOwner;
       }
     }
+  });
+  it("reads provider-backed analytics using the integration owner user", async () => {
+    const previousOwner = process.env.INTEGRATION_OWNER_USER_ID;
+    process.env.INTEGRATION_OWNER_USER_ID = "owner-mercury";
+
+    const { getCredentials } = await import("@/lib/analytics/credentials");
+    const { readLatestSnapshot } = await import("@/lib/analytics/snapshots");
+
+    try {
+      vi.mocked(readLatestSnapshot).mockResolvedValueOnce({
+        payload: MERCURY_DATA,
+        capturedAt: "2026-02-10T00:00:00.000Z",
+        expiresAt: "2026-02-10T01:00:00.000Z",
+        needsRefresh: false,
+        stale: false,
+        fromSnapshot: true,
+        status: "SUCCESS",
+        error: null,
+      } as never);
+
+      const { GET } = await import("@/app/api/analytics/route");
+      const response = await GET(
+        new Request("http://localhost/api/analytics?section=finance-mercury")
+      );
+
+      expect(response.status).toBe(200);
+      expect(getCredentials).toHaveBeenCalledWith("owner-mercury");
+      expect(readLatestSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "owner-mercury",
+          providerKey: "mercury",
+        }),
+      );
+    } finally {
+      if (previousOwner === undefined) {
+        delete process.env.INTEGRATION_OWNER_USER_ID;
+      } else {
+        process.env.INTEGRATION_OWNER_USER_ID = previousOwner;
+      }
+    }
+  });
+
+  it("live-fetches finance-critical Mercury data even when a snapshot exists", async () => {
+    const previousOwner = process.env.INTEGRATION_OWNER_USER_ID;
+    process.env.INTEGRATION_OWNER_USER_ID = "owner-mercury";
+
+    const staleMercury = {
+      ...MERCURY_DATA,
+      cashFlow: {
+        ...MERCURY_DATA.cashFlow,
+        totalBalance: 1000,
+        runway: 1,
+      },
+    };
+    const liveMercury = {
+      ...MERCURY_DATA,
+      cashFlow: {
+        ...MERCURY_DATA.cashFlow,
+        totalBalance: 3000000,
+        runway: 3000,
+      },
+    };
+
+    const { readLatestSnapshot, storeAnalyticsSnapshot } = await import("@/lib/analytics/snapshots");
+    const { fetchMercuryData } = await import("@/lib/analytics/fetchers");
+
+    try {
+      vi.mocked(readLatestSnapshot).mockResolvedValueOnce({
+        payload: staleMercury,
+        capturedAt: "2026-02-10T00:00:00.000Z",
+        expiresAt: "2026-02-10T01:00:00.000Z",
+        needsRefresh: false,
+        stale: false,
+        fromSnapshot: true,
+        status: "SUCCESS",
+        error: null,
+      } as never);
+      vi.mocked(fetchMercuryData).mockResolvedValueOnce(liveMercury as never);
+
+      const { GET } = await import("@/app/api/analytics/route");
+      const response = await GET(
+        new Request("http://localhost/api/analytics?section=finance-mercury")
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.mercury.cashFlow.totalBalance).toBe(3000000);
+      expect(body.mercury.cashFlow.runway).toBe(3000);
+      expect(storeAnalyticsSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "owner-mercury",
+          providerKey: "mercury",
+          payload: liveMercury,
+        }),
+      );
+    } finally {
+      if (previousOwner === undefined) {
+        delete process.env.INTEGRATION_OWNER_USER_ID;
+      } else {
+        process.env.INTEGRATION_OWNER_USER_ID = previousOwner;
+      }
+    }
+  });
+
+  it("falls back to the last successful finance snapshot when the live fetch fails", async () => {
+    const previousOwner = process.env.INTEGRATION_OWNER_USER_ID;
+    process.env.INTEGRATION_OWNER_USER_ID = "owner-mercury";
+
+    const fallbackMercury = {
+      ...MERCURY_DATA,
+      cashFlow: {
+        ...MERCURY_DATA.cashFlow,
+        totalBalance: 250000,
+        runway: 250,
+      },
+    };
+
+    const { readLatestSnapshot, readLatestSuccessfulSnapshot, storeAnalyticsSnapshotFailure } =
+      await import("@/lib/analytics/snapshots");
+    const { fetchMercuryData } = await import("@/lib/analytics/fetchers");
+
+    try {
+      vi.mocked(readLatestSnapshot).mockResolvedValueOnce({
+        payload: MERCURY_DATA,
+        capturedAt: "2026-02-10T00:00:00.000Z",
+        expiresAt: "2026-02-10T01:00:00.000Z",
+        needsRefresh: false,
+        stale: false,
+        fromSnapshot: true,
+        status: "SUCCESS",
+        error: null,
+      } as never);
+      vi.mocked(fetchMercuryData).mockRejectedValueOnce(new Error("Mercury timeout"));
+      vi.mocked(readLatestSuccessfulSnapshot).mockResolvedValueOnce({
+        payload: fallbackMercury,
+        capturedAt: "2026-02-10T00:00:00.000Z",
+        expiresAt: "2026-02-10T01:00:00.000Z",
+        needsRefresh: false,
+        stale: true,
+        fromSnapshot: true,
+        status: "SUCCESS",
+        error: null,
+      } as never);
+
+      const { GET } = await import("@/app/api/analytics/route");
+      const response = await GET(
+        new Request("http://localhost/api/analytics?section=finance-mercury")
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.mercury.cashFlow.totalBalance).toBe(250000);
+      expect(body.staleDomains).toContain("mercury");
+      expect(body.errors).toContainEqual(
+        expect.objectContaining({
+          source: "mercury",
+          message: "Mercury timeout",
+        }),
+      );
+      expect(storeAnalyticsSnapshotFailure).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "owner-mercury",
+          providerKey: "mercury",
+          error: "Mercury timeout",
+        }),
+      );
+    } finally {
+      if (previousOwner === undefined) {
+        delete process.env.INTEGRATION_OWNER_USER_ID;
+      } else {
+        process.env.INTEGRATION_OWNER_USER_ID = previousOwner;
+      }
+    }
+  });
+
+  it("keeps non-finance domains snapshot-first on normal requests", async () => {
+    const snapshotGa = {
+      ...GA_DATA,
+      sessions30d: 4321,
+    };
+
+    const { readLatestSnapshot } = await import("@/lib/analytics/snapshots");
+    const { fetchGAData } = await import("@/lib/analytics/fetchers-ga-webflow");
+
+    vi.mocked(readLatestSnapshot).mockResolvedValueOnce({
+      payload: snapshotGa,
+      capturedAt: "2026-02-10T00:00:00.000Z",
+      expiresAt: "2026-02-10T01:00:00.000Z",
+      needsRefresh: false,
+      stale: false,
+      fromSnapshot: true,
+      status: "SUCCESS",
+      error: null,
+    } as never);
+
+    const { GET } = await import("@/app/api/analytics/route");
+    const response = await GET(
+      new Request("http://localhost/api/analytics?section=ads-google-analytics")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.googleAnalytics.sessions30d).toBe(4321);
+    expect(fetchGAData).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/analytics/route.test.ts
+++ b/src/app/api/analytics/route.test.ts
@@ -465,7 +465,7 @@ describe("GET /api/analytics", () => {
 
     expect(response.status).toBe(200);
     expect(body.demoAnalytics).toBeTruthy();
-    expect(body.demoAnalytics.upcomingCount).toBeGreaterThan(0);
+    expect(body.demoAnalytics.totalScheduled).toBeGreaterThan(0);
   });
 
   it("hydrates stripe customer links onto hubspot deals", async () => {

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -30,6 +30,7 @@ import {
   parseVisitorFunnelFilters,
   syncVisitorFunnelArtifacts,
 } from "@/lib/analytics/visitor-funnel";
+import { getVisitorFunnelPrisma } from "@/lib/analytics/visitor-funnel-availability";
 import type {
   AnalyticsDashboardData,
   AnalyticsRecommendation,
@@ -542,6 +543,31 @@ const DEFAULT_ASSUMPTIONS: ForecastAssumptions = {
   additionalMonthlyExpense: 0,
   additionalMonthlyRevenue: 0,
 };
+
+const LIVE_FIRST_FINANCE_SECTIONS = new Set([
+  "overview",
+  "finance",
+  "finance-mercury",
+  "finance-stripe",
+  "finance-hubspot",
+  "finance-planning",
+  "finance-forecast",
+  "finance-pnl",
+  "finance-unit-economics",
+]);
+
+const LIVE_FIRST_FINANCE_DOMAINS = new Set<FetchEntry["key"]>([
+  "hubspot",
+  "stripe",
+  "mercury",
+]);
+
+function isLiveFirstDomain(
+  section: string | null,
+  domain: FetchEntry["key"],
+): boolean {
+  return section !== null && LIVE_FIRST_FINANCE_SECTIONS.has(section) && LIVE_FIRST_FINANCE_DOMAINS.has(domain);
+}
 
 async function buildFinancialPlanningData(
   userId: string,
@@ -1282,6 +1308,7 @@ export async function GET(request: Request) {
 
   const settled = await Promise.allSettled(
     fetchers.map(async (entry): Promise<FetchOutcome> => {
+      const liveFirst = isLiveFirstDomain(section, entry.key);
       const latestSnapshot = await readLatestSnapshot({
         userId: entry.snapshotUserId,
         providerKey: entry.key,
@@ -1291,7 +1318,7 @@ export async function GET(request: Request) {
         toDate,
       });
 
-      if (!forceRefresh && latestSnapshot.payload) {
+      if (!forceRefresh && !liveFirst && latestSnapshot.payload) {
         if (latestSnapshot.needsRefresh) {
           queueStaleSnapshotRefresh({
             userId: entry.snapshotUserId,
@@ -1437,24 +1464,28 @@ export async function GET(request: Request) {
     result.customerJourney = buildCustomerJourneyData(result);
   }
   if (domains.has("visitorFunnel")) {
-    const funnelPrisma = prisma as PrismaClientType;
-    await syncVisitorFunnelArtifacts({
-      prisma: funnelPrisma,
-      analyticsData: result,
-      stripeKey: creds.stripeKey ?? null,
-      from: fromDate,
-      to: toDate,
-    });
-    result.visitorFunnel = await buildVisitorFunnelData(funnelPrisma, {
-      from: fromDate,
-      to: toDate,
-      filters: parseVisitorFunnelFilters(url.searchParams),
-      closedWonCount: (result.hubspot?.deals ?? []).filter(
-        (deal) => deal.stageLabel.trim().toLowerCase() === "closed won",
-      ).length,
-      includeOperationalMetadata:
-        ((session.user as { role?: string } | undefined)?.role ?? null) === "admin",
-    });
+    const funnelPrisma = getVisitorFunnelPrisma(prisma as PrismaClientType);
+    if (funnelPrisma) {
+      await syncVisitorFunnelArtifacts({
+        prisma: funnelPrisma,
+        analyticsData: result,
+        stripeKey: creds.stripeKey ?? null,
+        from: fromDate,
+        to: toDate,
+      });
+      result.visitorFunnel = await buildVisitorFunnelData(funnelPrisma, {
+        from: fromDate,
+        to: toDate,
+        filters: parseVisitorFunnelFilters(url.searchParams),
+        closedWonCount: (result.hubspot?.deals ?? []).filter(
+          (deal) => deal.stageLabel.trim().toLowerCase() === "closed won",
+        ).length,
+        includeOperationalMetadata:
+          ((session.user as { role?: string } | undefined)?.role ?? null) === "admin",
+      });
+    } else {
+      result.visitorFunnel = null;
+    }
   }
   if (domains.has("recommendations")) {
     result.recommendations = buildRecommendations(result);

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -1444,7 +1444,7 @@ export async function GET(request: Request) {
     }
   });
 
-  await hydrateStripeCustomerLinks(integrationUserId, result);
+  await hydrateStripeCustomerLinks(userId, result);
 
   if (domains.has("funnelJourney")) {
     const { buildCrossFunnelData } = await loadFunnelBuilders();

--- a/src/app/api/analytics/summary/route.test.ts
+++ b/src/app/api/analytics/summary/route.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { AnalyticsSnapshotStatus, IntegrationProvider } from "@/generated/prisma/client";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/credentials", () => ({
+  getCredentials: vi.fn(),
+}));
+
+vi.mock("@/lib/integrations/ownership", () => ({
+  resolveIntegrationOwnerUserId: vi.fn((userId: string) => `owner:${userId}`),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    task: { groupBy: vi.fn(), count: vi.fn() },
+    project: { count: vi.fn() },
+    statusHistory: { findMany: vi.fn() },
+    analyticsSnapshot: { findMany: vi.fn() },
+  },
+}));
+
+function freshness(provider: IntegrationProvider) {
+  return {
+    provider,
+    source: "connection" as const,
+    status: null,
+    connectedAt: null,
+    lastSyncedAt: null,
+    lastError: null,
+  };
+}
+
+describe("GET /api/analytics/summary", () => {
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    const { auth } = await import("@/lib/auth");
+    const { getCredentials } = await import("@/lib/analytics/credentials");
+    const { prisma } = await import("@/lib/prisma");
+
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "user-1", email: "viewer@example.com" },
+    } as never);
+
+    vi.mocked(getCredentials).mockResolvedValue({
+      hubspotToken: "hubspot-token",
+      stripeKey: "stripe-token",
+      mercuryKey: "mercury-token",
+      gaPropertyId: null,
+      gaClientEmail: null,
+      gaPrivateKey: null,
+      googleAdsDevToken: null,
+      googleAdsCustomerId: null,
+      googleAdsRefreshToken: null,
+      googleAdsClientId: null,
+      googleAdsClientSecret: null,
+      googleAdsLoginCustomerId: null,
+      metaAccessToken: null,
+      metaAdAccountId: null,
+      metaPageId: null,
+      metaInstagramAccountId: null,
+      redditClientId: null,
+      redditClientSecret: null,
+      redditRefreshToken: null,
+      redditAdAccountId: null,
+      redditUserAgent: null,
+      webflowApiToken: null,
+      webflowSiteId: null,
+      semrushApiToken: null,
+      semrushDomain: null,
+      codaApiToken: null,
+      codaDocId: null,
+      pylonApiKey: null,
+      pylonBaseUrl: null,
+      googleWorkspaceAccessToken: null,
+      slackAccessToken: null,
+      freshness: {
+        [IntegrationProvider.GOOGLE_WORKSPACE]: freshness(IntegrationProvider.GOOGLE_WORKSPACE),
+        [IntegrationProvider.HUBSPOT]: freshness(IntegrationProvider.HUBSPOT),
+        [IntegrationProvider.SLACK]: freshness(IntegrationProvider.SLACK),
+        [IntegrationProvider.CODA]: freshness(IntegrationProvider.CODA),
+        [IntegrationProvider.REDDIT]: freshness(IntegrationProvider.REDDIT),
+        [IntegrationProvider.GOOGLE_ANALYTICS]: freshness(IntegrationProvider.GOOGLE_ANALYTICS),
+        [IntegrationProvider.STRIPE]: freshness(IntegrationProvider.STRIPE),
+        [IntegrationProvider.MERCURY]: freshness(IntegrationProvider.MERCURY),
+        [IntegrationProvider.WEBFLOW]: freshness(IntegrationProvider.WEBFLOW),
+        [IntegrationProvider.GOOGLE_ADS]: freshness(IntegrationProvider.GOOGLE_ADS),
+        [IntegrationProvider.META_ADS]: freshness(IntegrationProvider.META_ADS),
+        [IntegrationProvider.META_PAGE]: freshness(IntegrationProvider.META_PAGE),
+        [IntegrationProvider.SEMRUSH]: freshness(IntegrationProvider.SEMRUSH),
+        [IntegrationProvider.PYLON]: freshness(IntegrationProvider.PYLON),
+      },
+    } as never);
+
+    vi.mocked(prisma.task.groupBy).mockResolvedValue([
+      { status: "DONE", _count: { status: 3 } },
+      { status: "ACTIVE", _count: { status: 2 } },
+    ] as never);
+    vi.mocked(prisma.task.count).mockResolvedValue(1 as never);
+    vi.mocked(prisma.project.count).mockResolvedValue(4 as never);
+    vi.mocked(prisma.statusHistory.findMany).mockResolvedValue([
+      { changedBy: "user-1" },
+      { changedBy: "user-2" },
+    ] as never);
+    vi.mocked(prisma.analyticsSnapshot.findMany).mockResolvedValue([
+      {
+        providerKey: "mercury",
+        status: AnalyticsSnapshotStatus.SUCCESS,
+        expiresAt: new Date("2099-02-10T00:00:00.000Z"),
+        capturedAt: new Date("2026-02-10T00:00:00.000Z"),
+        lastError: null,
+      },
+    ] as never);
+  });
+
+  it("uses the integration owner for credentials and snapshot health", async () => {
+    const { getCredentials } = await import("@/lib/analytics/credentials");
+    const { prisma } = await import("@/lib/prisma");
+    const { GET } = await import("@/app/api/analytics/summary/route");
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/analytics/summary?range=30d"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(getCredentials).toHaveBeenCalledWith("owner:user-1");
+    expect(prisma.analyticsSnapshot.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          userId: "owner:user-1",
+        }),
+      }),
+    );
+    expect(body.primarySections.some((section: { status: string }) => section.status !== "missing")).toBe(true);
+  });
+});

--- a/src/app/api/analytics/summary/route.ts
+++ b/src/app/api/analytics/summary/route.ts
@@ -5,6 +5,7 @@ import { AnalyticsSnapshotStatus } from "@/generated/prisma/client";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { getCredentials } from "@/lib/analytics/credentials";
+import { resolveIntegrationOwnerUserId } from "@/lib/integrations/ownership";
 import { parseAnalyticsTimeRange } from "@/lib/analytics/time-range";
 import { getAuthenticatedUser } from "@/lib/session-user";
 import {
@@ -37,9 +38,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const range = parseAnalyticsTimeRange(request.nextUrl.searchParams);
     const from = new Date(`${range.from}T00:00:00.000Z`);
     const to = new Date(`${range.to}T23:59:59.999Z`);
+    const integrationOwnerUserId = resolveIntegrationOwnerUserId(user.id);
 
     const [creds, tasksByStatus, overdueTasks, activeProjects, contributors, latestSnapshots] = await Promise.all([
-      getCredentials(user.id),
+      getCredentials(integrationOwnerUserId),
       prisma.task.groupBy({ by: ["status"], _count: { status: true } }),
       prisma.task.count({
         where: {
@@ -58,7 +60,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       }),
       prisma.analyticsSnapshot.findMany({
         where: {
-          userId: user.id,
+          userId: integrationOwnerUserId,
           rangePreset: range.preset,
           toDate: to,
           providerKey: {

--- a/src/components/analytics/ai-insights-page.tsx
+++ b/src/components/analytics/ai-insights-page.tsx
@@ -38,7 +38,7 @@ export function AiInsightsPage() {
 
       const response = await fetch(`/api/analytics?${params.toString()}`, {
         signal,
-        cache: refresh ? "no-store" : "default",
+        cache: "no-store",
       });
       if (!response.ok) {
         throw new Error(`Analytics overview request failed (${response.status})`);
@@ -46,7 +46,7 @@ export function AiInsightsPage() {
       return (await response.json()) as AnalyticsDashboardData;
     },
     getLastUpdatedAt: (payload) =>
-      payload.meta?.servedAt ?? payload.lastFullRefresh ?? payload.generatedAt ?? null,
+      payload.meta?.servedAt ?? payload.lastFullRefresh ?? null,
     mapError: (error) =>
       error instanceof Error && error.message ? error.message : "Could not load insights.",
   });
@@ -72,7 +72,6 @@ export function AiInsightsPage() {
     createTaskFromInsight,
     creatingTaskForId,
     sortAndFilter,
-    dismissedIds,
   } = useInsightPreferences();
 
   useEffect(() => {
@@ -80,11 +79,11 @@ export function AiInsightsPage() {
     populateConnectionStatus(data.freshness, data);
   }, [data]);
 
-  const allInsights = data?.aiInsights?.global ?? [];
+  const allInsights = useMemo(() => data?.aiInsights?.global ?? [], [data?.aiInsights?.global]);
 
   const dismissedCount = useMemo(
     () => allInsights.filter((i) => isDismissed(i.id)).length,
-    [allInsights, isDismissed, dismissedIds]
+    [allInsights, isDismissed]
   );
 
   const filtered = useMemo(() => {
@@ -109,7 +108,7 @@ export function AiInsightsPage() {
         : b.confidence - a.confidence;
 
     return [...pinned, ...unpinned.sort(sortFn)];
-  }, [allInsights, severityFilter, sectionFilter, sortMode, sortAndFilter, showDismissed, isPinned, dismissedIds]);
+  }, [allInsights, severityFilter, sectionFilter, sortMode, sortAndFilter, showDismissed, isPinned]);
 
   const totalInsights = filtered.length;
   const pageCount = Math.max(1, Math.ceil(totalInsights / pageSize));

--- a/src/components/analytics/analytics-section-page.test.tsx
+++ b/src/components/analytics/analytics-section-page.test.tsx
@@ -48,6 +48,7 @@ describe("AnalyticsSectionPage", () => {
       expect(screen.getByText("Google Ads data is unavailable")).toBeTruthy();
     });
 
+    expect(vi.mocked(fetch).mock.calls[0]?.[1]).toMatchObject({ cache: "no-store" });
     expect(screen.getByText("Google Ads API quota exceeded")).toBeTruthy();
     expect(screen.getByText("Manage integration connection status in Settings")).toBeTruthy();
   });

--- a/src/components/analytics/analytics-section-page.tsx
+++ b/src/components/analytics/analytics-section-page.tsx
@@ -284,7 +284,7 @@ export function AnalyticsSectionPage({ sectionId }: AnalyticsSectionPageProps) {
 
       const response = await fetch(`/api/analytics?${analyticsParams.toString()}`, {
         signal,
-        cache: refresh ? "no-store" : "default",
+        cache: "no-store",
       });
       if (!response.ok) {
         throw new Error(`Analytics section request failed (${response.status})`);

--- a/src/components/analytics/analytics-summary-page.test.tsx
+++ b/src/components/analytics/analytics-summary-page.test.tsx
@@ -77,6 +77,11 @@ describe("AnalyticsSummaryPage", () => {
       expect(screen.getByText("Analytics Overview")).toBeTruthy();
     });
 
+    const fetchMock = vi.mocked(fetch);
+    expect(fetchMock).toHaveBeenCalled();
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ cache: "no-store" });
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({ cache: "no-store" });
+
     expect(
       screen.queryByText("Showing cached analytics while background refresh completes or retries.")
     ).toBeNull();

--- a/src/components/analytics/analytics-summary-page.tsx
+++ b/src/components/analytics/analytics-summary-page.tsx
@@ -109,11 +109,11 @@ export function AnalyticsSummaryPage() {
       const [summarySettled, overviewSettled] = await Promise.allSettled([
         fetch(`/api/analytics/summary${summaryParams.toString() ? `?${summaryParams.toString()}` : ""}`, {
           signal,
-          cache: refresh ? "no-store" : "default",
+          cache: "no-store",
         }),
         fetch(`/api/analytics?${overviewParams.toString()}`, {
           signal,
-          cache: refresh ? "no-store" : "default",
+          cache: "no-store",
         }),
       ]);
 

--- a/src/components/analytics/customer-journey-page.tsx
+++ b/src/components/analytics/customer-journey-page.tsx
@@ -4,8 +4,6 @@ import { useEffect, useState } from "react";
 import { HorizontalFunnel } from "@/components/charts";
 import { StatCard } from "./stat-card";
 import { DashboardSectionCard } from "./dashboard-section-card";
-import { AiInsightsPanel } from "./ai-insights-panel";
-import { AnalyticsTimeRangeControls } from "@/components/analytics/time-range-controls";
 import type {
   AnalyticsDashboardData,
   LifecycleStageId,
@@ -32,14 +30,17 @@ export function CustomerJourneyPage() {
     cacheKey: "analytics:overview:v1",
     deps: [],
     load: async ({ signal }) => {
-      const response = await fetch("/api/analytics?section=overview", { signal });
+      const response = await fetch("/api/analytics?section=overview", {
+        signal,
+        cache: "no-store",
+      });
       if (!response.ok) {
         throw new Error(`Analytics overview request failed (${response.status})`);
       }
       return (await response.json()) as AnalyticsDashboardData;
     },
     getLastUpdatedAt: (payload) =>
-      payload.meta?.servedAt ?? payload.lastFullRefresh ?? payload.generatedAt ?? null,
+      payload.meta?.servedAt ?? payload.lastFullRefresh ?? null,
     mapError: (error) =>
       error instanceof Error && error.message ? error.message : "Could not load journey data.",
   });


### PR DESCRIPTION
## Summary
- keep provider-backed analytics and snapshot reads owner-scoped while preserving viewer-scoped records like Stripe customer links
- make Mercury, Stripe, and HubSpot live-first for overview and finance sections, with snapshot fallback on provider failure
- disable browser response caching for analytics fetches and add regression coverage for owner-scoped reads and live refresh behavior

## Verification
- /Users/kylehenson/WIPGuard/node_modules/.bin/vitest run src/app/api/analytics/route.test.ts src/app/api/analytics/summary/route.test.ts src/components/analytics/analytics-summary-page.test.tsx src/components/analytics/analytics-section-page.test.tsx src/components/analytics/ai-insights-page.test.tsx src/components/dashboard/use-dashboard-resource.test.tsx