### PR TITLE
Improve Arda tenant resolution

### DIFF
--- a/src/lib/retention/arda-tenant-resolution.test.ts
+++ b/src/lib/retention/arda-tenant-resolution.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  discoverArdaTenantIdsFromUserDetails,
+  extractArdaTenantIdsFromResult,
+  normalizeArdaTenantLookupKey,
+} from "@/lib/retention/arda-tenant-resolution";
+
+describe("arda tenant resolution helpers", () => {
+  it("extracts tenant UUIDs from nested result payloads", () => {
+    expect(
+      extractArdaTenantIdsFromResult({
+        metadata: {
+          tenantId: "9189acf9-4f89-46cd-9760-0d4933d58c67",
+        },
+        payload: {
+          eId: "1193d42d-ef80-4bc8-ab11-84e5c8046892",
+        },
+      })
+    ).toEqual([
+      "9189acf9-4f89-46cd-9760-0d4933d58c67",
+      "1193d42d-ef80-4bc8-ab11-84e5c8046892",
+    ]);
+  });
+
+  it("extracts tenant UUIDs from JSON-encoded result payloads", () => {
+    expect(
+      extractArdaTenantIdsFromResult(
+        JSON.stringify({
+          metadata: {
+            tenantId: "6fa02301-2cd9-4cfa-a258-40474b828945",
+          },
+        })
+      )
+    ).toEqual(["6fa02301-2cd9-4cfa-a258-40474b828945"]);
+  });
+
+  it("discovers tenant UUIDs from non-generic email domains", () => {
+    const discovered = discoverArdaTenantIdsFromUserDetails(
+      [
+        {
+          configuredTenantId: "northstarchemical",
+          companyName: "Northstar Chemical",
+        },
+        {
+          configuredTenantId: "ArdaMerch",
+          companyName: "Arda Dogfood",
+        },
+      ],
+      [
+        {
+          email: "abrock@northstarchemical.com",
+          tenantId: "6fa02301-2cd9-4cfa-a258-40474b828945",
+        },
+        {
+          email: "customer-success+northstar@arda.cards",
+          tenantId: "6fa02301-2cd9-4cfa-a258-40474b828945",
+        },
+      ]
+    );
+
+    expect(
+      discovered.get(normalizeArdaTenantLookupKey("northstarchemical"))
+    ).toEqual(["6fa02301-2cd9-4cfa-a258-40474b828945"]);
+    expect(discovered.has(normalizeArdaTenantLookupKey("ArdaMerch"))).toBe(false);
+  });
+
+  it("requires a unique best match before assigning a UUID", () => {
+    const discovered = discoverArdaTenantIdsFromUserDetails(
+      [
+        {
+          configuredTenantId: "smartcona",
+          companyName: "Smartcon Solutions A",
+        },
+        {
+          configuredTenantId: "smartconb",
+          companyName: "Smartcon Solutions B",
+        },
+      ],
+      [
+        {
+          email: "ops@smartconsolutions.com",
+          tenantId: "e24408eb-69b3-477d-9090-97e314113996",
+        },
+      ]
+    );
+
+    expect(discovered.size).toBe(0);
+  });
+});

--- a/src/lib/retention/arda-tenant-resolution.ts
+++ b/src/lib/retention/arda-tenant-resolution.ts
@@ -1,0 +1,173 @@
+export interface ArdaTenantResolutionConfig {
+  configuredTenantId: string;
+  companyName: string;
+}
+
+export interface ArdaTenantUserDetailsRow {
+  email: string | null;
+  tenantId: string | null;
+}
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const GENERIC_EMAIL_ROOTS = new Set([
+  "arda",
+  "gmail",
+  "yahoo",
+  "outlook",
+  "hotmail",
+  "icloud",
+]);
+
+function isUuid(value: string | null): value is string {
+  return Boolean(value && UUID_PATTERN.test(value));
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+export function normalizeArdaTenantLookupKey(value: string | null): string {
+  return (value ?? "")
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^a-z0-9]+/g, "");
+}
+
+function simplifyArdaIdentifier(value: string | null): string {
+  return normalizeArdaTenantLookupKey(value).replace(
+    /(llc|inc|ltd|company|co|mfg|manufacturing|systems|group|services)$/,
+    ""
+  );
+}
+
+function domainRootFromEmail(email: string | null): string | null {
+  const raw = asString(email);
+  if (!raw || !raw.includes("@")) return null;
+  const domain = raw
+    .slice(raw.indexOf("@") + 1)
+    .toLowerCase()
+    .replace(/^www\./, "")
+    .replace(/\/.*$/, "");
+  const parts = domain.split(".").filter(Boolean);
+  if (parts.length === 0) return null;
+  const root = parts.length >= 2 ? parts[parts.length - 2] : parts[0];
+  const normalized = normalizeArdaTenantLookupKey(root);
+  if (!normalized || GENERIC_EMAIL_ROOTS.has(normalized)) return null;
+  return normalized;
+}
+
+function scoreConfigMatch(root: string, config: ArdaTenantResolutionConfig): number {
+  const companyNorm = normalizeArdaTenantLookupKey(config.companyName);
+  const slugNorm = normalizeArdaTenantLookupKey(config.configuredTenantId);
+  const companySimple = simplifyArdaIdentifier(config.companyName);
+  const slugSimple = simplifyArdaIdentifier(config.configuredTenantId);
+
+  let score = 0;
+  if (root === slugNorm || root === companyNorm) score += 100;
+  if (root === slugSimple || root === companySimple) score += 90;
+  if (root && slugNorm.includes(root)) score += 40;
+  if (root && root.includes(slugNorm)) score += 40;
+  if (root && companyNorm.includes(root)) score += 30;
+  if (root && root.includes(companyNorm)) score += 30;
+  if (root && slugSimple && slugSimple.includes(root)) score += 20;
+  if (root && companySimple && companySimple.includes(root)) score += 20;
+  return score;
+}
+
+function parseEmbeddedJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function collectResultTenantIds(value: unknown, acc: Set<string>): void {
+  if (typeof value === "string") {
+    if (isUuid(value)) {
+      acc.add(value);
+      return;
+    }
+    const maybeJson = parseEmbeddedJson(value);
+    if (maybeJson !== value) collectResultTenantIds(maybeJson, acc);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) collectResultTenantIds(entry, acc);
+    return;
+  }
+
+  const record = asRecord(value);
+  for (const [key, child] of Object.entries(record)) {
+    const loweredKey = key.toLowerCase();
+    if (loweredKey === "tenantid" || loweredKey === "eid") {
+      const candidate = asString(child);
+      if (isUuid(candidate)) acc.add(candidate);
+    }
+    collectResultTenantIds(child, acc);
+  }
+}
+
+export function extractArdaTenantIdsFromResult(value: unknown): string[] {
+  const tenantIds = new Set<string>();
+  collectResultTenantIds(value, tenantIds);
+  return [...tenantIds];
+}
+
+export function discoverArdaTenantIdsFromUserDetails(
+  configs: ArdaTenantResolutionConfig[],
+  userDetailsRows: ArdaTenantUserDetailsRow[]
+): Map<string, string[]> {
+  const rootsByTenantUuid = new Map<string, Set<string>>();
+
+  for (const row of userDetailsRows) {
+    if (!isUuid(row.tenantId)) continue;
+    const root = domainRootFromEmail(row.email);
+    if (!root) continue;
+    const existing = rootsByTenantUuid.get(row.tenantId) ?? new Set<string>();
+    existing.add(root);
+    rootsByTenantUuid.set(row.tenantId, existing);
+  }
+
+  const discovered = new Map<string, Set<string>>();
+
+  for (const [tenantUuid, roots] of rootsByTenantUuid.entries()) {
+    const scored = configs
+      .map((config) => ({
+        config,
+        score: [...roots].reduce(
+          (best, root) => Math.max(best, scoreConfigMatch(root, config)),
+          0
+        ),
+      }))
+      .filter((entry) => entry.score > 0)
+      .sort(
+        (left, right) =>
+          right.score - left.score ||
+          left.config.companyName.localeCompare(right.config.companyName)
+      );
+
+    const best = scored[0];
+    const second = scored[1];
+    if (!best || best.score < 90) continue;
+    if (second && second.score >= best.score) continue;
+
+    const key = normalizeArdaTenantLookupKey(best.config.configuredTenantId);
+    const bucket = discovered.get(key) ?? new Set<string>();
+    bucket.add(tenantUuid);
+    discovered.set(key, bucket);
+  }
+
+  return new Map(
+    [...discovered.entries()].map(([key, tenantIds]) => [key, [...tenantIds]])
+  );
+}

--- a/src/lib/retention/pipeline.ts
+++ b/src/lib/retention/pipeline.ts
@@ -30,6 +30,11 @@ import {
   getPylonIssueStatus,
   getPylonIssueTags,
 } from "@/lib/integrations/pylon-client";
+import {
+  discoverArdaTenantIdsFromUserDetails,
+  extractArdaTenantIdsFromResult,
+  normalizeArdaTenantLookupKey,
+} from "@/lib/retention/arda-tenant-resolution";
 import { normalizeCodaMasterOrderArchiveRow } from "@/lib/retention/coda-normalization";
 
 interface SourceSeedRecord {
@@ -76,6 +81,7 @@ interface ArdaTenantConfig {
   mainCodaDocId: string | null;
   orderArchiveDocumentId: string | null;
   churned: boolean;
+  resultTenantIds: string[];
 }
 
 interface ArdaEntityRecord {
@@ -358,7 +364,8 @@ async function fetchCodaApiRows(
   docId: string,
   tableId: string,
   token: string,
-  pageLimit = 10
+  pageLimit = 10,
+  useColumnNames = true
 ): Promise<CodaApiRow[]> {
   const headers = {
     Authorization: `Bearer ${token}`,
@@ -371,7 +378,7 @@ async function fetchCodaApiRows(
       `https://coda.io/apis/v1/docs/${encodeURIComponent(docId)}/tables/${encodeURIComponent(tableId)}/rows`
     );
     url.searchParams.set("limit", "500");
-    url.searchParams.set("useColumnNames", "true");
+    url.searchParams.set("useColumnNames", useColumnNames ? "true" : "false");
     if (pageToken) url.searchParams.set("pageToken", pageToken);
     const response = await fetch(url, { headers, cache: "no-store" });
     if (!response.ok) {
@@ -414,17 +421,63 @@ function normalizeArdaTenantConfigRow(row: CodaApiRow): ArdaTenantConfig | null 
     mainCodaDocId: asString(values.mainCodaDocId) ?? asString(values["ActiveMainDoc ID"]),
     orderArchiveDocumentId: asString(values.orderArchiveDocumentId),
     churned: Boolean(asBoolean(values.Churned)),
+    resultTenantIds: extractArdaTenantIdsFromResult(values.Result),
   };
 }
 
-function resolveArdaTenantIds(config: ArdaTenantConfig): string[] {
+async function discoverArdaTenantIdsByConfig(
+  docId: string,
+  token: string,
+  configs: ArdaTenantConfig[]
+): Promise<Map<string, string[]>> {
+  const userDetailsTableId =
+    process.env.ARDA_USER_DETAILS_TABLE_ID?.trim() ??
+    "grid-sync-22507-RowDataObject-dynamic-76fe62dd30b7a8c4df850cd9ee639fcfdf09c9067d2e7472911d2a718e7e2f1f";
+  try {
+    const rows = await fetchCodaApiRows(docId, userDetailsTableId, token, 5, false);
+    return discoverArdaTenantIdsFromUserDetails(
+      configs.map((config) => ({
+        configuredTenantId: config.configuredTenantId,
+        companyName: config.companyName,
+      })),
+      rows.map((row) => {
+        const values = asRecord(row.values);
+        return {
+          email: asString(values["c-qNAXS3SO0E"]),
+          tenantId: asString(values["c-WEBsoGYauT"]),
+        };
+      })
+    );
+  } catch (error) {
+    console.warn(
+      `[retention] Unable to derive Arda tenant UUIDs from User Details: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    return new Map();
+  }
+}
+
+function resolveArdaTenantIds(
+  config: ArdaTenantConfig,
+  discoveredTenantIdsByConfig: Map<string, string[]>
+): string[] {
   if (isUuid(config.tenantId)) return [config.tenantId];
+  if (config.resultTenantIds.length > 0) return config.resultTenantIds;
 
   const normalizedCompanyName =
     normalizeArdaCustomerName(config.companyName) ?? normalizeArdaCustomerName(config.tenantName);
-  if (!normalizedCompanyName) return [];
+  if (normalizedCompanyName) {
+    const manualTenantIds = ARDA_CUSTOMER_TENANT_IDS[normalizedCompanyName];
+    if (manualTenantIds?.length) return manualTenantIds;
+  }
 
-  return ARDA_CUSTOMER_TENANT_IDS[normalizedCompanyName] ?? [];
+  return (
+    discoveredTenantIdsByConfig.get(
+      normalizeArdaTenantLookupKey(config.configuredTenantId)
+    ) ??
+    []
+  );
 }
 
 async function loadArdaTenantConfigs(): Promise<ArdaTenantConfig[]> {
@@ -437,11 +490,16 @@ async function loadArdaTenantConfigs(): Promise<ArdaTenantConfig[]> {
   const configs = rows
     .map(normalizeArdaTenantConfigRow)
     .filter((config): config is ArdaTenantConfig => config !== null);
+  const discoveredTenantIdsByConfig = await discoverArdaTenantIdsByConfig(
+    docId,
+    token,
+    configs
+  );
   const resolved: ArdaTenantConfig[] = [];
   const unresolved: string[] = [];
 
   for (const config of configs) {
-    const tenantIds = resolveArdaTenantIds(config);
+    const tenantIds = resolveArdaTenantIds(config, discoveredTenantIdsByConfig);
     if (tenantIds.length === 0) {
       unresolved.push(config.companyName);
       continue;
@@ -452,6 +510,12 @@ async function loadArdaTenantConfigs(): Promise<ArdaTenantConfig[]> {
         tenantId,
       });
     }
+  }
+
+  if (discoveredTenantIdsByConfig.size > 0) {
+    console.info(
+      `[retention] Discovered ${discoveredTenantIdsByConfig.size} Arda tenant UUID mappings from User Details`
+    );
   }
 
   if (unresolved.length > 0) {


### PR DESCRIPTION
## Summary
- extract Arda tenant UUIDs directly from tenant config Result payloads when present
- derive additional tenant UUID matches from the Coda User Details table using email-domain heuristics
- add focused unit coverage for tenant-id extraction and ambiguous-match handling

## Testing
- ./node_modules/.bin/vitest run src/lib/retention/arda-tenant-resolution.test.ts src/lib/retention/pipeline.test.ts src/lib/retention/status.test.ts src/lib/retention/reporting.test.ts
- ./node_modules/.bin/tsc --noEmit --incremental false