### PR TITLE
feat(finance): monthly P&L history + AI executive brief

### DIFF
--- a/src/app/api/analytics/summary/route.ts
+++ b/src/app/api/analytics/summary/route.ts
@@ -151,6 +151,8 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       financeForecast: Boolean(creds.stripeKey || creds.mercuryKey),
       financePnl: Boolean(creds.stripeKey || creds.mercuryKey),
       financeUnitEconomics: Boolean(creds.stripeKey),
+      financeMonthlyHistory: Boolean(creds.stripeKey || creds.mercuryKey),
+      financeAiBrief: Boolean(creds.stripeKey || creds.mercuryKey),
       product: true,
       customerJourney: true,
       visitorFunnel: true,

--- a/src/app/api/financial-planning/ai-analysis/route.ts
+++ b/src/app/api/financial-planning/ai-analysis/route.ts
@@ -1,0 +1,45 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { buildMonthlyPnLHistory } from "@/lib/analytics/monthly-pnl-history";
+import { generateExecutiveAnalysis } from "@/lib/analytics/executive-ai-analysis";
+
+export async function GET(): Promise<NextResponse> {
+  try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const userId = (session.user as { id: string }).id;
+
+    // Build the monthly history, then generate AI analysis from it
+    const history = await buildMonthlyPnLHistory(userId, 12);
+
+    if (history.months.length === 0) {
+      return NextResponse.json(
+        { error: "No monthly financial data available for analysis" },
+        { status: 422 },
+      );
+    }
+
+    const analysis = await generateExecutiveAnalysis(history);
+
+    return NextResponse.json(analysis, {
+      headers: {
+        // Cache for 5 minutes — analysis is expensive
+        "Cache-Control": "private, max-age=300, stale-while-revalidate=600",
+      },
+    });
+  } catch (error) {
+    console.error("GET /api/financial-planning/ai-analysis error:", error);
+
+    const message =
+      error instanceof Error && error.message.includes("OPENAI_API_KEY")
+        ? "AI analysis is not configured. Set OPENAI_API_KEY to enable."
+        : "Failed to generate executive analysis";
+
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/financial-planning/monthly-history/route.ts
+++ b/src/app/api/financial-planning/monthly-history/route.ts
@@ -1,0 +1,32 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { buildMonthlyPnLHistory } from "@/lib/analytics/monthly-pnl-history";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const userId = (session.user as { id: string }).id;
+    const monthsParam = request.nextUrl.searchParams.get("months");
+    const monthsBack = monthsParam ? Math.min(Math.max(parseInt(monthsParam, 10) || 12, 1), 24) : 12;
+
+    const history = await buildMonthlyPnLHistory(userId, monthsBack);
+
+    return NextResponse.json(history, {
+      headers: {
+        "Cache-Control": "private, max-age=60, stale-while-revalidate=300",
+      },
+    });
+  } catch (error) {
+    console.error("GET /api/financial-planning/monthly-history error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch monthly P&L history" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/analytics/analytics-section-page.tsx
+++ b/src/components/analytics/analytics-section-page.tsx
@@ -48,6 +48,8 @@ const FinancePlanningTab = dynamic(() => import("@/components/analytics/finance-
 const FinanceForecastTab = dynamic(() => import("@/components/analytics/finance-forecast-tab").then((m) => m.FinanceForecastTab), { loading: () => <DashboardLoadingState message="Loading section..." className="h-48" /> });
 const FinancePnlTab = dynamic(() => import("@/components/analytics/finance-pnl-tab").then((m) => m.FinancePnlTab), { loading: () => <DashboardLoadingState message="Loading section..." className="h-48" /> });
 const FinanceUnitEconomicsTab = dynamic(() => import("@/components/analytics/finance-unit-economics-tab").then((m) => m.FinanceUnitEconomicsTab), { loading: () => <DashboardLoadingState message="Loading section..." className="h-48" /> });
+const FinanceMonthlyHistoryTab = dynamic(() => import("@/components/analytics/finance-monthly-history-tab").then((m) => m.FinanceMonthlyHistoryTab), { loading: () => <DashboardLoadingState message="Loading section..." className="h-48" /> });
+const ExecutiveAiBrief = dynamic(() => import("@/components/analytics/executive-ai-brief").then((m) => m.ExecutiveAiBrief), { loading: () => <DashboardLoadingState message="Loading section..." className="h-48" /> });
 import type { AnalyticsDashboardData } from "@/lib/analytics/types";
 import { buildRangeQuery } from "@/lib/analytics/time-range";
 import {
@@ -114,6 +116,8 @@ export type AnalyticsChildRenderKind =
   | "finance-forecast"
   | "finance-pnl"
   | "finance-unit-economics"
+  | "finance-monthly-history"
+  | "finance-ai-brief"
   | "snapshot";
 
 const CHILD_ID_TO_RENDER_KIND = {
@@ -125,6 +129,8 @@ const CHILD_ID_TO_RENDER_KIND = {
   "finance-forecast": "finance-forecast",
   "finance-pnl": "finance-pnl",
   "finance-unit-economics": "finance-unit-economics",
+  "finance-monthly-history": "finance-monthly-history",
+  "finance-ai-brief": "finance-ai-brief",
   // Sales
   "sales-hubspot": "sales-hubspot",
   "sales-stripe": "sales-stripe",
@@ -363,6 +369,8 @@ export function AnalyticsSectionPage({ sectionId }: AnalyticsSectionPageProps) {
     if (renderKind === "finance-forecast") return <FinanceForecastTab data={analyticsData} />;
     if (renderKind === "finance-pnl") return <FinancePnlTab data={analyticsData} />;
     if (renderKind === "finance-unit-economics") return <FinanceUnitEconomicsTab data={analyticsData} />;
+    if (renderKind === "finance-monthly-history") return <FinanceMonthlyHistoryTab />;
+    if (renderKind === "finance-ai-brief") return <ExecutiveAiBrief />;
     // Sales
     if (renderKind === "sales-hubspot") return <SalesHubspotTab data={analyticsData} />;
     if (renderKind === "sales-stripe") return <SalesStripeTab data={analyticsData} />;

--- a/src/components/analytics/executive-ai-brief.tsx
+++ b/src/components/analytics/executive-ai-brief.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Brain,
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  Lightbulb,
+  RefreshCw,
+  Loader2,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+import {
+  SectionCard,
+  AlertBanner,
+} from "@/components/analytics/dashboard-primitives";
+import type { ExecutiveAnalysis, TrendItem, RiskItem, RecommendationItem } from "@/lib/analytics/executive-ai-analysis";
+
+/* ── Subcomponents ───────────────────────────────────── */
+
+function TrendBadge({ direction }: { direction: TrendItem["direction"] }) {
+  const config = {
+    improving: { icon: TrendingUp, color: "text-emerald-500 bg-emerald-500/10", label: "Improving" },
+    declining: { icon: TrendingDown, color: "text-red-500 bg-red-500/10", label: "Declining" },
+    stable: { icon: Minus, color: "text-blue-500 bg-blue-500/10", label: "Stable" },
+  }[direction];
+  const Icon = config.icon;
+
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${config.color}`}>
+      <Icon className="h-3 w-3" />
+      {config.label}
+    </span>
+  );
+}
+
+function SeverityBadge({ severity }: { severity: RiskItem["severity"] }) {
+  const config = {
+    critical: "bg-red-500/15 text-red-600 dark:text-red-400 border-red-500/20",
+    warning: "bg-amber-500/15 text-amber-600 dark:text-amber-400 border-amber-500/20",
+    info: "bg-blue-500/15 text-blue-600 dark:text-blue-400 border-blue-500/20",
+  }[severity];
+
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${config}`}>
+      {severity.charAt(0).toUpperCase() + severity.slice(1)}
+    </span>
+  );
+}
+
+function PriorityBadge({ priority }: { priority: RecommendationItem["priority"] }) {
+  const config = {
+    P0: "bg-red-500/15 text-red-600 dark:text-red-400",
+    P1: "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+    P2: "bg-blue-500/15 text-blue-600 dark:text-blue-400",
+  }[priority];
+
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-bold ${config}`}>
+      {priority}
+    </span>
+  );
+}
+
+/* ── Main Component ──────────────────────────────────── */
+
+export function ExecutiveAiBrief() {
+  const [data, setData] = useState<ExecutiveAnalysis | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(true);
+
+  const fetchAnalysis = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/financial-planning/ai-analysis");
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
+        throw new Error(body.error || `HTTP ${res.status}`);
+      }
+      const json = await res.json();
+      setData(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAnalysis();
+  }, []);
+
+  if (loading) {
+    return (
+      <SectionCard title="AI Executive Brief" subtitle="Generating analysis...">
+        <div className="flex h-32 items-center justify-center">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          <span className="ml-2 text-sm text-muted-foreground">Analyzing financial data...</span>
+        </div>
+      </SectionCard>
+    );
+  }
+
+  if (error) {
+    return (
+      <SectionCard title="AI Executive Brief" subtitle="Analysis unavailable">
+        <AlertBanner severity="info" title="AI analysis unavailable" description={error} />
+      </SectionCard>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="space-y-4">
+      {/* Header with collapse toggle */}
+      <div
+        className="flex cursor-pointer items-center justify-between rounded-xl border border-border bg-card p-4 shadow-sm transition-shadow hover:shadow-md"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <div className="flex items-center gap-3">
+          <div className="rounded-lg bg-violet-500/10 p-2">
+            <Brain className="h-5 w-5 text-violet-500" />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-foreground">AI Executive Brief</h3>
+            <p className="text-xs text-muted-foreground">
+              Generated {new Date(data.generatedAt).toLocaleDateString("en-US", { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              fetchAnalysis();
+            }}
+            className="inline-flex items-center gap-1 rounded-md border border-border bg-secondary/40 px-2.5 py-1 text-xs text-foreground hover:bg-secondary/60"
+          >
+            <RefreshCw className="h-3 w-3" />
+            Regenerate
+          </button>
+          {expanded ? <ChevronUp className="h-4 w-4 text-muted-foreground" /> : <ChevronDown className="h-4 w-4 text-muted-foreground" />}
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="space-y-4">
+          {/* Narrative */}
+          <SectionCard title="Executive Summary">
+            <div className="prose prose-sm max-w-none text-foreground dark:prose-invert">
+              {data.narrative.split("\n\n").map((p, i) => (
+                <p key={i} className="text-sm leading-relaxed text-foreground/90">
+                  {p}
+                </p>
+              ))}
+            </div>
+          </SectionCard>
+
+          {/* Trend Analysis */}
+          {data.trendAnalysis.length > 0 && (
+            <SectionCard title="Trend Analysis" subtitle="Key metric trajectories">
+              <div className="space-y-3">
+                {data.trendAnalysis.map((trend, i) => (
+                  <div key={i} className="flex items-start gap-3 rounded-lg border border-border/50 bg-secondary/10 p-3">
+                    <TrendBadge direction={trend.direction} />
+                    <div>
+                      <p className="text-sm font-medium text-foreground">{trend.metric}</p>
+                      <p className="mt-0.5 text-xs text-muted-foreground">{trend.summary}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </SectionCard>
+          )}
+
+          {/* Risks */}
+          {data.risks.length > 0 && (
+            <SectionCard title="Risk Flags" subtitle="Items requiring attention">
+              <div className="space-y-3">
+                {data.risks.map((risk, i) => (
+                  <div key={i} className="flex items-start gap-3 rounded-lg border border-border/50 bg-secondary/10 p-3">
+                    <SeverityBadge severity={risk.severity} />
+                    <div>
+                      <p className="text-sm font-medium text-foreground">{risk.title}</p>
+                      <p className="mt-0.5 text-xs text-muted-foreground">{risk.description}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </SectionCard>
+          )}
+
+          {/* Recommendations */}
+          {data.recommendations.length > 0 && (
+            <SectionCard title="Recommendations" subtitle="Prioritized actions">
+              <div className="space-y-3">
+                {data.recommendations.map((rec, i) => (
+                  <div key={i} className="rounded-lg border border-border/50 bg-secondary/10 p-3">
+                    <div className="flex items-start gap-3">
+                      <PriorityBadge priority={rec.priority} />
+                      <div className="flex-1">
+                        <p className="text-sm font-medium text-foreground">{rec.title}</p>
+                        <p className="mt-0.5 text-xs text-muted-foreground">{rec.description}</p>
+                        <div className="mt-2 flex items-center gap-1.5">
+                          <Lightbulb className="h-3 w-3 text-amber-500" />
+                          <span className="text-xs font-medium text-amber-600 dark:text-amber-400">
+                            Expected: {rec.expectedImpact}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </SectionCard>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/analytics/finance-monthly-history-tab.tsx
+++ b/src/components/analytics/finance-monthly-history-tab.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+import { useEffect, useState, useMemo } from "react";
+import {
+  Calendar,
+  TrendingUp,
+  TrendingDown,
+  RefreshCw,
+  Loader2,
+} from "lucide-react";
+import {
+  fmt$,
+  fmtPct,
+  SectionCard,
+  AlertBanner,
+} from "@/components/analytics/dashboard-primitives";
+import { AreaTrend } from "@/components/charts/area-trend";
+import { SparkLine } from "@/components/charts/spark-line";
+import type { MonthlyPnLEntry, MonthlyPnLHistory } from "@/lib/analytics/monthly-pnl-history";
+
+/* ── Helpers ─────────────────────────────────────────── */
+
+function formatMonth(month: string): string {
+  const [y, m] = month.split("-");
+  const date = new Date(parseInt(y), parseInt(m) - 1);
+  return date.toLocaleDateString("en-US", { month: "short", year: "2-digit" });
+}
+
+function cellColor(diff: number, invertForExpense = false): string {
+  if (diff === 0) return "text-muted-foreground";
+  if (invertForExpense) {
+    return diff < 0 ? "text-emerald-500" : "text-red-500";
+  }
+  return diff > 0 ? "text-emerald-500" : "text-red-500";
+}
+
+function momChange(current: number, previous: number): string {
+  if (previous === 0) return current === 0 ? "—" : "+∞";
+  const pct = ((current - previous) / Math.abs(previous)) * 100;
+  return `${pct >= 0 ? "+" : ""}${pct.toFixed(1)}%`;
+}
+
+/* ── Line Item Row ───────────────────────────────────── */
+
+type LineItemKey =
+  | "revenue"
+  | "cogs"
+  | "grossProfit"
+  | "payroll"
+  | "marketing"
+  | "infrastructure"
+  | "ops"
+  | "totalOpex"
+  | "operatingIncome"
+  | "netIncome";
+
+interface LineItemDef {
+  key: LineItemKey;
+  label: string;
+  isBold: boolean;
+  isExpense: boolean;
+  extract: (entry: MonthlyPnLEntry) => number;
+}
+
+const LINE_ITEMS: LineItemDef[] = [
+  { key: "revenue", label: "Revenue", isBold: false, isExpense: false, extract: (e) => e.revenue },
+  { key: "cogs", label: "Cost of Goods Sold", isBold: false, isExpense: true, extract: (e) => e.cogs },
+  { key: "grossProfit", label: "Gross Profit", isBold: true, isExpense: false, extract: (e) => e.grossProfit },
+  { key: "payroll", label: "  Payroll & Compensation", isBold: false, isExpense: true, extract: (e) => e.operatingExpenses.payroll },
+  { key: "marketing", label: "  Marketing & Sales", isBold: false, isExpense: true, extract: (e) => e.operatingExpenses.marketing },
+  { key: "infrastructure", label: "  Infrastructure & Tools", isBold: false, isExpense: true, extract: (e) => e.operatingExpenses.infrastructure },
+  { key: "ops", label: "  General & Administrative", isBold: false, isExpense: true, extract: (e) => e.operatingExpenses.ops },
+  { key: "totalOpex", label: "Total Operating Expenses", isBold: true, isExpense: true, extract: (e) => e.totalOpex },
+  { key: "operatingIncome", label: "Operating Income", isBold: true, isExpense: false, extract: (e) => e.operatingIncome },
+  { key: "netIncome", label: "Net Income", isBold: true, isExpense: false, extract: (e) => e.netIncome },
+];
+
+/* ── KPI Summary Row ─────────────────────────────────── */
+
+interface KpiDef {
+  label: string;
+  extract: (entry: MonthlyPnLEntry) => number | null;
+  format: (v: number) => string;
+}
+
+const KPI_ROWS: KpiDef[] = [
+  { label: "MRR", extract: (e) => e.mrr, format: (v) => fmt$(v) },
+  { label: "Gross Margin", extract: (e) => e.grossMarginPct, format: (v) => fmtPct(v) },
+  { label: "Operating Margin", extract: (e) => e.operatingMarginPct, format: (v) => fmtPct(v) },
+  { label: "Cash Balance", extract: (e) => e.cashBalance, format: (v) => fmt$(v) },
+  { label: "Monthly Burn", extract: (e) => e.burnRate, format: (v) => fmt$(v) },
+  { label: "Active Subs", extract: (e) => e.activeSubscriptions, format: (v) => v.toLocaleString() },
+  { label: "Churn Rate", extract: (e) => e.churnRate, format: (v) => fmtPct(v) },
+];
+
+/* ── Component ───────────────────────────────────────── */
+
+export function FinanceMonthlyHistoryTab() {
+  const [data, setData] = useState<MonthlyPnLHistory | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/financial-planning/monthly-history?months=12");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json();
+      setData(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const months = useMemo(() => data?.months ?? [], [data]);
+
+  // Revenue trend data for chart
+  const revenueTrendData = useMemo(
+    () => months.map((m) => ({ month: formatMonth(m.month), revenue: m.revenue, netIncome: m.netIncome })),
+    [months],
+  );
+
+  if (loading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        <span className="ml-2 text-sm text-muted-foreground">Loading monthly history...</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <AlertBanner
+        severity="warning"
+        title="Failed to load monthly history"
+        description={error}
+      />
+    );
+  }
+
+  if (months.length === 0) {
+    return (
+      <div className="flex h-64 flex-col items-center justify-center rounded-lg border border-dashed border-border/60 bg-secondary/20 text-center">
+        <Calendar className="mb-3 h-8 w-8 text-muted-foreground/50" />
+        <p className="text-sm font-medium text-muted-foreground">No monthly data available</p>
+        <p className="mt-1 text-xs text-muted-foreground/70">
+          Monthly snapshots will appear after Stripe and Mercury integrations have been connected for at least one billing cycle.
+        </p>
+      </div>
+    );
+  }
+
+  const mom = data?.latestMoM;
+
+  return (
+    <div className="space-y-6">
+      {/* MoM Summary Alerts */}
+      {mom && (
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <MomKpiCard
+            label="Revenue MoM"
+            value={mom.revenueChangePct}
+            delta={fmt$(mom.revenueChange)}
+            positive={mom.revenueChange >= 0}
+          />
+          <MomKpiCard
+            label="Net Income MoM"
+            value={mom.netIncomeChangePct}
+            delta={fmt$(mom.netIncomeChange)}
+            positive={mom.netIncomeChange >= 0}
+          />
+          <MomKpiCard
+            label="Gross Margin MoM"
+            value={mom.grossMarginChange}
+            delta={`${mom.grossMarginChange >= 0 ? "+" : ""}${mom.grossMarginChange.toFixed(1)}pp`}
+            positive={mom.grossMarginChange >= 0}
+            suffix="pp"
+          />
+          {mom.burnRateChange != null && (
+            <MomKpiCard
+              label="Burn Rate MoM"
+              value={0}
+              delta={fmt$(mom.burnRateChange)}
+              positive={mom.burnRateChange <= 0}
+              invertColors
+            />
+          )}
+        </div>
+      )}
+
+      {/* Revenue & Net Income Trend Chart */}
+      {revenueTrendData.length >= 2 && (
+        <SectionCard title="Revenue & Net Income Trend" subtitle="Monthly trajectory">
+          <AreaTrend
+            data={revenueTrendData}
+            xKey="month"
+            yKeys={["revenue", "netIncome"]}
+            height={220}
+            yFormatter={(v) => fmt$(v)}
+          />
+        </SectionCard>
+      )}
+
+      {/* Monthly P&L Table */}
+      <SectionCard
+        title="Monthly P&L Statement"
+        subtitle={`${formatMonth(months[0].month)} — ${formatMonth(months[months.length - 1].month)}`}
+      >
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-xs uppercase tracking-wider text-muted-foreground">
+                <th className="sticky left-0 bg-card pb-2 pr-4 text-left font-medium">Line Item</th>
+                {months.map((m) => (
+                  <th key={m.month} className="pb-2 pr-4 text-right font-medium last:pr-0">
+                    {formatMonth(m.month)}
+                  </th>
+                ))}
+                <th className="pb-2 text-right font-medium">Trend</th>
+              </tr>
+            </thead>
+            <tbody>
+              {LINE_ITEMS.map((item) => {
+                const values = months.map(item.extract);
+                const borderClass = item.isBold ? "border-t border-border" : "";
+                return (
+                  <tr key={item.key} className={`${borderClass} hover:bg-secondary/20`}>
+                    <td className={`sticky left-0 bg-card py-2 pr-4 ${item.isBold ? "font-semibold text-foreground" : "text-foreground"}`}>
+                      {item.label}
+                    </td>
+                    {values.map((v, i) => {
+                      const prev = i > 0 ? values[i - 1] : v;
+                      const diff = v - prev;
+                      const color = i > 0 ? cellColor(diff, item.isExpense) : "text-foreground";
+                      const display = item.isExpense && v > 0 ? `-${fmt$(v)}` : fmt$(v);
+                      return (
+                        <td key={months[i].month} className={`py-2 pr-4 text-right tabular-nums last:pr-0 ${item.isBold ? "font-semibold" : ""}`}>
+                          <span className={i > 0 && diff !== 0 ? color : "text-foreground"}>{display}</span>
+                          {i > 0 && (
+                            <span className={`block text-[10px] ${color}`}>
+                              {momChange(v, prev)}
+                            </span>
+                          )}
+                        </td>
+                      );
+                    })}
+                    <td className="py-2 text-right">
+                      {values.length >= 2 && (
+                        <SparkLine data={values} width={64} height={20} />
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </SectionCard>
+
+      {/* Key Metrics History */}
+      <SectionCard title="Key Metrics History" subtitle="Monthly operating metrics">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-xs uppercase tracking-wider text-muted-foreground">
+                <th className="sticky left-0 bg-card pb-2 pr-4 text-left font-medium">Metric</th>
+                {months.map((m) => (
+                  <th key={m.month} className="pb-2 pr-4 text-right font-medium last:pr-0">
+                    {formatMonth(m.month)}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {KPI_ROWS.map((kpi) => {
+                const values = months.map(kpi.extract);
+                const hasData = values.some((v) => v != null);
+                if (!hasData) return null;
+                return (
+                  <tr key={kpi.label} className="hover:bg-secondary/20">
+                    <td className="sticky left-0 bg-card py-2 pr-4 text-foreground">{kpi.label}</td>
+                    {values.map((v, i) => (
+                      <td key={months[i].month} className="py-2 pr-4 text-right tabular-nums last:pr-0 text-foreground">
+                        {v != null ? kpi.format(v) : "—"}
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </SectionCard>
+
+      {/* Refresh */}
+      <div className="flex justify-end">
+        <button
+          onClick={fetchData}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-secondary/40 px-3 py-1.5 text-xs text-foreground hover:bg-secondary/60"
+        >
+          <RefreshCw className="h-3 w-3" />
+          Refresh
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ── MoM KPI Card ────────────────────────────────────── */
+
+function MomKpiCard({
+  label,
+  value,
+  delta,
+  positive,
+  invertColors = false,
+  suffix = "%",
+}: {
+  label: string;
+  value: number;
+  delta: string;
+  positive: boolean;
+  invertColors?: boolean;
+  suffix?: string;
+}) {
+  const isGood = invertColors ? !positive : positive;
+  const color = isGood ? "text-emerald-500" : "text-red-500";
+  const Icon = positive ? TrendingUp : TrendingDown;
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-4 shadow-sm">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <div className="mt-1 flex items-end gap-2">
+        <Icon className={`h-4 w-4 ${color}`} />
+        <span className={`text-lg font-bold tabular-nums ${color}`}>
+          {value >= 0 ? "+" : ""}{value.toFixed(1)}{suffix}
+        </span>
+      </div>
+      <p className="mt-0.5 text-xs text-muted-foreground">{delta}</p>
+    </div>
+  );
+}

--- a/src/components/analytics/finance-tab.tsx
+++ b/src/components/analytics/finance-tab.tsx
@@ -21,6 +21,7 @@ import { fmtDelta, fmtMonths, fmtRatio, runwayColor, ltvCacSeverity } from "@/li
 import { StatCard } from "./stat-card";
 import { RingStat } from "./bar-display";
 import { FinanceDataEmptyState } from "./finance-empty-state";
+import { ExecutiveAiBrief } from "./executive-ai-brief";
 
 interface FinanceTabProps {
   data: AnalyticsDashboardData | null;
@@ -225,6 +226,11 @@ export function FinanceTab({ data }: FinanceTabProps) {
           icon={TrendingDown}
         />
       </div>
+
+      {/* ═══════════════════════════════════════════════════════════ */}
+      {/* AI EXECUTIVE BRIEF                                        */}
+      {/* ═══════════════════════════════════════════════════════════ */}
+      <ExecutiveAiBrief />
 
       {/* ═══════════════════════════════════════════════════════════ */}
       {/* UNIT ECONOMICS                                            */}

--- a/src/lib/analytics/executive-ai-analysis.ts
+++ b/src/lib/analytics/executive-ai-analysis.ts
@@ -1,0 +1,175 @@
+// Executive AI Analysis — generates narrative financial analysis and
+// recommendations from monthly P&L history and current KPIs using an LLM.
+
+import OpenAI from "openai";
+import type { MonthlyPnLHistory } from "./monthly-pnl-history";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ExecutiveAnalysis {
+  /** 2-3 paragraph executive narrative */
+  narrative: string;
+  /** Revenue, margin, and expense trends */
+  trendAnalysis: TrendItem[];
+  /** Prioritized risk flags */
+  risks: RiskItem[];
+  /** Actionable recommendations */
+  recommendations: RecommendationItem[];
+  /** ISO timestamp of when this analysis was generated */
+  generatedAt: string;
+}
+
+export interface TrendItem {
+  metric: string;
+  direction: "improving" | "declining" | "stable";
+  summary: string;
+}
+
+export interface RiskItem {
+  severity: "critical" | "warning" | "info";
+  title: string;
+  description: string;
+}
+
+export interface RecommendationItem {
+  priority: "P0" | "P1" | "P2";
+  title: string;
+  description: string;
+  expectedImpact: string;
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI client
+// ---------------------------------------------------------------------------
+
+let client: OpenAI | null = null;
+
+function getClient(): OpenAI {
+  const apiKey = process.env.OPENAI_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is not configured — executive AI analysis unavailable");
+  }
+  if (!client) {
+    client = new OpenAI({ apiKey });
+  }
+  return client;
+}
+
+// ---------------------------------------------------------------------------
+// Prompt builder
+// ---------------------------------------------------------------------------
+
+function buildFinancialContext(history: MonthlyPnLHistory): string {
+  const months = history.months;
+  if (months.length === 0) return "No monthly financial data available.";
+
+  const latest = months[months.length - 1];
+  const lines: string[] = [];
+
+  lines.push(`## Monthly P&L History (${months.length} months)\n`);
+  lines.push("| Month | Revenue | COGS | Gross Profit | Gross Margin | OpEx | Net Income | MRR | Cash | Burn Rate | Churn |");
+  lines.push("|-------|---------|------|-------------|-------------|------|-----------|-----|------|-----------|-------|");
+
+  for (const m of months) {
+    lines.push(
+      `| ${m.month} | $${m.revenue.toLocaleString()} | $${m.cogs.toLocaleString()} | $${m.grossProfit.toLocaleString()} | ${m.grossMarginPct}% | $${m.totalOpex.toLocaleString()} | $${m.netIncome.toLocaleString()} | ${m.mrr != null ? `$${m.mrr.toLocaleString()}` : "N/A"} | ${m.cashBalance != null ? `$${m.cashBalance.toLocaleString()}` : "N/A"} | ${m.burnRate != null ? `$${m.burnRate.toLocaleString()}` : "N/A"} | ${m.churnRate != null ? `${m.churnRate.toFixed(1)}%` : "N/A"} |`,
+    );
+  }
+
+  if (history.latestMoM) {
+    const mom = history.latestMoM;
+    lines.push(`\n## Latest Month-over-Month Changes`);
+    lines.push(`- Revenue: ${mom.revenueChangePct >= 0 ? "+" : ""}${mom.revenueChangePct}% ($${mom.revenueChange.toLocaleString()})`);
+    lines.push(`- Net Income: ${mom.netIncomeChangePct >= 0 ? "+" : ""}${mom.netIncomeChangePct}% ($${mom.netIncomeChange.toLocaleString()})`);
+    lines.push(`- Gross Margin: ${mom.grossMarginChange >= 0 ? "+" : ""}${mom.grossMarginChange}pp`);
+    if (mom.burnRateChange != null) {
+      lines.push(`- Burn Rate: ${mom.burnRateChange >= 0 ? "+" : ""}$${mom.burnRateChange.toLocaleString()}`);
+    }
+  }
+
+  // Expense breakdown for latest month
+  lines.push(`\n## Latest Month Expense Breakdown (${latest.month})`);
+  lines.push(`- Payroll & Compensation: $${latest.operatingExpenses.payroll.toLocaleString()}`);
+  lines.push(`- Marketing & Sales: $${latest.operatingExpenses.marketing.toLocaleString()}`);
+  lines.push(`- Infrastructure & Tools: $${latest.operatingExpenses.infrastructure.toLocaleString()}`);
+  lines.push(`- General & Administrative: $${latest.operatingExpenses.ops.toLocaleString()}`);
+
+  return lines.join("\n");
+}
+
+const SYSTEM_PROMPT = `You are a senior financial analyst providing an executive briefing for a startup CEO.
+You analyze monthly P&L statements, operating metrics, and financial trends to provide actionable insights.
+
+Your analysis must be:
+- Data-driven: cite specific numbers and trends from the data
+- Concise: executives have limited time
+- Actionable: every insight should lead to a clear next step
+- Honest: flag real risks without sugarcoating
+
+Respond ONLY with valid JSON matching this schema:
+{
+  "narrative": "2-3 paragraph executive summary of financial performance, what happened, why it matters, and top priorities",
+  "trendAnalysis": [
+    { "metric": "string", "direction": "improving|declining|stable", "summary": "1-2 sentence explanation" }
+  ],
+  "risks": [
+    { "severity": "critical|warning|info", "title": "short title", "description": "1-2 sentence explanation" }
+  ],
+  "recommendations": [
+    { "priority": "P0|P1|P2", "title": "short title", "description": "what to do", "expectedImpact": "expected outcome" }
+  ]
+}
+
+Guidelines:
+- Include 3-5 trend items covering revenue, margins, burn, churn, and cash
+- Include 2-4 risks ranked by severity
+- Include 3-5 recommendations ranked by priority (P0 = do this week)
+- Narrative should be 2-3 paragraphs, professional but direct
+- If data is limited (few months), note that projections have low confidence`;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function generateExecutiveAnalysis(
+  history: MonthlyPnLHistory,
+): Promise<ExecutiveAnalysis> {
+  const client = getClient();
+  const financialContext = buildFinancialContext(history);
+
+  const response = await client.chat.completions.create({
+    model: "gpt-4o",
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      {
+        role: "user",
+        content: `Analyze the following financial data and provide your executive briefing:\n\n${financialContext}`,
+      },
+    ],
+    temperature: 0.3,
+    max_tokens: 2000,
+    response_format: { type: "json_object" },
+  });
+
+  const content = response.choices[0]?.message?.content;
+  if (!content) {
+    throw new Error("Empty response from AI analysis");
+  }
+
+  const parsed = JSON.parse(content) as {
+    narrative: string;
+    trendAnalysis: TrendItem[];
+    risks: RiskItem[];
+    recommendations: RecommendationItem[];
+  };
+
+  return {
+    narrative: parsed.narrative,
+    trendAnalysis: parsed.trendAnalysis ?? [],
+    risks: parsed.risks ?? [],
+    recommendations: parsed.recommendations ?? [],
+    generatedAt: new Date().toISOString(),
+  };
+}

--- a/src/lib/analytics/insight-engine.ts
+++ b/src/lib/analytics/insight-engine.ts
@@ -484,6 +484,12 @@ function buildFinanceInsights(data: AnalyticsDashboardData): AiInsight[] {
   // 10. Revenue vs. forecast gap
   insights.push(...buildRevenueVsForecastInsights(data, financeStale));
 
+  // 11. Expense growth outpacing revenue growth
+  insights.push(...buildExpenseRevenueGrowthDivergenceInsights(data, financeStale));
+
+  // 12. Multi-month revenue trend pattern detection
+  insights.push(...buildRevenueTrendPatternInsights(data, financeStale));
+
   return insights;
 }
 
@@ -901,6 +907,175 @@ function buildRevenueVsForecastInsights(
       ],
     },
   ];
+}
+
+// ── Expense vs Revenue Growth Divergence ────────────────
+
+function buildExpenseRevenueGrowthDivergenceInsights(
+  data: AnalyticsDashboardData,
+  stale: boolean,
+): AiInsight[] {
+  const revenueGrowth = data.stripe?.revenue?.revenueGrowth ?? 0;
+  const outflows = data.mercury?.cashFlow?.outflows30d ?? 0;
+  const revenue = data.stripe?.revenue?.totalRevenue30d ?? 0;
+
+  // If expenses are growing faster than revenue (expense ratio worsening)
+  // We detect this when burn rate exceeds 80% of revenue while revenue growth is below 10%
+  if (revenue > 0 && outflows > 0 && outflows > revenue * 0.8 && revenueGrowth < 10) {
+    const expenseRatio = (outflows / revenue) * 100;
+    return [
+      {
+        id: "ai-finance-expense-revenue-divergence",
+        section: "finance" as const,
+        subsectionId: "finance-pnl",
+        severity: expenseRatio > 100 ? ("critical" as const) : ("warning" as const),
+        title: "Expenses growing faster than revenue",
+        why: `Expense-to-revenue ratio is ${expenseRatio.toFixed(0)}% with revenue growth at only ${revenueGrowth.toFixed(1)}%. Operating expenses of $${outflows.toLocaleString()} are ${expenseRatio > 100 ? "exceeding" : "approaching"} revenue of $${revenue.toLocaleString()}.`,
+        confidence: clampConfidence(0.83),
+        expectedImpact: "Correcting the divergence by 10% extends runway and improves path to profitability.",
+        stale,
+        evidence: [
+          {
+            source: "Stripe + Mercury",
+            domain: "stripe" as const,
+            metric: "Expense/Revenue Ratio",
+            value: `${expenseRatio.toFixed(0)}%`,
+            delta: `Revenue growth: ${revenueGrowth.toFixed(1)}%`,
+          },
+        ],
+        actions: [
+          {
+            type: "create_task",
+            label: "Conduct expense audit and identify reduction targets",
+            payload: {
+              title: "Expense-to-revenue ratio audit",
+              priority: "P1",
+              status: "QUEUED",
+            },
+          },
+        ],
+      },
+    ];
+  }
+
+  return [];
+}
+
+// ── Revenue Trend Pattern Detection ─────────────────────
+
+function buildRevenueTrendPatternInsights(
+  data: AnalyticsDashboardData,
+  stale: boolean,
+): AiInsight[] {
+  const trend = data.stripe?.revenueTrend ?? [];
+  if (trend.length < 3) return [];
+
+  const insights: AiInsight[] = [];
+  const values = trend.map((t) => t.revenue);
+
+  // Detect consecutive decline (3+ months)
+  let consecutiveDeclines = 0;
+  for (let i = 1; i < values.length; i++) {
+    if (values[i] < values[i - 1]) {
+      consecutiveDeclines++;
+    } else {
+      consecutiveDeclines = 0;
+    }
+  }
+
+  if (consecutiveDeclines >= 3) {
+    const firstDecline = values[values.length - consecutiveDeclines - 1];
+    const latest = values[values.length - 1];
+    const totalDrop = firstDecline > 0 ? ((firstDecline - latest) / firstDecline * 100).toFixed(1) : "N/A";
+
+    insights.push({
+      id: "ai-finance-consecutive-revenue-decline",
+      section: "finance" as const,
+      subsectionId: "finance-stripe",
+      severity: consecutiveDeclines >= 4 ? ("critical" as const) : ("warning" as const),
+      title: `Revenue declining for ${consecutiveDeclines} consecutive months`,
+      why: `Revenue has declined each month for ${consecutiveDeclines} months, a total drop of ${totalDrop}%. This pattern suggests a structural issue rather than seasonal variation.`,
+      confidence: clampConfidence(0.88),
+      expectedImpact: "Identifying and addressing the root cause (churn, pricing, acquisition) is critical to stabilize MRR.",
+      stale,
+      evidence: [
+        {
+          source: "Stripe",
+          domain: "stripe" as const,
+          metric: "Revenue Trend",
+          value: `${consecutiveDeclines}-month decline`,
+          delta: `-${totalDrop}% total`,
+          trendValues: values,
+        },
+      ],
+      actions: [
+        {
+          type: "create_task",
+          label: "Investigate revenue decline root cause",
+          payload: {
+            title: "Multi-month revenue decline investigation",
+            priority: "P0",
+            status: "WORKING_ON_TODAY",
+          },
+        },
+      ],
+    });
+  }
+
+  // Detect accelerating growth (3+ months of increasing MoM growth rate)
+  if (values.length >= 4) {
+    const growthRates: number[] = [];
+    for (let i = 1; i < values.length; i++) {
+      growthRates.push(values[i - 1] > 0 ? ((values[i] - values[i - 1]) / values[i - 1]) * 100 : 0);
+    }
+
+    let accelerating = 0;
+    for (let i = 1; i < growthRates.length; i++) {
+      if (growthRates[i] > growthRates[i - 1] && growthRates[i] > 0) {
+        accelerating++;
+      } else {
+        accelerating = 0;
+      }
+    }
+
+    if (accelerating >= 3) {
+      const latestGrowth = growthRates[growthRates.length - 1];
+      insights.push({
+        id: "ai-finance-accelerating-growth",
+        section: "finance" as const,
+        subsectionId: "finance-stripe",
+        severity: "info" as const,
+        title: "Revenue growth accelerating — consider scaling investment",
+        why: `MoM revenue growth has accelerated for ${accelerating} consecutive months, reaching ${latestGrowth.toFixed(1)}%. This signals strong product-market fit momentum.`,
+        confidence: clampConfidence(0.80),
+        expectedImpact: "Scaling acquisition spend during acceleration can compound growth before the inflection point.",
+        stale,
+        evidence: [
+          {
+            source: "Stripe",
+            domain: "stripe" as const,
+            metric: "MoM Growth Rate",
+            value: `${latestGrowth.toFixed(1)}%`,
+            delta: `Accelerating for ${accelerating} months`,
+            trendValues: values,
+          },
+        ],
+        actions: [
+          {
+            type: "create_task",
+            label: "Evaluate scaling acquisition spend",
+            payload: {
+              title: "Growth acceleration opportunity assessment",
+              priority: "P1",
+              status: "QUEUED",
+            },
+          },
+        ],
+      });
+    }
+  }
+
+  return insights;
 }
 
 // ── Sales & Pipeline ─────────────────────────────────────

--- a/src/lib/analytics/monthly-pnl-history.ts
+++ b/src/lib/analytics/monthly-pnl-history.ts
@@ -1,0 +1,207 @@
+// Monthly P&L History — builds month-by-month P&L statements from historical
+// AnalyticsSnapshot records for Stripe and Mercury providers.
+
+import { prisma } from "@/lib/prisma";
+import { AnalyticsSnapshotStatus } from "@/generated/prisma/client";
+import { buildProfitAndLossCore } from "./pnl-builder";
+import { normalizeMercuryDataPayload } from "./mercury-normalization";
+import { resolveIntegrationOwnerUserId } from "@/lib/integrations/ownership";
+import type { StripeData, MercuryData, PnLRow } from "./types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MonthlyPnLEntry {
+  /** ISO month string, e.g. "2026-03" */
+  month: string;
+  revenue: number;
+  cogs: number;
+  grossProfit: number;
+  grossMarginPct: number;
+  operatingExpenses: {
+    payroll: number;
+    marketing: number;
+    infrastructure: number;
+    ops: number;
+  };
+  totalOpex: number;
+  operatingIncome: number;
+  operatingMarginPct: number;
+  netIncome: number;
+  /** Mercury cash balance at snapshot time */
+  cashBalance: number | null;
+  /** Mercury burn rate at snapshot time */
+  burnRate: number | null;
+  /** Stripe MRR at snapshot time */
+  mrr: number | null;
+  /** Stripe active subscriptions at snapshot time */
+  activeSubscriptions: number | null;
+  /** Stripe churn rate at snapshot time */
+  churnRate: number | null;
+}
+
+export interface MonthlyPnLHistory {
+  months: MonthlyPnLEntry[];
+  /** Summary MoM changes for the most recent two months */
+  latestMoM: {
+    revenueChange: number;
+    revenueChangePct: number;
+    netIncomeChange: number;
+    netIncomeChangePct: number;
+    grossMarginChange: number;
+    burnRateChange: number | null;
+  } | null;
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot loading
+// ---------------------------------------------------------------------------
+
+interface MonthlySnapshot {
+  month: string;
+  stripe: StripeData | null;
+  mercury: MercuryData | null;
+}
+
+async function loadMonthlySnapshots(
+  userId: string,
+  monthsBack: number,
+): Promise<MonthlySnapshot[]> {
+  const now = new Date();
+  const cutoff = new Date(now.getFullYear(), now.getMonth() - monthsBack, 1);
+
+  // Fetch all successful snapshots for stripe and mercury since cutoff
+  const snapshots = await prisma.analyticsSnapshot.findMany({
+    where: {
+      userId,
+      providerKey: { in: ["stripe", "mercury"] },
+      status: AnalyticsSnapshotStatus.SUCCESS,
+      capturedAt: { gte: cutoff },
+    },
+    orderBy: { capturedAt: "desc" },
+    select: {
+      providerKey: true,
+      payload: true,
+      capturedAt: true,
+    },
+  });
+
+  // Group by month, taking the latest snapshot per provider per month
+  const monthMap = new Map<string, { stripe: StripeData | null; mercury: MercuryData | null }>();
+
+  for (const snap of snapshots) {
+    const month = `${snap.capturedAt.getFullYear()}-${String(snap.capturedAt.getMonth() + 1).padStart(2, "0")}`;
+    if (!monthMap.has(month)) {
+      monthMap.set(month, { stripe: null, mercury: null });
+    }
+    const entry = monthMap.get(month)!;
+    // Only take the first (latest due to desc ordering) per provider per month
+    if (snap.providerKey === "stripe" && !entry.stripe) {
+      entry.stripe = snap.payload as StripeData | null;
+    }
+    if (snap.providerKey === "mercury" && !entry.mercury) {
+      entry.mercury = snap.payload as MercuryData | null;
+    }
+  }
+
+  // Sort months chronologically
+  const sortedMonths = [...monthMap.entries()].sort(([a], [b]) => a.localeCompare(b));
+
+  return sortedMonths.map(([month, data]) => ({
+    month,
+    stripe: data.stripe,
+    mercury: data.mercury ? normalizeMercuryDataPayload(data.mercury) : null,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// P&L builder per month
+// ---------------------------------------------------------------------------
+
+function pnlRowValue(row: PnLRow): number {
+  return row.currentPeriod;
+}
+
+function buildMonthEntry(
+  month: string,
+  stripe: StripeData | null,
+  mercury: MercuryData | null,
+): MonthlyPnLEntry {
+  const pnl = buildProfitAndLossCore(stripe, mercury);
+
+  const revenue = pnlRowValue(pnl.revenue);
+  const grossProfit = pnlRowValue(pnl.grossProfit);
+  const operatingIncome = pnlRowValue(pnl.operatingIncome);
+
+  const opexMap: Record<string, number> = {};
+  for (const row of pnl.operatingExpenses) {
+    if (row.label.includes("Payroll")) opexMap.payroll = pnlRowValue(row);
+    else if (row.label.includes("Marketing")) opexMap.marketing = pnlRowValue(row);
+    else if (row.label.includes("Infrastructure")) opexMap.infrastructure = pnlRowValue(row);
+    else if (row.label.includes("General")) opexMap.ops = pnlRowValue(row);
+  }
+
+  return {
+    month,
+    revenue,
+    cogs: pnlRowValue(pnl.cogs),
+    grossProfit,
+    grossMarginPct: revenue === 0 ? 0 : Math.round((grossProfit / revenue) * 1000) / 10,
+    operatingExpenses: {
+      payroll: opexMap.payroll ?? 0,
+      marketing: opexMap.marketing ?? 0,
+      infrastructure: opexMap.infrastructure ?? 0,
+      ops: opexMap.ops ?? 0,
+    },
+    totalOpex: pnlRowValue(pnl.totalOpex),
+    operatingIncome,
+    operatingMarginPct: revenue === 0 ? 0 : Math.round((operatingIncome / revenue) * 1000) / 10,
+    netIncome: pnlRowValue(pnl.netIncome),
+    cashBalance: mercury?.cashFlow?.totalBalance ?? null,
+    burnRate: mercury?.cashFlow?.burnRate ?? null,
+    mrr: stripe?.revenue?.mrr ?? null,
+    activeSubscriptions: stripe?.subscriptions?.active ?? null,
+    churnRate: stripe?.subscriptions?.churnRate ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+function pctChange(current: number, previous: number): number {
+  if (previous === 0) return current === 0 ? 0 : 100;
+  return Math.round(((current - previous) / Math.abs(previous)) * 1000) / 10;
+}
+
+export async function buildMonthlyPnLHistory(
+  sessionUserId: string,
+  monthsBack = 12,
+): Promise<MonthlyPnLHistory> {
+  const userId = resolveIntegrationOwnerUserId(sessionUserId);
+  const snapshots = await loadMonthlySnapshots(userId, monthsBack);
+
+  const months = snapshots.map((s) =>
+    buildMonthEntry(s.month, s.stripe, s.mercury),
+  );
+
+  let latestMoM: MonthlyPnLHistory["latestMoM"] = null;
+  if (months.length >= 2) {
+    const curr = months[months.length - 1];
+    const prev = months[months.length - 2];
+    latestMoM = {
+      revenueChange: Math.round((curr.revenue - prev.revenue) * 100) / 100,
+      revenueChangePct: pctChange(curr.revenue, prev.revenue),
+      netIncomeChange: Math.round((curr.netIncome - prev.netIncome) * 100) / 100,
+      netIncomeChangePct: pctChange(curr.netIncome, prev.netIncome),
+      grossMarginChange: Math.round((curr.grossMarginPct - prev.grossMarginPct) * 10) / 10,
+      burnRateChange:
+        curr.burnRate != null && prev.burnRate != null
+          ? Math.round((curr.burnRate - prev.burnRate) * 100) / 100
+          : null,
+    };
+  }
+
+  return { months, latestMoM };
+}

--- a/src/lib/analytics/section-registry.ts
+++ b/src/lib/analytics/section-registry.ts
@@ -8,6 +8,14 @@ export type AnalyticsPrimarySectionId =
   | "demo-analytics"
   | "process-analytics";
 
+export type FinanceDataDomain =
+  | "financePlanning"
+  | "financeForecast"
+  | "financePnl"
+  | "financeUnitEconomics"
+  | "financeMonthlyHistory"
+  | "financeAiBrief";
+
 export interface AnalyticsPrimarySection {
   id: AnalyticsPrimarySectionId;
   label: string;
@@ -44,7 +52,9 @@ export interface AnalyticsSubSection {
     | "financePlanning"
     | "financeForecast"
     | "financePnl"
-    | "financeUnitEconomics";
+    | "financeUnitEconomics"
+    | "financeMonthlyHistory"
+    | "financeAiBrief";
 }
 
 export const ANALYTICS_PRIMARY_SECTIONS: AnalyticsPrimarySection[] = [
@@ -114,6 +124,8 @@ export const ANALYTICS_SUB_SECTIONS: AnalyticsSubSection[] = [
   { id: "finance-forecast", label: "Forecasts", path: "/analytics/finance-forecast", parentId: "finance", dataDomain: "financeForecast" },
   { id: "finance-pnl", label: "P&L", path: "/analytics/finance-pnl", parentId: "finance", dataDomain: "financePnl" },
   { id: "finance-unit-economics", label: "Unit Economics", path: "/analytics/finance-unit-economics", parentId: "finance", dataDomain: "financeUnitEconomics" },
+  { id: "finance-monthly-history", label: "Monthly History", path: "/analytics/finance-monthly-history", parentId: "finance", dataDomain: "financeMonthlyHistory" },
+  { id: "finance-ai-brief", label: "AI Executive Brief", path: "/analytics/finance-ai-brief", parentId: "finance", dataDomain: "financeAiBrief" },
 
   { id: "sales-hubspot", label: "HubSpot", path: "/analytics/sales-hubspot", parentId: "sales-pipeline", dataDomain: "hubspot" },
   { id: "sales-stripe", label: "Stripe", path: "/analytics/sales-stripe", parentId: "sales-pipeline", dataDomain: "stripe" },
@@ -207,4 +219,6 @@ export const LEGACY_ANALYTICS_ROUTE_REDIRECTS: Record<string, string> = {
   "finance-forecast": "/analytics/finance-forecast",
   "finance-pnl": "/analytics/finance-pnl",
   "finance-unit-economics": "/analytics/finance-unit-economics",
+  "finance-monthly-history": "/analytics/finance-monthly-history",
+  "finance-ai-brief": "/analytics/finance-ai-brief",
 };


### PR DESCRIPTION
## Summary
- **Monthly P&L History** — API route and full table component showing up to 12 months of P&L statements (revenue, COGS, gross profit, opex breakdown, net income) with MoM change indicators and sparklines per row
- **AI Executive Brief** — GPT-4o-powered analysis generating executive narrative, trend analysis, risk flags (severity-ranked), and prioritized recommendations with expected impact
- **Enhanced Insight Engine** — Two new multi-month finance insights: expense/revenue growth divergence detection and consecutive revenue decline/accelerating growth pattern detection
- **New Finance Sub-Tabs** — "Monthly History" and "AI Executive Brief" wired into analytics section routing

## New Files
- `src/lib/analytics/monthly-pnl-history.ts` — queries AnalyticsSnapshot for monthly Stripe + Mercury data
- `src/lib/analytics/executive-ai-analysis.ts` — structured LLM prompt → JSON executive analysis
- `src/app/api/financial-planning/monthly-history/route.ts`
- `src/app/api/financial-planning/ai-analysis/route.ts`
- `src/components/analytics/finance-monthly-history-tab.tsx`
- `src/components/analytics/executive-ai-brief.tsx`

## Test plan
- [x] TypeScript compiles with 0 new errors
- [x] All 193 finance-related tests pass
- [x] ESLint passes with 0 warnings
- [ ] Verify `/analytics/finance` shows AI Executive Brief section
- [ ] Verify `/analytics/finance-monthly-history` shows monthly P&L table
- [ ] Verify `/analytics/finance-ai-brief` generates narrative analysis
- [ ] Verify AI brief gracefully degrades when OPENAI_API_KEY is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)