### PR TITLE
fix(finance): remove missing mercury-normalization import

### DIFF
--- a/src/lib/analytics/monthly-pnl-history.ts
+++ b/src/lib/analytics/monthly-pnl-history.ts
@@ -4,7 +4,6 @@
 import { prisma } from "@/lib/prisma";
 import { AnalyticsSnapshotStatus } from "@/generated/prisma/client";
 import { buildProfitAndLossCore } from "./pnl-builder";
-import { normalizeMercuryDataPayload } from "./mercury-normalization";
 import { resolveIntegrationOwnerUserId } from "@/lib/integrations/ownership";
 import type { StripeData, MercuryData, PnLRow } from "./types";
 
@@ -111,7 +110,7 @@ async function loadMonthlySnapshots(
   return sortedMonths.map(([month, data]) => ({
     month,
     stripe: data.stripe,
-    mercury: data.mercury ? normalizeMercuryDataPayload(data.mercury) : null,
+    mercury: data.mercury,
   }));
 }
 


### PR DESCRIPTION
## Summary
- Fixes build failure from #544 — `mercury-normalization.ts` doesn't exist on main (only on a feature branch)
- Snapshots stored in the DB are already normalized at ingest time, so the call was unnecessary

## Test plan
- [x] Lint + typecheck pass
- [ ] CI build succeeds (was failing on `Module not found: Can't resolve './mercury-normalization'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)