### PR TITLE
test(customer-success): cover dismissed alert route flow

### DIFF
--- a/src/app/api/customer-success/customer-success-routes.test.ts
+++ b/src/app/api/customer-success/customer-success-routes.test.ts
@@ -468,4 +468,38 @@ describe("customer-success mutation routes", () => {
       status: "IN_PROGRESS",
     });
   });
+
+  it("maps dismissed alert status updates into updateCustomerSuccessAlertStatus", async () => {
+    const { requireCustomerSuccessActor } = await import("@/lib/customer-success/access");
+    const { updateCustomerSuccessAlertStatus } = await import("@/lib/customer-success/service");
+
+    vi.mocked(requireCustomerSuccessActor).mockResolvedValue({ actor: ACTOR });
+    vi.mocked(updateCustomerSuccessAlertStatus).mockResolvedValue({
+      id: "alert_1",
+      status: "DISMISSED",
+    } as never);
+
+    const { POST } = await import(
+      "@/app/api/customer-success/accounts/[accountId]/alerts/[alertId]/status/route"
+    );
+    const response = await POST(
+      new NextRequest("http://localhost/api/customer-success/accounts/acct_1/alerts/alert_1/status", {
+        method: "POST",
+        body: JSON.stringify({ status: "DISMISSED" }),
+        headers: { "content-type": "application/json" },
+      }),
+      alertContext()
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: "alert_1",
+      status: "DISMISSED",
+    });
+    expect(updateCustomerSuccessAlertStatus).toHaveBeenCalledWith(ACTOR, {
+      accountId: "acct_1",
+      alertId: "alert_1",
+      status: "DISMISSED",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add route coverage for dismissing a customer-success alert
- verify the route forwards the dismissed status into the service layer
- verify the route returns the dismissed alert payload from the service

## Testing
- npm test -- src/app/api/customer-success/customer-success-routes.test.ts
- npm run lint -- src/app/api/customer-success/customer-success-routes.test.ts