### PR TITLE
[codex] Fix blank Demo Scheduling records

### DIFF
--- a/src/lib/__tests__/analytics-demo-analytics.test.ts
+++ b/src/lib/__tests__/analytics-demo-analytics.test.ts
@@ -221,6 +221,62 @@ describe("buildDemoAnalyticsData", () => {
     ]);
   });
 
+  it("includes uncovered post-demo HubSpot deals in the scheduling records", () => {
+    const data = baseData();
+    data.hubspot = {
+      funnel: {
+        totalDeals: 2,
+        closedWon: 1,
+        closedLost: 0,
+        unlikely: 0,
+        churn: 0,
+        activeSubscriptions: 0,
+        noShows: 0,
+        demoScheduled: 2,
+        demoFollowUp: 1,
+        avgDealSize: 4500,
+        winRate: 50,
+        effectiveWinRate: 50,
+        noShowRate: 0,
+        stages: [],
+        dealsBySource: [],
+      },
+      contacts: { totalContacts: 0, recentContacts: 0, bySource: [] },
+      deals: [
+        makeDeal({
+          dealId: "follow-up-deal",
+          dealName: "Follow Up Co",
+          stageId: "follow",
+          stageLabel: "Demo Follow-Up",
+          amount: 4000,
+          source: "Organic",
+          ownerId: null,
+          updatedAt: "2026-02-12T00:00:00.000Z",
+          createdAt: "2026-01-10T00:00:00.000Z",
+        }),
+        makeDeal({
+          dealId: "won-deal",
+          dealName: "Won Co",
+          stageId: "won",
+          stageLabel: "Closed Won",
+          amount: 5000,
+          source: "Paid",
+          ownerId: null,
+          updatedAt: "2026-02-15T00:00:00.000Z",
+          createdAt: "2026-01-12T00:00:00.000Z",
+        }),
+      ],
+      _meta: META,
+    };
+
+    const demo = buildDemoAnalyticsData(data);
+
+    expect(demo.totalScheduled).toBe(2);
+    expect(demo.demos.map((record) => record.dealId)).toEqual(["follow-up-deal", "won-deal"]);
+    expect(demo.demos.every((record) => record.isUpcoming === false)).toBe(true);
+    expect(demo.demos.every((record) => record.outcome === "completed")).toBe(true);
+  });
+
   it("builds journey path analysis across full lifecycle", () => {
     const data = baseData();
     data.hubspot = {

--- a/src/lib/analytics/demo-analytics.ts
+++ b/src/lib/analytics/demo-analytics.ts
@@ -792,8 +792,12 @@ export function buildDemoAnalyticsData(
   );
 
   const hubSpotFallbacks = deals
-    .filter((deal) => deal.stageLabel === "Demo Scheduled" && !coveredHubSpotDealIds.has(deal.dealId))
-    .map((deal) => buildUnscheduledFallbackRecord({ deal }));
+    .filter((deal) => DEMO_ENTRY_STAGES.has(deal.stageLabel) && !coveredHubSpotDealIds.has(deal.dealId))
+    .map((deal) => (
+      deal.stageLabel === "Demo Scheduled"
+        ? buildUnscheduledFallbackRecord({ deal })
+        : buildDealAggregateRecord({ now, deal })
+    ));
 
   const demos = [...meetingBackedDemos, ...hubSpotFallbacks].sort((a, b) => {
     const timeDiff = new Date(a.scheduledAt).getTime() - new Date(b.scheduledAt).getTime();


### PR DESCRIPTION
## What changed
- Include uncovered post-demo HubSpot deals in Demo Scheduling fallback records, not just deals still in `Demo Scheduled`.
- Add a regression test covering post-demo fallback rows in the scheduling dataset.

## Why
The Demo Scheduling table was building `demo.demos` from calendar-backed meetings plus HubSpot fallbacks, but the fallback path only included deals still in `Demo Scheduled`.
That left completed follow-up and closed-won demo-stage deals out of the table entirely, even though the aggregate counts showed demos existed.

## Impact
- Demo Scheduling now shows rows for uncovered demo-stage deals that have already moved past scheduling.
- The table and summary metrics stay aligned instead of showing a blank records table next to non-zero demo totals.

## Root cause
Fallback record construction was filtered to `stageLabel === "Demo Scheduled"` instead of all `DEMO_ENTRY_STAGES` not already covered by meetings.

## Validation
- `npm test -- src/lib/__tests__/analytics-demo-analytics.test.ts`
