### PR TITLE
test(e2e): align deals flow with detail navigation

### DIFF
--- a/src/components/deals/deal-detail.tsx
+++ b/src/components/deals/deal-detail.tsx
@@ -314,6 +314,8 @@ export function DealDetail({ dealId }: { dealId: string }) {
                 value={form.stage}
                 onChange={(e) => setForm((p) => ({ ...p, stage: e.target.value as DealStage }))}
                 className="modal-input w-full rounded-md border px-3 py-2 text-sm"
+                aria-label="Deal stage"
+                data-testid="deal-stage-select"
               >
                 {Object.entries(DEAL_STAGE_LABELS).map(([val, label]) => (
                   <option key={val} value={val}>{label}</option>
@@ -403,6 +405,8 @@ export function DealDetail({ dealId }: { dealId: string }) {
               onClick={saveDeal}
               disabled={saving}
               className="btn-primary-theme flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium disabled:opacity-50"
+              aria-label="Save deal changes"
+              data-testid="save-deal-changes"
             >
               <Save className="h-4 w-4" />
               {saving ? "Saving..." : "Save Changes"}

--- a/src/components/deals/deals-dashboard.tsx
+++ b/src/components/deals/deals-dashboard.tsx
@@ -304,7 +304,12 @@ export function DealsDashboard() {
           ) : (
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
               {pipelineColumns.map((col) => (
-                <div key={col.stage} className="space-y-2">
+                <div
+                  key={col.stage}
+                  className="space-y-2"
+                  data-stage={col.label}
+                  data-testid={`stage-${col.label.toLowerCase().replace(/\s+/g, "-")}`}
+                >
                   <div className="flex items-center justify-between">
                     <h3 className="text-sm font-semibold text-foreground">{col.label}</h3>
                     <span className="text-xs tabular-nums text-muted-foreground">{col.deals.length}</span>

--- a/tests/e2e/deals.spec.ts
+++ b/tests/e2e/deals.spec.ts
@@ -50,14 +50,18 @@ test.describe('Deal Pipeline', () => {
 
     await dealsPage.createDeal(dealName);
 
-    // Verify the deal appears on the page
-    await expect(dealsPage.getDeal(dealName)).toBeVisible({ timeout: 10_000 });
+    await expect(page).toHaveURL(/\/deals\/[^/]+$/i);
+    await expect(dealsPage.getDealDetailHeading(dealName)).toBeVisible({ timeout: 10_000 });
   });
 
   test('should show new deal in the first pipeline stage', async ({ page }) => {
     const dealName = uniqueDealName();
 
     await dealsPage.createDeal(dealName);
+    await expect(page).toHaveURL(/\/deals\/[^/]+$/i);
+    await expect(dealsPage.getDealDetailHeading(dealName)).toBeVisible({ timeout: 10_000 });
+
+    await dealsPage.goto();
     await expect(dealsPage.getDeal(dealName)).toBeVisible({ timeout: 10_000 });
 
     // Check deal is in the first stage column
@@ -77,30 +81,23 @@ test.describe('Deal Pipeline', () => {
 
     // Create the deal
     await dealsPage.createDeal(dealName);
-    await expect(dealsPage.getDeal(dealName)).toBeVisible({ timeout: 10_000 });
+    await expect(page).toHaveURL(/\/deals\/[^/]+$/i);
+    await expect(dealsPage.getDealDetailHeading(dealName)).toBeVisible({ timeout: 10_000 });
 
-    // Try to advance the deal to the next stage
     const targetStage = DEAL_STAGES[1]; // "Qualified"
+    const saveResponse = page.waitForResponse((response) =>
+      response.request().method() === 'PATCH' &&
+      /\/api\/deals\/[^/]+$/i.test(response.url()) &&
+      response.ok()
+    );
 
-    try {
-      await dealsPage.advanceDealToStage(dealName, targetStage);
-      await page.waitForLoadState('networkidle');
-    } catch {
-      // If drag-and-drop doesn't work, try clicking on the deal and using a button
-      try {
-        await dealsPage.getDeal(dealName).click();
-        const advanceButton = dealsPage.getAdvanceButton();
-        const advVisible = await advanceButton.isVisible().catch(() => false);
-        if (advVisible) {
-          await advanceButton.click();
-        }
-      } catch {
-        // Pipeline advancement UI may vary - test that deal is still visible
-      }
-    }
+    await page.getByLabel(/deal stage/i).selectOption({ label: targetStage });
+    await page.getByRole('button', { name: /save changes/i }).click();
+    await saveResponse;
 
-    // Verify deal is still visible after attempted advancement
-    await expect(dealsPage.getDeal(dealName)).toBeVisible({ timeout: 10_000 });
+    await dealsPage.goto();
+    const qualifiedStage = dealsPage.getStageColumn(targetStage);
+    await expect(qualifiedStage.getByText(dealName)).toBeVisible({ timeout: 10_000 });
   });
 
   test('should allow creating multiple deals', async ({ page }) => {
@@ -108,13 +105,16 @@ test.describe('Deal Pipeline', () => {
     const deal2 = uniqueDealName();
 
     await dealsPage.createDeal(deal1);
-    await expect(dealsPage.getDeal(deal1)).toBeVisible({ timeout: 10_000 });
+    await expect(page).toHaveURL(/\/deals\/[^/]+$/i);
+    await expect(dealsPage.getDealDetailHeading(deal1)).toBeVisible({ timeout: 10_000 });
 
     // Creating a deal navigates to its detail view; go back to the deals list before creating another.
     await dealsPage.goto();
+    await expect(dealsPage.getDeal(deal1)).toBeVisible({ timeout: 10_000 });
 
     await dealsPage.createDeal(deal2);
-    await expect(dealsPage.getDeal(deal2)).toBeVisible({ timeout: 10_000 });
+    await expect(page).toHaveURL(/\/deals\/[^/]+$/i);
+    await expect(dealsPage.getDealDetailHeading(deal2)).toBeVisible({ timeout: 10_000 });
 
     // Back on the list, both deals should be visible.
     await dealsPage.goto();

--- a/tests/e2e/helpers/pages.ts
+++ b/tests/e2e/helpers/pages.ts
@@ -2,7 +2,7 @@
  * Page Object helpers for common E2E interactions.
  * Encapsulates selectors and actions for reuse across test suites.
  */
-import { type Page, type Locator, expect } from '@playwright/test';
+import { type Page, type Locator } from '@playwright/test';
 
 /**
  * Helper for authentication-related page interactions.
@@ -237,7 +237,8 @@ export class SprintPage {
     return this.page.getByRole('button', { name: /commit|add.*task|assign/i });
   }
 
-  async createSprint(_name: string): Promise<string> {
+  async createSprint(name: string): Promise<string> {
+    void name;
     await this.getCreateSprintButton().click();
     // Sprint label is computed from dates in the UI; create a short sprint range.
     const today = new Date();
@@ -291,6 +292,12 @@ export class DealsPage {
     return this.page.getByRole('button', { name: /^create deal$|^creating\.\.\.$/i });
   }
 
+  getDealDetailHeading(name: string): Locator {
+    return this.page.getByRole('heading', {
+      name: new RegExp(name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'),
+    });
+  }
+
   getDeal(name: string): Locator {
     return this.page.getByText(name, { exact: false });
   }
@@ -314,10 +321,7 @@ export class DealsPage {
     await this.getSubmitButton().click();
     await this.page.getByRole('dialog').waitFor({ state: 'hidden', timeout: 10_000 }).catch(() => {});
     // Creation navigates to the deal detail page; wait for the heading to render.
-    await this.page
-      .getByRole('heading', { name: new RegExp(name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i') })
-      .waitFor({ state: 'visible', timeout: 15_000 })
-      .catch(() => {});
+    await this.getDealDetailHeading(name).waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
   }
 
   async advanceDealToStage(dealName: string, targetStage: string) {


### PR DESCRIPTION
## Summary
- update deals E2E assertions to follow the current create -> detail-page flow
- navigate back to /deals before asserting pipeline/list placement
- add stable stage/detail selectors used by the revised tests

## Validation
- npm run lint -- tests/e2e/deals.spec.ts tests/e2e/helpers/pages.ts src/components/deals/deals-dashboard.tsx src/components/deals/deal-detail.tsx

## Notes
- Full local Playwright was not runnable in this environment because auth.setup.ts fails locally with 'No supported login method found on /login'; CI is the authoritative check for this path.