### PR TITLE
Add relationship intelligence to customer success

### DIFF
--- a/src/components/analytics/__tests__/customer-success-test-helpers.ts
+++ b/src/components/analytics/__tests__/customer-success-test-helpers.ts
@@ -143,6 +143,7 @@ export function makeAccount(
     renewalDate: input.renewalDate ?? "2026-06-01T00:00:00.000Z",
     segment: input.segment,
     tier: input.tier,
+    relationship: input.relationship,
   };
 }
 
@@ -170,6 +171,13 @@ export function makePortfolio(): CustomerSuccessPortfolio {
         health: makeHealth({ score: 58, grade: "D" }),
         openAlertCount: 2,
         lifecycleStage: "AT_RISK",
+        relationship: {
+          connectedSystems: 3,
+          retentionStatus: "At Risk",
+          primaryLirPassed: false,
+          implementationStage: "LIVE",
+          missingSources: ["pylon"],
+        },
         nextAction: "Schedule exec check-in",
       },
     ],
@@ -200,9 +208,7 @@ export function makePortfolio(): CustomerSuccessPortfolio {
       },
     ],
     accounts: [
-      {
-        accountId: "acct_2",
-        ...makeAccount("acct_2", {
+      makeAccount("acct_2", {
           name: "Beacon Ltd",
           segment: "Enterprise",
           tier: "Strategic",
@@ -211,11 +217,15 @@ export function makePortfolio(): CustomerSuccessPortfolio {
           lastActivityAt: "2026-03-10T12:00:00.000Z",
           renewalDate: "2026-05-30T00:00:00.000Z",
           openAlertCount: 5,
+          relationship: {
+            connectedSystems: 2,
+            retentionStatus: "Healthy",
+            primaryLirPassed: true,
+            implementationStage: "LIVE",
+            missingSources: [],
+          },
         }),
-      },
-      {
-        accountId: "acct_1",
-        ...makeAccount("acct_1", {
+      makeAccount("acct_1", {
           name: "Acme Co",
           segment: "Mid-market",
           tier: "Growth",
@@ -224,8 +234,14 @@ export function makePortfolio(): CustomerSuccessPortfolio {
           lastActivityAt: "2026-03-09T12:00:00.000Z",
           renewalDate: "2026-04-20T00:00:00.000Z",
           openAlertCount: 2,
+          relationship: {
+            connectedSystems: 3,
+            retentionStatus: "At Risk",
+            primaryLirPassed: false,
+            implementationStage: "LIVE",
+            missingSources: ["pylon"],
+          },
         }),
-      },
     ],
   };
 }

--- a/src/components/analytics/customer-success-portfolio-panels.test.tsx
+++ b/src/components/analytics/customer-success-portfolio-panels.test.tsx
@@ -61,6 +61,9 @@ describe("CustomerSuccessPortfolioPanels", () => {
       expect(screen.getByText("Portfolio Accounts")).toBeTruthy();
     });
 
+    expect(screen.getByText("Accounts With Coda")).toBeTruthy();
+    expect(screen.getAllByText("At Risk").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Missing pylon/).length).toBeGreaterThan(0);
     expect(screen.getByText("Leading Indicator Pressure")).toBeTruthy();
     expect(screen.getByText("Health Distribution")).toBeTruthy();
     expect(screen.getByText("Attention Queue")).toBeTruthy();

--- a/src/components/analytics/customer-success-portfolio-panels.tsx
+++ b/src/components/analytics/customer-success-portfolio-panels.tsx
@@ -62,6 +62,8 @@ export function CustomerSuccessPortfolioPanels() {
   }
 
   const portfolio = resource.data;
+  const accountsWithCoda = portfolio.accounts.filter((account) => !(account.relationship?.missingSources ?? []).includes("coda")).length;
+  const coverageGaps = portfolio.accounts.filter((account) => (account.relationship?.missingSources.length ?? 0) > 0).length;
   const weakSignalThreshold = 65;
   const {
     filteredAccounts,
@@ -88,8 +90,10 @@ export function CustomerSuccessPortfolioPanels() {
       ) : null}
 
       <PortfolioSummaryCards
+        accountsWithCoda={accountsWithCoda}
         avgHealthScore={portfolio.summary.avgHealthScore}
         atRiskAccounts={portfolio.summary.atRiskAccounts}
+        coverageGaps={coverageGaps}
         formatNumber={formatNumber}
         healthTone={healthTone}
         openAlerts={portfolio.summary.openAlerts}

--- a/src/components/analytics/customer-success-portfolio-sections.test.tsx
+++ b/src/components/analytics/customer-success-portfolio-sections.test.tsx
@@ -21,8 +21,10 @@ describe("customer-success-portfolio-sections", () => {
   it("renders the portfolio summary cards", () => {
     render(
       <PortfolioSummaryCards
+        accountsWithCoda={9}
         avgHealthScore={74}
         atRiskAccounts={3}
+        coverageGaps={4}
         formatNumber={formatNumber}
         healthTone={healthTone}
         openAlerts={6}
@@ -34,6 +36,8 @@ describe("customer-success-portfolio-sections", () => {
     expect(screen.getByText("12")).toBeTruthy();
     expect(screen.getByText("Average Health")).toBeTruthy();
     expect(screen.getByText("74")).toBeTruthy();
+    expect(screen.getByText("Accounts With Coda")).toBeTruthy();
+    expect(screen.getByText("Coverage Gaps")).toBeTruthy();
   });
 
   it("renders pressure, attention, alert, activity, and distribution panels", () => {
@@ -155,6 +159,13 @@ describe("customer-success-portfolio-sections", () => {
               },
               openAlertCount: 2,
               lifecycleStage: "AT_RISK",
+              relationship: {
+                connectedSystems: 3,
+                retentionStatus: "At Risk",
+                primaryLirPassed: false,
+                implementationStage: "LIVE",
+                missingSources: ["pylon"],
+              },
               nextAction: "Schedule exec check-in",
             },
           ]}
@@ -199,6 +210,8 @@ describe("customer-success-portfolio-sections", () => {
     expect(screen.getByText("Filtering table")).toBeTruthy();
     expect(screen.getByText("Health Distribution")).toBeTruthy();
     expect(screen.getByText("Attention Queue")).toBeTruthy();
+    expect(screen.getByText(/At Risk/)).toBeTruthy();
+    expect(screen.getByText("3 systems • LIVE • Missing pylon")).toBeTruthy();
     expect(screen.getByText("Primary risk: Activity recency • 7d since touch")).toBeTruthy();
     expect(screen.getByText("Open Alerts")).toBeTruthy();
     expect(screen.getByText("Renewal risk rising")).toBeTruthy();

--- a/src/components/analytics/customer-success-portfolio-sections.tsx
+++ b/src/components/analytics/customer-success-portfolio-sections.tsx
@@ -13,18 +13,36 @@ type PortfolioAlert = CustomerSuccessPortfolio["alerts"][number];
 type PortfolioActivity = CustomerSuccessPortfolio["recentActivity"][number];
 type PortfolioAttentionAccount = CustomerSuccessPortfolio["attentionAccounts"][number];
 
+function relationshipTone(status?: string): string {
+  if (status === "Healthy") return "text-[var(--success)]";
+  if (status === "Watch" || status === "Onboarding Risk") return "text-[var(--warning)]";
+  if (status === "At Risk" || status === "Billing Risk") return "text-red-500";
+  return "text-muted-foreground";
+}
+
 export function PortfolioSummaryCards(props: {
+  accountsWithCoda: number;
   avgHealthScore: number;
   atRiskAccounts: number;
+  coverageGaps: number;
   formatNumber: (value: number | null | undefined) => string;
   healthTone: (score: number) => string;
   openAlerts: number;
   totalAccounts: number;
 }) {
-  const { avgHealthScore, atRiskAccounts, formatNumber, healthTone, openAlerts, totalAccounts } = props;
+  const {
+    accountsWithCoda,
+    avgHealthScore,
+    atRiskAccounts,
+    coverageGaps,
+    formatNumber,
+    healthTone,
+    openAlerts,
+    totalAccounts,
+  } = props;
 
   return (
-    <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+    <div className="grid grid-cols-2 gap-3 lg:grid-cols-6">
       <div className="rounded-xl border border-border bg-card px-4 py-3">
         <p className="text-xs text-muted-foreground">Customer Records</p>
         <p className="mt-1 text-2xl font-semibold text-foreground">{formatNumber(totalAccounts)}</p>
@@ -40,6 +58,14 @@ export function PortfolioSummaryCards(props: {
       <div className="rounded-xl border border-border bg-card px-4 py-3">
         <p className="text-xs text-muted-foreground">Open Alerts</p>
         <p className="mt-1 text-2xl font-semibold text-foreground">{formatNumber(openAlerts)}</p>
+      </div>
+      <div className="rounded-xl border border-border bg-card px-4 py-3">
+        <p className="text-xs text-muted-foreground">Accounts With Coda</p>
+        <p className="mt-1 text-2xl font-semibold text-foreground">{formatNumber(accountsWithCoda)}</p>
+      </div>
+      <div className="rounded-xl border border-border bg-card px-4 py-3">
+        <p className="text-xs text-muted-foreground">Coverage Gaps</p>
+        <p className="mt-1 text-2xl font-semibold text-[var(--warning)]">{formatNumber(coverageGaps)}</p>
       </div>
     </div>
   );
@@ -100,6 +126,13 @@ export function PortfolioAttentionQueuePanel(props: {
                   <p className="mt-1 text-xs text-muted-foreground">
                     {account.lifecycleStage} • {account.ownerName || "Unassigned"} • {account.openAlertCount} open alerts
                   </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {account.relationship?.connectedSystems ?? 0} systems
+                    {account.relationship?.implementationStage ? ` • ${account.relationship.implementationStage}` : ""}
+                    {account.relationship?.missingSources.length
+                      ? ` • Missing ${account.relationship.missingSources.join(", ")}`
+                      : ""}
+                  </p>
                   <p className="mt-2 text-xs text-muted-foreground">
                     Primary risk: {primarySignal.label} • {primarySignal.value}
                   </p>
@@ -108,6 +141,14 @@ export function PortfolioAttentionQueuePanel(props: {
                   <p className={`text-sm font-semibold ${healthTone(account.health.score)}`}>
                     {account.health.grade} {formatNumber(account.health.score)}
                   </p>
+                  {account.relationship?.retentionStatus ? (
+                    <p className={`mt-1 text-xs ${relationshipTone(account.relationship.retentionStatus)}`}>
+                      {account.relationship.retentionStatus}
+                      {account.relationship.primaryLirPassed !== undefined
+                        ? ` • LIR ${account.relationship.primaryLirPassed ? "pass" : "fail"}`
+                        : ""}
+                    </p>
+                  ) : null}
                   <p className="mt-1 text-xs text-muted-foreground">{account.nextAction || "Review account workspace"}</p>
                 </div>
               </div>
@@ -316,6 +357,8 @@ export function PortfolioAccountsTable(props: {
               <th className="pb-2 font-medium">Account</th>
               <th className="pb-2 font-medium">Owner</th>
               <th className="pb-2 font-medium">Health</th>
+              <th className="pb-2 font-medium">Retention</th>
+              <th className="pb-2 font-medium">Systems</th>
               <th className="pb-2 font-medium">Primary Signal</th>
               <th className="pb-2 font-medium">Alerts</th>
               <th className="pb-2 font-medium">Last Activity</th>
@@ -343,6 +386,22 @@ export function PortfolioAccountsTable(props: {
                   <td className={`py-3 font-medium ${healthTone(account.health.score)}`}>
                     {account.health.grade} {formatNumber(account.health.score)}
                   </td>
+                  <td className={`py-3 text-sm ${relationshipTone(account.relationship?.retentionStatus)}`}>
+                    {account.relationship?.retentionStatus || "—"}
+                    {account.relationship?.primaryLirPassed !== undefined ? (
+                      <div className="text-xs text-muted-foreground">
+                        LIR {account.relationship.primaryLirPassed ? "pass" : "fail"}
+                      </div>
+                    ) : null}
+                  </td>
+                  <td className="py-3 text-muted-foreground">
+                    {formatNumber(account.relationship?.connectedSystems)}
+                    {account.relationship?.missingSources.length ? (
+                      <div className="text-xs text-[var(--warning)]">
+                        Missing {account.relationship.missingSources.join(", ")}
+                      </div>
+                    ) : null}
+                  </td>
                   <td className="py-3">
                     <div className="text-foreground">{primarySignal.label}</div>
                     <div className="text-xs text-muted-foreground">{primarySignal.value}</div>
@@ -355,7 +414,7 @@ export function PortfolioAccountsTable(props: {
             })}
             {filteredAccounts.length === 0 ? (
               <tr>
-                <td colSpan={7} className="py-6 text-center text-sm text-muted-foreground">
+                <td colSpan={9} className="py-6 text-center text-sm text-muted-foreground">
                   No accounts match the current leading-indicator filter.
                 </td>
               </tr>

--- a/src/components/analytics/customer-success-tab.test.tsx
+++ b/src/components/analytics/customer-success-tab.test.tsx
@@ -38,6 +38,9 @@ describe("CustomerSuccessTab", () => {
     expect(screen.getByText("Renewal risk rising")).toBeTruthy();
     expect(screen.getByText("QBR completed")).toBeTruthy();
     expect(screen.getByText("Integration Delivery Status")).toBeTruthy();
+    expect(screen.getByText("Accounts With Coda")).toBeTruthy();
+    expect(screen.getAllByText("At Risk").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Missing pylon/).length).toBeGreaterThan(0);
     expect(screen.getByText("Connected but stale")).toBeTruthy();
     expect(screen.getByText("Leading Indicator Pressure")).toBeTruthy();
     expect(screen.getByText("Accounts with indicator scores below 65 across the portfolio.")).toBeTruthy();

--- a/src/components/customer-success/account-workspace.test.tsx
+++ b/src/components/customer-success/account-workspace.test.tsx
@@ -138,6 +138,61 @@ function buildDetail(overrides: Partial<CustomerSuccessAccountDetail> = {}): Cus
       paymentStatus: "current",
       expansionPotential: "medium",
     },
+    relationshipIntelligence: {
+      providers: [
+        {
+          provider: "CODA",
+          externalObjectType: "doc",
+          externalId: "VYLC2rzPN_",
+          label: "Customer Success and Implementation",
+          isPrimary: true,
+          url: "https://coda.io/d/_dVYLC2rzPN_",
+        },
+      ],
+      retention: {
+        status: "Watch",
+        lifecyclePhase: "MATURE",
+        primaryLirLabel: "5 orders / 5 items in 30 days",
+        primaryLirPassed: false,
+        primaryLirValue: 2,
+        primaryLirThreshold: 5,
+        currentMonthActivity: 4,
+        trendVsPriorPct: -37.5,
+        implementationStage: "LIVE",
+        goLiveDate: "2025-10-01T00:00:00.000Z",
+        subscriptionStartDate: "2025-09-15T00:00:00.000Z",
+        firstOrderDate: "2025-10-05T00:00:00.000Z",
+        explanation: "watch because activity is trailing and recent usage is below the habit threshold.",
+        reasonCodes: [
+          {
+            code: "low_recent_activity",
+            label: "Low recent activity",
+            detail: "Recent activity is below the current habit threshold.",
+            severity: "warning",
+            dimension: "usage",
+          },
+        ],
+        coverage: {
+          arda: true,
+          coda: true,
+          stripe: true,
+          hubspot: true,
+          pylon: false,
+          missingSources: ["pylon"],
+        },
+        detailUrl: "/analytics/retention/acct_1",
+      },
+      coda: {
+        customerStatus: "Won",
+        configuredHealth: "Yellow",
+        mainDocId: "VYLC2rzPN_",
+        mainDocUrl: "https://coda.io/d/_dVYLC2rzPN_",
+        orderArchiveDocumentId: "cgSn33D4N9",
+        orderArchiveDocumentUrl: "https://coda.io/d/_dcgSn33D4N9",
+        lastOrderAt: "2026-03-07T10:00:00.000Z",
+        sourceRecordCount: 12,
+      },
+    },
     ...overrides,
   };
 }
@@ -237,5 +292,24 @@ describe("CustomerSuccessAccountWorkspace", () => {
     expect(screen.getByText("Retention Leading Indicators")).toBeTruthy();
     expect(screen.getByText("Activity recency")).toBeTruthy();
     expect(screen.getByText("5d since touch")).toBeTruthy();
+  });
+
+  it("renders relationship intelligence from Coda and retention overlays", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => buildDetail(),
+    })) as unknown as typeof fetch);
+
+    render(<CustomerSuccessAccountWorkspace accountId="acct_1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Relationship Intelligence")).toBeTruthy();
+    });
+
+    expect(screen.getByText("Unified provider links, Coda account metadata, and current retention posture.")).toBeTruthy();
+    expect(screen.getByText("Main Coda Doc")).toBeTruthy();
+    expect(screen.getByText("Low recent activity")).toBeTruthy();
+    expect(screen.getByText(/Customer Success and Implementation/)).toBeTruthy();
   });
 });

--- a/src/components/customer-success/account-workspace.tsx
+++ b/src/components/customer-success/account-workspace.tsx
@@ -54,6 +54,11 @@ function formatNumber(value?: number): string {
   return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(value);
 }
 
+function formatPercent(value?: number): string {
+  if (value === undefined || value === null) return "—";
+  return `${value.toFixed(1)}%`;
+}
+
 function formatHealthTone(score: number): string {
   if (score >= 80) return "text-[var(--success)]";
   if (score >= 65) return "text-[var(--warning)]";
@@ -179,6 +184,9 @@ export function CustomerSuccessAccountWorkspace({ accountId }: { accountId: stri
 
   const detail = resource.data;
   const activeAlerts = detail.alerts.filter((alert) => alert.status === "open" || alert.status === "in_progress");
+  const relationship = detail.relationshipIntelligence;
+  const retention = relationship?.retention;
+  const coda = relationship?.coda;
 
   return (
     <div className="space-y-6">
@@ -281,7 +289,178 @@ export function CustomerSuccessAccountWorkspace({ accountId }: { accountId: stri
                 <p className="text-xs text-muted-foreground">Success Plan Milestones</p>
                 <p className="mt-1 text-sm font-medium text-foreground">{detail.successPlan.milestones.length}</p>
               </div>
+              <div className="rounded-xl border border-border bg-background p-4">
+                <p className="text-xs text-muted-foreground">Connected Systems</p>
+                <p className="mt-1 text-sm font-medium text-foreground">{relationship?.providers.length ?? 0}</p>
+              </div>
+              <div className="rounded-xl border border-border bg-background p-4">
+                <p className="text-xs text-muted-foreground">Primary LIR</p>
+                <p className="mt-1 text-sm font-medium text-foreground">
+                  {retention ? `${retention.primaryLirPassed ? "Pass" : "Fail"} · ${retention.primaryLirLabel}` : "—"}
+                </p>
+              </div>
             </div>
+
+            {relationship ? (
+              <div className="mt-4 rounded-xl border border-border bg-background p-4">
+                <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                  <div>
+                    <h3 className="text-sm font-semibold text-foreground">Relationship Intelligence</h3>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Unified provider links, Coda account metadata, and current retention posture.
+                    </p>
+                  </div>
+                  {retention ? (
+                    <Link href={retention.detailUrl} className="text-xs text-primary hover:underline">
+                      Open retention detail
+                    </Link>
+                  ) : null}
+                </div>
+
+                <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+                  <div className="rounded-xl border border-border bg-card px-4 py-3">
+                    <p className="text-xs text-muted-foreground">Retention Status</p>
+                    <p className="mt-1 text-sm font-medium text-foreground">{retention?.status || "No retention snapshot"}</p>
+                  </div>
+                  <div className="rounded-xl border border-border bg-card px-4 py-3">
+                    <p className="text-xs text-muted-foreground">Implementation</p>
+                    <p className="mt-1 text-sm font-medium text-foreground">{retention?.implementationStage || "—"}</p>
+                  </div>
+                  <div className="rounded-xl border border-border bg-card px-4 py-3">
+                    <p className="text-xs text-muted-foreground">Current Activity</p>
+                    <p className="mt-1 text-sm font-medium text-foreground">{formatNumber(retention?.currentMonthActivity)}</p>
+                  </div>
+                  <div className="rounded-xl border border-border bg-card px-4 py-3">
+                    <p className="text-xs text-muted-foreground">Trend vs Prior</p>
+                    <p className="mt-1 text-sm font-medium text-foreground">{formatPercent(retention?.trendVsPriorPct)}</p>
+                  </div>
+                </div>
+
+                {retention?.explanation ? (
+                  <p className="mt-4 text-sm text-muted-foreground">{retention.explanation}</p>
+                ) : null}
+
+                <div className="mt-4 grid gap-4 lg:grid-cols-[0.9fr_1.1fr]">
+                  <div className="space-y-4">
+                    <div>
+                      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Source Coverage</h4>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {retention ? (
+                          ["arda", "coda", "stripe", "hubspot", "pylon"].map((source) => {
+                            const covered = retention.coverage[source as keyof typeof retention.coverage];
+                            if (typeof covered !== "boolean") return null;
+                            return (
+                              <span
+                                key={source}
+                                className={`rounded-full border px-2 py-1 text-[11px] ${
+                                  covered
+                                    ? "border-[var(--success)]/30 bg-[var(--success)]/10 text-[var(--success)]"
+                                    : "border-[var(--warning)]/30 bg-[var(--warning)]/10 text-[var(--warning)]"
+                                }`}
+                              >
+                                {source} {covered ? "connected" : "missing"}
+                              </span>
+                            );
+                          })
+                        ) : (
+                          <span className="text-xs text-muted-foreground">No coverage snapshot.</span>
+                        )}
+                      </div>
+                    </div>
+
+                    {coda ? (
+                      <div>
+                        <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Coda</h4>
+                        <div className="mt-2 space-y-2 text-sm">
+                          <p className="text-muted-foreground">Customer Status: <span className="text-foreground">{coda.customerStatus || "—"}</span></p>
+                          <p className="text-muted-foreground">Configured Health: <span className="text-foreground">{coda.configuredHealth || "—"}</span></p>
+                          <p className="text-muted-foreground">Last Coda Order: <span className="text-foreground">{formatDate(coda.lastOrderAt)}</span></p>
+                          <p className="text-muted-foreground">Order Records: <span className="text-foreground">{formatNumber(coda.sourceRecordCount)}</span></p>
+                          <div className="flex flex-wrap gap-2 pt-1">
+                            {coda.mainDocUrl ? (
+                              <a
+                                href={coda.mainDocUrl}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="rounded-full border border-border px-3 py-1 text-xs text-foreground hover:bg-secondary"
+                              >
+                                Main Coda Doc
+                              </a>
+                            ) : null}
+                            {coda.orderArchiveDocumentUrl ? (
+                              <a
+                                href={coda.orderArchiveDocumentUrl}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="rounded-full border border-border px-3 py-1 text-xs text-foreground hover:bg-secondary"
+                              >
+                                Order Archive
+                              </a>
+                            ) : null}
+                          </div>
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+
+                  <div className="space-y-4">
+                    <div>
+                      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Connected Records</h4>
+                      <div className="mt-2 space-y-2">
+                        {relationship.providers.length > 0 ? (
+                          relationship.providers.map((provider) => (
+                            <div key={`${provider.provider}:${provider.externalObjectType}:${provider.externalId}`} className="rounded-xl border border-border bg-card px-3 py-2 text-sm">
+                              <div className="flex items-center justify-between gap-3">
+                                <p className="font-medium text-foreground">
+                                  {formatEnumLabel(provider.provider)} {provider.label ? `• ${provider.label}` : ""}
+                                </p>
+                                {provider.isPrimary ? (
+                                  <span className="rounded-full border border-border px-2 py-0.5 text-[11px] text-muted-foreground">
+                                    Primary
+                                  </span>
+                                ) : null}
+                              </div>
+                              <p className="mt-1 text-xs text-muted-foreground">
+                                {provider.externalObjectType} · {provider.externalId}
+                              </p>
+                              {provider.url ? (
+                                <a
+                                  href={provider.url}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  className="mt-2 inline-block text-xs text-primary hover:underline"
+                                >
+                                  Open linked record
+                                </a>
+                              ) : null}
+                            </div>
+                          ))
+                        ) : (
+                          <p className="text-sm text-muted-foreground">No provider links on this account yet.</p>
+                        )}
+                      </div>
+                    </div>
+
+                    {retention?.reasonCodes.length ? (
+                      <div>
+                        <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Current Drivers</h4>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          {retention.reasonCodes.map((reason) => (
+                            <span
+                              key={reason.code}
+                              title={reason.detail}
+                              className="rounded-full border border-border bg-card px-2 py-1 text-[11px] text-muted-foreground"
+                            >
+                              {reason.label}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            ) : null}
           </div>
 
           <div className="rounded-2xl border border-border bg-card p-5">

--- a/src/lib/customer-success/service.test.ts
+++ b/src/lib/customer-success/service.test.ts
@@ -25,6 +25,19 @@ function accountFixture(
     paymentStatus: overrides.paymentStatus ?? "current",
     expansionPotential: overrides.expansionPotential ?? "medium",
     externalProviders: overrides.externalProviders ?? ["HUBSPOT", "STRIPE", "SLACK", "GOOGLE_WORKSPACE", "CODA"],
+    externalRefs: overrides.externalRefs ?? [
+      {
+        provider: "CODA",
+        externalObjectType: "doc",
+        externalId: "VYLC2rzPN_",
+        label: "Customer Success and Implementation",
+        isPrimary: true,
+        metadata: {
+          docUrl: "https://coda.io/d/_dVYLC2rzPN_",
+        },
+        updatedAt: new Date("2026-03-06T00:00:00.000Z"),
+      },
+    ],
     contacts: overrides.contacts ?? [
       {
         id: `${overrides.id}-contact-1`,
@@ -239,6 +252,12 @@ describe("customer success service", () => {
     ).toBeLessThan(
       portfolio.accounts.find((account) => account.accountId === "acct-healthy")!.health.score
     );
+    expect(portfolio.accounts.find((account) => account.accountId === "acct-stalled")?.relationship).toEqual(
+      expect.objectContaining({
+        connectedSystems: 1,
+        missingSources: [],
+      })
+    );
   });
 
   it("verifies health score composition and grade output from all five translated components", () => {
@@ -348,6 +367,7 @@ describe("customer success service", () => {
         id: "acct-partial-detail",
         name: "Partial Detail",
         externalProviders: [],
+        externalRefs: [],
         contacts: [],
         notes: [],
         outreach: [],
@@ -369,5 +389,25 @@ describe("customer success service", () => {
     expect(detail.tasks).toEqual([]);
     expect(detail.successPlan.milestones).toEqual([]);
     expect(detail.outreach.recentMessages).toEqual([]);
+  });
+
+  it("exposes connected provider links on the account detail payload", () => {
+    const detail = buildCustomerSuccessAccountDetailFromSnapshot(
+      accountFixture({
+        id: "acct-links",
+        name: "Provider Links",
+      }),
+      NOW
+    );
+
+    expect(detail.relationshipIntelligence?.providers).toEqual([
+      expect.objectContaining({
+        provider: "CODA",
+        externalObjectType: "doc",
+        externalId: "VYLC2rzPN_",
+        label: "Customer Success and Implementation",
+        url: "https://coda.io/d/_dVYLC2rzPN_",
+      }),
+    ]);
   });
 });

--- a/src/lib/customer-success/service.ts
+++ b/src/lib/customer-success/service.ts
@@ -32,6 +32,11 @@ import type {
   CustomerSuccessHealthComponent,
   CustomerSuccessLeadingIndicator,
   CustomerSuccessPortfolio,
+  CustomerSuccessPortfolioRelationshipSummary,
+  CustomerSuccessProviderLink,
+  CustomerSuccessRelationshipIntelligence,
+  CustomerSuccessRelationshipReason,
+  CustomerSuccessRetentionSummary,
   CustomerSuccessTaskSummary,
   CustomerSuccessStakeholder,
   SendCustomerSuccessOutreachInput,
@@ -140,6 +145,15 @@ export interface CustomerSuccessAccountSnapshot {
   paymentStatus: string | null;
   expansionPotential: string | null;
   externalProviders: CustomerExternalProvider[];
+  externalRefs: Array<{
+    provider: CustomerExternalProvider;
+    externalObjectType: string;
+    externalId: string;
+    label: string | null;
+    isPrimary: boolean;
+    metadata: Record<string, unknown> | null;
+    updatedAt: Date;
+  }>;
   contacts: Array<{
     id: string;
     firstName: string;
@@ -261,6 +275,24 @@ function normalizeOptionalString(value: string | null | undefined): string | nul
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asArray<T = unknown>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function asBoolean(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
 }
 
 function toJsonMetadata(value: Record<string, unknown> | undefined): Prisma.InputJsonValue | undefined {
@@ -979,6 +1011,41 @@ function buildTaskSummaries(snapshot: CustomerSuccessAccountSnapshot): CustomerS
   }));
 }
 
+function providerDocUrl(provider: CustomerExternalProvider, externalId: string, metadata: Record<string, unknown> | null): string | undefined {
+  const browserLink =
+    asString(metadata?.browserLink) ??
+    asString(metadata?.url) ??
+    asString(metadata?.docUrl) ??
+    asString(metadata?.sourceUrl);
+  if (browserLink) return browserLink;
+
+  if (provider === CustomerExternalProvider.CODA) {
+    return `https://coda.io/d/_d${encodeURIComponent(externalId)}`;
+  }
+
+  return undefined;
+}
+
+function buildProviderLinks(snapshot: CustomerSuccessAccountSnapshot): CustomerSuccessProviderLink[] {
+  return snapshot.externalRefs
+    .slice()
+    .sort((left, right) => {
+      if (left.provider !== right.provider) return left.provider.localeCompare(right.provider);
+      if (left.externalObjectType !== right.externalObjectType) {
+        return left.externalObjectType.localeCompare(right.externalObjectType);
+      }
+      return right.updatedAt.getTime() - left.updatedAt.getTime();
+    })
+    .map((ref) => ({
+      provider: ref.provider,
+      externalObjectType: ref.externalObjectType,
+      externalId: ref.externalId,
+      label: ref.label ?? undefined,
+      isPrimary: ref.isPrimary,
+      url: providerDocUrl(ref.provider, ref.externalId, ref.metadata),
+    }));
+}
+
 export function buildCustomerSuccessAccountDetailFromSnapshot(
   snapshot: CustomerSuccessAccountSnapshot,
   now: Date = new Date()
@@ -1028,12 +1095,16 @@ export function buildCustomerSuccessAccountDetailFromSnapshot(
       paymentStatus: snapshot.paymentStatus ?? undefined,
       expansionPotential: snapshot.expansionPotential ?? undefined,
     },
+    relationshipIntelligence: {
+      providers: buildProviderLinks(snapshot),
+    },
   };
 }
 
 export function buildCustomerSuccessPortfolioFromSnapshots(
   snapshots: CustomerSuccessAccountSnapshot[],
-  now: Date = new Date()
+  now: Date = new Date(),
+  relationshipMap: Map<string, Omit<CustomerSuccessPortfolioRelationshipSummary, "connectedSystems">> = new Map()
 ): CustomerSuccessPortfolio {
   const generatedAt = now.toISOString();
   const accounts = snapshots.map((snapshot) => {
@@ -1043,6 +1114,7 @@ export function buildCustomerSuccessPortfolioFromSnapshots(
     const activeUsers30d = buildStakeholders(snapshot, now).filter(
       (stakeholder) => stakeholder.coverageStatus === "covered"
     ).length;
+    const relationship = relationshipMap.get(snapshot.id);
 
     return {
       accountId: snapshot.id,
@@ -1055,6 +1127,13 @@ export function buildCustomerSuccessPortfolioFromSnapshots(
       activeUsers30d,
       renewalDate: snapshot.renewalDate?.toISOString(),
       openAlertCount,
+      relationship: {
+        connectedSystems: snapshot.externalRefs.length,
+        retentionStatus: relationship?.retentionStatus,
+        primaryLirPassed: relationship?.primaryLirPassed,
+        implementationStage: relationship?.implementationStage,
+        missingSources: relationship?.missingSources ?? [],
+      },
     };
   });
 
@@ -1090,6 +1169,7 @@ export function buildCustomerSuccessPortfolioFromSnapshots(
       health: account.health,
       openAlertCount: account.openAlertCount,
       lifecycleStage: snapshots.find((snapshot) => snapshot.id === account.accountId)?.lifecycleStage ?? "ACTIVE",
+      relationship: account.relationship,
       nextAction:
         alerts.find((alert) => alert.accountId === account.accountId && alert.status !== "resolved")?.suggestedAction ??
         pickLeadingIndicatorAction(account.health) ??
@@ -1160,6 +1240,15 @@ function mapCustomerRecordToSnapshot(record: CustomerRecordWithRelations): Custo
           ? "high"
           : null,
     externalProviders: record.externalRefs.map((ref) => ref.provider),
+    externalRefs: record.externalRefs.map((ref) => ({
+      provider: ref.provider,
+      externalObjectType: ref.externalObjectType,
+      externalId: ref.externalId,
+      label: ref.label,
+      isPrimary: ref.isPrimary,
+      metadata: ref.metadata && typeof ref.metadata === "object" ? (ref.metadata as Record<string, unknown>) : null,
+      updatedAt: ref.updatedAt,
+    })),
     contacts: Array.from(contactsById.values()),
     notes: record.notes.map((note) => ({
       id: note.id,
@@ -1276,11 +1365,227 @@ async function listCustomerSuccessSnapshots(actor: CustomerSuccessActor): Promis
   });
 }
 
+async function getCustomerSuccessSnapshotById(
+  actor: CustomerSuccessActor,
+  accountId: string
+): Promise<CustomerSuccessAccountSnapshot | null> {
+  return withCustomerSuccessContext(actor, async () => {
+    const record = await prisma.customerRecord.findFirst({
+      where: {
+        organizationId: actor.organizationId,
+        id: accountId,
+        status: { not: CustomerRecordStatus.MERGED },
+      },
+      include: CUSTOMER_RECORD_INCLUDE,
+    });
+
+    return record ? mapCustomerRecordToSnapshot(record) : null;
+  });
+}
+
+function humanizeRetentionStatus(value: string | null | undefined): string {
+  const normalized = (value ?? "WATCH").replace(/_/g, " ").toLowerCase();
+  return normalized
+    .split(" ")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function parseRelationshipReasons(value: unknown): CustomerSuccessRelationshipReason[] {
+  return asArray<Record<string, unknown>>(value)
+    .map((entry) => {
+      const code = asString(entry.code);
+      const label = asString(entry.label);
+      const detail = asString(entry.detail);
+      const severity = asString(entry.severity);
+      const dimension = asString(entry.dimension);
+      if (!code || !label || !detail || !severity || !dimension) return null;
+      return {
+        code,
+        label,
+        detail,
+        severity: severity as CustomerSuccessRelationshipReason["severity"],
+        dimension: dimension as CustomerSuccessRelationshipReason["dimension"],
+      };
+    })
+    .filter((entry): entry is CustomerSuccessRelationshipReason => entry !== null);
+}
+
+function buildDerivedCoverage(
+  sourceRows: Array<{ source: string }>
+): CustomerSuccessRetentionSummary["coverage"] {
+  const seen = new Set(sourceRows.map((row) => row.source.toLowerCase()));
+  const missingSources = ["arda", "coda", "stripe", "hubspot", "pylon"].filter((source) => !seen.has(source));
+  return {
+    arda: seen.has("arda"),
+    coda: seen.has("coda"),
+    stripe: seen.has("stripe"),
+    hubspot: seen.has("hubspot"),
+    pylon: seen.has("pylon"),
+    missingSources,
+  };
+}
+
+function buildPortfolioRelationshipSummary(input: {
+  connectedSystems: number;
+  retentionCurrent?: {
+    status: string;
+    primaryLirPassed: boolean;
+    detailData: unknown;
+    monthFact?: { coverageData: unknown } | null;
+  } | null;
+}): CustomerSuccessPortfolioRelationshipSummary {
+  const detailData = input.retentionCurrent ? asRecord(input.retentionCurrent.detailData) : {};
+  const coverageData =
+    input.retentionCurrent?.monthFact ? asRecord(input.retentionCurrent.monthFact.coverageData) : {};
+
+  return {
+    connectedSystems: input.connectedSystems,
+    retentionStatus: input.retentionCurrent ? humanizeRetentionStatus(input.retentionCurrent.status) : undefined,
+    primaryLirPassed: input.retentionCurrent?.primaryLirPassed ?? undefined,
+    implementationStage: asString(detailData.implementationStage) ?? undefined,
+    missingSources: asArray<string>(coverageData.missingSources),
+  };
+}
+
+async function buildRelationshipIntelligence(
+  actor: CustomerSuccessActor,
+  snapshot: CustomerSuccessAccountSnapshot
+): Promise<CustomerSuccessRelationshipIntelligence> {
+  const [retentionCurrent, sourceRows] = await withCustomerSuccessContext(actor, async () =>
+    Promise.all([
+      prisma.retentionTenantCurrent.findFirst({
+        where: {
+          organizationId: actor.organizationId,
+          customerRecordId: snapshot.id,
+        },
+        include: {
+          monthFact: {
+            select: {
+              coverageData: true,
+            },
+          },
+        },
+      }),
+      prisma.retentionSourceRecord.findMany({
+        where: {
+          organizationId: actor.organizationId,
+          customerRecordId: snapshot.id,
+          source: { in: ["ARDA", "CODA", "STRIPE", "HUBSPOT", "PYLON"] },
+        },
+        orderBy: [{ sourceUpdatedAt: "desc" }, { occurredAt: "desc" }, { createdAt: "desc" }],
+        select: {
+          source: true,
+          objectType: true,
+          occurredAt: true,
+          sourceUpdatedAt: true,
+          payload: true,
+        },
+      }),
+    ])
+  );
+
+  const providers = buildProviderLinks(snapshot);
+  const latestArdaTenant = sourceRows.find((row) => row.source === "ARDA" && row.objectType === "tenant") ?? null;
+  const codaOrderRows = sourceRows.filter((row) => row.source === "CODA");
+  const latestCodaOrder = codaOrderRows
+    .map((row) => row.occurredAt ?? row.sourceUpdatedAt)
+    .filter((value): value is Date => value instanceof Date)
+    .sort((left, right) => right.getTime() - left.getTime())[0];
+
+  const latestArdaPayload = latestArdaTenant ? asRecord(latestArdaTenant.payload) : {};
+  const retentionDetail = retentionCurrent ? asRecord(retentionCurrent.detailData) : {};
+  const retentionCoverageRaw =
+    retentionCurrent && retentionCurrent.monthFact ? asRecord(retentionCurrent.monthFact.coverageData) : null;
+  const coverage =
+    retentionCoverageRaw && Object.keys(retentionCoverageRaw).length > 0
+      ? {
+          arda: Boolean(asBoolean(retentionCoverageRaw.arda)),
+          coda: Boolean(asBoolean(retentionCoverageRaw.coda)),
+          stripe: Boolean(asBoolean(retentionCoverageRaw.stripe)),
+          hubspot: Boolean(asBoolean(retentionCoverageRaw.hubspot)),
+          pylon: Boolean(asBoolean(retentionCoverageRaw.pylon)),
+          missingSources: asArray<string>(retentionCoverageRaw.missingSources),
+        }
+      : buildDerivedCoverage(sourceRows);
+
+  return {
+    providers,
+    retention: retentionCurrent
+      ? {
+          status: humanizeRetentionStatus(retentionCurrent.status),
+          lifecyclePhase: retentionCurrent.lifecyclePhase,
+          primaryLirLabel: retentionCurrent.primaryLirLabel,
+          primaryLirPassed: retentionCurrent.primaryLirPassed,
+          primaryLirValue: retentionCurrent.primaryLirValue ?? undefined,
+          primaryLirThreshold: retentionCurrent.primaryLirThreshold ?? undefined,
+          currentMonthActivity: retentionCurrent.currentMonthActivity ?? undefined,
+          trendVsPriorPct: retentionCurrent.activityTrendPct ?? undefined,
+          implementationStage: asString(retentionDetail.implementationStage) ?? undefined,
+          goLiveDate: asString(retentionDetail.goLiveDate) ?? undefined,
+          subscriptionStartDate: asString(retentionDetail.subscriptionStartDate) ?? undefined,
+          firstOrderDate: asString(retentionDetail.firstOrderDate) ?? undefined,
+          explanation: asString(retentionDetail.explanation) ?? undefined,
+          reasonCodes: parseRelationshipReasons(retentionCurrent.reasonCodes),
+          coverage,
+          detailUrl: `/analytics/retention/${snapshot.id}`,
+        }
+      : undefined,
+    coda:
+      latestArdaTenant || codaOrderRows.length > 0
+        ? {
+            customerStatus: asString(latestArdaPayload.customerStatus) ?? undefined,
+            configuredHealth: asString(latestArdaPayload.health) ?? undefined,
+            mainDocId: asString(latestArdaPayload.mainCodaDocId) ?? undefined,
+            orderArchiveDocumentId: asString(latestArdaPayload.orderArchiveDocumentId) ?? undefined,
+            mainDocUrl: asString(latestArdaPayload.mainCodaDocId)
+              ? `https://coda.io/d/_d${encodeURIComponent(asString(latestArdaPayload.mainCodaDocId)!)}`
+              : undefined,
+            orderArchiveDocumentUrl: asString(latestArdaPayload.orderArchiveDocumentId)
+              ? `https://coda.io/d/_d${encodeURIComponent(asString(latestArdaPayload.orderArchiveDocumentId)!)}`
+              : undefined,
+            lastOrderAt: latestCodaOrder?.toISOString(),
+            sourceRecordCount: codaOrderRows.length,
+          }
+        : undefined,
+  };
+}
+
 export async function getCustomerSuccessPortfolio(
   actor: CustomerSuccessActor
 ): Promise<CustomerSuccessPortfolio> {
   const snapshots = await listCustomerSuccessSnapshots(actor);
-  return buildCustomerSuccessPortfolioFromSnapshots(snapshots);
+  const retentionCurrents = await withCustomerSuccessContext(actor, async () =>
+    prisma.retentionTenantCurrent.findMany({
+      where: {
+        organizationId: actor.organizationId,
+        customerRecordId: { in: snapshots.map((snapshot) => snapshot.id) },
+      },
+      include: {
+        monthFact: {
+          select: {
+            coverageData: true,
+          },
+        },
+      },
+    })
+  );
+
+  const relationshipMap = new Map<string, Omit<CustomerSuccessPortfolioRelationshipSummary, "connectedSystems">>();
+  retentionCurrents.forEach((current) => {
+    const summary = buildPortfolioRelationshipSummary({
+      connectedSystems: 0,
+      retentionCurrent: current,
+    });
+    relationshipMap.set(current.customerRecordId, {
+      retentionStatus: summary.retentionStatus,
+      primaryLirPassed: summary.primaryLirPassed,
+      implementationStage: summary.implementationStage,
+      missingSources: summary.missingSources,
+    });
+  });
+
+  return buildCustomerSuccessPortfolioFromSnapshots(snapshots, new Date(), relationshipMap);
 }
 
 export async function getCustomerSuccessAlertFeed(
@@ -1315,10 +1620,11 @@ export async function getCustomerSuccessAccountDetail(
   actor: CustomerSuccessActor,
   accountId: string
 ): Promise<CustomerSuccessAccountDetail | null> {
-  const snapshots = await listCustomerSuccessSnapshots(actor);
-  const snapshot = snapshots.find((item) => item.id === accountId);
+  const snapshot = await getCustomerSuccessSnapshotById(actor, accountId);
   if (!snapshot) return null;
-  return buildCustomerSuccessAccountDetailFromSnapshot(snapshot);
+  const detail = buildCustomerSuccessAccountDetailFromSnapshot(snapshot);
+  detail.relationshipIntelligence = await buildRelationshipIntelligence(actor, snapshot);
+  return detail;
 }
 
 export async function createCustomerSuccessNote(

--- a/src/lib/customer-success/types.ts
+++ b/src/lib/customer-success/types.ts
@@ -268,6 +268,74 @@ export interface CustomerSuccessTaskSummary {
   priority?: string;
 }
 
+export interface CustomerSuccessProviderLink {
+  provider: CustomerExternalProvider;
+  externalObjectType: string;
+  externalId: string;
+  label?: string;
+  isPrimary: boolean;
+  url?: string;
+}
+
+export interface CustomerSuccessRelationshipReason {
+  code: string;
+  label: string;
+  detail: string;
+  severity: "info" | "warning" | "critical";
+  dimension: "usage" | "adoption" | "support" | "billing" | "onboarding" | "commercial" | "data";
+}
+
+export interface CustomerSuccessRetentionSummary {
+  status: string;
+  lifecyclePhase: "ONBOARDING" | "MATURE";
+  primaryLirLabel: string;
+  primaryLirPassed: boolean;
+  primaryLirValue?: number;
+  primaryLirThreshold?: number;
+  currentMonthActivity?: number;
+  trendVsPriorPct?: number;
+  implementationStage?: string;
+  goLiveDate?: string;
+  subscriptionStartDate?: string;
+  firstOrderDate?: string;
+  explanation?: string;
+  reasonCodes: CustomerSuccessRelationshipReason[];
+  coverage: {
+    arda: boolean;
+    coda: boolean;
+    stripe: boolean;
+    hubspot: boolean;
+    pylon: boolean;
+    missingSources: string[];
+  };
+  detailUrl: string;
+}
+
+export interface CustomerSuccessCodaSummary {
+  customerStatus?: string;
+  configuredHealth?: string;
+  mainDocId?: string;
+  orderArchiveDocumentId?: string;
+  mainDocUrl?: string;
+  orderArchiveDocumentUrl?: string;
+  lastOrderAt?: string;
+  sourceRecordCount: number;
+}
+
+export interface CustomerSuccessRelationshipIntelligence {
+  providers: CustomerSuccessProviderLink[];
+  retention?: CustomerSuccessRetentionSummary;
+  coda?: CustomerSuccessCodaSummary;
+}
+
+export interface CustomerSuccessPortfolioRelationshipSummary {
+  connectedSystems: number;
+  retentionStatus?: string;
+  primaryLirPassed?: boolean;
+  implementationStage?: string;
+  missingSources: string[];
+}
+
 export interface CustomerSuccessPortfolioAccount {
   accountId: string;
   name: string;
@@ -279,6 +347,7 @@ export interface CustomerSuccessPortfolioAccount {
   activeUsers30d?: number;
   renewalDate?: string;
   openAlertCount: number;
+  relationship?: CustomerSuccessPortfolioRelationshipSummary;
 }
 
 export interface CustomerSuccessPortfolio {
@@ -301,6 +370,7 @@ export interface CustomerSuccessPortfolio {
     openAlertCount: number;
     lifecycleStage: string;
     nextAction?: string;
+    relationship?: CustomerSuccessPortfolioRelationshipSummary;
   }>;
   alerts: CustomerSuccessAlert[];
   recentActivity: CustomerSuccessEvent[];
@@ -360,6 +430,7 @@ export interface CustomerSuccessAccountDetail {
     paymentStatus?: string;
     expansionPotential?: string;
   };
+  relationshipIntelligence?: CustomerSuccessRelationshipIntelligence;
 }
 
 export interface CreateCustomerSuccessNoteInput {


### PR DESCRIPTION
## Summary
- expose connected external refs and retention overlays in the customer success account detail payload
- add portfolio-level relationship summaries to the customer success tab and account workspace UI
- add focused tests for the new relationship intelligence rendering and service mapping

## Testing
- ./node_modules/.bin/tsc --noEmit --incremental false
- npx vitest run src/lib/customer-success/service.test.ts src/components/customer-success/account-workspace.test.tsx src/components/analytics/customer-success-tab.test.tsx