### PR TITLE
Add Instagram video performance analysis

### DIFF
--- a/src/components/analytics/marketing-tab-new.test.tsx
+++ b/src/components/analytics/marketing-tab-new.test.tsx
@@ -60,4 +60,396 @@ describe("MarketingTabNew provider states", () => {
 
     expect(screen.getByText("No Google Ads data in selected range")).toBeTruthy();
   });
+
+  it("renders Instagram creative-analysis coverage and sampled note", () => {
+    const data = makeData();
+    data.instagram = {
+      followers: 1200,
+      reach30d: 500,
+      engagement30d: 90,
+      traffic: 0,
+      bounceRate: 0,
+      clicks: 0,
+      returningVisitors: 0,
+      topPosts: [
+        {
+          id: "ig-post-1",
+          message: "How are you handling replenishment?",
+          reach: 90,
+          engagement: 90,
+          createdAt: "2026-01-15T12:00:00.000Z",
+          mediaType: "VIDEO",
+          mediaProductType: "REELS",
+          permalink: null,
+          thumbnailUrl: null,
+          likeCount: 80,
+          commentCount: 10,
+          performanceScore: 1.82,
+          engagementRate: 7.5,
+          ageInDays: 4.5,
+          engagementVelocity: 20,
+          captionLength: 36,
+          hashtagCount: 0,
+          mentionCount: 0,
+          emojiCount: 0,
+          hasQuestionHook: true,
+          hasCallToAction: false,
+          postedTimeBucket: "morning",
+          isVideo: true,
+          isReel: true,
+          isCarousel: false,
+          creativeSummary: "Founder on camera with bold text overlay.",
+          hasPersonVisible: true,
+          hasTextOverlayVisible: true,
+          looksLikeShopFloor: false,
+          looksLikeProductDemo: false,
+          looksEducational: true,
+          looksPromotional: false,
+          performanceDrivers: [
+            {
+              key: "hasPersonVisible",
+              label: "Person visible in creative",
+              source: "ai_visual",
+              sampled: true,
+              confidence: "medium",
+              liftPct: 50,
+            },
+            {
+              key: "hasQuestionHook",
+              label: "Question-led hooks",
+              source: "metadata",
+              sampled: false,
+              confidence: "high",
+              liftPct: 22,
+            },
+          ],
+          nextTests: [
+            {
+              key: "hasCallToAction",
+              label: "Clear CTA language",
+              action: "add",
+              source: "metadata",
+              sampled: false,
+              confidence: "high",
+              estimatedImpactPct: 18,
+            },
+            {
+              key: "hasHashtags",
+              label: "Hashtags",
+              action: "reduce",
+              source: "metadata",
+              sampled: false,
+              confidence: "high",
+              estimatedImpactPct: 20,
+            },
+          ],
+        },
+      ],
+      topVideos: [
+        {
+          id: "ig-post-1",
+          message: "How are you handling replenishment?",
+          reach: 90,
+          engagement: 90,
+          createdAt: "2026-01-15T12:00:00.000Z",
+          mediaType: "VIDEO",
+          mediaProductType: "REELS",
+          permalink: null,
+          thumbnailUrl: null,
+          likeCount: 80,
+          commentCount: 10,
+          performanceScore: 1.82,
+          engagementRate: 7.5,
+          ageInDays: 4.5,
+          engagementVelocity: 20,
+          captionLength: 36,
+          hashtagCount: 0,
+          mentionCount: 0,
+          emojiCount: 0,
+          hasQuestionHook: true,
+          hasCallToAction: false,
+          postedTimeBucket: "morning",
+          isVideo: true,
+          isReel: true,
+          isCarousel: false,
+          creativeSummary: "Founder on camera with bold text overlay.",
+          hasPersonVisible: true,
+          hasTextOverlayVisible: true,
+          looksLikeShopFloor: false,
+          looksLikeProductDemo: false,
+          looksEducational: true,
+          looksPromotional: false,
+          performanceDrivers: [
+            {
+              key: "hasPersonVisible",
+              label: "Person visible in creative",
+              source: "ai_visual",
+              sampled: true,
+              confidence: "medium",
+              liftPct: 50,
+            },
+            {
+              key: "hasQuestionHook",
+              label: "Question-led hooks",
+              source: "metadata",
+              sampled: false,
+              confidence: "high",
+              liftPct: 22,
+            },
+          ],
+          nextTests: [
+            {
+              key: "hasCallToAction",
+              label: "Clear CTA language",
+              action: "add",
+              source: "metadata",
+              sampled: false,
+              confidence: "high",
+              estimatedImpactPct: 18,
+            },
+            {
+              key: "hasHashtags",
+              label: "Hashtags",
+              action: "reduce",
+              source: "metadata",
+              sampled: false,
+              confidence: "high",
+              estimatedImpactPct: 20,
+            },
+          ],
+        },
+      ],
+      videosToImprove: [
+        {
+          id: "ig-post-2",
+          message: "Warehouse update from this week",
+          reach: 24,
+          engagement: 24,
+          createdAt: "2026-01-19T12:00:00.000Z",
+          mediaType: "VIDEO",
+          mediaProductType: "REELS",
+          permalink: null,
+          thumbnailUrl: null,
+          likeCount: 20,
+          commentCount: 4,
+          performanceScore: 0.64,
+          engagementRate: 2,
+          ageInDays: 5.5,
+          engagementVelocity: 4.4,
+          captionLength: 27,
+          hashtagCount: 2,
+          mentionCount: 0,
+          emojiCount: 0,
+          hasQuestionHook: false,
+          hasCallToAction: false,
+          postedTimeBucket: "afternoon",
+          isVideo: true,
+          isReel: true,
+          isCarousel: false,
+          nextTests: [
+            {
+              key: "hasQuestionHook",
+              label: "Question-led hooks",
+              action: "add",
+              source: "metadata",
+              sampled: false,
+              confidence: "high",
+              estimatedImpactPct: 22,
+            },
+            {
+              key: "hasHashtags",
+              label: "Hashtags",
+              action: "reduce",
+              source: "metadata",
+              sampled: false,
+              confidence: "high",
+              estimatedImpactPct: 20,
+            },
+          ],
+        },
+      ],
+      mediaTypeBreakdown: {
+        image: 0,
+        video: 0,
+        reel: 1,
+        carousel: 0,
+        other: 0,
+      },
+      creativeAnalysis: {
+        analyzedVideos: 3,
+        totalVideoCandidates: 8,
+        sampled: true,
+      },
+      opportunities: [
+        {
+          key: "hasCallToAction",
+          label: "Clear CTA language",
+          source: "metadata",
+          sampled: false,
+          confidence: "high",
+          estimatedImpactPct: 18,
+          adoptionPct: 25,
+        },
+        {
+          key: "hasPersonVisible",
+          label: "Person visible in creative",
+          source: "ai_visual",
+          sampled: true,
+          confidence: "medium",
+          estimatedImpactPct: 50,
+          adoptionPct: 33,
+        },
+      ],
+      experimentPlan: [
+        {
+          key: "add:hasCallToAction",
+          title: "Test adding clear cta language",
+          brief: "Create follow-up variants that introduce clear cta language in otherwise similar videos.",
+          action: "add",
+          source: "metadata",
+          sampled: false,
+          confidence: "high",
+          estimatedImpactPct: 18,
+          supportingVideos: 2,
+          exampleVideos: ["How are you handling replenishment?"],
+        },
+      ],
+      testBacklog: [
+        {
+          key: "hasCallToAction",
+          label: "Clear CTA language",
+          action: "add",
+          source: "metadata",
+          sampled: false,
+          confidence: "high",
+          estimatedImpactPct: 18,
+          supportingVideos: 2,
+        },
+        {
+          key: "hasHashtags",
+          label: "Hashtags",
+          action: "reduce",
+          source: "metadata",
+          sampled: false,
+          confidence: "high",
+          estimatedImpactPct: 20,
+          supportingVideos: 2,
+        },
+      ],
+      attributeCorrelations: [
+        {
+          key: "hasPersonVisible",
+          label: "Person visible in creative",
+          source: "ai_visual",
+          correlation: 0.42,
+          sampleSize: 3,
+          comparisonSampleSize: 3,
+          eligiblePostCount: 6,
+          coveragePct: 75,
+          trueAvgEngagement: 120,
+          falseAvgEngagement: 80,
+          liftPct: 50,
+          sampled: true,
+          confidence: "medium",
+          confidenceScore: 68,
+          interpretation: "Person visible in creative correlate with higher normalized performance (+50% vs. posts without that attribute).",
+        },
+      ],
+      winningPatterns: [
+        {
+          title: "Person visible in creative",
+          detail: "Person visible in creative are associated with 50% stronger normalized performance on average (medium confidence).",
+          source: "ai_visual",
+          sampled: true,
+          confidence: "medium",
+        },
+      ],
+      losingPatterns: [
+        {
+          title: "Hashtags",
+          detail: "Hashtags are associated with 20% weaker normalized performance on average (high confidence).",
+          source: "metadata",
+          sampled: false,
+          confidence: "high",
+        },
+      ],
+      _meta: {
+        fetchedAt: "2026-01-30T00:00:00.000Z",
+        nextRefresh: "2026-01-30T01:00:00.000Z",
+        source: "live",
+      },
+    };
+
+    render(<MarketingTabNew data={data} />);
+
+    expect(
+      screen.getByText(
+        "Ranked by normalized performance across engagement rate, engagement velocity, and raw engagement in the selected window."
+      )
+    ).toBeTruthy();
+    expect(screen.getByText("Experiment Plan")).toBeTruthy();
+    expect(screen.getByText("Test adding clear cta language · high confidence")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Create follow-up variants that introduce clear cta language in otherwise similar videos. Expected impact ~18% across 2 top videos."
+      )
+    ).toBeTruthy();
+    expect(screen.getByText("Examples: How are you handling replenishment?")).toBeTruthy();
+    expect(screen.getByText("Underused Opportunities")).toBeTruthy();
+    expect(
+      screen.getByText("Clear CTA language is only showing up in 25% of eligible posts (~18% upside, high confidence)")
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Person visible in creative is only showing up in 33% of eligible posts (~50% upside, medium confidence, sampled)")
+    ).toBeTruthy();
+    expect(screen.getByText("Recommended Tests")).toBeTruthy();
+    expect(
+      screen.getByText("Add clear cta language across 2 top videos (~18% impact, high confidence)")
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Reduce hashtags across 2 top videos (~20% impact, high confidence)")
+    ).toBeTruthy();
+    expect(screen.getByText("AI creative analysis coverage: 3 of 8 eligible videos analyzed in this pass.")).toBeTruthy();
+    expect(
+      screen.getByText("AI visual signals are based on a top-video sample, not the full Instagram post set.")
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Correlations use the same normalized Instagram performance score rather than raw lifetime engagement alone."
+      )
+    ).toBeTruthy();
+    expect(screen.getByText("Winning Patterns")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Person visible in creative are associated with 50% stronger normalized performance on average (medium confidence)."
+      )
+    ).toBeTruthy();
+    expect(screen.getByText("Underperforming Patterns")).toBeTruthy();
+    expect(
+      screen.getByText("Hashtags are associated with 20% weaker normalized performance on average (high confidence).")
+    ).toBeTruthy();
+    expect(screen.getAllByText("Person visible in creative · AI visual · sampled · medium confidence").length).toBe(2);
+    expect(screen.getByText("Reel · Score 1.82x baseline · 90 engagement")).toBeTruthy();
+    expect(screen.getByText("7.50% engagement rate · 20.0/day · 4.5 days old")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Why this is likely working: Person visible in creative (+50%, medium confidence, sampled) · Question-led hooks (+22%, high confidence)"
+      )
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "What to test next: Add clear cta language (~18% impact, high confidence) · Reduce hashtags (~20% impact, high confidence)"
+      )
+    ).toBeTruthy();
+    expect(screen.getByText("Videos To Improve")).toBeTruthy();
+    expect(screen.getByText("Warehouse update from this week")).toBeTruthy();
+    expect(screen.getByText("Reel · Score 0.64x baseline · 24 engagement")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Best next tests: Add question-led hooks (~22% impact, high confidence) · Reduce hashtags (~20% impact, high confidence)"
+      )
+    ).toBeTruthy();
+    expect(screen.getByText("3/3 posts · 75% coverage")).toBeTruthy();
+    expect(screen.getByText("Founder on camera with bold text overlay.")).toBeTruthy();
+  });
 });

--- a/src/components/analytics/marketing-tab-new.tsx
+++ b/src/components/analytics/marketing-tab-new.tsx
@@ -343,6 +343,16 @@ export function MarketingTabNew({ data }: MarketingTabNewProps) {
   const igClicks = data.instagram?.clicks || 0;
   const igReturningVisitors = data.instagram?.returningVisitors || 0;
   const igTopPosts = data.instagram?.topPosts || [];
+  const igTopVideos = data.instagram?.topVideos || [];
+  const igVideosToImprove = data.instagram?.videosToImprove || [];
+  const igMediaTypeBreakdown = data.instagram?.mediaTypeBreakdown;
+  const igCreativeAnalysis = data.instagram?.creativeAnalysis;
+  const igOpportunities = data.instagram?.opportunities || [];
+  const igExperimentPlan = data.instagram?.experimentPlan || [];
+  const igTestBacklog = data.instagram?.testBacklog || [];
+  const igAttributeCorrelations = data.instagram?.attributeCorrelations || [];
+  const igWinningPatterns = data.instagram?.winningPatterns || [];
+  const igLosingPatterns = data.instagram?.losingPatterns || [];
 
   return (
     <div className="space-y-6">
@@ -879,6 +889,270 @@ export function MarketingTabNew({ data }: MarketingTabNewProps) {
                 </div>
               </div>
 
+              {igMediaTypeBreakdown && (
+                <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+                  <div className="bg-secondary/40 rounded-lg p-3">
+                    <p className="text-xs text-muted-foreground mb-1">Reels</p>
+                    <p className="text-lg font-semibold text-foreground">{fmtNum(igMediaTypeBreakdown.reel)}</p>
+                  </div>
+                  <div className="bg-secondary/40 rounded-lg p-3">
+                    <p className="text-xs text-muted-foreground mb-1">Videos</p>
+                    <p className="text-lg font-semibold text-foreground">{fmtNum(igMediaTypeBreakdown.video)}</p>
+                  </div>
+                  <div className="bg-secondary/40 rounded-lg p-3">
+                    <p className="text-xs text-muted-foreground mb-1">Images</p>
+                    <p className="text-lg font-semibold text-foreground">{fmtNum(igMediaTypeBreakdown.image)}</p>
+                  </div>
+                  <div className="bg-secondary/40 rounded-lg p-3">
+                    <p className="text-xs text-muted-foreground mb-1">Carousels</p>
+                    <p className="text-lg font-semibold text-foreground">{fmtNum(igMediaTypeBreakdown.carousel)}</p>
+                  </div>
+                  <div className="bg-secondary/40 rounded-lg p-3">
+                    <p className="text-xs text-muted-foreground mb-1">Other</p>
+                    <p className="text-lg font-semibold text-foreground">{fmtNum(igMediaTypeBreakdown.other)}</p>
+                  </div>
+                </div>
+              )}
+
+              {igTopVideos.length > 0 && (
+                <div>
+                  <p className="text-sm font-semibold text-foreground mb-3">Top Videos</p>
+                  <p className="text-xs text-muted-foreground mb-3">
+                    Ranked by normalized performance across engagement rate, engagement velocity, and raw engagement in the selected window.
+                  </p>
+                  {igExperimentPlan.length > 0 ? (
+                    <div className="mb-3">
+                      <p className="text-xs font-medium text-foreground mb-2">Experiment Plan</p>
+                      <div className="space-y-2">
+                        {igExperimentPlan.map((item) => (
+                          <div
+                            key={item.key}
+                            className="p-2 bg-secondary/40 rounded text-xs text-muted-foreground"
+                          >
+                            <p className="text-foreground font-medium">
+                              {item.title}
+                              {` · ${item.confidence} confidence`}
+                              {item.sampled ? " · sampled" : ""}
+                            </p>
+                            <p className="mt-1">
+                              {item.brief} {`Expected impact ~${item.estimatedImpactPct.toFixed(0)}% across ${item.supportingVideos} top video${item.supportingVideos === 1 ? "" : "s"}.`}
+                            </p>
+                            {item.exampleVideos.length > 0 ? (
+                              <p className="mt-1">
+                                Examples: {item.exampleVideos.join(" · ")}
+                              </p>
+                            ) : null}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                  {igOpportunities.length > 0 ? (
+                    <div className="mb-3">
+                      <p className="text-xs font-medium text-foreground mb-2">Underused Opportunities</p>
+                      <div className="space-y-2">
+                        {igOpportunities.map((item) => (
+                          <div
+                            key={item.key}
+                            className="p-2 bg-secondary/40 rounded text-xs text-muted-foreground"
+                          >
+                            {item.label}
+                            {` is only showing up in ${item.adoptionPct.toFixed(0)}% of eligible posts`}
+                            {` (~${item.estimatedImpactPct.toFixed(0)}% upside, ${item.confidence} confidence`}
+                            {item.sampled ? ", sampled" : ""}
+                            )
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                  {igTestBacklog.length > 0 ? (
+                    <div className="mb-3">
+                      <p className="text-xs font-medium text-foreground mb-2">Recommended Tests</p>
+                      <div className="space-y-2">
+                        {igTestBacklog.map((idea) => (
+                          <div
+                            key={`${idea.action}-${idea.key}`}
+                            className="p-2 bg-secondary/40 rounded text-xs text-muted-foreground"
+                          >
+                            {idea.action === "add" ? "Add" : "Reduce"} {idea.label.toLowerCase()}
+                            {` across ${idea.supportingVideos} top video${idea.supportingVideos === 1 ? "" : "s"}`}
+                            {` (~${idea.estimatedImpactPct.toFixed(0)}% impact, ${idea.confidence} confidence`}
+                            {idea.sampled ? ", sampled" : ""}
+                            )
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                  {igCreativeAnalysis?.totalVideoCandidates ? (
+                    <p className="text-xs text-muted-foreground mb-3">
+                      AI creative analysis coverage: {fmtNum(igCreativeAnalysis.analyzedVideos)} of{" "}
+                      {fmtNum(igCreativeAnalysis.totalVideoCandidates)} eligible videos
+                      {igCreativeAnalysis.sampled ? " analyzed in this pass." : "."}
+                    </p>
+                  ) : null}
+                  <div className="space-y-2 max-h-48 overflow-y-auto">
+                    {igTopVideos.slice(0, 5).map((post, idx) => (
+                      <div key={idx} className="p-2 bg-secondary/40 rounded text-sm">
+                        <p className="text-foreground line-clamp-2">{post.message}</p>
+                        <p className="text-xs text-muted-foreground mt-1">
+                          {post.isReel ? "Reel" : post.mediaType} · Score {post.performanceScore.toFixed(2)}x baseline ·{" "}
+                          {fmtNum(post.engagement)} engagement
+                        </p>
+                        <p className="text-xs text-muted-foreground mt-1">
+                          {fmtPct(post.engagementRate)} engagement rate · {post.engagementVelocity.toFixed(1)}/day ·{" "}
+                          {post.ageInDays.toFixed(1)} days old
+                        </p>
+                        <p className="text-xs text-muted-foreground mt-1">
+                          {post.hasQuestionHook ? "Question hook" : "Statement hook"}
+                          {post.hasCallToAction ? " · CTA" : ""}
+                          {post.hashtagCount > 0 ? ` · ${post.hashtagCount} hashtags` : ""}
+                        </p>
+                        {post.performanceDrivers?.length ? (
+                          <p className="text-xs text-muted-foreground mt-1">
+                            Why this is likely working:{" "}
+                            {post.performanceDrivers
+                              .map((driver) => {
+                                const sampledSuffix = driver.sampled ? ", sampled" : "";
+                                return `${driver.label} (+${driver.liftPct.toFixed(0)}%, ${driver.confidence} confidence${sampledSuffix})`;
+                              })
+                              .join(" · ")}
+                          </p>
+                        ) : null}
+                        {post.nextTests?.length ? (
+                          <p className="text-xs text-muted-foreground mt-1">
+                            What to test next:{" "}
+                            {post.nextTests
+                              .map((idea) => {
+                                const actionLabel = idea.action === "add" ? "Add" : "Reduce";
+                                const sampledSuffix = idea.sampled ? ", sampled" : "";
+                                return `${actionLabel} ${idea.label.toLowerCase()} (~${idea.estimatedImpactPct.toFixed(
+                                  0
+                                )}% impact, ${idea.confidence} confidence${sampledSuffix})`;
+                              })
+                              .join(" · ")}
+                          </p>
+                        ) : null}
+                        {post.creativeSummary ? (
+                          <p className="text-xs text-muted-foreground mt-1">{post.creativeSummary}</p>
+                        ) : null}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {igVideosToImprove.length > 0 && (
+                <div>
+                  <p className="text-sm font-semibold text-foreground mb-3">Videos To Improve</p>
+                  <div className="space-y-2 max-h-48 overflow-y-auto">
+                    {igVideosToImprove.map((post, idx) => (
+                      <div key={`${post.id}-${idx}`} className="p-2 bg-secondary/40 rounded text-sm">
+                        <p className="text-foreground line-clamp-2">{post.message}</p>
+                        <p className="text-xs text-muted-foreground mt-1">
+                          {post.isReel ? "Reel" : post.mediaType} · Score {post.performanceScore.toFixed(2)}x baseline ·{" "}
+                          {fmtNum(post.engagement)} engagement
+                        </p>
+                        {post.nextTests?.length ? (
+                          <p className="text-xs text-muted-foreground mt-1">
+                            Best next tests:{" "}
+                            {post.nextTests
+                              .map((idea) => {
+                                const actionLabel = idea.action === "add" ? "Add" : "Reduce";
+                                const sampledSuffix = idea.sampled ? ", sampled" : "";
+                                return `${actionLabel} ${idea.label.toLowerCase()} (~${idea.estimatedImpactPct.toFixed(
+                                  0
+                                )}% impact, ${idea.confidence} confidence${sampledSuffix})`;
+                              })
+                              .join(" · ")}
+                          </p>
+                        ) : null}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {igAttributeCorrelations.length > 0 && (
+                <div>
+                  {igWinningPatterns.length > 0 ? (
+                    <div className="mb-4">
+                      <p className="text-sm font-semibold text-foreground mb-3">Winning Patterns</p>
+                      <div className="space-y-2">
+                        {igWinningPatterns.map((item, idx) => (
+                          <div key={`${item.title}-${idx}`} className="p-3 bg-secondary/40 rounded">
+                            <p className="text-sm font-medium text-foreground">
+                              {item.title}
+                              {item.source === "ai_visual" ? " · AI visual" : ""}
+                              {item.sampled ? " · sampled" : ""}
+                              {` · ${item.confidence} confidence`}
+                            </p>
+                            <p className="text-xs text-muted-foreground mt-1">{item.detail}</p>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                  {igLosingPatterns.length > 0 ? (
+                    <div className="mb-4">
+                      <p className="text-sm font-semibold text-foreground mb-3">Underperforming Patterns</p>
+                      <div className="space-y-2">
+                        {igLosingPatterns.map((item, idx) => (
+                          <div key={`${item.title}-${idx}`} className="p-3 bg-secondary/40 rounded">
+                            <p className="text-sm font-medium text-foreground">
+                              {item.title}
+                              {item.source === "ai_visual" ? " · AI visual" : ""}
+                              {item.sampled ? " · sampled" : ""}
+                              {` · ${item.confidence} confidence`}
+                            </p>
+                            <p className="text-xs text-muted-foreground mt-1">{item.detail}</p>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                  <p className="text-sm font-semibold text-foreground mb-3">What’s Correlating With Performance</p>
+                  <p className="text-xs text-muted-foreground mb-3">
+                    Correlations use the same normalized Instagram performance score rather than raw lifetime engagement alone.
+                  </p>
+                  {data.instagram?.creativeAnalysis?.sampled ? (
+                    <p className="text-xs text-muted-foreground mb-3">
+                      AI visual signals are based on a top-video sample, not the full Instagram post set.
+                    </p>
+                  ) : null}
+                  <div className="space-y-2">
+                    {igAttributeCorrelations.slice(0, 5).map((item) => (
+                      <div key={item.key} className="p-3 bg-secondary/40 rounded">
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <p className="text-sm font-medium text-foreground">
+                              {item.label}
+                              {item.source === "ai_visual" ? " · AI visual" : ""}
+                              {item.sampled ? " · sampled" : ""}
+                              {` · ${item.confidence} confidence`}
+                            </p>
+                            <p className="text-xs text-muted-foreground mt-1">{item.interpretation}</p>
+                          </div>
+                          <div className="text-right shrink-0">
+                            <p className={`text-sm font-semibold ${item.correlation >= 0 ? "text-emerald-600" : "text-rose-600"}`}>
+                              r={item.correlation.toFixed(2)}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              {item.liftPct >= 0 ? "+" : ""}
+                              {item.liftPct.toFixed(0)}%
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              {item.sampleSize}/{item.comparisonSampleSize} posts · {item.coveragePct.toFixed(0)}% coverage
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
               {igTopPosts.length > 0 && (
                 <div>
                   <p className="text-sm font-semibold text-foreground mb-3">Top Posts</p>
@@ -887,7 +1161,7 @@ export function MarketingTabNew({ data }: MarketingTabNewProps) {
                       <div key={idx} className="p-2 bg-secondary/40 rounded text-sm">
                         <p className="text-foreground line-clamp-2">{post.message}</p>
                         <p className="text-xs text-muted-foreground mt-1">
-                          {fmtNum(post.reach)} reach · {fmtNum(post.engagement)} engagement
+                          {post.isReel ? "Reel" : post.mediaType} · {fmtNum(post.engagement)} engagement
                         </p>
                       </div>
                     ))}

--- a/src/lib/__tests__/analytics-fetchers-ads.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-ads.test.ts
@@ -491,10 +491,43 @@ describe("analytics ads fetchers", () => {
           data: [
             {
               id: "media_1",
-              caption: "hello",
+              caption: "hello #manufacturing",
               timestamp: "2026-02-01T00:00:00+0000",
               like_count: 5,
               comments_count: 1,
+              media_type: "VIDEO",
+              media_product_type: "REELS",
+              permalink: "https://instagram.com/p/media_1",
+              thumbnail_url: "https://cdn.example.com/media_1.jpg",
+            },
+            {
+              id: "media_2",
+              caption: "Need cleaner replenishment?",
+              timestamp: "2026-02-02T00:00:00+0000",
+              like_count: 12,
+              comments_count: 4,
+              media_type: "VIDEO",
+              media_product_type: "REELS",
+              permalink: "https://instagram.com/p/media_2",
+              thumbnail_url: "https://cdn.example.com/media_2.jpg",
+            },
+            {
+              id: "media_3",
+              caption: "Shop floor stills",
+              timestamp: "2026-02-03T00:00:00+0000",
+              like_count: 2,
+              comments_count: 0,
+              media_type: "IMAGE",
+              media_product_type: "FEED",
+            },
+            {
+              id: "media_4",
+              caption: "Batch label update #ops",
+              timestamp: "2026-02-04T00:00:00+0000",
+              like_count: 3,
+              comments_count: 1,
+              media_type: "IMAGE",
+              media_product_type: "FEED",
             },
           ],
         })
@@ -511,10 +544,118 @@ describe("analytics ads fetchers", () => {
     );
 
     expect(data.followers).toBe(912);
+    expect(data.topPosts[0]?.id).toBe("media_2");
+    expect(data.topPosts[0]?.isVideo).toBe(true);
+    expect(data.topPosts[0]?.performanceScore).toBeGreaterThan(data.topPosts[1]?.performanceScore ?? 0);
+    expect(data.topPosts[0]?.engagementVelocity).toBeGreaterThan(0);
+    expect(data.topPosts[0]?.performanceDrivers?.length).toBeGreaterThan(0);
+    expect(
+      data.topPosts[0]?.performanceDrivers?.every((item) => item.confidence !== "low")
+    ).toBe(true);
+    if (data.topPosts[0]?.nextTests) {
+      expect(
+        data.topPosts[0].nextTests.every((item) => item.confidence !== "low")
+      ).toBe(true);
+    }
+    expect(data.opportunities?.every((item) => item.adoptionPct <= 50)).toBe(true);
+    expect(data.opportunities?.every((item) => item.estimatedImpactPct >= 0)).toBe(true);
+    expect(data.testBacklog?.length).toBeGreaterThan(0);
+    expect(data.testBacklog?.every((item) => item.supportingVideos >= 1)).toBe(true);
+    expect(data.experimentPlan?.length).toBeGreaterThan(0);
+    expect(data.experimentPlan?.every((item) => item.exampleVideos.length >= 1)).toBe(true);
+    expect(data.videosToImprove?.every((item) => item.isVideo)).toBe(true);
+    expect(data.videosToImprove?.every((item) => (item.nextTests?.length ?? 0) > 0)).toBe(true);
+    expect(data.topVideos?.length).toBe(2);
+    expect(data.mediaTypeBreakdown).toEqual({
+      image: 2,
+      video: 0,
+      reel: 2,
+      carousel: 0,
+      other: 0,
+    });
+    expect(data.creativeAnalysis).toEqual({
+      analyzedVideos: 0,
+      totalVideoCandidates: 2,
+      sampled: false,
+    });
+    expect(data.attributeCorrelations?.length).toBeGreaterThan(0);
+    expect(data.attributeCorrelations?.every((item) => typeof item.sampled === "boolean")).toBe(true);
+    expect(data.attributeCorrelations?.every((item) => item.source === "metadata" || item.source === "ai_visual")).toBe(true);
+    expect(
+      data.attributeCorrelations?.every(
+        (item) =>
+          typeof item.coveragePct === "number" &&
+          typeof item.confidenceScore === "number" &&
+          (item.confidence === "low" || item.confidence === "medium" || item.confidence === "high")
+      )
+    ).toBe(true);
     expect(fetchMock).toHaveBeenCalledTimes(3);
 
     const mediaUrl = String(fetchMock.mock.calls[2]?.[0] ?? "");
     expect(mediaUrl).toContain("/ig_123/media");
+    expect(mediaUrl).toContain("media_type");
+  });
+
+  it("ranks Instagram posts by normalized performance instead of raw lifetime engagement alone", async () => {
+    const fetchMock = vi.fn();
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          instagram_business_account: {
+            id: "ig_123",
+            username: "acme",
+            followers_count: 1000,
+            media_count: 2,
+          },
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: [
+            {
+              id: "older-post",
+              caption: "Steady performer",
+              timestamp: "2026-02-01T00:00:00+0000",
+              like_count: 30,
+              comments_count: 10,
+              media_type: "VIDEO",
+              media_product_type: "REELS",
+            },
+            {
+              id: "fresh-breakout",
+              caption: "Why is this workflow still manual?",
+              timestamp: "2026-02-22T00:00:00+0000",
+              like_count: 20,
+              comments_count: 8,
+              media_type: "VIDEO",
+              media_product_type: "REELS",
+            },
+          ],
+        })
+      );
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const data = await fetchMetaInstagramData(
+      "meta-token",
+      "page_999",
+      { pageId: "page_999" },
+      new Date("2026-02-01T00:00:00.000Z"),
+      new Date("2026-02-24T00:00:00.000Z")
+    );
+
+    expect(data.topPosts[0]?.id).toBe("fresh-breakout");
+    expect(data.topPosts[0]?.engagement).toBe(28);
+    expect(data.topPosts[1]?.engagement).toBe(40);
+    expect(data.topPosts[0]?.engagementVelocity).toBeGreaterThan(
+      data.topPosts[1]?.engagementVelocity ?? 0
+    );
+    expect(data.topPosts[0]?.performanceScore).toBeGreaterThan(
+      data.topPosts[1]?.performanceScore ?? 0
+    );
+    expect(data.engagement30d).toBe(68);
+    expect(data.winningPatterns?.every((item) => item.confidence !== "low")).toBe(true);
+    expect(data.losingPatterns?.every((item) => item.confidence !== "low")).toBe(true);
   });
 
   it("uses options.pageId to resolve Instagram account without failing first", async () => {
@@ -539,6 +680,8 @@ describe("analytics ads fetchers", () => {
               timestamp: "2026-02-10T00:00:00+0000",
               like_count: 2,
               comments_count: 0,
+              media_type: "IMAGE",
+              media_product_type: "FEED",
             },
           ],
         })

--- a/src/lib/analytics/fetchers-ads.ts
+++ b/src/lib/analytics/fetchers-ads.ts
@@ -5,9 +5,13 @@ import {
   MetaAdsData,
   MetaPageData,
   InstagramData,
+  InstagramTopPost,
+  InstagramAttributeCorrelation,
   RedditAdsData,
   AnalyticsTimestamp,
 } from "./types";
+import { pearsonCorrelation } from "./stats";
+import { enrichInstagramVideoCreatives } from "./instagram-creative-analysis";
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -44,6 +48,660 @@ function readNumber(value: unknown): number {
     }
   }
   return 0;
+}
+
+function readString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function countMatches(input: string, pattern: RegExp): number {
+  const matches = input.match(pattern);
+  return matches ? matches.length : 0;
+}
+
+async function withFallback<T>(
+  promise: Promise<T>,
+  fallback: T,
+  timeoutMs: number
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<T>((resolve) => {
+    timeoutId = setTimeout(() => resolve(fallback), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } catch {
+    return fallback;
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+function toPostedTimeBucket(input: string): InstagramTopPost["postedTimeBucket"] {
+  const date = new Date(input);
+  const hour = Number.isNaN(date.getTime()) ? 0 : date.getUTCHours();
+  if (hour >= 5 && hour < 12) return "morning";
+  if (hour >= 12 && hour < 17) return "afternoon";
+  if (hour >= 17 && hour < 22) return "evening";
+  return "overnight";
+}
+
+function roundTo(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+function median(values: number[]): number {
+  const filtered = values.filter((value) => Number.isFinite(value) && value > 0).sort((a, b) => a - b);
+  if (filtered.length === 0) return 1;
+  const middle = Math.floor(filtered.length / 2);
+  if (filtered.length % 2 === 0) {
+    return (filtered[middle - 1] + filtered[middle]) / 2;
+  }
+  return filtered[middle];
+}
+
+function daysSinceTimestamp(input: string, referenceDate: Date): number {
+  const createdAt = new Date(input);
+  if (Number.isNaN(createdAt.getTime())) return 0;
+  const diffMs = referenceDate.getTime() - createdAt.getTime();
+  if (!Number.isFinite(diffMs) || diffMs <= 0) return 0;
+  return diffMs / (24 * 60 * 60 * 1000);
+}
+
+function buildInstagramTopPost(input: {
+  id: string;
+  caption: string;
+  timestamp: string;
+  likes: number;
+  comments: number;
+  mediaType: string;
+  mediaProductType: string | null;
+  permalink: string | null;
+  thumbnailUrl: string | null;
+  followersCount: number;
+}): InstagramTopPost {
+  const caption = input.caption.trim();
+  const engagement = input.likes + input.comments;
+  const mediaType = input.mediaType.toUpperCase();
+  const mediaProductType = input.mediaProductType?.toUpperCase() ?? null;
+  const isReel = mediaProductType === "REELS";
+  const isCarousel = mediaType === "CAROUSEL_ALBUM";
+  const isVideo = isReel || mediaType === "VIDEO";
+  const captionLength = caption.length;
+  const hashtagCount = countMatches(caption, /(^|\s)#[^\s#]+/g);
+  const mentionCount = countMatches(caption, /(^|\s)@[^\s@]+/g);
+  const emojiCount = countMatches(caption, /\p{Extended_Pictographic}/gu);
+  const hasQuestionHook = /\?/.test(caption.slice(0, 120));
+  const hasCallToAction = /\b(comment|dm|message|reply|share|follow|save|watch|learn more|shop|book|schedule|click|link in bio)\b/i.test(
+    caption
+  );
+
+  return {
+    id: input.id,
+    message: caption,
+    reach: engagement,
+    engagement,
+    createdAt: input.timestamp,
+    mediaType,
+    mediaProductType,
+    permalink: input.permalink,
+    thumbnailUrl: input.thumbnailUrl,
+    likeCount: input.likes,
+    commentCount: input.comments,
+    performanceScore: engagement,
+    engagementRate:
+      input.followersCount > 0 ? (engagement / input.followersCount) * 100 : 0,
+    ageInDays: 0,
+    engagementVelocity: 0,
+    captionLength,
+    hashtagCount,
+    mentionCount,
+    emojiCount,
+    hasQuestionHook,
+    hasCallToAction,
+    postedTimeBucket: toPostedTimeBucket(input.timestamp),
+    isVideo,
+    isReel,
+    isCarousel,
+  };
+}
+
+function scoreInstagramPosts(
+  posts: InstagramTopPost[],
+  referenceDate: Date
+): InstagramTopPost[] {
+  if (posts.length === 0) return [];
+
+  const withDerivedMetrics = posts.map((post) => {
+    const ageInDays = roundTo(daysSinceTimestamp(post.createdAt, referenceDate), 1);
+    const effectiveAgeDays = Math.max(ageInDays, 3);
+    const engagementVelocity = roundTo(post.engagement / effectiveAgeDays, 2);
+    const engagementRateVelocity = post.engagementRate / effectiveAgeDays;
+
+    return {
+      post,
+      ageInDays,
+      engagementVelocity,
+      engagementRateVelocity,
+    };
+  });
+
+  const engagementMedian = median(withDerivedMetrics.map(({ post }) => post.engagement));
+  const velocityMedian = median(
+    withDerivedMetrics.map(({ engagementVelocity }) => engagementVelocity)
+  );
+  const engagementRateVelocityMedian = median(
+    withDerivedMetrics.map(({ engagementRateVelocity }) => engagementRateVelocity)
+  );
+
+  return withDerivedMetrics.map(
+    ({ post, ageInDays, engagementVelocity, engagementRateVelocity }) => ({
+      ...post,
+      ageInDays,
+      engagementVelocity,
+      performanceScore: roundTo(
+        (post.engagement / engagementMedian) * 0.2 +
+          (engagementVelocity / velocityMedian) * 0.35 +
+          (engagementRateVelocity / engagementRateVelocityMedian) * 0.45,
+        3
+      ),
+    })
+  );
+}
+
+function scoreInstagramCorrelationConfidence(input: {
+  totalPosts: number;
+  eligiblePosts: number;
+  trueCount: number;
+  falseCount: number;
+  correlation: number;
+  sampled: boolean;
+}): Pick<InstagramAttributeCorrelation, "coveragePct" | "confidenceScore" | "confidence"> {
+  const coveragePct =
+    input.totalPosts > 0 ? roundTo((input.eligiblePosts / input.totalPosts) * 100, 0) : 0;
+  const coverageScore = Math.min(input.eligiblePosts / Math.max(input.totalPosts, 1), 1);
+  const balanceScore =
+    input.trueCount > 0 && input.falseCount > 0
+      ? Math.min(input.trueCount, input.falseCount) / Math.max(input.trueCount, input.falseCount)
+      : 0;
+  const sampleDepthScore = Math.min(Math.min(input.trueCount, input.falseCount) / 3, 1);
+  const strengthScore = Math.min(Math.abs(input.correlation) / 0.4, 1);
+  const sampledScore = input.sampled ? 0.55 : 1;
+  const confidenceScore = roundTo(
+    (coverageScore * 0.3 +
+      balanceScore * 0.2 +
+      sampleDepthScore * 0.2 +
+      strengthScore * 0.2 +
+      sampledScore * 0.1) *
+      100,
+    0
+  );
+
+  return {
+    coveragePct,
+    confidenceScore,
+    confidence:
+      confidenceScore >= 75 ? "high" : confidenceScore >= 55 ? "medium" : "low",
+  };
+}
+
+function getInstagramAttributeDefs(): Array<{
+  key: string;
+  label: string;
+  source: InstagramAttributeCorrelation["source"];
+  test: (post: InstagramTopPost) => boolean | null;
+}> {
+  return [
+    { key: "isReel", label: "Reels", source: "metadata", test: (post) => post.isReel },
+    { key: "isVideo", label: "Video posts", source: "metadata", test: (post) => post.isVideo },
+    { key: "isCarousel", label: "Carousels", source: "metadata", test: (post) => post.isCarousel },
+    {
+      key: "shortCaption",
+      label: "Short captions (<= 80 chars)",
+      source: "metadata",
+      test: (post) => post.captionLength > 0 && post.captionLength <= 80,
+    },
+    {
+      key: "longCaption",
+      label: "Long captions (>= 220 chars)",
+      source: "metadata",
+      test: (post) => post.captionLength >= 220,
+    },
+    {
+      key: "hasHashtags",
+      label: "Hashtags",
+      source: "metadata",
+      test: (post) => post.hashtagCount > 0,
+    },
+    {
+      key: "hasMentions",
+      label: "Mentions",
+      source: "metadata",
+      test: (post) => post.mentionCount > 0,
+    },
+    {
+      key: "hasQuestionHook",
+      label: "Question-led hooks",
+      source: "metadata",
+      test: (post) => post.hasQuestionHook,
+    },
+    {
+      key: "hasCallToAction",
+      label: "Clear CTA language",
+      source: "metadata",
+      test: (post) => post.hasCallToAction,
+    },
+    {
+      key: "morningPost",
+      label: "Morning publish window",
+      source: "metadata",
+      test: (post) => post.postedTimeBucket === "morning",
+    },
+    {
+      key: "eveningPost",
+      label: "Evening publish window",
+      source: "metadata",
+      test: (post) => post.postedTimeBucket === "evening",
+    },
+    {
+      key: "hasPersonVisible",
+      label: "Person visible in creative",
+      source: "ai_visual",
+      test: (post) => post.hasPersonVisible ?? null,
+    },
+    {
+      key: "hasTextOverlayVisible",
+      label: "Visible text overlay",
+      source: "ai_visual",
+      test: (post) => post.hasTextOverlayVisible ?? null,
+    },
+    {
+      key: "looksLikeShopFloor",
+      label: "Shop-floor visual",
+      source: "ai_visual",
+      test: (post) => post.looksLikeShopFloor ?? null,
+    },
+    {
+      key: "looksLikeProductDemo",
+      label: "Product demo visual",
+      source: "ai_visual",
+      test: (post) => post.looksLikeProductDemo ?? null,
+    },
+    {
+      key: "looksEducational",
+      label: "Educational creative",
+      source: "ai_visual",
+      test: (post) => post.looksEducational ?? null,
+    },
+    {
+      key: "looksPromotional",
+      label: "Promotional creative",
+      source: "ai_visual",
+      test: (post) => post.looksPromotional ?? null,
+    },
+  ];
+}
+
+function buildInstagramAttributeCorrelations(
+  posts: InstagramTopPost[],
+  creativeAnalysis: {
+    analyzedVideos: number;
+    totalVideoCandidates: number;
+    sampled: boolean;
+  }
+): InstagramAttributeCorrelation[] {
+  if (posts.length < 3) return [];
+
+  const attributeDefs = getInstagramAttributeDefs();
+
+  return attributeDefs
+    .map((attribute) => {
+      const eligiblePosts = posts.filter((post) => attribute.test(post) !== null);
+      if (eligiblePosts.length < 4) return null;
+
+      const performance = eligiblePosts.map((post) => post.performanceScore);
+      const flags = eligiblePosts.map((post) => (attribute.test(post) ? 1 : 0));
+      const trueScores = eligiblePosts
+        .filter((post) => attribute.test(post) === true)
+        .map((post) => post.performanceScore);
+      const falseScores = eligiblePosts
+        .filter((post) => attribute.test(post) === false)
+        .map((post) => post.performanceScore);
+      if (trueScores.length < 2 || falseScores.length < 2) return null;
+
+      const trueAvgEngagement =
+        trueScores.reduce((sum, value) => sum + value, 0) / trueScores.length;
+      const falseAvgEngagement =
+        falseScores.reduce((sum, value) => sum + value, 0) / falseScores.length;
+      const liftPct =
+        falseAvgEngagement > 0
+          ? ((trueAvgEngagement - falseAvgEngagement) / falseAvgEngagement) * 100
+          : 0;
+      const correlation = pearsonCorrelation(flags, performance);
+      const direction = correlation >= 0 ? "higher" : "lower";
+      const liftAbs = Math.abs(liftPct);
+      const sampled = attribute.source === "ai_visual" && creativeAnalysis.sampled;
+      const confidence = scoreInstagramCorrelationConfidence({
+        totalPosts: posts.length,
+        eligiblePosts: eligiblePosts.length,
+        trueCount: trueScores.length,
+        falseCount: falseScores.length,
+        correlation,
+        sampled,
+      });
+
+      return {
+        key: attribute.key,
+        label: attribute.label,
+        source: attribute.source,
+        correlation,
+        sampleSize: trueScores.length,
+        comparisonSampleSize: falseScores.length,
+        eligiblePostCount: eligiblePosts.length,
+        coveragePct: confidence.coveragePct,
+        trueAvgEngagement,
+        falseAvgEngagement,
+        liftPct,
+        sampled,
+        confidence: confidence.confidence,
+        confidenceScore: confidence.confidenceScore,
+        interpretation:
+          liftAbs >= 1
+            ? `${attribute.label} correlate with ${direction} normalized performance (${liftPct >= 0 ? "+" : ""}${liftPct.toFixed(
+                0
+              )}% vs. posts without that attribute).`
+            : `${attribute.label} show only a small normalized-performance difference vs. posts without that attribute.`,
+      } satisfies InstagramAttributeCorrelation;
+    })
+    .filter((item): item is InstagramAttributeCorrelation => item !== null)
+    .sort((left, right) => {
+      if (right.confidenceScore !== left.confidenceScore) {
+        return right.confidenceScore - left.confidenceScore;
+      }
+      return Math.abs(right.correlation) - Math.abs(left.correlation);
+    });
+}
+
+function buildInstagramPerformanceDrivers(
+  posts: InstagramTopPost[],
+  correlations: InstagramAttributeCorrelation[]
+): InstagramTopPost[] {
+  const attributeDefs = new Map(
+    getInstagramAttributeDefs().map((attribute) => [attribute.key, attribute])
+  );
+  const positiveSignals = correlations
+    .filter((item) => item.correlation > 0 && item.confidence !== "low")
+    .sort((left, right) => {
+      if (right.confidenceScore !== left.confidenceScore) {
+        return right.confidenceScore - left.confidenceScore;
+      }
+      if (Math.abs(right.correlation) !== Math.abs(left.correlation)) {
+        return Math.abs(right.correlation) - Math.abs(left.correlation);
+      }
+      return right.liftPct - left.liftPct;
+    });
+
+  return posts.map((post) => {
+    const performanceDrivers = positiveSignals
+      .filter((item) => attributeDefs.get(item.key)?.test(post) === true)
+      .slice(0, 3)
+      .map((item) => ({
+        key: item.key,
+        label: item.label,
+        source: item.source,
+        sampled: item.sampled,
+        confidence: item.confidence,
+        liftPct: item.liftPct,
+      }));
+
+    return performanceDrivers.length > 0 ? { ...post, performanceDrivers } : post;
+  });
+}
+
+function buildInstagramOptimizationIdeas(
+  posts: InstagramTopPost[],
+  correlations: InstagramAttributeCorrelation[]
+): InstagramTopPost[] {
+  const attributeDefs = new Map(
+    getInstagramAttributeDefs().map((attribute) => [attribute.key, attribute])
+  );
+  const actionableSignals = correlations.filter((item) => item.confidence !== "low");
+
+  return posts.map((post) => {
+    const nextTests = actionableSignals
+      .filter((item) => {
+        const state = attributeDefs.get(item.key)?.test(post);
+        if (state === null || state === undefined) return false;
+        if (item.correlation > 0) return state === false;
+        if (item.correlation < 0) return state === true;
+        return false;
+      })
+      .sort((left, right) => {
+        if (right.confidenceScore !== left.confidenceScore) {
+          return right.confidenceScore - left.confidenceScore;
+        }
+        if (Math.abs(right.correlation) !== Math.abs(left.correlation)) {
+          return Math.abs(right.correlation) - Math.abs(left.correlation);
+        }
+        return Math.abs(right.liftPct) - Math.abs(left.liftPct);
+      })
+      .slice(0, 2)
+      .map((item) => ({
+        key: item.key,
+        label: item.label,
+        action: (item.correlation > 0 ? "add" : "reduce") as "add" | "reduce",
+        source: item.source,
+        sampled: item.sampled,
+        confidence: item.confidence,
+        estimatedImpactPct: Math.abs(item.liftPct),
+      }));
+
+    return nextTests.length > 0 ? { ...post, nextTests } : post;
+  });
+}
+
+function buildInstagramTestBacklog(
+  posts: InstagramTopPost[]
+): NonNullable<InstagramData["testBacklog"]> {
+  const summary = new Map<
+    string,
+    {
+      key: string;
+      label: string;
+      action: "add" | "reduce";
+      source: "metadata" | "ai_visual";
+      sampled: boolean;
+      confidence: "low" | "medium" | "high";
+      estimatedImpactPct: number;
+      supportingVideos: number;
+    }
+  >();
+
+  for (const post of posts) {
+    for (const idea of post.nextTests ?? []) {
+      const id = `${idea.action}:${idea.key}`;
+      const existing = summary.get(id);
+      if (existing) {
+        existing.supportingVideos += 1;
+        existing.estimatedImpactPct = roundTo(
+          (existing.estimatedImpactPct + idea.estimatedImpactPct) / 2,
+          0
+        );
+        if (
+          (idea.confidence === "high" && existing.confidence !== "high") ||
+          (idea.confidence === "medium" && existing.confidence === "low")
+        ) {
+          existing.confidence = idea.confidence;
+        }
+        existing.sampled = existing.sampled || idea.sampled;
+      } else {
+        summary.set(id, {
+          ...idea,
+          supportingVideos: 1,
+        });
+      }
+    }
+  }
+
+  return Array.from(summary.values())
+    .sort((left, right) => {
+      if (right.supportingVideos !== left.supportingVideos) {
+        return right.supportingVideos - left.supportingVideos;
+      }
+      const confidenceOrder = { high: 3, medium: 2, low: 1 };
+      if (confidenceOrder[right.confidence] !== confidenceOrder[left.confidence]) {
+        return confidenceOrder[right.confidence] - confidenceOrder[left.confidence];
+      }
+      return right.estimatedImpactPct - left.estimatedImpactPct;
+    })
+    .slice(0, 3);
+}
+
+function buildInstagramExperimentPlan(
+  posts: InstagramTopPost[],
+  testBacklog: NonNullable<InstagramData["testBacklog"]>
+): NonNullable<InstagramData["experimentPlan"]> {
+  return testBacklog.slice(0, 3).map((idea) => {
+    const exampleVideos = posts
+      .filter((post) =>
+        post.nextTests?.some((test) => test.key === idea.key && test.action === idea.action)
+      )
+      .slice(0, 2)
+      .map((post) => {
+        const normalized = post.message.trim();
+        return normalized.length > 60 ? `${normalized.slice(0, 60).trimEnd()}...` : normalized;
+      });
+
+    return {
+      key: `${idea.action}:${idea.key}`,
+      title: `${idea.action === "add" ? "Test adding" : "Test reducing"} ${idea.label.toLowerCase()}`,
+      brief:
+        idea.action === "add"
+          ? `Create follow-up variants that introduce ${idea.label.toLowerCase()} in otherwise similar videos.`
+          : `Create follow-up variants that reduce ${idea.label.toLowerCase()} while keeping the core hook similar.`,
+      action: idea.action,
+      source: idea.source,
+      sampled: idea.sampled,
+      confidence: idea.confidence,
+      estimatedImpactPct: idea.estimatedImpactPct,
+      supportingVideos: idea.supportingVideos,
+      exampleVideos,
+    };
+  });
+}
+
+function buildInstagramVideosToImprove(
+  posts: InstagramTopPost[]
+): NonNullable<InstagramData["videosToImprove"]> {
+  return posts
+    .filter((post) => post.isVideo && (post.nextTests?.length ?? 0) > 0)
+    .sort((left, right) => {
+      if (left.performanceScore !== right.performanceScore) {
+        return left.performanceScore - right.performanceScore;
+      }
+      return right.createdAt.localeCompare(left.createdAt);
+    })
+    .slice(0, 3);
+}
+
+function buildInstagramOpportunities(
+  correlations: InstagramAttributeCorrelation[]
+): NonNullable<InstagramData["opportunities"]> {
+  return correlations
+    .filter(
+      (item) =>
+        item.correlation > 0 &&
+        item.confidence !== "low" &&
+        item.eligiblePostCount > 0 &&
+        item.sampleSize > 0
+    )
+    .map((item) => ({
+      key: item.key,
+      label: item.label,
+      source: item.source,
+      sampled: item.sampled,
+      confidence: item.confidence,
+      estimatedImpactPct: Math.abs(item.liftPct),
+      adoptionPct: roundTo((item.sampleSize / item.eligiblePostCount) * 100, 0),
+    }))
+    .filter((item) => item.adoptionPct <= 50)
+    .sort((left, right) => {
+      if (left.adoptionPct !== right.adoptionPct) {
+        return left.adoptionPct - right.adoptionPct;
+      }
+      const confidenceOrder = { high: 3, medium: 2, low: 1 };
+      if (confidenceOrder[right.confidence] !== confidenceOrder[left.confidence]) {
+        return confidenceOrder[right.confidence] - confidenceOrder[left.confidence];
+      }
+      return right.estimatedImpactPct - left.estimatedImpactPct;
+    })
+    .slice(0, 3);
+}
+
+function buildInstagramWinningPatterns(
+  correlations: InstagramAttributeCorrelation[]
+): InstagramData["winningPatterns"] {
+  const strongest = correlations
+    .filter(
+      (item) => item.correlation > 0 && item.sampleSize >= 2 && item.confidence !== "low"
+    )
+    .sort((left, right) => {
+      if (right.confidenceScore !== left.confidenceScore) {
+        return right.confidenceScore - left.confidenceScore;
+      }
+      if (Math.abs(right.correlation) !== Math.abs(left.correlation)) {
+        return Math.abs(right.correlation) - Math.abs(left.correlation);
+      }
+      return right.liftPct - left.liftPct;
+    })
+    .slice(0, 3);
+
+  return strongest.map((item) => ({
+    title: item.label,
+    detail:
+      item.liftPct >= 1
+        ? `${item.label} are associated with ${item.liftPct.toFixed(0)}% stronger normalized performance on average (${item.confidence} confidence).`
+        : `${item.label} show a modest positive normalized-performance signal (${item.confidence} confidence).`,
+    source: item.source,
+    sampled: item.sampled,
+    confidence: item.confidence,
+  }));
+}
+
+function buildInstagramLosingPatterns(
+  correlations: InstagramAttributeCorrelation[]
+): InstagramData["losingPatterns"] {
+  const weakest = correlations
+    .filter(
+      (item) => item.correlation < 0 && item.sampleSize >= 2 && item.confidence !== "low"
+    )
+    .sort((left, right) => {
+      if (right.confidenceScore !== left.confidenceScore) {
+        return right.confidenceScore - left.confidenceScore;
+      }
+      if (Math.abs(right.correlation) !== Math.abs(left.correlation)) {
+        return Math.abs(right.correlation) - Math.abs(left.correlation);
+      }
+      return left.liftPct - right.liftPct;
+    })
+    .slice(0, 3);
+
+  return weakest.map((item) => ({
+    title: item.label,
+    detail:
+      item.liftPct <= -1
+        ? `${item.label} are associated with ${Math.abs(item.liftPct).toFixed(0)}% weaker normalized performance on average (${item.confidence} confidence).`
+        : `${item.label} show a modest negative normalized-performance signal (${item.confidence} confidence).`,
+    source: item.source,
+    sampled: item.sampled,
+    confidence: item.confidence,
+  }));
 }
 
 function extractApiErrorMessage(payload: unknown): string | null {
@@ -990,7 +1648,10 @@ export async function fetchMetaInstagramData(
   const mediaUrl = new URL(
     `https://graph.facebook.com/${META_GRAPH_VERSION}/${resolvedProfile.id}/media`
   );
-  mediaUrl.searchParams.set("fields", "id,caption,timestamp,like_count,comments_count");
+  mediaUrl.searchParams.set(
+    "fields",
+    "id,caption,timestamp,like_count,comments_count,media_type,media_product_type,permalink,thumbnail_url"
+  );
   
   const fromTime = Math.floor((from || new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)).getTime() / 1000);
   const toTime = Math.floor((to || new Date()).getTime() / 1000);
@@ -1013,6 +1674,10 @@ export async function fetchMetaInstagramData(
       timestamp?: string;
       like_count?: string | number;
       comments_count?: string | number;
+      media_type?: string;
+      media_product_type?: string;
+      permalink?: string;
+      thumbnail_url?: string;
     }>;
   }>(mediaResponse, "Instagram media")) as {
     data?: Array<{
@@ -1021,25 +1686,98 @@ export async function fetchMetaInstagramData(
       timestamp?: string;
       like_count?: string | number;
       comments_count?: string | number;
+      media_type?: string;
+      media_product_type?: string;
+      permalink?: string;
+      thumbnail_url?: string;
     }>;
   };
 
-  const media = (mediaData.data ?? []).map((item) => ({
-    id: item.id ?? "",
-    caption: item.caption ?? "",
-    timestamp: item.timestamp ?? "",
-    likes: readNumber(item.like_count),
-    comments: readNumber(item.comments_count),
-  }));
+  const media = scoreInstagramPosts(
+    (mediaData.data ?? [])
+    .map((item) =>
+      buildInstagramTopPost({
+        id: item.id ?? "",
+        caption: item.caption ?? "",
+        timestamp: item.timestamp ?? "",
+        likes: readNumber(item.like_count),
+        comments: readNumber(item.comments_count),
+        mediaType: readString(item.media_type) ?? "UNKNOWN",
+        mediaProductType: readString(item.media_product_type),
+        permalink: readString(item.permalink),
+        thumbnailUrl: readString(item.thumbnail_url),
+        followersCount: resolvedProfile.followersCount,
+      })
+    ),
+    to ?? new Date()
+  )
+    .sort((left, right) => {
+      if (right.performanceScore !== left.performanceScore) {
+        return right.performanceScore - left.performanceScore;
+      }
+      return right.createdAt.localeCompare(left.createdAt);
+    });
 
-  const engagement30d = media.reduce((sum, item) => sum + item.likes + item.comments, 0);
+  const emptyCreativeAnalysis = {
+    results: new Map(),
+    analyzedCount: 0,
+    totalCandidates: media.filter((post) => post.isVideo && post.thumbnailUrl).length,
+    sampled: false,
+  };
+  const creativeAnalysisResult = await withFallback(
+    enrichInstagramVideoCreatives(media, { limit: 6, concurrency: 2 }),
+    emptyCreativeAnalysis,
+    1500
+  );
+  const enrichedMedia = media.map((post) => {
+    const creative = creativeAnalysisResult.results.get(post.id);
+    return creative ? { ...post, ...creative } : post;
+  });
 
-  const topPosts = media.slice(0, 5).map((m) => ({
-    message: m.caption,
-    reach: m.likes + m.comments, // Using engagements as proxy reach if reach isn't pulled via insights
-    engagement: m.likes + m.comments,
-    createdAt: m.timestamp,
-  }));
+  const engagement30d = enrichedMedia.reduce((sum, item) => sum + item.engagement, 0);
+  const mediaTypeBreakdown = enrichedMedia.reduce(
+    (summary, item) => {
+      if (item.isReel) {
+        summary.reel += 1;
+      } else if (item.isCarousel) {
+        summary.carousel += 1;
+      } else if (item.isVideo) {
+        summary.video += 1;
+      } else if (item.mediaType === "IMAGE") {
+        summary.image += 1;
+      } else {
+        summary.other += 1;
+      }
+      return summary;
+    },
+    { image: 0, video: 0, reel: 0, carousel: 0, other: 0 }
+  );
+  const creativeAnalysis = {
+    analyzedVideos: creativeAnalysisResult.analyzedCount,
+    totalVideoCandidates: creativeAnalysisResult.totalCandidates,
+    sampled: creativeAnalysisResult.sampled,
+  };
+  const attributeCorrelations = buildInstagramAttributeCorrelations(
+    enrichedMedia,
+    creativeAnalysis
+  );
+  const explainedMedia = buildInstagramOptimizationIdeas(
+    buildInstagramPerformanceDrivers(
+      enrichedMedia,
+      attributeCorrelations
+    ),
+    attributeCorrelations
+  );
+  const winningPatterns = buildInstagramWinningPatterns(attributeCorrelations);
+  const losingPatterns = buildInstagramLosingPatterns(attributeCorrelations);
+  const topPosts = explainedMedia.slice(0, 5);
+  const topVideos = explainedMedia
+    .filter((item) => item.isVideo)
+    .slice(0, 5);
+  const videosToImprove = buildInstagramVideosToImprove(explainedMedia);
+  const opportunities = buildInstagramOpportunities(attributeCorrelations);
+  const testBacklog = buildInstagramTestBacklog(topVideos);
+  const experimentPlan = buildInstagramExperimentPlan(topVideos, testBacklog);
 
   return {
     followers: resolvedProfile.followersCount,
@@ -1050,6 +1788,16 @@ export async function fetchMetaInstagramData(
     clicks: 0,
     returningVisitors: 0,
     topPosts,
+    topVideos,
+    videosToImprove,
+    mediaTypeBreakdown,
+    creativeAnalysis,
+    opportunities,
+    experimentPlan,
+    testBacklog,
+    attributeCorrelations,
+    winningPatterns,
+    losingPatterns,
     _meta: makeMeta("live"),
   };
 }

--- a/src/lib/analytics/instagram-creative-analysis.ts
+++ b/src/lib/analytics/instagram-creative-analysis.ts
@@ -1,0 +1,157 @@
+import OpenAI from "openai";
+import type { ChatCompletionContentPart } from "openai/resources/chat/completions/completions";
+import type { InstagramTopPost } from "./types";
+
+type CreativeSignalResult = Pick<
+  InstagramTopPost,
+  | "creativeSummary"
+  | "hasPersonVisible"
+  | "hasTextOverlayVisible"
+  | "looksLikeShopFloor"
+  | "looksLikeProductDemo"
+  | "looksEducational"
+  | "looksPromotional"
+>;
+
+export interface InstagramCreativeEnrichmentResult {
+  results: Map<string, CreativeSignalResult>;
+  analyzedCount: number;
+  totalCandidates: number;
+  sampled: boolean;
+}
+
+let client: OpenAI | null = null;
+
+function getClient(): OpenAI | null {
+  const apiKey = process.env.OPENAI_API_KEY?.trim();
+  if (!apiKey) return null;
+  if (!client) {
+    client = new OpenAI({ apiKey });
+  }
+  return client;
+}
+
+function clampSummary(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized ? normalized.slice(0, 220) : null;
+}
+
+function asBoolean(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
+function parseCreativeSignalPayload(content: string): CreativeSignalResult | null {
+  try {
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    return {
+      creativeSummary: clampSummary(parsed.creativeSummary),
+      hasPersonVisible: asBoolean(parsed.hasPersonVisible),
+      hasTextOverlayVisible: asBoolean(parsed.hasTextOverlayVisible),
+      looksLikeShopFloor: asBoolean(parsed.looksLikeShopFloor),
+      looksLikeProductDemo: asBoolean(parsed.looksLikeProductDemo),
+      looksEducational: asBoolean(parsed.looksEducational),
+      looksPromotional: asBoolean(parsed.looksPromotional),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function analyzeSinglePost(post: InstagramTopPost): Promise<CreativeSignalResult | null> {
+  const openai = getClient();
+  if (!openai || !post.thumbnailUrl) return null;
+
+  const content: ChatCompletionContentPart[] = [
+    {
+      type: "text",
+      text: [
+        "Analyze this Instagram video creative using the caption plus thumbnail.",
+        "Return only JSON with this shape:",
+        '{"creativeSummary":"string","hasPersonVisible":true,"hasTextOverlayVisible":true,"looksLikeShopFloor":false,"looksLikeProductDemo":false,"looksEducational":true,"looksPromotional":false}',
+        "Use null only when a trait cannot be inferred reliably.",
+        `Caption: ${post.message || "(empty caption)"}`,
+      ].join("\n"),
+    },
+    {
+      type: "image_url",
+      image_url: {
+        url: post.thumbnailUrl,
+      },
+    },
+  ];
+
+  try {
+    const response = await openai.chat.completions.create({
+      model: process.env.OPENAI_INSTAGRAM_ANALYSIS_MODEL?.trim() || "gpt-4o-mini",
+      temperature: 0.1,
+      max_tokens: 300,
+      response_format: { type: "json_object" },
+      messages: [
+        {
+          role: "system",
+          content:
+            "You are analyzing short-form social video creatives. Be conservative. Infer only directly observable traits from the thumbnail and caption.",
+        },
+        {
+          role: "user",
+          content,
+        },
+      ],
+    });
+
+    const text = response.choices[0]?.message?.content;
+    if (!text) return null;
+    return parseCreativeSignalPayload(text);
+  } catch {
+    return null;
+  }
+}
+
+export async function enrichInstagramVideoCreatives(
+  posts: InstagramTopPost[],
+  options?: { limit?: number; concurrency?: number }
+): Promise<InstagramCreativeEnrichmentResult> {
+  const candidates = posts.filter((post) => post.isVideo && post.thumbnailUrl);
+  if (candidates.length === 0) {
+    return {
+      results: new Map(),
+      analyzedCount: 0,
+      totalCandidates: 0,
+      sampled: false,
+    };
+  }
+  if (!getClient()) {
+    return {
+      results: new Map(),
+      analyzedCount: 0,
+      totalCandidates: candidates.length,
+      sampled: false,
+    };
+  }
+
+  const limit = Math.max(1, Math.min(options?.limit ?? 8, 12));
+  const concurrency = Math.max(1, Math.min(options?.concurrency ?? 3, 4));
+  const queue = candidates.slice(0, limit);
+  const results = new Map<string, CreativeSignalResult>();
+  let cursor = 0;
+
+  async function worker(): Promise<void> {
+    while (cursor < queue.length) {
+      const current = queue[cursor];
+      cursor += 1;
+      const analyzed = await analyzeSinglePost(current);
+      if (analyzed) {
+        results.set(current.id, analyzed);
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, queue.length) }, () => worker()));
+  return {
+    results,
+    analyzedCount: queue.length,
+    totalCandidates: candidates.length,
+    sampled: candidates.length > queue.length,
+  };
+}

--- a/src/lib/analytics/monthly-pnl-history.ts
+++ b/src/lib/analytics/monthly-pnl-history.ts
@@ -4,7 +4,6 @@
 import { prisma } from "@/lib/prisma";
 import { AnalyticsSnapshotStatus } from "@/generated/prisma/client";
 import { buildProfitAndLossCore } from "./pnl-builder";
-import { normalizeMercuryDataPayload } from "./mercury-normalization";
 import { resolveIntegrationOwnerUserId } from "@/lib/integrations/ownership";
 import type { StripeData, MercuryData, PnLRow } from "./types";
 
@@ -111,7 +110,7 @@ async function loadMonthlySnapshots(
   return sortedMonths.map(([month, data]) => ({
     month,
     stripe: data.stripe,
-    mercury: data.mercury ? normalizeMercuryDataPayload(data.mercury) : null,
+    mercury: data.mercury,
   }));
 }
 

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -463,6 +463,76 @@ export interface MetaPageData {
 // INSTAGRAM PAGE TYPES
 // ══════════════════════════════════════════════════════════
 
+export interface InstagramTopPost {
+  id: string;
+  message: string;
+  reach: number;
+  engagement: number;
+  createdAt: string;
+  mediaType: string;
+  mediaProductType: string | null;
+  permalink: string | null;
+  thumbnailUrl: string | null;
+  likeCount: number;
+  commentCount: number;
+  performanceScore: number;
+  engagementRate: number;
+  ageInDays: number;
+  engagementVelocity: number;
+  captionLength: number;
+  hashtagCount: number;
+  mentionCount: number;
+  emojiCount: number;
+  hasQuestionHook: boolean;
+  hasCallToAction: boolean;
+  postedTimeBucket: "morning" | "afternoon" | "evening" | "overnight";
+  isVideo: boolean;
+  isReel: boolean;
+  isCarousel: boolean;
+  creativeSummary?: string | null;
+  hasPersonVisible?: boolean | null;
+  hasTextOverlayVisible?: boolean | null;
+  looksLikeShopFloor?: boolean | null;
+  looksLikeProductDemo?: boolean | null;
+  looksEducational?: boolean | null;
+  looksPromotional?: boolean | null;
+  performanceDrivers?: Array<{
+    key: string;
+    label: string;
+    source: "metadata" | "ai_visual";
+    sampled: boolean;
+    confidence: "low" | "medium" | "high";
+    liftPct: number;
+  }>;
+  nextTests?: Array<{
+    key: string;
+    label: string;
+    action: "add" | "reduce";
+    source: "metadata" | "ai_visual";
+    sampled: boolean;
+    confidence: "low" | "medium" | "high";
+    estimatedImpactPct: number;
+  }>;
+}
+
+export interface InstagramAttributeCorrelation {
+  key: string;
+  label: string;
+  source: "metadata" | "ai_visual";
+  correlation: number;
+  sampleSize: number;
+  comparisonSampleSize: number;
+  eligiblePostCount: number;
+  coveragePct: number;
+  trueAvgEngagement: number;
+  falseAvgEngagement: number;
+  liftPct: number;
+  sampled: boolean;
+  confidence: "low" | "medium" | "high";
+  confidenceScore: number;
+  interpretation: string;
+}
+
 export interface InstagramData {
   followers: number;
   reach30d: number;
@@ -471,7 +541,67 @@ export interface InstagramData {
   bounceRate: number;
   clicks: number;
   returningVisitors: number;
-  topPosts: { message: string; reach: number; engagement: number; createdAt: string }[];
+  topPosts: InstagramTopPost[];
+  topVideos?: InstagramTopPost[];
+  videosToImprove?: InstagramTopPost[];
+  mediaTypeBreakdown?: {
+    image: number;
+    video: number;
+    reel: number;
+    carousel: number;
+    other: number;
+  };
+  creativeAnalysis?: {
+    analyzedVideos: number;
+    totalVideoCandidates: number;
+    sampled: boolean;
+  };
+  opportunities?: Array<{
+    key: string;
+    label: string;
+    source: "metadata" | "ai_visual";
+    sampled: boolean;
+    confidence: "low" | "medium" | "high";
+    estimatedImpactPct: number;
+    adoptionPct: number;
+  }>;
+  experimentPlan?: Array<{
+    key: string;
+    title: string;
+    brief: string;
+    action: "add" | "reduce";
+    source: "metadata" | "ai_visual";
+    sampled: boolean;
+    confidence: "low" | "medium" | "high";
+    estimatedImpactPct: number;
+    supportingVideos: number;
+    exampleVideos: string[];
+  }>;
+  testBacklog?: Array<{
+    key: string;
+    label: string;
+    action: "add" | "reduce";
+    source: "metadata" | "ai_visual";
+    sampled: boolean;
+    confidence: "low" | "medium" | "high";
+    estimatedImpactPct: number;
+    supportingVideos: number;
+  }>;
+  attributeCorrelations?: InstagramAttributeCorrelation[];
+  winningPatterns?: Array<{
+    title: string;
+    detail: string;
+    source: "metadata" | "ai_visual";
+    sampled: boolean;
+    confidence: "low" | "medium" | "high";
+  }>;
+  losingPatterns?: Array<{
+    title: string;
+    detail: string;
+    source: "metadata" | "ai_visual";
+    sampled: boolean;
+    confidence: "low" | "medium" | "high";
+  }>;
   _meta: AnalyticsTimestamp;
 }
 


### PR DESCRIPTION
## Summary
- enrich Meta Instagram media with creative metadata and optional AI visual analysis
- add normalized performance scoring, correlations, opportunities, experiment planning, and per-video recommendations
- expand the analytics UI and tests to explain top videos and suggest how to improve weaker ones

## Verification
- npx vitest run src/lib/__tests__/analytics-fetchers-ads.test.ts src/components/analytics/marketing-tab-new.test.tsx src/app/api/analytics/route.test.ts
- pre-commit lint-staged ran successfully during commit