### PR TITLE
fix(deals): harden workspace loading states

### DIFF
--- a/src/app/api/deals/analytics/route.test.ts
+++ b/src/app/api/deals/analytics/route.test.ts
@@ -1,12 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
 
 const authMock = vi.hoisted(() => vi.fn());
+const enforcePermissionMock = vi.hoisted(() => vi.fn());
 const dealFindManyMock = vi.hoisted(() => vi.fn());
 const dealMeetingFindManyMock = vi.hoisted(() => vi.fn());
 const dealStageHistoryFindManyMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/auth", () => ({
   auth: authMock,
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  enforcePermission: enforcePermissionMock,
 }));
 
 vi.mock("@/lib/prisma", () => ({
@@ -35,6 +41,7 @@ describe("deals analytics route", () => {
       },
     });
 
+    enforcePermissionMock.mockResolvedValue({ role: "member" });
     dealFindManyMock.mockResolvedValue([]);
     dealMeetingFindManyMock.mockResolvedValue([]);
     dealStageHistoryFindManyMock.mockResolvedValue([]);
@@ -46,7 +53,7 @@ describe("deals analytics route", () => {
     );
 
     const { GET } = await import("@/app/api/deals/analytics/route");
-    const response = await GET();
+    const response = await GET(new NextRequest("http://localhost/api/deals/analytics"));
     const body = await response.json();
 
     expect(response.status).toBe(503);
@@ -59,7 +66,7 @@ describe("deals analytics route", () => {
   it("scopes analytics queries to the authenticated organization", async () => {
     const { GET } = await import("@/app/api/deals/analytics/route");
 
-    const response = await GET();
+    const response = await GET(new NextRequest("http://localhost/api/deals/analytics"));
 
     expect(response.status).toBe(200);
     expect(dealFindManyMock).toHaveBeenCalledWith(
@@ -77,5 +84,20 @@ describe("deals analytics route", () => {
         where: { deal: { organizationId: "org-1" } },
       }),
     );
+  });
+
+  it("blocks analytics when read permission is denied", async () => {
+    enforcePermissionMock.mockResolvedValueOnce({
+      role: "observer",
+      deniedResponse: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    });
+
+    const { GET } = await import("@/app/api/deals/analytics/route");
+    const response = await GET(new NextRequest("http://localhost/api/deals/analytics"));
+
+    expect(response.status).toBe(403);
+    expect(dealFindManyMock).not.toHaveBeenCalled();
+    expect(dealMeetingFindManyMock).not.toHaveBeenCalled();
+    expect(dealStageHistoryFindManyMock).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/deals/analytics/route.ts
+++ b/src/app/api/deals/analytics/route.ts
@@ -1,9 +1,11 @@
 export const dynamic = "force-dynamic";
 
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { DealStage, MeetingStatus } from "@/generated/prisma/client";
+import { enforcePermission } from "@/lib/permissions";
+import { getAuthenticatedUser } from "@/lib/session-user";
 import { toDealsErrorResponse } from "@/lib/deals/schema-guard";
 
 const OPEN_STAGES: DealStage[] = [DealStage.LEAD, DealStage.QUALIFIED, DealStage.PROPOSAL, DealStage.NEGOTIATION];
@@ -23,11 +25,22 @@ function daysBetween(a: Date, b: Date): number {
   return Math.abs(b.getTime() - a.getTime()) / (1000 * 60 * 60 * 24);
 }
 
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
     const session = await auth();
-    if (!session?.user) {
+    const user = getAuthenticatedUser(session);
+    if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { deniedResponse } = await enforcePermission({
+      userId: user.id,
+      action: "deals.read",
+      request,
+      targetType: "deal",
+    });
+    if (deniedResponse) {
+      return deniedResponse;
     }
 
     const organizationId = getOptionalOrganizationId(session);

--- a/src/app/api/deals/companies/route.ts
+++ b/src/app/api/deals/companies/route.ts
@@ -4,14 +4,24 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { enforcePermission } from "@/lib/permissions";
+import { getAuthenticatedUser } from "@/lib/session-user";
 import { toDealsErrorResponse } from "@/lib/deals/schema-guard";
 
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
     const session = await auth();
-    if (!session?.user) {
+    const user = getAuthenticatedUser(session);
+    if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+
+    const { deniedResponse } = await enforcePermission({
+      userId: user.id,
+      action: "deals.read",
+      request,
+      targetType: "deal",
+    });
+    if (deniedResponse) return deniedResponse;
 
     const companies = await prisma.dealCompany.findMany({
       include: { _count: { select: { contacts: true, deals: true } } },
@@ -27,12 +37,13 @@ export async function GET(): Promise<NextResponse> {
 export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
     const session = await auth();
-    if (!session?.user) {
+    const user = getAuthenticatedUser(session);
+    if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     const { deniedResponse } = await enforcePermission({
-      userId: session.user.id,
+      userId: user.id,
       action: "deals.write",
       request,
     });

--- a/src/app/api/deals/contacts/route.test.ts
+++ b/src/app/api/deals/contacts/route.test.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 const authMock = vi.hoisted(() => vi.fn());
 const enforcePermissionMock = vi.hoisted(() => vi.fn());
-const dealCompanyFindManyMock = vi.hoisted(() => vi.fn());
+const dealContactFindManyMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/auth", () => ({
   auth: authMock,
@@ -15,13 +15,13 @@ vi.mock("@/lib/permissions", () => ({
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {
-    dealCompany: {
-      findMany: dealCompanyFindManyMock,
+    dealContact: {
+      findMany: dealContactFindManyMock,
     },
   },
 }));
 
-describe("deal companies route", () => {
+describe("deal contacts route", () => {
   beforeEach(() => {
     vi.resetAllMocks();
 
@@ -33,16 +33,16 @@ describe("deal companies route", () => {
     });
 
     enforcePermissionMock.mockResolvedValue({ role: "member" });
-    dealCompanyFindManyMock.mockResolvedValue([]);
+    dealContactFindManyMock.mockResolvedValue([]);
   });
 
   it("returns setup-required when the deals schema is missing", async () => {
-    dealCompanyFindManyMock.mockRejectedValueOnce(
-      new Error("The table `public.DealCompany` does not exist"),
+    dealContactFindManyMock.mockRejectedValueOnce(
+      new Error("The table `public.DealContact` does not exist"),
     );
 
-    const { GET } = await import("@/app/api/deals/companies/route");
-    const response = await GET(new NextRequest("http://localhost/api/deals/companies"));
+    const { GET } = await import("@/app/api/deals/contacts/route");
+    const response = await GET(new NextRequest("http://localhost/api/deals/contacts"));
     const body = await response.json();
 
     expect(response.status).toBe(503);
@@ -52,16 +52,16 @@ describe("deal companies route", () => {
     });
   });
 
-  it("blocks company lookup when read permission is denied", async () => {
+  it("blocks contact lookup when read permission is denied", async () => {
     enforcePermissionMock.mockResolvedValueOnce({
       role: "observer",
       deniedResponse: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
     });
 
-    const { GET } = await import("@/app/api/deals/companies/route");
-    const response = await GET(new NextRequest("http://localhost/api/deals/companies"));
+    const { GET } = await import("@/app/api/deals/contacts/route");
+    const response = await GET(new NextRequest("http://localhost/api/deals/contacts"));
 
     expect(response.status).toBe(403);
-    expect(dealCompanyFindManyMock).not.toHaveBeenCalled();
+    expect(dealContactFindManyMock).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/deals/contacts/route.ts
+++ b/src/app/api/deals/contacts/route.ts
@@ -4,14 +4,24 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { enforcePermission } from "@/lib/permissions";
+import { getAuthenticatedUser } from "@/lib/session-user";
 import { toDealsErrorResponse } from "@/lib/deals/schema-guard";
 
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
     const session = await auth();
-    if (!session?.user) {
+    const user = getAuthenticatedUser(session);
+    if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+
+    const { deniedResponse } = await enforcePermission({
+      userId: user.id,
+      action: "deals.read",
+      request,
+      targetType: "deal",
+    });
+    if (deniedResponse) return deniedResponse;
 
     const contacts = await prisma.dealContact.findMany({
       include: { company: { select: { id: true, name: true } } },
@@ -27,12 +37,13 @@ export async function GET(): Promise<NextResponse> {
 export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
     const session = await auth();
-    if (!session?.user) {
+    const user = getAuthenticatedUser(session);
+    if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     const { deniedResponse } = await enforcePermission({
-      userId: session.user.id,
+      userId: user.id,
       action: "deals.write",
       request,
     });

--- a/src/components/deals/deals-analytics.tsx
+++ b/src/components/deals/deals-analytics.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 import { DashboardLoadingState } from "@/components/dashboard/dashboard-loading-state";
 import { DashboardEmptyState } from "@/components/dashboard/dashboard-empty-state";
@@ -104,6 +105,7 @@ const STAGE_COLORS: Record<string, string> = {
 };
 
 export function DealsAnalytics() {
+  const router = useRouter();
   const [data, setData] = useState<AnalyticsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -142,6 +144,38 @@ export function DealsAnalytics() {
         title={setupRequired ? "Deals setup required" : "Analytics unavailable"}
         message={error ?? (setupRequired ? DEALS_SCHEMA_MISSING_MESSAGE : "No analytics data available.")}
       />
+    );
+  }
+
+  const hasAnalyticsData =
+    data.pipeline.totalDeals > 0 ||
+    data.closeRate.won > 0 ||
+    data.closeRate.lost > 0 ||
+    data.meetings.total > 0 ||
+    data.sourceAttribution.some((entry) => entry.count > 0) ||
+    data.staleDeals.length > 0 ||
+    data.velocity.trend.length > 0 ||
+    data.closeRate.trend.length > 0;
+
+  if (!hasAnalyticsData) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <Link href="/deals" className="icon-btn-muted rounded-md p-2" aria-label="Back to deals">
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+          <div>
+            <h1 className="text-xl font-bold text-foreground">Deals Analytics</h1>
+            <p className="mt-1 text-sm text-muted-foreground">Pipeline health, velocity, and performance metrics.</p>
+          </div>
+        </div>
+        <DashboardEmptyState
+          title="No deals to analyze yet"
+          message="Load pipeline data first by creating a deal or syncing your current pipeline from HubSpot."
+          actionLabel="Open Pipeline View"
+          onAction={() => router.push("/deals")}
+        />
+      </div>
     );
   }
 

--- a/src/components/deals/deals-dashboard.tsx
+++ b/src/components/deals/deals-dashboard.tsx
@@ -59,6 +59,7 @@ export function DealsDashboard() {
   const [createOpen, setCreateOpen] = useState(false);
   const [meetingOpen, setMeetingOpen] = useState(false);
   const [syncing, setSyncing] = useState(false);
+  const [syncError, setSyncError] = useState<string | null>(null);
 
   const resource = useDashboardResource<DealListItem[]>({
     cacheKey: CACHE_KEY,
@@ -110,6 +111,14 @@ export function DealsDashboard() {
     });
   }, [deals, query, stageFilter, ownerFilter, minAmount, maxAmount]);
 
+  const hasActiveFilters = Boolean(
+    stageFilter ||
+      ownerFilter ||
+      query.trim() ||
+      minAmount.trim() ||
+      maxAmount.trim()
+  );
+
   const pipelineColumns = useMemo(() => {
     return OPEN_STAGES.map((stage) => ({
       stage,
@@ -120,12 +129,16 @@ export function DealsDashboard() {
 
   const syncFromHubSpot = async () => {
     setSyncing(true);
+    setSyncError(null);
     try {
       const res = await fetch("/api/deals/sync", { method: "POST" });
-      if (!res.ok) throw new Error("Sync failed");
+      const payload = (await res.json().catch(() => null)) as { error?: string } | null;
+      if (!res.ok) {
+        throw new Error(payload?.error || "Sync failed");
+      }
       await resource.refresh();
-    } catch {
-      // Non-fatal, refresh will show updated state
+    } catch (error) {
+      setSyncError(error instanceof Error ? error.message : "Sync failed");
     } finally {
       setSyncing(false);
     }
@@ -240,6 +253,7 @@ export function DealsDashboard() {
       )}
 
       {resource.error && <DashboardErrorBanner message={resource.error} onRetry={resource.refresh} />}
+      {syncError ? <DashboardErrorBanner message={syncError} onRetry={syncFromHubSpot} /> : null}
 
       {/* Filters + View Toggle */}
       <div className="flex flex-wrap items-center gap-3">
@@ -318,12 +332,21 @@ export function DealsDashboard() {
       {viewMode === "pipeline" && (
         <>
           {filtered.length === 0 ? (
-            <DashboardEmptyState
-              title="No deals match filters"
-              message="Try adjusting filters or create a new deal."
-              actionLabel="New Deal"
-              onAction={() => setCreateOpen(true)}
-            />
+            deals.length === 0 && !hasActiveFilters ? (
+              <DashboardEmptyState
+                title="No deals loaded yet"
+                message="Create a deal manually or pull your current pipeline in from HubSpot."
+                actionLabel={syncing ? "Syncing..." : "Sync from HubSpot"}
+                onAction={syncFromHubSpot}
+              />
+            ) : (
+              <DashboardEmptyState
+                title="No deals match filters"
+                message="Try adjusting filters or create a new deal."
+                actionLabel="New Deal"
+                onAction={() => setCreateOpen(true)}
+              />
+            )
           ) : (
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
               {pipelineColumns.map((col) => (


### PR DESCRIPTION
Summary:
- harden deals workspace API reads with consistent deals.read permission enforcement
- replace misleading zero-data renders with explicit empty states on /deals and /deals/analytics
- surface HubSpot sync failures in the deals dashboard instead of silently swallowing them

Testing:
- npm test for the deals route and stage-transition suites
- npm run lint against the touched deals API and UI files

Notes:
- local Playwright verification of the deals spec passed before branch isolation
- running Playwright from the clean worktree hit a Turbopack node_modules symlink limitation, so branch validation is delegated to GitHub CI after push