### PR TITLE
test(customer-success): cover in-progress alert service flow

### DIFF
--- a/src/lib/customer-success/service-write.test.ts
+++ b/src/lib/customer-success/service-write.test.ts
@@ -244,6 +244,37 @@ describe("customer success write service", () => {
     });
   });
 
+  it("moves customer-success alerts into progress and clears resolvedAt", async () => {
+    vi.mocked(prisma.customerSuccessAlertRecord.findFirst).mockResolvedValue({
+      id: "alert_1",
+    } as never);
+    vi.mocked(prisma.customerSuccessAlertRecord.update).mockResolvedValue({
+      id: "alert_1",
+      status: CustomerSuccessAlertStatus.IN_PROGRESS,
+      resolvedAt: null,
+    } as never);
+
+    const updated = await updateCustomerSuccessAlertStatus(ACTOR, {
+      accountId: "acct_1",
+      alertId: "alert_1",
+      status: "IN_PROGRESS",
+    });
+
+    expect(prisma.customerSuccessAlertRecord.update).toHaveBeenCalledWith({
+      where: { id: "alert_1" },
+      data: expect.objectContaining({
+        status: CustomerSuccessAlertStatus.IN_PROGRESS,
+        resolvedAt: null,
+        lastEvaluatedAt: expect.any(Date),
+      }),
+    });
+    expect(updated).toMatchObject({
+      id: "alert_1",
+      status: CustomerSuccessAlertStatus.IN_PROGRESS,
+      resolvedAt: null,
+    });
+  });
+
   it("queues outreach sends and publishes an outbox event after persisting the message", async () => {
     const tx = {
       customerSuccessOutreachMessage: {


### PR DESCRIPTION
## Summary
- add write-service coverage for moving a customer-success alert into progress
- verify the service clears resolvedAt when reopening an alert
- verify the service still records a fresh lastEvaluatedAt timestamp

## Testing
- npm test -- src/lib/customer-success/service-write.test.ts
- npm run lint -- src/lib/customer-success/service-write.test.ts