### PR TITLE
feat: harden transcript-backed demo coaching

### DIFF
--- a/src/app/api/deals/meetings/[id]/route.test.ts
+++ b/src/app/api/deals/meetings/[id]/route.test.ts
@@ -6,80 +6,93 @@ vi.mock("@/lib/auth", () => ({
 }));
 
 vi.mock("@/lib/permissions", () => ({
-  enforcePermission: vi.fn(async () => ({ deniedResponse: null })),
+  enforcePermission: vi.fn(async () => ({ role: "member" })),
 }));
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     dealMeeting: {
       findUnique: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
     },
   },
 }));
 
-describe("GET /api/deals/meetings/[id]", () => {
-  beforeEach(() => {
+describe("deal meeting detail route", () => {
+  beforeEach(async () => {
     vi.resetAllMocks();
-    vi.resetModules();
+
+    const { auth } = await import("@/lib/auth");
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-1",
+        email: "user@example.com",
+      },
+    } as never);
   });
 
-  it("returns enriched meeting detail including transcript metadata", async () => {
-    const { auth } = await import("@/lib/auth");
+  it("returns transcript and analysis fields for the meeting detail response", async () => {
     const { prisma } = await import("@/lib/prisma");
-
-    vi.mocked(auth).mockResolvedValue({ user: { id: "user_1" } } as never);
     vi.mocked(prisma.dealMeeting.findUnique).mockResolvedValue({
-      id: "meeting_1",
-      title: "Demo",
-      status: "COMPLETED",
-      startAt: new Date("2026-03-10T18:00:00.000Z"),
-      endAt: new Date("2026-03-10T18:30:00.000Z"),
-      location: null,
-      notes: "Call notes",
-      googleDriveFileId: "drive_1",
-      googleDriveFileName: "demo transcript",
-      googleDriveFileUrl: "https://drive.test/file",
-      transcriptMatchedAt: new Date("2026-03-10T19:00:00.000Z"),
-      transcriptMatchConfidence: 0.91,
-      analysisArtifactId: "artifact_1",
-      demoQualityScore: 87,
-      demoQualitySummary: "Strong demo",
-      demoStrengthsJson: ["Discovery"],
-      demoGapsJson: ["Pricing"],
-      analyzedAt: new Date("2026-03-10T19:30:00.000Z"),
-      expectedAttendees: 2,
-      actualAttendees: 2,
-      dealId: "deal_1",
-      deal: { id: "deal_1", name: "Acme" },
-      companyId: "company_1",
-      company: { id: "company_1", name: "Acme Co" },
+      id: "meeting-1",
+      title: "Acme demo",
+      googleDriveFileId: "file-1",
+      googleDriveFileName: "Acme Demo Transcript",
+      googleDriveFileUrl: "https://drive.google.com/file/d/file-1/view",
+      transcriptMatchedAt: new Date("2026-03-11T18:00:00.000Z"),
+      transcriptMatchConfidence: 0.92,
+      analysisArtifactId: "artifact-1",
+      demoQualityScore: 86,
+      demoQualitySummary: "Handled discovery well and closed on next steps.",
+      demoStrengthsJson: ["Strong discovery", "Clear next steps"],
+      demoGapsJson: ["Pricing objection handling"],
+      analyzedAt: new Date("2026-03-11T19:00:00.000Z"),
+      deal: { id: "deal-1", name: "Acme" },
+      company: { id: "company-1", name: "Acme Corp" },
       attendees: [
-        { id: "contact_1", firstName: "Taylor", lastName: "Kim", email: "taylor@test.com" },
+        {
+          id: "contact-1",
+          firstName: "Avery",
+          lastName: "Buyer",
+          email: "avery@acme.com",
+        },
       ],
-      createdAt: new Date("2026-03-01T00:00:00.000Z"),
-      updatedAt: new Date("2026-03-10T19:30:00.000Z"),
     } as never);
 
     const { GET } = await import("@/app/api/deals/meetings/[id]/route");
-    const response = await GET(
-      new NextRequest("http://localhost/api/deals/meetings/meeting_1"),
-      { params: Promise.resolve({ id: "meeting_1" }) }
-    );
-    const body = await response.json();
+    const response = await GET(new NextRequest("http://localhost/api/deals/meetings/meeting-1"), {
+      params: Promise.resolve({ id: "meeting-1" }),
+    });
+    const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body).toMatchObject({
-      id: "meeting_1",
-      googleDriveFileId: "drive_1",
-      transcriptMatchConfidence: 0.91,
-      analysisArtifactId: "artifact_1",
-      demoQualityScore: 87,
-      attendees: [
-        expect.objectContaining({
-          id: "contact_1",
-          email: "taylor@test.com",
-        }),
-      ],
+    expect(data).toEqual(
+      expect.objectContaining({
+        id: "meeting-1",
+        googleDriveFileId: "file-1",
+        googleDriveFileName: "Acme Demo Transcript",
+        googleDriveFileUrl: "https://drive.google.com/file/d/file-1/view",
+        transcriptMatchConfidence: 0.92,
+        analysisArtifactId: "artifact-1",
+        demoQualityScore: 86,
+        demoQualitySummary: "Handled discovery well and closed on next steps.",
+        demoStrengthsJson: ["Strong discovery", "Clear next steps"],
+        demoGapsJson: ["Pricing objection handling"],
+      })
+    );
+  });
+
+  it("returns a 404 when the meeting is missing", async () => {
+    const { prisma } = await import("@/lib/prisma");
+    vi.mocked(prisma.dealMeeting.findUnique).mockResolvedValue(null as never);
+
+    const { GET } = await import("@/app/api/deals/meetings/[id]/route");
+    const response = await GET(new NextRequest("http://localhost/api/deals/meetings/missing"), {
+      params: Promise.resolve({ id: "missing" }),
     });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Meeting not found" });
   });
 });

--- a/src/app/api/deals/meetings/route.test.ts
+++ b/src/app/api/deals/meetings/route.test.ts
@@ -4,69 +4,99 @@ vi.mock("@/lib/auth", () => ({
   auth: vi.fn(),
 }));
 
+vi.mock("@/lib/permissions", () => ({
+  enforcePermission: vi.fn(async () => ({ role: "member" })),
+}));
+
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     dealMeeting: {
       findMany: vi.fn(),
+      create: vi.fn(),
     },
   },
 }));
 
-describe("GET /api/deals/meetings", () => {
-  beforeEach(() => {
+describe("deal meetings route", () => {
+  beforeEach(async () => {
     vi.resetAllMocks();
-    vi.resetModules();
+
+    const { auth } = await import("@/lib/auth");
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "user-1",
+        email: "user@example.com",
+      },
+    } as never);
   });
 
-  it("returns transcript and analysis fields on meetings", async () => {
-    const { auth } = await import("@/lib/auth");
+  it("returns transcript and analysis fields in the meetings list", async () => {
     const { prisma } = await import("@/lib/prisma");
-
-    vi.mocked(auth).mockResolvedValue({ user: { id: "user_1" } } as never);
     vi.mocked(prisma.dealMeeting.findMany).mockResolvedValue([
       {
-        id: "meeting_1",
-        title: "Demo",
-        status: "COMPLETED",
-        startAt: new Date("2026-03-10T18:00:00.000Z"),
-        endAt: new Date("2026-03-10T18:30:00.000Z"),
-        location: null,
-        notes: null,
-        googleDriveFileId: "drive_1",
-        googleDriveFileName: "demo transcript",
-        googleDriveFileUrl: "https://drive.test/file",
-        transcriptMatchedAt: new Date("2026-03-10T19:00:00.000Z"),
-        transcriptMatchConfidence: 0.91,
-        analysisArtifactId: "artifact_1",
-        demoQualityScore: 87,
-        demoQualitySummary: "Strong demo",
-        demoStrengthsJson: ["Discovery"],
-        demoGapsJson: ["Pricing"],
-        analyzedAt: new Date("2026-03-10T19:30:00.000Z"),
-        expectedAttendees: 2,
-        actualAttendees: 2,
-        dealId: "deal_1",
-        deal: { id: "deal_1", name: "Acme" },
-        companyId: "company_1",
-        company: { id: "company_1", name: "Acme Co" },
-        _count: { attendees: 2 },
-        createdAt: new Date("2026-03-01T00:00:00.000Z"),
-        updatedAt: new Date("2026-03-10T19:30:00.000Z"),
+        id: "meeting-1",
+        title: "Acme demo",
+        googleDriveFileId: "file-1",
+        googleDriveFileName: "Acme Demo Transcript",
+        googleDriveFileUrl: "https://drive.google.com/file/d/file-1/view",
+        transcriptMatchedAt: new Date("2026-03-11T18:00:00.000Z"),
+        transcriptMatchConfidence: 0.92,
+        analysisArtifactId: "artifact-1",
+        demoQualityScore: 86,
+        demoQualitySummary: "Handled discovery well and closed on next steps.",
+        demoStrengthsJson: ["Strong discovery", "Clear next steps"],
+        demoGapsJson: ["Pricing objection handling"],
+        analyzedAt: new Date("2026-03-11T19:00:00.000Z"),
+        deal: { id: "deal-1", name: "Acme" },
+        company: { id: "company-1", name: "Acme Corp" },
+        _count: { attendees: 3 },
+      },
+      {
+        id: "meeting-2",
+        title: "Beta follow-up",
+        googleDriveFileId: null,
+        googleDriveFileName: null,
+        googleDriveFileUrl: null,
+        transcriptMatchedAt: null,
+        transcriptMatchConfidence: null,
+        analysisArtifactId: null,
+        demoQualityScore: null,
+        demoQualitySummary: null,
+        demoStrengthsJson: null,
+        demoGapsJson: null,
+        analyzedAt: null,
+        deal: { id: "deal-2", name: "Beta" },
+        company: { id: "company-2", name: "Beta LLC" },
+        _count: { attendees: 1 },
       },
     ] as never);
 
     const { GET } = await import("@/app/api/deals/meetings/route");
     const response = await GET();
-    const body = await response.json();
+    const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body[0]).toMatchObject({
-      id: "meeting_1",
-      googleDriveFileId: "drive_1",
-      googleDriveFileName: "demo transcript",
-      analysisArtifactId: "artifact_1",
-      demoQualityScore: 87,
-      demoQualitySummary: "Strong demo",
-    });
+    expect(data).toEqual([
+      expect.objectContaining({
+        id: "meeting-1",
+        googleDriveFileId: "file-1",
+        transcriptMatchConfidence: 0.92,
+        analysisArtifactId: "artifact-1",
+        demoQualityScore: 86,
+        demoQualitySummary: "Handled discovery well and closed on next steps.",
+        demoStrengthsJson: ["Strong discovery", "Clear next steps"],
+        demoGapsJson: ["Pricing objection handling"],
+      }),
+      expect.objectContaining({
+        id: "meeting-2",
+        googleDriveFileId: null,
+        transcriptMatchConfidence: null,
+        analysisArtifactId: null,
+        demoQualityScore: null,
+        demoQualitySummary: null,
+        demoStrengthsJson: null,
+        demoGapsJson: null,
+      }),
+    ]);
   });
 });

--- a/src/components/analytics/analytics-section-page.demo-coaching.test.tsx
+++ b/src/components/analytics/analytics-section-page.demo-coaching.test.tsx
@@ -48,6 +48,7 @@ describe("AnalyticsSectionPage demo coaching", () => {
         {
           dealId: "deal-1",
           dealName: "Acme",
+          ownerName: "Jordan",
           contactEmail: null,
           scheduledAt: "2026-03-05T18:00:00.000Z",
           meetingId: "meeting-1",

--- a/src/components/analytics/demo-analytics-tab.test.tsx
+++ b/src/components/analytics/demo-analytics-tab.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DemoAnalyticsTab } from "./demo-analytics-tab";
+import { createEmptyAnalyticsDashboardData } from "@/lib/analytics/response-shape";
+
+describe("DemoAnalyticsTab", () => {
+  it("shows owner context on upcoming demo cards", () => {
+    const data = createEmptyAnalyticsDashboardData({
+      freshness: {},
+      timeRange: {
+        preset: "30d",
+        from: "2026-02-01",
+        to: "2026-03-01",
+        days: 30,
+        label: "Last 30 days",
+      },
+    });
+
+    data.demoAnalytics = {
+      totalScheduled: 2,
+      totalCompleted: 1,
+      totalNoShows: 0,
+      noShowRate: 0,
+      avgLeadTimeDays: 2,
+      upcomingCount: 1,
+      meetingBackedUpcomingCount: 1,
+      unscheduledDemoCount: 0,
+      analyzedDemoCount: 0,
+      avgDemoQualityScore: 0,
+      transcriptCoveragePct: 0,
+      topStrengthThemes: [],
+      topGapThemes: [],
+      demos: [],
+      upcomingDemos: [
+        {
+          dealId: "deal-1",
+          dealName: "Acme",
+          ownerName: "Jordan",
+          contactEmail: "buyer@acme.test",
+          scheduledAt: "2026-03-15T18:00:00.000Z",
+          meetingId: "meeting-1",
+          meetingTitle: "Acme Demo",
+          meetingEndAt: "2026-03-15T18:30:00.000Z",
+          meetingStatus: "SCHEDULED",
+          isUpcoming: true,
+          isUnscheduledFallback: false,
+          source: "Organic",
+          outcome: "pending",
+          followUpSent: false,
+          daysToNextStage: null,
+          resultingStage: "Demo Scheduled",
+          transcriptStatus: "missing",
+          transcriptMatchConfidence: null,
+          transcriptSourceUrl: null,
+          transcriptSourceTitle: null,
+          transcriptSourceDocumentId: null,
+          transcriptText: null,
+          analysisStatus: "missing",
+          qualityScore: null,
+          qualitySummary: null,
+          strengths: [],
+          gaps: [],
+          nextSteps: [],
+          customerSignals: [],
+          outcomeConfidence: null,
+          coachingMemo: null,
+          nextStepMemo: null,
+        },
+      ],
+      bySource: [],
+      byOutcome: [
+        { outcome: "completed", count: 1, pct: 100 },
+        { outcome: "no-show", count: 0, pct: 0 },
+        { outcome: "rescheduled", count: 0, pct: 0 },
+        { outcome: "pending", count: 0, pct: 0 },
+        { outcome: "unknown", count: 0, pct: 0 },
+      ],
+      conversionFunnel: [
+        { label: "Demo Scheduled", count: 2, conversionFromPrevious: null },
+        { label: "Demo Completed", count: 1, conversionFromPrevious: 50 },
+        { label: "Follow-Up Sent", count: 1, conversionFromPrevious: 100 },
+        { label: "Closed Won", count: 1, conversionFromPrevious: 50 },
+      ],
+      weeklyTrend: [],
+      journeyPaths: [],
+    };
+
+    render(<DemoAnalyticsTab data={data} />);
+
+    expect(screen.getByText("Owner: Jordan")).toBeTruthy();
+    expect(screen.getByText("Acme Demo")).toBeTruthy();
+  });
+});

--- a/src/components/analytics/demo-analytics-tab.tsx
+++ b/src/components/analytics/demo-analytics-tab.tsx
@@ -113,6 +113,9 @@ export function DemoAnalyticsTab({ data }: { data: AnalyticsDashboardData | null
                     <p className="text-xs text-muted-foreground">
                       {record.meetingTitle ?? "No calendar event linked"}
                     </p>
+                    {record.ownerName && (
+                      <p className="text-[11px] text-muted-foreground">Owner: {record.ownerName}</p>
+                    )}
                   </div>
                   <span className="text-xs tabular-nums text-muted-foreground">
                     {record.isUnscheduledFallback ? "Unscheduled" : new Date(record.scheduledAt).toLocaleString()}

--- a/src/components/analytics/demo-coaching-view.test.tsx
+++ b/src/components/analytics/demo-coaching-view.test.tsx
@@ -9,6 +9,7 @@ function makeDemoRecord(
     Pick<DemoRecord, "dealId" | "dealName" | "scheduledAt" | "source" | "outcome">,
 ): DemoRecord {
   return {
+    ownerName: null,
     contactEmail: null,
     meetingId: null,
     meetingTitle: null,

--- a/src/components/analytics/demo-volume-chart.test.tsx
+++ b/src/components/analytics/demo-volume-chart.test.tsx
@@ -11,6 +11,7 @@ function makeDemoRecord(
     Pick<DemoRecord, "dealId" | "dealName" | "scheduledAt" | "source" | "outcome">,
 ): DemoRecord {
   return {
+    ownerName: null,
     contactEmail: null,
     meetingId: null,
     meetingTitle: null,

--- a/src/lib/__tests__/analytics-demo-analytics.test.ts
+++ b/src/lib/__tests__/analytics-demo-analytics.test.ts
@@ -355,6 +355,7 @@ describe("buildDemoAnalyticsData", () => {
           amount: 4000,
           source: "Organic",
           ownerId: null,
+          repName: "Avery",
           updatedAt: "2026-02-10T00:00:00.000Z",
           createdAt: "2026-02-01T00:00:00.000Z",
         }),
@@ -469,6 +470,7 @@ describe("buildDemoAnalyticsData", () => {
     expect(demo.transcriptCoveragePct).toBe(100);
     expect(demo.upcomingDemos).toHaveLength(2);
     expect(demo.upcomingDemos[0].meetingId).toBe("meeting-upcoming");
+    expect(demo.upcomingDemos[0].ownerName).toBe("Avery");
     expect(demo.upcomingDemos[1].isUnscheduledFallback).toBe(true);
     expect(demo.topStrengthThemes).toEqual([{ label: "Discovery depth", count: 1 }]);
     expect(demo.topGapThemes).toEqual([{ label: "Pricing clarity", count: 1 }]);

--- a/src/lib/analytics/demo-analytics.ts
+++ b/src/lib/analytics/demo-analytics.ts
@@ -245,6 +245,7 @@ function buildDemoRecordFromMeeting(input: {
   return {
     dealId: input.deal?.dealId ?? input.meeting.dealId ?? input.meeting.id,
     dealName: input.deal?.dealName ?? input.meeting.dealName ?? input.meeting.title,
+    ownerName: input.deal?.repName ?? null,
     contactEmail: input.meeting.attendeeEmails[0] ?? input.deal?.primaryContactEmail ?? null,
     scheduledAt,
     meetingId: input.meeting.id,
@@ -293,6 +294,7 @@ function buildUnscheduledFallbackRecord(input: {
   return {
     dealId: input.deal.dealId,
     dealName: input.deal.dealName,
+    ownerName: input.deal.repName ?? null,
     contactEmail: input.deal.primaryContactEmail ?? null,
     scheduledAt,
     meetingId: null,
@@ -346,6 +348,7 @@ function buildDealAggregateRecord(input: {
   return {
     dealId: input.deal.dealId,
     dealName: input.deal.dealName,
+    ownerName: input.deal.repName ?? null,
     contactEmail: input.deal.primaryContactEmail ?? null,
     scheduledAt,
     meetingId: null,

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -1273,6 +1273,7 @@ export type DemoOutcomeConfidence = "low" | "medium" | "high";
 export interface DemoRecord {
   dealId: string;
   dealName: string;
+  ownerName: string | null;
   contactEmail: string | null;
   scheduledAt: string;
   meetingId: string | null;


### PR DESCRIPTION
## Summary
- harden transcript-backed demo coaching artifacts and archive workflow creation
- expose archived transcript metadata/text and owner context in demo analytics and coaching views
- add focused coverage for meeting APIs, demo coaching routing, transcript capture payloads, and upcoming demo owner display

## Testing
- npm test -- src/lib/__tests__/automations-store.test.ts src/lib/__tests__/analytics-demo-analytics.test.ts src/lib/__tests__/automations-runtime.test.ts src/lib/__tests__/google-drive-transcript-capture.test.ts src/app/api/analytics/route.test.ts src/lib/__tests__/integrations-orchestrator.test.ts 'src/app/api/deals/meetings/route.test.ts' 'src/app/api/deals/meetings/[id]/route.test.ts' src/components/analytics/demo-coaching-view.test.tsx src/components/analytics/analytics-section-page.demo-coaching.test.tsx src/components/analytics/demo-analytics-tab.test.tsx
- npm run typecheck:staged -- src/lib/analytics/types.ts src/lib/analytics/demo-analytics.ts src/components/analytics/demo-analytics-tab.tsx src/components/analytics/demo-analytics-tab.test.tsx src/components/analytics/demo-coaching-view.test.tsx src/components/analytics/analytics-section-page.demo-coaching.test.tsx src/lib/__tests__/analytics-demo-analytics.test.ts
- pre-commit lint-staged (eslint --fix + staged typecheck)