### PR TITLE
test(customer-success): cover task route auth

### DIFF
--- a/src/app/api/customer-success/customer-success-routes.test.ts
+++ b/src/app/api/customer-success/customer-success-routes.test.ts
@@ -112,6 +112,31 @@ describe("customer-success mutation routes", () => {
     expect(updateCustomerSuccessAlertStatus).not.toHaveBeenCalled();
   });
 
+  it("passes through auth failures for linked task creation", async () => {
+    const { requireCustomerSuccessActor } = await import("@/lib/customer-success/access");
+    const { enforcePermission } = await import("@/lib/permissions");
+    const { createCustomerSuccessTask } = await import("@/lib/customer-success/service");
+
+    vi.mocked(requireCustomerSuccessActor).mockResolvedValue({
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    });
+
+    const { POST } = await import("@/app/api/customer-success/accounts/[accountId]/tasks/route");
+    const response = await POST(
+      new NextRequest("http://localhost/api/customer-success/accounts/acct_1/tasks", {
+        method: "POST",
+        body: JSON.stringify({ title: "Coordinate escalation" }),
+        headers: { "content-type": "application/json" },
+      }),
+      accountContext()
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(enforcePermission).not.toHaveBeenCalled();
+    expect(createCustomerSuccessTask).not.toHaveBeenCalled();
+  });
+
   it("returns the customer-success portfolio for authenticated actors", async () => {
     const { requireCustomerSuccessActor } = await import("@/lib/customer-success/access");
     const { getCustomerSuccessPortfolio } = await import("@/lib/customer-success/service");


### PR DESCRIPTION
## Summary
- add auth-failure coverage for the linked task route
- verify the route passes through the auth response directly
- verify permission checks and task creation do not run when auth fails

## Testing
- npm test -- src/app/api/customer-success/customer-success-routes.test.ts
- npm run lint -- src/app/api/customer-success/customer-success-routes.test.ts