### PR TITLE
test(customer-success): cover alert route fallback 500s

### DIFF
--- a/src/app/api/customer-success/customer-success-routes.test.ts
+++ b/src/app/api/customer-success/customer-success-routes.test.ts
@@ -490,6 +490,29 @@ describe("customer-success mutation routes", () => {
     await expect(response.json()).resolves.toEqual({ error: "Database unavailable" });
   });
 
+  it("returns generic 500s for non-error alert update failures", async () => {
+    const { requireCustomerSuccessActor } = await import("@/lib/customer-success/access");
+    const { updateCustomerSuccessAlertStatus } = await import("@/lib/customer-success/service");
+
+    vi.mocked(requireCustomerSuccessActor).mockResolvedValue({ actor: ACTOR });
+    vi.mocked(updateCustomerSuccessAlertStatus).mockRejectedValue("db-down");
+
+    const { POST } = await import(
+      "@/app/api/customer-success/accounts/[accountId]/alerts/[alertId]/status/route"
+    );
+    const response = await POST(
+      new NextRequest("http://localhost/api/customer-success/accounts/acct_1/alerts/alert_1/status", {
+        method: "POST",
+        body: JSON.stringify({ status: "RESOLVED" }),
+        headers: { "content-type": "application/json" },
+      }),
+      alertContext()
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "Failed to update customer success alert" });
+  });
+
   it("rejects alert updates when status is missing", async () => {
     const { requireCustomerSuccessActor } = await import("@/lib/customer-success/access");
     const { updateCustomerSuccessAlertStatus } = await import("@/lib/customer-success/service");


### PR DESCRIPTION
## Summary
- add route coverage for non-Error alert update failures
- verify the route returns the generic fallback 500 message
- complete the alert route error-handling matrix

## Testing
- npm test -- src/app/api/customer-success/customer-success-routes.test.ts
- npm run lint -- src/app/api/customer-success/customer-success-routes.test.ts