### PR TITLE
fix(analytics): recover Stripe dashboard data from env fallback

### DIFF
--- a/src/app/api/analytics/route.test.ts
+++ b/src/app/api/analytics/route.test.ts
@@ -152,6 +152,32 @@ const STRIPE_DATA = {
   _meta: META,
 };
 
+const ZERO_STRIPE_DATA = {
+  revenue: {
+    mrr: 0,
+    mrrChange: 0,
+    totalRevenue30d: 0,
+    totalRevenuePrev30d: 0,
+    revenueGrowth: 0,
+    avgRevenuePerCustomer: 0,
+  },
+  subscriptions: {
+    active: 0,
+    pastDue: 0,
+    canceled: 0,
+    trialing: 0,
+    churnRate: 0,
+    recentChurnEvents: [],
+  },
+  payments: {
+    succeeded: 0,
+    failed: 0,
+    successRate: 0,
+  },
+  revenueTrend: [],
+  _meta: META,
+};
+
 const MERCURY_DATA = {
   accounts: [],
   cashFlow: {
@@ -541,6 +567,96 @@ describe("GET /api/analytics", () => {
       ).toBe(false);
     } finally {
       vi.useRealTimers();
+    }
+  });
+
+  it("falls back to the env stripe key when the connection-backed account is empty", async () => {
+    const previousStripeSecretKey = process.env.STRIPE_SECRET_KEY;
+
+    try {
+      process.env.STRIPE_SECRET_KEY = "stripe-env";
+
+      const { getCredentials } = await import("@/lib/analytics/credentials");
+      vi.mocked(getCredentials).mockResolvedValue({
+        hubspotToken: "hubspot",
+        stripeKey: "stripe-connection",
+        mercuryKey: "mercury",
+        gaPropertyId: "ga-prop",
+        gaClientEmail: "ga@example.com",
+        gaPrivateKey: "ga-key",
+        googleAdsDevToken: "ads-dev",
+        googleAdsCustomerId: "ads-customer",
+        googleAdsRefreshToken: "ads-refresh",
+        googleAdsClientId: "ads-client",
+        googleAdsClientSecret: "ads-secret",
+        googleAdsLoginCustomerId: null,
+        metaAccessToken: "meta-token",
+        metaAdAccountId: "meta-ad",
+        metaPageId: "meta-page",
+        metaInstagramAccountId: null,
+        redditClientId: "reddit-client",
+        redditClientSecret: "reddit-secret",
+        redditRefreshToken: "reddit-refresh",
+        redditAdAccountId: "reddit-account",
+        redditUserAgent: "ua",
+        webflowApiToken: "webflow-token",
+        webflowSiteId: "webflow-site",
+        semrushApiToken: "semrush-token",
+        semrushDomain: "example.com",
+        codaApiToken: "coda-token",
+        codaDocId: "coda-doc",
+        pylonApiKey: "pylon-token",
+        pylonBaseUrl: null,
+        googleWorkspaceAccessToken: "workspace-token",
+        slackAccessToken: "slack-token",
+        freshness: {
+          [IntegrationProvider.GOOGLE_WORKSPACE]: freshness(IntegrationProvider.GOOGLE_WORKSPACE),
+          [IntegrationProvider.HUBSPOT]: freshness(IntegrationProvider.HUBSPOT),
+          [IntegrationProvider.SLACK]: freshness(IntegrationProvider.SLACK),
+          [IntegrationProvider.CODA]: freshness(IntegrationProvider.CODA),
+          [IntegrationProvider.REDDIT]: freshness(IntegrationProvider.REDDIT),
+          [IntegrationProvider.GOOGLE_ANALYTICS]: freshness(IntegrationProvider.GOOGLE_ANALYTICS),
+          [IntegrationProvider.STRIPE]: freshness(IntegrationProvider.STRIPE),
+          [IntegrationProvider.MERCURY]: freshness(IntegrationProvider.MERCURY),
+          [IntegrationProvider.WEBFLOW]: freshness(IntegrationProvider.WEBFLOW),
+          [IntegrationProvider.GOOGLE_ADS]: freshness(IntegrationProvider.GOOGLE_ADS),
+          [IntegrationProvider.META_ADS]: freshness(IntegrationProvider.META_ADS),
+          [IntegrationProvider.META_PAGE]: freshness(IntegrationProvider.META_PAGE),
+          [IntegrationProvider.SEMRUSH]: freshness(IntegrationProvider.SEMRUSH),
+          [IntegrationProvider.PYLON]: freshness(IntegrationProvider.PYLON),
+        },
+      } as never);
+
+      const { fetchStripeData } = await import("@/lib/analytics/fetchers");
+      vi.mocked(fetchStripeData)
+        .mockResolvedValueOnce(ZERO_STRIPE_DATA as never)
+        .mockResolvedValueOnce(STRIPE_DATA as never);
+
+      const { GET } = await import("@/app/api/analytics/route");
+      const response = await GET(
+        new Request("http://localhost/api/analytics?section=finance-stripe")
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.stripe).toEqual(STRIPE_DATA);
+      expect(body.freshness.stripe.source).toBe("env");
+      expect(fetchStripeData).toHaveBeenNthCalledWith(
+        1,
+        "stripe-connection",
+        expect.objectContaining({})
+      );
+      expect(fetchStripeData).toHaveBeenNthCalledWith(
+        2,
+        "stripe-env",
+        expect.objectContaining({})
+      );
+    } finally {
+      if (previousStripeSecretKey === undefined) {
+        delete process.env.STRIPE_SECRET_KEY;
+      } else {
+        process.env.STRIPE_SECRET_KEY = previousStripeSecretKey;
+      }
     }
   });
 

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -571,6 +571,24 @@ function isLiveFirstDomain(
   return section !== null && LIVE_FIRST_FINANCE_SECTIONS.has(section) && LIVE_FIRST_FINANCE_DOMAINS.has(domain);
 }
 
+function stripePayloadHasSignal(data: StripeData | null | undefined): boolean {
+  if (!data) return false;
+
+  return Boolean(
+    data.revenue.mrr > 0 ||
+      data.revenue.totalRevenue30d > 0 ||
+      data.revenue.totalRevenuePrev30d > 0 ||
+      data.subscriptions.active > 0 ||
+      data.subscriptions.pastDue > 0 ||
+      data.subscriptions.canceled > 0 ||
+      data.subscriptions.trialing > 0 ||
+      data.subscriptions.recentChurnEvents.length > 0 ||
+      data.payments.succeeded > 0 ||
+      data.payments.failed > 0 ||
+      data.revenueTrend.some((point) => point.revenue > 0)
+  );
+}
+
 async function buildFinancialPlanningData(
   userId: string,
   data: AnalyticsDashboardData,
@@ -714,6 +732,8 @@ function providerForDomain(
   | "coda"
   | "reddit"
   | "redditAds"
+  | "stripe"
+  | "mercury"
   | "googleAnalytics"
   | "googleAds"
   | "metaAds"
@@ -726,6 +746,8 @@ function providerForDomain(
   if (domain === "googleWorkspace") return "google_workspace";
   if (domain === "slack") return "slack";
   if (domain === "coda" || domain === "codaOps") return "coda";
+  if (domain === "stripe") return "stripe";
+  if (domain === "mercury") return "mercury";
   if (domain === "googleAnalytics") return "googleAnalytics";
   if (domain === "googleAds") return "googleAds";
   if (domain === "metaAds") return "metaAds";
@@ -1059,7 +1081,29 @@ export async function GET(request: Request) {
           snapshotUserId: integrationUserId,
           fn: async () => {
             const { fetchStripeData } = await loadCoreAnalyticsFetchers();
-            return fetchStripeData(creds.stripeKey!, { fromDate, toDate });
+            const primary = await fetchStripeData(creds.stripeKey!, { fromDate, toDate });
+            const envStripeKey = process.env.STRIPE_SECRET_KEY?.trim() ?? null;
+            const shouldTryEnvFallback =
+              creds.freshness.STRIPE.source === "connection" &&
+              Boolean(envStripeKey) &&
+              envStripeKey !== creds.stripeKey &&
+              !stripePayloadHasSignal(primary);
+
+            if (!shouldTryEnvFallback) {
+              return primary;
+            }
+
+            try {
+              const fallback = await fetchStripeData(envStripeKey!, { fromDate, toDate });
+              if (stripePayloadHasSignal(fallback)) {
+                stripeUsedEnvFallback = true;
+                return fallback;
+              }
+            } catch (error) {
+              console.warn("[analytics] Stripe env fallback fetch failed", error);
+            }
+
+            return primary;
           },
         }]
       : []),
@@ -1307,6 +1351,7 @@ export async function GET(request: Request) {
 
   const snapshotExpiresAt = snapshotExpiryFromNow(1);
   const capturedAtByDomain: Partial<Record<DomainKey, string | null>> = {};
+  let stripeUsedEnvFallback = false;
 
   const settled = await Promise.allSettled(
     fetchers.map(async (entry): Promise<FetchOutcome> => {
@@ -1440,6 +1485,7 @@ export async function GET(request: Request) {
         result.freshness[provider] = patchFreshnessWithStale(existing, {
           stale,
           capturedAt,
+          source: key === "stripe" && stripeUsedEnvFallback ? "env" : undefined,
           lastError: fallbackError ?? null,
         });
       }


### PR DESCRIPTION
## Summary
- retry Stripe analytics with STRIPE_SECRET_KEY when a connection-backed key returns a zero-signal payload
- update freshness mapping for Stripe and Mercury domains so source metadata is patched correctly
- add a route regression test for the empty connection account fallback path

## Testing
- unable to run npm test -- src/app/api/analytics/route.test.ts in this worktree because the local install is missing the prisma binary
- previously validated the same route test in another WIPGuard checkout after applying the identical patch