### PR TITLE
Add retention analysis exports

### DIFF
--- a/docs/retention/analysis-output.json
+++ b/docs/retention/analysis-output.json
@@ -1,0 +1,101 @@
+{
+  "generatedAt": "2026-03-15T10:49:47.728Z",
+  "organizationId": "org_default_000000000",
+  "candidates": [
+    {
+      "definition": {
+        "id": "onboarding-active-days",
+        "label": "Meaningful activity days",
+        "lifecyclePhase": "ONBOARDING",
+        "metricKey": "daysActiveLast30",
+        "comparator": "gte",
+        "threshold": 6,
+        "windowLabel": "Last 30 days",
+        "description": "Tenant shows repeated operational activity across six or more days in the last 30 days.",
+        "rationale": "Repeated activity is stronger than one-time setup completion."
+      },
+      "coverage": 100,
+      "lift": 102.1,
+      "segmentSpread": 0,
+      "interpretabilityScore": 90,
+      "score": 99.4,
+      "label": "Meaningful activity days (onboarding)"
+    },
+    {
+      "definition": {
+        "id": "mature-active-weeks",
+        "label": "Active weeks trailing 8",
+        "lifecyclePhase": "MATURE",
+        "metricKey": "activeWeeksTrailing8",
+        "comparator": "gte",
+        "threshold": 5,
+        "windowLabel": "Trailing 8 weeks",
+        "description": "Tenant is active in at least five of the last eight weeks.",
+        "rationale": "Habitual weekly operations are usually the clearest signal of embedded workflow value."
+      },
+      "coverage": 100,
+      "lift": 100,
+      "segmentSpread": 0,
+      "interpretabilityScore": 90,
+      "score": 98.5,
+      "label": "Active weeks trailing 8 (mature)"
+    },
+    {
+      "definition": {
+        "id": "mature-orders-cadence",
+        "label": "Monthly order cadence",
+        "lifecyclePhase": "MATURE",
+        "metricKey": "ordersPerMonth",
+        "comparator": "gte",
+        "threshold": 8,
+        "windowLabel": "Current month",
+        "description": "Tenant sustains at least eight order events in the current month.",
+        "rationale": "Order throughput is the most direct signal of recurring operational value for Arda."
+      },
+      "coverage": 100,
+      "lift": 100,
+      "segmentSpread": 0,
+      "interpretabilityScore": 90,
+      "score": 98.5,
+      "label": "Monthly order cadence (mature)"
+    },
+    {
+      "definition": {
+        "id": "mature-recent-baseline",
+        "label": "Recent activity vs baseline",
+        "lifecyclePhase": "MATURE",
+        "metricKey": "recentBaselineRatio",
+        "comparator": "gte",
+        "threshold": 0.7,
+        "windowLabel": "Last 30 vs trailing 90 days",
+        "description": "Current activity stays above 70% of the trailing baseline.",
+        "rationale": "Current-month collapse is more actionable than historical average usage."
+      },
+      "coverage": 4.8,
+      "lift": 100,
+      "segmentSpread": 0,
+      "interpretabilityScore": 75,
+      "score": 72.5,
+      "label": "Recent activity vs baseline (mature)"
+    },
+    {
+      "definition": {
+        "id": "onboarding-first-order",
+        "label": "Time to first order",
+        "lifecyclePhase": "ONBOARDING",
+        "metricKey": "timeToFirstOrderDays",
+        "comparator": "lte",
+        "threshold": 21,
+        "windowLabel": "First 30 days",
+        "description": "Tenant places its first meaningful order within 21 days of go-live.",
+        "rationale": "Early value realization is the cleanest onboarding-stage proxy for future retention."
+      },
+      "coverage": 0,
+      "lift": 0,
+      "segmentSpread": 0,
+      "interpretabilityScore": 90,
+      "score": 28.5,
+      "label": "Time to first order (onboarding)"
+    }
+  ]
+}

--- a/docs/retention/gaps-report.json
+++ b/docs/retention/gaps-report.json
@@ -1,0 +1,115 @@
+{
+  "generatedAt": "2026-03-15T10:50:50.352Z",
+  "organizationId": "org_default_000000000",
+  "summary": {
+    "unresolvedRecords": 21,
+    "unresolvedBuckets": 2,
+    "sourcesImpacted": 2
+  },
+  "buckets": [
+    {
+      "source": "STRIPE",
+      "objectType": "subscription",
+      "unresolvedRecords": 11,
+      "examples": [
+        {
+          "source": "STRIPE",
+          "objectType": "subscription",
+          "externalId": "sub_1T4aaIBj5FeOe1MmrZFTrCDH",
+          "tenantKey": "cus_TbBZ0zfmk88oWo",
+          "occurredAt": "2026-02-25T05:24:30.000Z",
+          "candidateName": null,
+          "candidateDomain": "gmail.com"
+        },
+        {
+          "source": "STRIPE",
+          "objectType": "subscription",
+          "externalId": "sub_1RvfwfBj5FeOe1MmlQrKpXxd",
+          "tenantKey": "cus_SrOke059TzpQN3",
+          "occurredAt": "2025-08-13T14:46:28.000Z",
+          "candidateName": null,
+          "candidateDomain": null
+        },
+        {
+          "source": "STRIPE",
+          "objectType": "subscription",
+          "externalId": "sub_1RtQl7Bj5FeOe1MmsUjvXfIW",
+          "tenantKey": "cus_Sp4wr7OSzE362H",
+          "occurredAt": "2025-08-07T10:10:58.000Z",
+          "candidateName": null,
+          "candidateDomain": null
+        },
+        {
+          "source": "STRIPE",
+          "objectType": "subscription",
+          "externalId": "sub_1RtOJPBj5FeOe1MmxMd9A711",
+          "tenantKey": "cus_Sp2OQwSoKL4kks",
+          "occurredAt": "2025-08-07T07:33:06.000Z",
+          "candidateName": null,
+          "candidateDomain": null
+        },
+        {
+          "source": "STRIPE",
+          "objectType": "subscription",
+          "externalId": "sub_1QRhpZBj5FeOe1MmwiDycFib",
+          "tenantKey": "cus_RKMYSNLodEB7XN",
+          "occurredAt": "2024-12-02T22:11:01.000Z",
+          "candidateName": null,
+          "candidateDomain": null
+        }
+      ]
+    },
+    {
+      "source": "ARDA",
+      "objectType": "tenant",
+      "unresolvedRecords": 10,
+      "examples": [
+        {
+          "source": "ARDA",
+          "objectType": "tenant",
+          "externalId": "e335bfe0-5010-4a97-bb89-45d013906fbe",
+          "tenantKey": "e335bfe0-5010-4a97-bb89-45d013906fbe",
+          "occurredAt": null,
+          "candidateName": "a",
+          "candidateDomain": null
+        },
+        {
+          "source": "ARDA",
+          "objectType": "tenant",
+          "externalId": "ca7843da-9d3f-5a65-afcc-5ddc2947910c",
+          "tenantKey": "ca7843da-9d3f-5a65-afcc-5ddc2947910c",
+          "occurredAt": null,
+          "candidateName": "a",
+          "candidateDomain": null
+        },
+        {
+          "source": "ARDA",
+          "objectType": "tenant",
+          "externalId": "433ae8a1-ccea-41f3-83fa-4b4df2ad3153",
+          "tenantKey": "433ae8a1-ccea-41f3-83fa-4b4df2ad3153",
+          "occurredAt": null,
+          "candidateName": "a",
+          "candidateDomain": null
+        },
+        {
+          "source": "ARDA",
+          "objectType": "tenant",
+          "externalId": "9189acf9-4f89-46cd-9760-0d4933d58c67",
+          "tenantKey": "9189acf9-4f89-46cd-9760-0d4933d58c67",
+          "occurredAt": null,
+          "candidateName": "Gimbel Group",
+          "candidateDomain": null
+        },
+        {
+          "source": "ARDA",
+          "objectType": "tenant",
+          "externalId": "9db131b9-da94-4c20-bcab-0f70e079bd0d",
+          "tenantKey": "9db131b9-da94-4c20-bcab-0f70e079bd0d",
+          "occurredAt": null,
+          "candidateName": "Reachable Technology LLC",
+          "candidateDomain": null
+        }
+      ]
+    }
+  ]
+}

--- a/docs/retention/gaps-report.md
+++ b/docs/retention/gaps-report.md
@@ -1,0 +1,29 @@
+# Identity Gaps Report
+
+Generated at: 2026-03-15T10:50:50.352Z
+Organization: org_default_000000000
+
+## Summary
+- Unresolved records: 21
+- Unresolved source/object buckets: 2
+- Sources impacted: 2
+
+## Buckets
+
+### STRIPE / subscription
+- Unresolved records: 11
+- Sample unresolved records:
+  - sub_1T4aaIBj5FeOe1MmrZFTrCDH | tenantKey=cus_TbBZ0zfmk88oWo | domain=gmail.com | occurredAt=2026-02-25T05:24:30.000Z
+  - sub_1RvfwfBj5FeOe1MmlQrKpXxd | tenantKey=cus_SrOke059TzpQN3 | occurredAt=2025-08-13T14:46:28.000Z
+  - sub_1RtQl7Bj5FeOe1MmsUjvXfIW | tenantKey=cus_Sp4wr7OSzE362H | occurredAt=2025-08-07T10:10:58.000Z
+  - sub_1RtOJPBj5FeOe1MmxMd9A711 | tenantKey=cus_Sp2OQwSoKL4kks | occurredAt=2025-08-07T07:33:06.000Z
+  - sub_1QRhpZBj5FeOe1MmwiDycFib | tenantKey=cus_RKMYSNLodEB7XN | occurredAt=2024-12-02T22:11:01.000Z
+
+### ARDA / tenant
+- Unresolved records: 10
+- Sample unresolved records:
+  - e335bfe0-5010-4a97-bb89-45d013906fbe | tenantKey=e335bfe0-5010-4a97-bb89-45d013906fbe | name=a
+  - ca7843da-9d3f-5a65-afcc-5ddc2947910c | tenantKey=ca7843da-9d3f-5a65-afcc-5ddc2947910c | name=a
+  - 433ae8a1-ccea-41f3-83fa-4b4df2ad3153 | tenantKey=433ae8a1-ccea-41f3-83fa-4b4df2ad3153 | name=a
+  - 9189acf9-4f89-46cd-9760-0d4933d58c67 | tenantKey=9189acf9-4f89-46cd-9760-0d4933d58c67 | name=Gimbel Group
+  - 9db131b9-da94-4c20-bcab-0f70e079bd0d | tenantKey=9db131b9-da94-4c20-bcab-0f70e079bd0d | name=Reachable Technology LLC


### PR DESCRIPTION
## Summary
- add the latest retention candidate ranking export
- add the latest retention identity gaps exports in JSON and Markdown
- keep the retention workflow outputs aligned with the docs/retention README

## Validation
- jq empty docs/retention/analysis-output.json docs/retention/gaps-report.json