### PR TITLE
feat(automations): archive standalone transcript documents

### DIFF
--- a/src/lib/__tests__/automations-store.test.ts
+++ b/src/lib/__tests__/automations-store.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   buildRunExecutionContext,
   materializeSourceDocumentsFromTrigger,
+  persistStandaloneSourceDocument,
   persistAutomationEnvelope,
 } from "@/lib/automations/store";
 import { prisma } from "@/lib/prisma";
@@ -25,8 +26,13 @@ vi.mock("@/lib/prisma", () => ({
     automationRecommendation: {
       upsert: vi.fn(),
     },
+    workflowDefinition: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
     workflowRun: {
       findUnique: vi.fn(),
+      create: vi.fn(),
     },
   },
 }));
@@ -139,6 +145,81 @@ describe("automation store", () => {
           requiresApproval: true,
           status: AutomationRecommendationStatus.PENDING_APPROVAL,
           approvedAt: null,
+        }),
+      })
+    );
+  });
+
+  it("persists standalone source documents through a system-managed archive workflow", async () => {
+    vi.mocked(prisma.workflowDefinition.findFirst).mockResolvedValue(null as never);
+    vi.mocked(prisma.workflowDefinition.create).mockResolvedValue({
+      id: "wf_archive_1",
+    } as never);
+    vi.mocked(prisma.workflowRun.findUnique).mockResolvedValue(null as never);
+    vi.mocked(prisma.workflowRun.create).mockResolvedValue({
+      id: "run_archive_1",
+    } as never);
+    vi.mocked(prisma.automationSourceDocument.upsert).mockResolvedValue({
+      id: "doc_archive_1",
+    } as never);
+
+    const result = await persistStandaloneSourceDocument({
+      ownerId: "user_1",
+      requestedById: "user_1",
+      operatorKey: "SALES_FOLLOWUP",
+      provider: IntegrationProvider.GOOGLE_WORKSPACE,
+      eventType: "google-workspace.drive.transcript_captured",
+      externalId: "file_1",
+      triggerPayload: {
+        fileId: "file_1",
+      },
+      documentType: "transcript",
+      title: "Acme transcript",
+      mimeType: "text/plain",
+      sourceUrl: "https://drive.test/file_1",
+      textContent: "Transcript body",
+      metadata: {
+        fileId: "file_1",
+      },
+      dedupeKey: "google-workspace:drive-transcript:file_1:2026-03-11t00:00:00.000z",
+    });
+
+    expect(result).toEqual({
+      workflowId: "wf_archive_1",
+      runId: "run_archive_1",
+      sourceDocumentId: "doc_archive_1",
+    });
+
+    expect(prisma.workflowDefinition.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          ownerId: "user_1",
+          name: "System Transcript Archive",
+          isSystemManaged: true,
+          providers: [IntegrationProvider.GOOGLE_WORKSPACE],
+        }),
+      })
+    );
+    expect(prisma.workflowRun.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          workflowId: "wf_archive_1",
+          triggerType: "google-workspace.drive.transcript_captured",
+          triggerId: "file_1",
+        }),
+      })
+    );
+    expect(prisma.automationSourceDocument.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          dedupeKey: "google-workspace:drive-transcript:file_1:2026-03-11t00:00:00.000z",
+        },
+        create: expect.objectContaining({
+          workflowId: "wf_archive_1",
+          runId: "run_archive_1",
+          documentType: "transcript",
+          title: "Acme transcript",
+          textContent: "Transcript body",
         }),
       })
     );

--- a/src/lib/automations/store.ts
+++ b/src/lib/automations/store.ts
@@ -7,6 +7,8 @@ import {
   type AutomationOperatorKey,
   type IntegrationProvider,
   Prisma,
+  WorkflowScope,
+  WorkflowStatus,
 } from "@/generated/prisma/client";
 import { prisma } from "@/lib/prisma";
 
@@ -58,6 +60,8 @@ export interface AutomationResultEnvelope {
   raw?: Record<string, unknown> | null;
 }
 
+const SYSTEM_TRANSCRIPT_ARCHIVE_WORKFLOW_NAME = "System Transcript Archive";
+
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return null;
@@ -88,6 +92,50 @@ function toNullableJsonValue(
     return Prisma.DbNull;
   }
   return value as Prisma.InputJsonValue;
+}
+
+async function ensureSystemTranscriptArchiveWorkflow(input: {
+  ownerId: string;
+  provider?: IntegrationProvider | null;
+  operatorKey?: AutomationOperatorKey | null;
+}): Promise<string> {
+  const existing = await prisma.workflowDefinition.findFirst({
+    where: {
+      ownerId: input.ownerId,
+      name: SYSTEM_TRANSCRIPT_ARCHIVE_WORKFLOW_NAME,
+      isSystemManaged: true,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  if (existing) {
+    return existing.id;
+  }
+
+  const created = await prisma.workflowDefinition.create({
+    data: {
+      ownerId: input.ownerId,
+      name: SYSTEM_TRANSCRIPT_ARCHIVE_WORKFLOW_NAME,
+      description: "System-managed archive workflow for durable transcript persistence.",
+      scope: WorkflowScope.PRIVATE,
+      status: WorkflowStatus.ACTIVE,
+      providers: input.provider ? [input.provider] : [],
+      operatorKey: input.operatorKey ?? null,
+      isSystemManaged: true,
+      graph: {
+        nodes: [],
+        edges: [],
+      } as Prisma.InputJsonValue,
+      lastPublishedAt: new Date(),
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  return created.id;
 }
 
 export function recommendationRequiresApproval(actionType: string): boolean {
@@ -206,6 +254,96 @@ export async function materializeSourceDocumentsFromTrigger(input: {
   }
 
   return prepared.length;
+}
+
+export async function persistStandaloneSourceDocument(input: {
+  ownerId: string;
+  requestedById?: string | null;
+  operatorKey?: AutomationOperatorKey | null;
+  provider?: IntegrationProvider | null;
+  eventType?: string | null;
+  externalId?: string | null;
+  triggerPayload?: Record<string, unknown> | null;
+  documentType: string;
+  title?: string | null;
+  mimeType?: string | null;
+  sourceUrl?: string | null;
+  textContent?: string | null;
+  structuredData?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
+  dedupeKey: string;
+}): Promise<{ workflowId: string; runId: string; sourceDocumentId: string }> {
+  const workflowId = await ensureSystemTranscriptArchiveWorkflow({
+    ownerId: input.ownerId,
+    provider: input.provider ?? null,
+    operatorKey: input.operatorKey ?? null,
+  });
+
+  const runDedupeKey = `${input.dedupeKey}:run`;
+  const existingRun = await prisma.workflowRun.findUnique({
+    where: { dedupeKey: runDedupeKey },
+    select: { id: true },
+  });
+
+  const runId = existingRun
+    ? existingRun.id
+    : (
+        await prisma.workflowRun.create({
+          data: {
+            workflowId,
+            requestedById: input.requestedById ?? input.ownerId,
+            triggerProvider: input.provider ?? null,
+            triggerType: input.eventType ?? "system.transcript.archive",
+            triggerId: input.externalId ?? null,
+            triggerPayload: toNullableJsonValue(input.triggerPayload ?? null),
+            dedupeKey: runDedupeKey,
+            status: "SUCCEEDED",
+            startedAt: new Date(),
+            finishedAt: new Date(),
+          },
+          select: { id: true },
+        })
+      ).id;
+
+  const sourceDocument = await prisma.automationSourceDocument.upsert({
+    where: { dedupeKey: input.dedupeKey },
+    create: {
+      workflowId,
+      runId,
+      operatorKey: input.operatorKey ?? null,
+      provider: input.provider ?? null,
+      eventType: input.eventType ?? null,
+      externalId: input.externalId ?? null,
+      documentType: input.documentType,
+      status: AutomationSourceDocumentStatus.READY,
+      title: input.title ?? null,
+      mimeType: input.mimeType ?? null,
+      sourceUrl: input.sourceUrl ?? null,
+      textContent: input.textContent ?? null,
+      structuredData: toNullableJsonValue(input.structuredData),
+      metadata: toNullableJsonValue(input.metadata),
+      dedupeKey: input.dedupeKey,
+    },
+    update: {
+      title: input.title ?? null,
+      mimeType: input.mimeType ?? null,
+      sourceUrl: input.sourceUrl ?? null,
+      textContent: input.textContent ?? null,
+      structuredData: toNullableJsonValue(input.structuredData),
+      metadata: toNullableJsonValue(input.metadata),
+      status: AutomationSourceDocumentStatus.READY,
+      observedAt: new Date(),
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  return {
+    workflowId,
+    runId,
+    sourceDocumentId: sourceDocument.id,
+  };
 }
 
 export async function buildRunExecutionContext(runId: string): Promise<Record<string, unknown>> {

--- a/src/lib/integrations/google-drive-transcript-capture.ts
+++ b/src/lib/integrations/google-drive-transcript-capture.ts
@@ -6,6 +6,7 @@ import {
   type TaskStatus,
 } from "@/generated/prisma/client";
 import { dispatchWorkflowTriggerEvents, enqueueWorkflowTriggerEvent } from "@/lib/automations/runtime";
+import { persistStandaloneSourceDocument } from "@/lib/automations/store";
 import { prisma } from "@/lib/prisma";
 import { withRetries } from "@/lib/integrations/with-retries";
 import {
@@ -596,6 +597,29 @@ export async function runGoogleDriveTranscriptCapture(input: {
           continue;
         }
 
+        const archivedDocument = await persistStandaloneSourceDocument({
+          ownerId: input.userId,
+          requestedById: input.userId,
+          operatorKey: "SALES_FOLLOWUP",
+          provider: IntegrationProvider.GOOGLE_WORKSPACE,
+          eventType: "google-workspace.drive.transcript_captured",
+          externalId: file.id,
+          triggerPayload: {
+            sourceUrl,
+            fileId: file.id,
+            fileName: file.name ?? `Transcript ${file.id}`,
+            modifiedTime: observedAtIso,
+            matchedMeetingId: bestMatch?.meetingId ?? null,
+          },
+          documentType: "transcript",
+          title: file.name ?? `Transcript ${file.id}`,
+          mimeType: file.mimeType ?? "text/plain",
+          sourceUrl,
+          textContent,
+          metadata,
+          dedupeKey: `google-workspace:drive-transcript:${file.id}:${normalizeKey(observedAtIso)}`,
+        });
+
         const receiptDedupeKey = buildTranscriptReceiptDedupeKey(file);
         await prisma.integrationReceipt.upsert({
           where: { dedupeKey: receiptDedupeKey },
@@ -606,12 +630,18 @@ export async function runGoogleDriveTranscriptCapture(input: {
             externalObjectId: file.id,
             sourceUrl,
             lastObservedAt: Number.isFinite(observedAtMs) ? new Date(observedAtMs) : new Date(),
-            metadata: metadata as Prisma.InputJsonValue,
+            metadata: {
+              ...metadata,
+              sourceDocumentId: archivedDocument.sourceDocumentId,
+            } as Prisma.InputJsonValue,
           },
           update: {
             sourceUrl,
             lastObservedAt: Number.isFinite(observedAtMs) ? new Date(observedAtMs) : new Date(),
-            metadata: metadata as Prisma.InputJsonValue,
+            metadata: {
+              ...metadata,
+              sourceDocumentId: archivedDocument.sourceDocumentId,
+            } as Prisma.InputJsonValue,
           },
         });
 
@@ -623,7 +653,7 @@ export async function runGoogleDriveTranscriptCapture(input: {
             operation: "stored",
             meetingId: null,
             confidence: null,
-            sourceDocumentId: null,
+            sourceDocumentId: archivedDocument.sourceDocumentId,
           });
           continue;
         }
@@ -666,6 +696,7 @@ export async function runGoogleDriveTranscriptCapture(input: {
             dealName: matchedMeeting.deal?.name ?? null,
             title: matchedMeeting.title,
             sourceUrl,
+            sourceDocumentId: archivedDocument.sourceDocumentId,
             transcript: textContent,
             documents: [
               {
@@ -675,7 +706,10 @@ export async function runGoogleDriveTranscriptCapture(input: {
                 mimeType: file.mimeType ?? "text/plain",
                 sourceUrl,
                 textContent,
-                metadata,
+                metadata: {
+                  ...metadata,
+                  archivedSourceDocumentId: archivedDocument.sourceDocumentId,
+                },
               },
             ],
             meeting: {
@@ -703,7 +737,7 @@ export async function runGoogleDriveTranscriptCapture(input: {
           operation: "matched",
           meetingId: matchedMeeting.id,
           confidence: bestMatch.confidence,
-          sourceDocumentId: null,
+          sourceDocumentId: archivedDocument.sourceDocumentId,
         });
       } catch (error) {
         failedFiles += 1;


### PR DESCRIPTION
## Summary
- persist Google Drive transcript captures as standalone automation source documents
- create or reuse a system-managed archive workflow/run for durable transcript storage
- cover the archive path with focused automation store tests

## Verification
- npx tsc --noEmit --pretty false
- npx vitest run src/lib/__tests__/automations-store.test.ts src/lib/__tests__/google-drive-transcript-capture.test.ts