### PR TITLE
feat: ship CEO metric trust layer and analytics-first surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 
 # testing
 /coverage
+/playwright-report/
+/test-results/
+/tests/e2e/.auth/*
+!/tests/e2e/.auth/.gitkeep
 
 # next.js
 /.next/

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,6 @@ USER nextjs
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
-  CMD node -e "fetch('http://127.0.0.1:3000/api/health').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))"
+  CMD node -e "fetch('http://127.0.0.1:3000/api/health/live').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))"
 
 ENTRYPOINT ["sh", "/app/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,18 @@
 #!/bin/sh
 set -e
 
-MIGRATIONS_MODE="${MIGRATIONS_MODE:-best-effort}"
+MIGRATIONS_DIR="${MIGRATIONS_DIR:-/app/prisma/migrations}"
+if [ ! -d "$MIGRATIONS_DIR" ] && [ -d "prisma/migrations" ]; then
+  MIGRATIONS_DIR="prisma/migrations"
+fi
+
+if [ -z "${MIGRATIONS_MODE+x}" ]; then
+  if [ -d "$MIGRATIONS_DIR" ] && find "$MIGRATIONS_DIR" -maxdepth 1 -type d -name "*ceo_metric*" | grep -q .; then
+    MIGRATIONS_MODE="strict"
+  else
+    MIGRATIONS_MODE="best-effort"
+  fi
+fi
 
 case "$MIGRATIONS_MODE" in
   skip)

--- a/docs/runbooks/ceo-metric-production-rollout.md
+++ b/docs/runbooks/ceo-metric-production-rollout.md
@@ -1,0 +1,61 @@
+# CEO Metric Production Rollout
+
+This runbook validates the CEO Metric Trust Layer before a Railway production deploy.
+
+## Readiness Rule
+
+The CEO command center is visible to authenticated users, but generated metrics and reports must remain `not_board_final` until every default report-pack metric has:
+
+- an explicit calculator
+- a source-system citation
+- source lineage
+- a fresh source under its metric-specific SLA
+- a non-empty value
+- parity coverage against the source dashboard or snapshot calculation
+
+Metrics that are stale, partial, missing, errored, conflicted, or unverified can be shown only with the trust state and failing readiness gate.
+
+## Pre-Deploy Gate
+
+Run these checks from the repository root:
+
+```bash
+npm test
+npx tsc --noEmit --pretty false
+npm run lint
+npm run build
+MIGRATIONS_MODE=strict node migrate.cjs
+```
+
+The production container defaults to strict migrations when the CEO metric migration is present. Do not deploy this phase with `MIGRATIONS_MODE=best-effort` unless rolling back the CEO feature is the explicit incident response.
+
+## Railway Deploy
+
+1. Confirm the target Railway service is production.
+2. Confirm `DATABASE_URL` points at the production Postgres service.
+3. Confirm `MIGRATIONS_MODE` is unset or set to `strict`.
+4. Deploy the app service.
+5. Watch startup logs for `Running migrations (MIGRATIONS_MODE=strict)...`.
+6. Stop the rollout if migrations fail; the app should not start in this phase.
+
+## Smoke Checks
+
+After deployment, verify:
+
+```bash
+curl -fsS https://<production-host>/api/health/live
+curl -fsS https://<production-host>/api/ceo/metrics
+curl -fsS https://<production-host>/api/ceo/reports
+```
+
+Then sign in and verify:
+
+- `/analytics/ceo` loads for an authenticated user.
+- The production readiness banner is visible.
+- Any failing gates are shown as `not_board_final`.
+- Weekly Exec, Board Meeting, Investor Update, and Custom Metric Snapshot report packs can generate report runs.
+- Markdown, CSV, and slide-ready JSON exports include readiness status, failing gates, trust labels, source lineage, and freshness warnings.
+
+## Rollback
+
+If metrics are unavailable but the app is otherwise healthy, leave the route visible and investigate the failing gates. If strict migration failure blocks startup, roll back to the last known-good Railway deployment and inspect the failed migration against production-like data before retrying.

--- a/docs/superpowers/plans/2026-05-05-analytics-api-meeting-place-surface-removal.md
+++ b/docs/superpowers/plans/2026-05-05-analytics-api-meeting-place-surface-removal.md
@@ -1,0 +1,566 @@
+# Analytics API Meeting Place Surface Removal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make WIPGuard's visible product surface analytics-first by sending authenticated users to `/analytics`, hiding task/board/work-management routes and CTAs, and reframing legacy task-derived CEO metrics as internal execution data while preserving existing backend contracts.
+**Architecture:** Add a shared analytics-home route constant, redirect legacy work-management pages to `/analytics`, make workspace navigation analytics-first, prune task/board settings tabs, update marketing copy, remove task creation controls from analytics, and keep legacy data/API surfaces available for compatibility.
+**Tech Stack:** Next.js App Router, React, TypeScript, Vitest/React Testing Library, existing analytics registry, existing CEO metric trust layer, Prisma models preserved.
+
+---
+
+## Operating Constraints
+
+- [ ] Do not delete Prisma task, board, project, sprint, priority, or department models in this phase.
+- [ ] Do not remove task/project/sprint API routes in this phase.
+- [ ] Do not change automation execution contracts that currently emit `create_task` actions.
+- [ ] Do remove visible navigation, pages, settings tabs, and CTA paths that position WIPGuard as a task or board product.
+- [ ] Keep all redirects authenticated by the existing `(dashboard)` layout. Page-level auth checks are unnecessary for legacy pages inside that layout.
+- [ ] Stage and commit only files touched by this implementation. The worktree contains unrelated changes that must be preserved.
+
+## Task 1: Centralize Analytics Home And Redirect Legacy Product Routes
+
+- [ ] Add a route constant file at `src/lib/platform/routes.ts`:
+
+  ```ts
+  export const ANALYTICS_HOME = "/analytics" as const;
+  ```
+
+- [ ] Add a legacy redirect helper at `src/app/(dashboard)/legacy-analytics-redirect.ts`:
+
+  ```ts
+  import { redirect } from "next/navigation";
+  import { ANALYTICS_HOME } from "@/lib/platform/routes";
+
+  export function redirectToAnalyticsHome(): never {
+    redirect(ANALYTICS_HOME);
+  }
+  ```
+
+- [ ] Update `src/app/page.tsx` so authenticated users redirect to `ANALYTICS_HOME` instead of `"/dashboard"`:
+
+  ```ts
+  import { ANALYTICS_HOME } from "@/lib/platform/routes";
+
+  if (session?.user) {
+    redirect(ANALYTICS_HOME);
+  }
+  ```
+
+- [ ] Replace legacy product pages with calls to `redirectToAnalyticsHome()`:
+
+  - `src/app/(dashboard)/dashboard/page.tsx`
+  - `src/app/(dashboard)/tasks/page.tsx`
+  - `src/app/(dashboard)/board/page.tsx`
+  - `src/app/(dashboard)/my-tasks/page.tsx`
+  - `src/app/(dashboard)/projects/page.tsx`
+  - `src/app/(dashboard)/standup/page.tsx`
+  - `src/app/(dashboard)/today/page.tsx`
+  - `src/app/(dashboard)/whip/page.tsx`
+  - `src/app/(dashboard)/table/page.tsx`
+  - `src/app/(dashboard)/logbook/page.tsx`
+
+  Each page should become the same shape:
+
+  ```ts
+  import { redirectToAnalyticsHome } from "@/app/(dashboard)/legacy-analytics-redirect";
+
+  export default function LegacyDashboardRoute() {
+    redirectToAnalyticsHome();
+  }
+  ```
+
+- [ ] Remove `KanbanBoard` and `auth` imports from `src/app/(dashboard)/tasks/page.tsx`.
+- [ ] Keep `src/app/(dashboard)/automations/ralph-board/page.tsx` redirecting to `/automations`; it already prevents the board UI from rendering and keeps automation context in the automation workspace.
+- [ ] Replace `src/app/(dashboard)/tasks/page.test.tsx` with redirect coverage for the new `TasksPage` behavior, or move it into the new route test file below.
+- [ ] Add `src/app/(dashboard)/legacy-product-routes.test.tsx` covering all redirected legacy pages:
+
+  ```ts
+  import { beforeEach, describe, expect, it, vi } from "vitest";
+  import DashboardPage from "@/app/(dashboard)/dashboard/page";
+  import TasksPage from "@/app/(dashboard)/tasks/page";
+  import BoardPage from "@/app/(dashboard)/board/page";
+  import MyTasksPage from "@/app/(dashboard)/my-tasks/page";
+  import ProjectsPage from "@/app/(dashboard)/projects/page";
+  import StandupPage from "@/app/(dashboard)/standup/page";
+  import TodayPage from "@/app/(dashboard)/today/page";
+  import WhipPage from "@/app/(dashboard)/whip/page";
+  import TablePage from "@/app/(dashboard)/table/page";
+  import LogbookPage from "@/app/(dashboard)/logbook/page";
+  import { ANALYTICS_HOME } from "@/lib/platform/routes";
+
+  vi.mock("next/navigation", () => ({
+    redirect: vi.fn((target: string) => {
+      throw new Error(`NEXT_REDIRECT:${target}`);
+    }),
+  }));
+
+  const routes = [
+    ["dashboard", DashboardPage],
+    ["tasks", TasksPage],
+    ["board", BoardPage],
+    ["my-tasks", MyTasksPage],
+    ["projects", ProjectsPage],
+    ["standup", StandupPage],
+    ["today", TodayPage],
+    ["whip", WhipPage],
+    ["table", TablePage],
+    ["logbook", LogbookPage],
+  ] as const;
+
+  describe("legacy product routes", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it.each(routes)("redirects /%s to analytics", async (_name, Page) => {
+      const { redirect } = await import("next/navigation");
+
+      await expect(async () => Page()).rejects.toThrow(`NEXT_REDIRECT:${ANALYTICS_HOME}`);
+      expect(redirect).toHaveBeenCalledWith(ANALYTICS_HOME);
+    });
+  });
+  ```
+
+- [ ] Run:
+
+  ```bash
+  npm test -- 'src/app/(dashboard)/legacy-product-routes.test.tsx' 'src/app/(dashboard)/tasks/page.test.tsx'
+  ```
+
+  Expected output: Vitest reports the listed route tests passing. If `tasks/page.test.tsx` is removed, omit it from the command.
+
+## Task 2: Make The Sidebar Analytics-First
+
+- [ ] Update `src/lib/platform/workspaces.ts`:
+
+  - Remove `"dashboard"` from `WorkspaceId`.
+  - Remove the Dashboard entry from `WORKSPACE_NAV_ITEMS`.
+  - Put `analytics` first, then `integrations`, then `deals`, then `automations`.
+  - Update analytics description to: `"Metric trust, source health, customer journey, and operating intelligence."`
+  - Keep CEO Command Center as the first analytics child.
+
+- [ ] Update `src/components/layout/sidebar-nav-config.ts`:
+
+  - Remove `LayoutDashboard` import.
+  - Remove `dashboard: LayoutDashboard` from `WORKSPACE_ICONS`.
+  - Keep icon mappings for `analytics`, `integrations`, `deals`, and `automations`.
+
+- [ ] Update `src/components/layout/sidebar.tsx`:
+
+  - Replace the brand icon import with `Activity`.
+  - Replace visible brand text from `WIPGuard` to `WIPGuard Analytics`.
+  - Keep the Settings secondary link.
+
+  Target brand block:
+
+  ```tsx
+  <Activity className="h-6 w-6 text-primary" aria-hidden="true" />
+  <span className="text-lg font-bold text-foreground">WIPGuard Analytics</span>
+  ```
+
+- [ ] Update `src/lib/__tests__/sidebar-analytics-nav.test.ts`:
+
+  - Rename `"builds the five top-level product pillars"` to `"builds the analytics-first workspace pillars"`.
+  - Expect top-level IDs in this order:
+
+    ```ts
+    expect(navItems.map((item) => item.id)).toEqual([
+      "analytics",
+      "integrations",
+      "deals",
+      "automations",
+    ]);
+    ```
+
+  - Keep assertions for `/analytics/ai-insights`, `/integrations`, `/automations`, and `/automations/artifacts`.
+  - Add an assertion that `navItems.some((item) => item.href === "/dashboard")` is `false`.
+
+- [ ] Run:
+
+  ```bash
+  npm test -- src/lib/__tests__/sidebar-analytics-nav.test.ts
+  ```
+
+  Expected output: Sidebar nav tests pass and no type errors reference the removed `dashboard` workspace ID.
+
+## Task 3: Remove Task/Board Settings Tabs From The Visible Product
+
+- [ ] Update `src/app/(dashboard)/settings/page.tsx`:
+
+  - Remove imports for:
+    - `BoardSettingsTab`
+    - `SprintsTab`
+    - `ProjectsTab`
+    - `PrioritiesTab`
+    - `DepartmentsTab`
+    - `DesignInterviewTab`
+  - Keep imports for `TeamTab` and `OperationsTab`.
+  - Replace `TABS` with:
+
+    ```ts
+    const TABS = [
+      { id: "team", label: "Team" },
+      { id: "operations", label: "Operations" },
+    ] as const;
+    ```
+
+  - Add:
+
+    ```ts
+    const LEGACY_SETTINGS_TABS = new Set([
+      "board",
+      "sprints",
+      "projects",
+      "departments",
+      "priorities",
+      "design-interview",
+    ]);
+    ```
+
+  - Change the default active tab to `"team"`.
+  - Keep `tab=integrations` redirecting to `/integrations` with remaining query params preserved.
+  - Redirect any legacy settings tab to the same settings URL with `tab=team`, preserving remaining query params:
+
+    ```ts
+    if (tabParam && LEGACY_SETTINGS_TABS.has(tabParam)) {
+      const params = new URLSearchParams(searchParams?.toString() ?? "");
+      params.set("tab", "team");
+      const basePath = pathname || "/settings";
+      router.replace(`${basePath}?${params.toString()}`, { scroll: false });
+    }
+    ```
+
+  - Return `null` while `tab=integrations` or a legacy settings tab is being redirected.
+  - Replace the settings subtitle with:
+
+    ```tsx
+    Configure team access and analytics operating guardrails.
+    ```
+
+  - Render only:
+
+    ```tsx
+    {activeTab === "team" && <TeamTab />}
+    {activeTab === "operations" && <OperationsTab />}
+    ```
+
+- [ ] Update `src/app/(dashboard)/settings/page.test.tsx`:
+
+  - Mock only `TeamTab` and `OperationsTab`.
+  - Assert default render shows `Team` and `Operations`.
+  - Assert these visible tabs are absent:
+    - `Board & WIP Limits`
+    - `Sprints`
+    - `Projects`
+    - `Departments`
+    - `Company Priorities`
+    - `Design Interview`
+  - Keep the legacy integrations redirect test.
+  - Add a legacy tab redirect test:
+
+    ```ts
+    mockSearchParams = new URLSearchParams("tab=board&source=old-link");
+
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith(
+        "/settings?tab=team&source=old-link",
+        { scroll: false },
+      );
+    });
+    ```
+
+- [ ] Run:
+
+  ```bash
+  npm test -- 'src/app/(dashboard)/settings/page.test.tsx'
+  ```
+
+  Expected output: Settings tests pass and no removed settings tab component is imported by the page.
+
+## Task 4: Reframe Marketing Copy Around Analytics And Metric Trust
+
+- [ ] Update `src/components/marketing/home-landing.tsx` to remove board/WIP/task positioning from the public landing page.
+- [ ] Replace the hero eyebrow with:
+
+  ```tsx
+  Analytics API meeting place
+  ```
+
+- [ ] Replace the H1 with:
+
+  ```tsx
+  Make every business metric traceable.
+  ```
+
+- [ ] Replace hero body copy with:
+
+  ```tsx
+  WIPGuard brings finance, sales, marketing, customer success, and internal execution sources into one governed metric layer with freshness, lineage, and board-ready exports.
+  ```
+
+- [ ] Keep the primary CTA text `Access workspace`.
+- [ ] Replace the secondary CTA text with `See the metric layer`.
+- [ ] Replace task/board-oriented stat cards with analytics-oriented cards:
+
+  ```ts
+  const METRICS = [
+    {
+      label: "Source trust",
+      value: "Freshness, lineage, and warnings stay attached to every number",
+    },
+    {
+      label: "Board packs",
+      value: "Weekly exec, board, investor, and custom snapshots reuse the same facts",
+    },
+    {
+      label: "Live integrations",
+      value: "Finance, CRM, ads, web, CS, and workspace systems meet in one API layer",
+    },
+  ];
+  ```
+
+- [ ] Replace any remaining visible phrases in `home-landing.tsx` that position the product as task management:
+
+  - `WIP-limited GTM operating system`
+  - `Stop starting. Start finishing revenue work.`
+  - `Board movement`
+  - `WIP policies`
+  - `task gets pulled`
+  - `See the flow`
+
+- [ ] Update `src/components/marketing/home-landing.test.tsx`:
+
+  ```ts
+  expect(
+    screen.getByRole("heading", {
+      name: /make every business metric traceable\./i,
+    })
+  ).toBeTruthy();
+  expect(screen.getAllByRole("link", { name: /access workspace/i }).length).toBeGreaterThan(0);
+  expect(screen.getByRole("link", { name: /see the metric layer/i })).toBeTruthy();
+  ```
+
+- [ ] Run:
+
+  ```bash
+  npm test -- src/components/marketing/home-landing.test.tsx
+  ```
+
+  Expected output: Landing page test passes with analytics-first copy.
+
+## Task 5: Remove Analytics Task Creation CTAs
+
+- [ ] Update `src/components/analytics/insight-card-actions.tsx`:
+
+  - Remove `onCreateTask` and `isCreatingTask` props.
+  - Remove the `Task` button.
+  - Keep only pin and dismiss actions.
+
+- [ ] Update `src/components/analytics/insight-card-full.tsx`:
+
+  - Remove `onCreateTask` and `isCreatingTask` props.
+  - Change `showActions` to:
+
+    ```ts
+    const showActions = onTogglePin != null && onDismiss != null;
+    ```
+
+  - Pass only `isPinned`, `onTogglePin`, and `onDismiss` to `InsightCardActions`.
+
+- [ ] Update `src/components/analytics/ai-insights-page.tsx`:
+
+  - Stop destructuring `createTaskFromInsight` and `creatingTaskForId` from `useInsightPreferences()`.
+  - Remove `taskError`, `setTaskError`, and `handleCreateTask`.
+  - Remove the task error banner.
+  - Stop passing `onCreateTask` and `isCreatingTask` to `InsightCardFull`.
+  - In the right-side action queue, remove the `Create task` button and keep only the destination link when present.
+  - Rename the right-side heading from `Action queue` to `Recommended moves`.
+  - Keep `Actionable Plays` as a signal count because it describes insight metadata, not task management.
+
+- [ ] Leave `src/lib/hooks/use-insight-preferences.ts` unchanged in this phase. It is an internal compatibility hook and may still be used by future automation flows.
+- [ ] Update `src/components/analytics/ai-insights-page.test.tsx`:
+
+  - Keep the existing pagination and rerun tests.
+  - Strengthen the create-task absence assertion:
+
+    ```ts
+    expect(screen.queryByRole("button", { name: /create task/i })).toBeNull();
+    expect(screen.queryByText(/^Task$/)).toBeNull();
+    expect(screen.queryByText(/Creating\.\.\./)).toBeNull();
+    ```
+
+  - Assert the side panel heading is `Recommended moves`.
+
+- [ ] Keep `src/components/analytics/__tests__/insight-card-actions.test.tsx` expecting exactly two buttons.
+- [ ] Run:
+
+  ```bash
+  npm test -- src/components/analytics/ai-insights-page.test.tsx src/components/analytics/__tests__/insight-card-actions.test.tsx
+  ```
+
+  Expected output: AI insights and action toolbar tests pass with no visible create-task controls.
+
+## Task 6: Reframe Legacy Execution Metrics Without Breaking Metric Keys
+
+- [ ] Update `src/lib/ceo/metric-trust.ts` labels and descriptions without changing metric keys:
+
+  - `ceo.flow_reliability_score`
+    - Label: `Internal Execution Reliability`
+    - Description: `Composite legacy internal execution reliability score from overdue, stale, blocker, throughput, and work-in-progress signals.`
+  - `ceo.throughput_30d`
+    - Label: `Internal Execution Throughput 30d`
+    - Description: `Completed legacy internal execution items over the trailing 30 days.`
+  - `ceo.overdue_open_tasks`
+    - Label: `Legacy Open Execution Items`
+    - Description: `Open legacy internal execution items past their expected date.`
+
+- [ ] Update report section titles in `src/lib/ceo/metric-trust.ts`:
+
+  - `Execution` to `Internal Execution`
+  - `Operating System` to `Operational Signals`
+
+- [ ] Update `src/components/analytics/ceo-command-center.test.tsx` fixtures and assertions from `Flow Reliability Score` to `Internal Execution Reliability`.
+- [ ] Update `src/components/analytics/customer-success-operational-view-model.ts` label `Overdue Open Tasks` to `Legacy Open Execution Items`.
+- [ ] Update `src/components/analytics/ops-insights.tsx` labels:
+
+  - `Flow Reliability` to `Internal Execution Reliability`
+  - `Overdue Open Tasks` to `Legacy Open Execution Items`
+
+- [ ] Update any tests that assert the old labels:
+
+  ```bash
+  rg -n "Flow Reliability|Throughput 30d|Overdue Open Tasks|Operating System|Execution" src/**/*.test.ts src/**/*.test.tsx src/lib src/components
+  ```
+
+  Expected output after edits: no user-facing assertions remain for old task-management labels except intentional internal metric keys.
+
+- [ ] Run:
+
+  ```bash
+  npm test -- src/components/analytics/ceo-command-center.test.tsx src/lib/ceo/service.test.ts
+  ```
+
+  Expected output: CEO command center and CEO service tests pass. Service tests may keep metric-key assertions; only display labels should change.
+
+## Task 7: Fix Analytics Registry Legacy Redirects And Labels
+
+- [ ] Update `src/lib/analytics/section-registry.ts`:
+
+  - Change `LEGACY_ANALYTICS_ROUTE_REDIRECTS.tasks` from `"/dashboard"` to `"/analytics/customer-success"`.
+  - Keep `LEGACY_ANALYTICS_TAB_REDIRECTS.tasks` at `"/analytics/customer-success"`.
+  - Rename subsection label `Free Kanban Generator (Whitepaper)` to `Coda Lead Magnet (Whitepaper)` while preserving id `ads-coda-kanban` and path `/analytics/ads-coda-kanban` for compatibility.
+
+- [ ] Update `src/lib/__tests__/analytics-section-registry.test.ts`:
+
+  - Add:
+
+    ```ts
+    expect(LEGACY_ANALYTICS_ROUTE_REDIRECTS.tasks).toBe("/analytics/customer-success");
+    ```
+
+  - Add an assertion that the `ads-coda-kanban` subsection label is `Coda Lead Magnet (Whitepaper)`.
+
+- [ ] Run:
+
+  ```bash
+  npm test -- src/lib/__tests__/analytics-section-registry.test.ts
+  ```
+
+  Expected output: Analytics registry tests pass and no legacy analytics route points to `/dashboard`.
+
+## Task 8: Focused Verification
+
+- [ ] Run the focused surface-removal suite:
+
+  ```bash
+  npm test -- \
+    'src/app/(dashboard)/legacy-product-routes.test.tsx' \
+    'src/app/(dashboard)/settings/page.test.tsx' \
+    src/lib/__tests__/sidebar-analytics-nav.test.ts \
+    src/lib/__tests__/analytics-section-registry.test.ts \
+    src/components/marketing/home-landing.test.tsx \
+    src/components/analytics/ai-insights-page.test.tsx \
+    src/components/analytics/__tests__/insight-card-actions.test.tsx \
+    src/components/analytics/ceo-command-center.test.tsx \
+    src/lib/ceo/service.test.ts
+  ```
+
+  Expected output: all listed tests pass.
+
+- [ ] Run typecheck:
+
+  ```bash
+  npx tsc --noEmit --pretty false
+  ```
+
+  Expected output: command exits 0 with no TypeScript errors.
+
+- [ ] Run lint:
+
+  ```bash
+  npm run lint
+  ```
+
+  Expected output: command exits 0.
+
+- [ ] Run production build:
+
+  ```bash
+  npm run build
+  ```
+
+  Expected output: Next.js build exits 0.
+
+## Task 9: Manual Product Smoke
+
+- [ ] Start the local server:
+
+  ```bash
+  npm run dev
+  ```
+
+- [ ] In an authenticated browser session, verify:
+
+  - `/` redirects to `/analytics`.
+  - `/dashboard` redirects to `/analytics`.
+  - `/tasks` redirects to `/analytics`.
+  - `/board` redirects to `/analytics`.
+  - `/projects` redirects to `/analytics`.
+  - `/settings` shows only `Team` and `Operations`.
+  - `/settings?tab=board` redirects or replaces URL to `/settings?tab=team`.
+  - Sidebar top-level nav shows `Analytics`, `Integrations`, `Deals`, and `Automations`.
+  - Sidebar does not show `Dashboard`, `Tasks`, `Board`, `Projects`, `Sprints`, or task-management settings links.
+  - `/analytics/ai-insights` has no visible `Create task`, `Task`, or `Creating...` controls.
+  - `/analytics/ceo` still loads and shows the CEO metric trust layer.
+
+- [ ] Stop the local dev server before ending the implementation turn.
+
+## Task 10: Commit Scope
+
+- [ ] Inspect changed files:
+
+  ```bash
+  git status --short
+  ```
+
+- [ ] Stage only files touched by this implementation.
+- [ ] Do not stage unrelated existing changes in CEO metrics, Mercury, HubSpot MRR, or other analytics work unless this implementation directly modified them.
+- [ ] Commit with:
+
+  ```bash
+  git commit -m "feat: make analytics the primary product surface"
+  ```
+
+## Completion Criteria
+
+- [ ] Authenticated users land on `/analytics`, not `/dashboard`.
+- [ ] Legacy product routes redirect to `/analytics`.
+- [ ] Sidebar no longer exposes task, board, or dashboard product surfaces.
+- [ ] Settings no longer exposes task/board/project/sprint/priority/department tabs.
+- [ ] Marketing copy positions WIPGuard as an analytics API meeting place and metric trust layer.
+- [ ] AI insights no longer create tasks from the UI.
+- [ ] CEO metric keys remain stable, but task-flavored display labels are reframed as internal execution data.
+- [ ] Focused tests, typecheck, lint, and build pass.
+- [ ] No backend schema or API compatibility is removed in this phase.

--- a/docs/superpowers/specs/2026-05-05-analytics-api-meeting-place-surface-removal-design.md
+++ b/docs/superpowers/specs/2026-05-05-analytics-api-meeting-place-surface-removal-design.md
@@ -1,0 +1,147 @@
+# Analytics API Meeting Place Surface Removal
+
+Date: 2026-05-05
+
+## Purpose
+
+WIPGuard is pivoting away from task management. The product should become an analytics API meeting place: a governed layer where source systems meet, metrics are computed consistently, freshness and lineage are visible, and reports/API consumers can reuse the same trusted facts.
+
+This phase removes the task-management product surface while retaining legacy task, project, sprint, and board tables as internal historical inputs until analytics dependencies are replaced.
+
+## Product Decision
+
+Use the product-surface removal path first.
+
+User-facing navigation, routes, settings, and calls to action should stop presenting WIPGuard as a task, board, sprint, standup, or WIP management tool. Legacy task-related APIs and Prisma models stay temporarily so existing analytics, customer-success summaries, automations, and CEO metric lineage do not break during the transition.
+
+## In Scope
+
+- Make `/analytics` the primary authenticated landing experience. Keep `/analytics/ceo` as a prominent analytics child route.
+- Remove task-management entries from primary navigation and workspace definitions.
+- Hide or redirect these product routes from the main UI:
+  - `/board`
+  - `/tasks`
+  - `/my-tasks`
+  - `/projects`
+  - `/standup`
+  - `/today`
+  - `/whip`
+  - `/table`
+- Remove board/project/sprint/priority/department settings tabs from the visible settings surface unless a tab directly supports analytics source configuration.
+- Remove dashboard cards, empty states, and CTAs that push users toward managing tasks or boards.
+- Reframe task-derived analytics as legacy internal execution data where still displayed.
+- Keep existing CEO metrics and reports working, but label task-flow metrics as internal execution metrics until replaced by provider snapshot/event metrics.
+- Keep task-related API routes and Prisma models available for legacy/internal dependencies in this phase.
+
+## Out of Scope
+
+- Deleting Prisma `Task`, `Project`, `Sprint`, board settings, priority, or department models.
+- Dropping task-related database tables.
+- Removing internal integrations that currently create or update local tasks.
+- Replacing every task-derived metric with a new event model.
+- Public API version removals for `/api/tasks`, `/api/projects`, or `/api/sprints`.
+
+Those belong in a later hard-deprecation phase after analytics replacements exist.
+
+## Architecture
+
+The app shell should define the new product shape through workspace configuration. The visible top-level product areas should be:
+
+- Analytics
+- CEO Metrics and Reports
+- Integrations
+- Deals, framed as revenue source context rather than pipeline task execution
+- Automations, framed around analytics sync, data processing, reports, and remediation artifacts
+
+Task-management modules become legacy/internal modules. They remain importable by analytics and integration jobs but should not be reachable from primary user navigation.
+
+## Data Flow
+
+No database migration is required in this phase.
+
+Existing analytics data flow remains:
+
+1. Provider integrations fetch or sync source data.
+2. Analytics snapshots store provider payloads and source health.
+3. Canonical metrics compute from provider snapshots plus retained legacy internal data where necessary.
+4. CEO reports and analytics UI consume canonical metric output.
+
+The only change is product routing and presentation: users enter through analytics/reporting surfaces, not task execution surfaces.
+
+## Route Behavior
+
+Deprecated product routes should not 404 abruptly. They should redirect authenticated users to the closest analytics surface:
+
+- `/board`, `/tasks`, `/my-tasks`, `/projects`, `/table` -> `/analytics`
+- `/standup`, `/today`, `/whip` -> `/analytics`
+
+If a route still needs to exist for a hidden internal workflow, it should render no primary navigation affordance and should be marked legacy in code comments or route metadata.
+
+## API Behavior
+
+Task APIs remain available but should be treated as legacy/internal. No public removal happens in this phase.
+
+If a user-facing automation still creates local tasks, it should either:
+
+- remain hidden from the product surface, or
+- be relabeled as creating remediation artifacts instead of task-board work, if that can be done without changing behavior.
+
+Actual task-write behavior changes are deferred unless a workflow is visibly exposed in the UI.
+
+## UI Behavior
+
+The UI should use analytics-first language:
+
+- "Sources"
+- "Metrics"
+- "Freshness"
+- "Lineage"
+- "Reports"
+- "Exports"
+- "Readiness"
+- "Provider health"
+- "Data quality"
+
+Avoid primary labels such as:
+
+- "Board"
+- "Tasks"
+- "My Tasks"
+- "Projects"
+- "Sprints"
+- "Standup"
+- "WIP"
+
+Historical/internal metric labels may still mention internal execution data when needed for accuracy.
+
+## Testing
+
+Focused tests should cover:
+
+- Workspace/navigation config no longer exposes task-management destinations.
+- Deprecated product routes redirect to analytics destinations.
+- Settings no longer exposes board/project/sprint/priority/department product tabs.
+- Analytics and CEO routes still render.
+- Existing task APIs still compile and existing analytics tests pass.
+
+Regression gates:
+
+- `npm test`
+- `npx tsc --noEmit --pretty false`
+- `npm run lint`
+- `npm run build`
+
+## Rollout
+
+This change is production-safe because it does not delete data or schema. It changes product entry points and visible navigation first. After deployment, validate:
+
+- `/` lands on the analytics-first experience.
+- `/analytics` loads.
+- `/analytics/ceo` loads.
+- `/integrations` loads.
+- Deprecated task-management routes redirect.
+- CEO report generation still works.
+
+## Follow-Up Phase
+
+After this surface removal is stable, replace task-derived analytics with provider snapshot and event-derived metrics. Once no board-grade metric or integration depends on legacy task tables, plan a separate hard-deprecation migration for task/project/sprint/board schema and APIs.

--- a/prisma/migrations/20260501170000_add_ceo_metric_trust_layer/migration.sql
+++ b/prisma/migrations/20260501170000_add_ceo_metric_trust_layer/migration.sql
@@ -1,0 +1,195 @@
+-- CreateEnum
+CREATE TYPE "CeoMetricUnit" AS ENUM ('COUNT', 'CURRENCY', 'DAYS', 'PERCENT', 'RATIO', 'SCORE', 'TEXT');
+
+-- CreateEnum
+CREATE TYPE "CeoMetricTrustStatus" AS ENUM ('FRESH', 'STALE', 'PARTIAL', 'MISSING', 'ERROR', 'CONFLICTED');
+
+-- CreateEnum
+CREATE TYPE "CeoReportCadence" AS ENUM ('WEEKLY', 'MONTHLY', 'QUARTERLY', 'AD_HOC');
+
+-- CreateEnum
+CREATE TYPE "CeoReportAudience" AS ENUM ('CEO', 'BOARD', 'TEAM', 'INVESTOR');
+
+-- CreateTable
+CREATE TABLE "CeoMetricDefinition" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "domain" TEXT NOT NULL,
+    "ownerAudience" "CeoReportAudience" NOT NULL,
+    "unit" "CeoMetricUnit" NOT NULL,
+    "calculationVersion" TEXT NOT NULL,
+    "sourceDependencies" TEXT[],
+    "freshnessSlaHours" INTEGER NOT NULL,
+    "boardEligible" BOOLEAN NOT NULL DEFAULT false,
+    "weeklyEligible" BOOLEAN NOT NULL DEFAULT false,
+    "description" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CeoMetricDefinition_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CeoMetricValueSnapshot" (
+    "id" TEXT NOT NULL,
+    "metricKey" TEXT NOT NULL,
+    "definitionId" TEXT,
+    "userId" TEXT,
+    "organizationId" TEXT,
+    "periodStart" TIMESTAMP(3) NOT NULL,
+    "periodEnd" TIMESTAMP(3) NOT NULL,
+    "value" JSONB NOT NULL,
+    "priorValue" JSONB,
+    "delta" DOUBLE PRECISION,
+    "asOf" TIMESTAMP(3) NOT NULL,
+    "computedAt" TIMESTAMP(3) NOT NULL,
+    "trustStatus" "CeoMetricTrustStatus" NOT NULL,
+    "confidence" DOUBLE PRECISION NOT NULL,
+    "warnings" TEXT[],
+    "sourceState" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CeoMetricValueSnapshot_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CeoMetricSourceLineage" (
+    "id" TEXT NOT NULL,
+    "valueSnapshotId" TEXT NOT NULL,
+    "sourceKey" TEXT NOT NULL,
+    "sourceType" TEXT NOT NULL,
+    "sourceId" TEXT,
+    "capturedAt" TIMESTAMP(3),
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CeoMetricSourceLineage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CeoReportPack" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "cadence" "CeoReportCadence" NOT NULL,
+    "audience" "CeoReportAudience" NOT NULL,
+    "metricKeys" TEXT[],
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "userId" TEXT,
+    "organizationId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CeoReportPack_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CeoReportSection" (
+    "id" TEXT NOT NULL,
+    "packId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "position" INTEGER NOT NULL,
+    "metricKeys" TEXT[],
+
+    CONSTRAINT "CeoReportSection_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CeoReportRun" (
+    "id" TEXT NOT NULL,
+    "packId" TEXT,
+    "packSlug" TEXT NOT NULL,
+    "packName" TEXT NOT NULL,
+    "userId" TEXT,
+    "organizationId" TEXT,
+    "generatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "metricPayload" JSONB NOT NULL,
+    "deterministicNotes" TEXT[],
+    "markdown" TEXT NOT NULL,
+    "csv" TEXT NOT NULL,
+    "slideJson" JSONB NOT NULL,
+    "aiDraft" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CeoReportRun_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CeoMetricDefinition_key_key" ON "CeoMetricDefinition"("key");
+
+-- CreateIndex
+CREATE INDEX "CeoMetricDefinition_domain_idx" ON "CeoMetricDefinition"("domain");
+
+-- CreateIndex
+CREATE INDEX "CeoMetricDefinition_boardEligible_idx" ON "CeoMetricDefinition"("boardEligible");
+
+-- CreateIndex
+CREATE INDEX "CeoMetricDefinition_weeklyEligible_idx" ON "CeoMetricDefinition"("weeklyEligible");
+
+-- CreateIndex
+CREATE INDEX "CeoMetricValueSnapshot_metricKey_periodEnd_idx" ON "CeoMetricValueSnapshot"("metricKey", "periodEnd" DESC);
+
+-- CreateIndex
+CREATE INDEX "CeoMetricValueSnapshot_userId_periodEnd_idx" ON "CeoMetricValueSnapshot"("userId", "periodEnd" DESC);
+
+-- CreateIndex
+CREATE INDEX "CeoMetricValueSnapshot_organizationId_periodEnd_idx" ON "CeoMetricValueSnapshot"("organizationId", "periodEnd" DESC);
+
+-- CreateIndex
+CREATE INDEX "CeoMetricValueSnapshot_trustStatus_idx" ON "CeoMetricValueSnapshot"("trustStatus");
+
+-- CreateIndex
+CREATE INDEX "CeoMetricSourceLineage_valueSnapshotId_idx" ON "CeoMetricSourceLineage"("valueSnapshotId");
+
+-- CreateIndex
+CREATE INDEX "CeoMetricSourceLineage_sourceKey_capturedAt_idx" ON "CeoMetricSourceLineage"("sourceKey", "capturedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CeoReportPack_organizationId_userId_slug_key" ON "CeoReportPack"("organizationId", "userId", "slug");
+
+-- CreateIndex
+CREATE INDEX "CeoReportPack_isDefault_idx" ON "CeoReportPack"("isDefault");
+
+-- CreateIndex
+CREATE INDEX "CeoReportSection_packId_position_idx" ON "CeoReportSection"("packId", "position");
+
+-- CreateIndex
+CREATE INDEX "CeoReportRun_packSlug_generatedAt_idx" ON "CeoReportRun"("packSlug", "generatedAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "CeoReportRun_userId_generatedAt_idx" ON "CeoReportRun"("userId", "generatedAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "CeoReportRun_organizationId_generatedAt_idx" ON "CeoReportRun"("organizationId", "generatedAt" DESC);
+
+-- AddForeignKey
+ALTER TABLE "CeoMetricValueSnapshot" ADD CONSTRAINT "CeoMetricValueSnapshot_definitionId_fkey" FOREIGN KEY ("definitionId") REFERENCES "CeoMetricDefinition"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CeoMetricValueSnapshot" ADD CONSTRAINT "CeoMetricValueSnapshot_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CeoMetricValueSnapshot" ADD CONSTRAINT "CeoMetricValueSnapshot_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CeoMetricSourceLineage" ADD CONSTRAINT "CeoMetricSourceLineage_valueSnapshotId_fkey" FOREIGN KEY ("valueSnapshotId") REFERENCES "CeoMetricValueSnapshot"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CeoReportPack" ADD CONSTRAINT "CeoReportPack_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CeoReportPack" ADD CONSTRAINT "CeoReportPack_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CeoReportSection" ADD CONSTRAINT "CeoReportSection_packId_fkey" FOREIGN KEY ("packId") REFERENCES "CeoReportPack"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CeoReportRun" ADD CONSTRAINT "CeoReportRun_packId_fkey" FOREIGN KEY ("packId") REFERENCES "CeoReportPack"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CeoReportRun" ADD CONSTRAINT "CeoReportRun_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CeoReportRun" ADD CONSTRAINT "CeoReportRun_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,9 @@ model Organization {
   retentionSourceRecords          RetentionSourceRecord[]
   retentionTenantMonths           RetentionTenantMonth[]
   retentionTenantCurrents         RetentionTenantCurrent[]
+  ceoMetricValueSnapshots         CeoMetricValueSnapshot[]
+  ceoReportPacks                  CeoReportPack[]
+  ceoReportRuns                   CeoReportRun[]
 }
 
 // ============================================================
@@ -111,6 +114,9 @@ model User {
 
   submissionEvents   SubmissionEvent[]
   insightPreferences InsightPreference[]
+  ceoMetricValueSnapshots CeoMetricValueSnapshot[]
+  ceoReportPacks          CeoReportPack[]
+  ceoReportRuns           CeoReportRun[]
 
   organizationId String?
   organization   Organization? @relation(fields: [organizationId], references: [id])
@@ -975,6 +981,185 @@ model MetricHistory {
   @@index([userId, metricKey, periodEnd(sort: Desc)])
   @@index([userId, section, periodEnd(sort: Desc)])
   @@index([capturedAt])
+}
+
+// ============================================================
+// CEO METRIC TRUST LAYER
+// ============================================================
+
+enum CeoMetricUnit {
+  COUNT
+  CURRENCY
+  DAYS
+  PERCENT
+  RATIO
+  SCORE
+  TEXT
+}
+
+enum CeoMetricTrustStatus {
+  FRESH
+  STALE
+  PARTIAL
+  MISSING
+  ERROR
+  CONFLICTED
+}
+
+enum CeoReportCadence {
+  WEEKLY
+  MONTHLY
+  QUARTERLY
+  AD_HOC
+}
+
+enum CeoReportAudience {
+  CEO
+  BOARD
+  TEAM
+  INVESTOR
+}
+
+model CeoMetricDefinition {
+  id                 String        @id @default(cuid())
+  key                String        @unique
+  label              String
+  domain             String
+  ownerAudience      CeoReportAudience
+  unit               CeoMetricUnit
+  calculationVersion String
+  sourceDependencies String[]
+  freshnessSlaHours  Int
+  boardEligible      Boolean       @default(false)
+  weeklyEligible     Boolean       @default(false)
+  description        String        @db.Text
+
+  valueSnapshots CeoMetricValueSnapshot[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([domain])
+  @@index([boardEligible])
+  @@index([weeklyEligible])
+}
+
+model CeoMetricValueSnapshot {
+  id           String              @id @default(cuid())
+  metricKey    String
+  definitionId String?
+  definition   CeoMetricDefinition? @relation(fields: [definitionId], references: [id], onDelete: SetNull)
+
+  userId String?
+  user   User?   @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  organizationId String?
+  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+
+  periodStart DateTime
+  periodEnd   DateTime
+  value       Json
+  priorValue  Json?
+  delta       Float?
+  asOf        DateTime
+  computedAt  DateTime
+
+  trustStatus CeoMetricTrustStatus
+  confidence  Float
+  warnings    String[]
+  sourceState Json
+
+  lineage CeoMetricSourceLineage[]
+
+  createdAt DateTime @default(now())
+
+  @@index([metricKey, periodEnd(sort: Desc)])
+  @@index([userId, periodEnd(sort: Desc)])
+  @@index([organizationId, periodEnd(sort: Desc)])
+  @@index([trustStatus])
+}
+
+model CeoMetricSourceLineage {
+  id              String                 @id @default(cuid())
+  valueSnapshotId String
+  valueSnapshot   CeoMetricValueSnapshot @relation(fields: [valueSnapshotId], references: [id], onDelete: Cascade)
+
+  sourceKey  String
+  sourceType String
+  sourceId   String?
+  capturedAt DateTime?
+  metadata   Json?
+
+  createdAt DateTime @default(now())
+
+  @@index([valueSnapshotId])
+  @@index([sourceKey, capturedAt])
+}
+
+model CeoReportPack {
+  id          String            @id @default(cuid())
+  slug        String
+  name        String
+  description String            @db.Text
+  cadence     CeoReportCadence
+  audience    CeoReportAudience
+  metricKeys  String[]
+  isDefault   Boolean           @default(false)
+
+  userId String?
+  user   User?   @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  organizationId String?
+  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+
+  sections CeoReportSection[]
+  runs     CeoReportRun[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([organizationId, userId, slug])
+  @@index([isDefault])
+}
+
+model CeoReportSection {
+  id     String        @id @default(cuid())
+  packId String
+  pack   CeoReportPack @relation(fields: [packId], references: [id], onDelete: Cascade)
+
+  title      String
+  position   Int
+  metricKeys String[]
+
+  @@index([packId, position])
+}
+
+model CeoReportRun {
+  id       String         @id @default(cuid())
+  packId   String?
+  pack     CeoReportPack? @relation(fields: [packId], references: [id], onDelete: SetNull)
+  packSlug String
+  packName String
+
+  userId String?
+  user   User?   @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  organizationId String?
+  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+
+  generatedAt        DateTime @default(now())
+  metricPayload      Json
+  deterministicNotes String[]
+  markdown           String   @db.Text
+  csv                String   @db.Text
+  slideJson          Json
+  aiDraft            String?  @db.Text
+
+  createdAt DateTime @default(now())
+
+  @@index([packSlug, generatedAt(sort: Desc)])
+  @@index([userId, generatedAt(sort: Desc)])
+  @@index([organizationId, generatedAt(sort: Desc)])
 }
 
 enum InsightFeedbackAction {

--- a/railway.json
+++ b/railway.json
@@ -6,7 +6,7 @@
   "deploy": {
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10,
-    "healthcheckPath": "/api/health",
+    "healthcheckPath": "/api/health/live",
     "healthcheckTimeout": 120
   }
 }

--- a/src/app/(dashboard)/analytics/ceo/page.tsx
+++ b/src/app/(dashboard)/analytics/ceo/page.tsx
@@ -1,0 +1,5 @@
+import { CeoCommandCenter } from "@/components/analytics/ceo-command-center";
+
+export default function CeoAnalyticsPage() {
+  return <CeoCommandCenter />;
+}

--- a/src/app/(dashboard)/board/page.tsx
+++ b/src/app/(dashboard)/board/page.tsx
@@ -1,5 +1,5 @@
-import { redirect } from "next/navigation";
+import { redirectToAnalyticsHome } from "@/app/(dashboard)/legacy-analytics-redirect";
 
 export default function LegacyBoardRoute() {
-  redirect("/dashboard");
+  redirectToAnalyticsHome();
 }

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,5 +1,5 @@
-import { OperatorDashboard } from "@/components/dashboard/operator-dashboard";
+import { redirectToAnalyticsHome } from "@/app/(dashboard)/legacy-analytics-redirect";
 
 export default function DashboardPage() {
-  return <OperatorDashboard />;
+  redirectToAnalyticsHome();
 }

--- a/src/app/(dashboard)/legacy-analytics-redirect.ts
+++ b/src/app/(dashboard)/legacy-analytics-redirect.ts
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+import { ANALYTICS_HOME } from "@/lib/platform/routes";
+
+export function redirectToAnalyticsHome(): never {
+  redirect(ANALYTICS_HOME);
+}

--- a/src/app/(dashboard)/legacy-product-routes.test.tsx
+++ b/src/app/(dashboard)/legacy-product-routes.test.tsx
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import DashboardPage from "@/app/(dashboard)/dashboard/page";
+import TasksPage from "@/app/(dashboard)/tasks/page";
+import BoardPage from "@/app/(dashboard)/board/page";
+import MyTasksPage from "@/app/(dashboard)/my-tasks/page";
+import ProjectsPage from "@/app/(dashboard)/projects/page";
+import StandupPage from "@/app/(dashboard)/standup/page";
+import TodayPage from "@/app/(dashboard)/today/page";
+import WhipPage from "@/app/(dashboard)/whip/page";
+import TablePage from "@/app/(dashboard)/table/page";
+import LogbookPage from "@/app/(dashboard)/logbook/page";
+import { ANALYTICS_HOME } from "@/lib/platform/routes";
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((target: string) => {
+    throw new Error(`NEXT_REDIRECT:${target}`);
+  }),
+}));
+
+const routes = [
+  ["dashboard", DashboardPage],
+  ["tasks", TasksPage],
+  ["board", BoardPage],
+  ["my-tasks", MyTasksPage],
+  ["projects", ProjectsPage],
+  ["standup", StandupPage],
+  ["today", TodayPage],
+  ["whip", WhipPage],
+  ["table", TablePage],
+  ["logbook", LogbookPage],
+] as const;
+
+describe("legacy product routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each(routes)("redirects /%s to analytics", async (_name, Page) => {
+    const { redirect } = await import("next/navigation");
+
+    await expect(async () => Page()).rejects.toThrow(`NEXT_REDIRECT:${ANALYTICS_HOME}`);
+    expect(redirect).toHaveBeenCalledWith(ANALYTICS_HOME);
+  });
+});

--- a/src/app/(dashboard)/logbook/page.tsx
+++ b/src/app/(dashboard)/logbook/page.tsx
@@ -1,5 +1,5 @@
-import { redirect } from "next/navigation";
+import { redirectToAnalyticsHome } from "@/app/(dashboard)/legacy-analytics-redirect";
 
 export default function LogbookPage() {
-  redirect("/dashboard");
+  redirectToAnalyticsHome();
 }

--- a/src/app/(dashboard)/my-tasks/page.tsx
+++ b/src/app/(dashboard)/my-tasks/page.tsx
@@ -1,5 +1,5 @@
-import { redirect } from "next/navigation";
+import { redirectToAnalyticsHome } from "@/app/(dashboard)/legacy-analytics-redirect";
 
 export default function MyTasksPage() {
-  redirect("/dashboard");
+  redirectToAnalyticsHome();
 }

--- a/src/app/(dashboard)/projects/page.tsx
+++ b/src/app/(dashboard)/projects/page.tsx
@@ -1,5 +1,5 @@
-import { redirect } from "next/navigation";
+import { redirectToAnalyticsHome } from "@/app/(dashboard)/legacy-analytics-redirect";
 
 export default function ProjectsPage() {
-  redirect("/dashboard");
+  redirectToAnalyticsHome();
 }

--- a/src/app/(dashboard)/settings/page.test.tsx
+++ b/src/app/(dashboard)/settings/page.test.tsx
@@ -11,32 +11,8 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => mockSearchParams,
 }));
 
-vi.mock("@/components/settings/board-settings-tab", () => ({
-  BoardSettingsTab: () => <div>Board Settings</div>,
-}));
-
-vi.mock("@/components/settings/sprints-tab", () => ({
-  SprintsTab: () => <div>Sprints</div>,
-}));
-
-vi.mock("@/components/settings/projects-tab", () => ({
-  ProjectsTab: () => <div>Projects</div>,
-}));
-
-vi.mock("@/components/settings/priorities-tab", () => ({
-  PrioritiesTab: () => <div>Priorities</div>,
-}));
-
-vi.mock("@/components/settings/design-interview-tab", () => ({
-  DesignInterviewTab: () => <div>Design Interview</div>,
-}));
-
 vi.mock("@/components/settings/team-tab", () => ({
   TeamTab: () => <div>Team</div>,
-}));
-
-vi.mock("@/components/settings/departments-tab", () => ({
-  DepartmentsTab: () => <div>Departments</div>,
 }));
 
 vi.mock("@/components/settings/operations-tab", () => ({
@@ -49,12 +25,18 @@ describe("SettingsPage", () => {
     replace.mockReset();
   });
 
-  it("renders settings tabs without an integrations tab", () => {
-    const { queryByRole, getByText } = render(<SettingsPage />);
+  it("renders only analytics-era settings tabs", () => {
+    const { queryByRole } = render(<SettingsPage />);
 
-    expect(getByText("Board Settings")).toBeTruthy();
-    expect(queryByRole("tab", { name: "Design Interview" })).toBeTruthy();
+    expect(queryByRole("tab", { name: "Team" })).toBeTruthy();
+    expect(queryByRole("tab", { name: "Operations" })).toBeTruthy();
     expect(queryByRole("tab", { name: "Integrations" })).toBeNull();
+    expect(queryByRole("tab", { name: "Board & WIP Limits" })).toBeNull();
+    expect(queryByRole("tab", { name: "Sprints" })).toBeNull();
+    expect(queryByRole("tab", { name: "Projects" })).toBeNull();
+    expect(queryByRole("tab", { name: "Departments" })).toBeNull();
+    expect(queryByRole("tab", { name: "Company Priorities" })).toBeNull();
+    expect(queryByRole("tab", { name: "Design Interview" })).toBeNull();
   });
 
   it("redirects legacy integrations tab links into the integrations workspace", async () => {
@@ -65,6 +47,19 @@ describe("SettingsPage", () => {
     await waitFor(() => {
       expect(replace).toHaveBeenCalledWith(
         "/integrations?status=connected&integration=slack",
+        { scroll: false },
+      );
+    });
+  });
+
+  it("redirects legacy task-management tabs to team settings", async () => {
+    mockSearchParams = new URLSearchParams("tab=board&source=old-link");
+
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith(
+        "/settings?tab=team&source=old-link",
         { scroll: false },
       );
     });

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -4,37 +4,35 @@ import { useCallback, useEffect } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Settings as SettingsIcon } from "lucide-react";
 import { clsx } from "clsx";
-import { BoardSettingsTab } from "@/components/settings/board-settings-tab";
-import { SprintsTab } from "@/components/settings/sprints-tab";
-import { ProjectsTab } from "@/components/settings/projects-tab";
-import { PrioritiesTab } from "@/components/settings/priorities-tab";
 import { TeamTab } from "@/components/settings/team-tab";
-import { DepartmentsTab } from "@/components/settings/departments-tab";
 import { OperationsTab } from "@/components/settings/operations-tab";
-import { DesignInterviewTab } from "@/components/settings/design-interview-tab";
 
 const TABS = [
-  { id: "board", label: "Board & WIP Limits" },
-  { id: "sprints", label: "Sprints" },
-  { id: "projects", label: "Projects" },
-  { id: "departments", label: "Departments" },
-  { id: "priorities", label: "Company Priorities" },
-  { id: "design-interview", label: "Design Interview" },
   { id: "team", label: "Team" },
   { id: "operations", label: "Operations" },
 ] as const;
 
 type TabId = (typeof TABS)[number]["id"];
 
+const LEGACY_SETTINGS_TABS = new Set([
+  "board",
+  "sprints",
+  "projects",
+  "departments",
+  "priorities",
+  "design-interview",
+]);
+
 export default function SettingsPage() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const tabParam = searchParams?.get("tab");
+  const isLegacySettingsTab = tabParam ? LEGACY_SETTINGS_TABS.has(tabParam) : false;
   const activeTab: TabId =
     tabParam && TABS.some((candidate) => candidate.id === tabParam)
       ? (tabParam as TabId)
-      : "board";
+      : "team";
 
   useEffect(() => {
     if (tabParam !== "integrations") return;
@@ -44,6 +42,15 @@ export default function SettingsPage() {
     const suffix = params.toString();
     router.replace(`/integrations${suffix ? `?${suffix}` : ""}`, { scroll: false });
   }, [router, searchParams, tabParam]);
+
+  useEffect(() => {
+    if (!isLegacySettingsTab) return;
+
+    const params = new URLSearchParams(searchParams?.toString() ?? "");
+    params.set("tab", "team");
+    const basePath = pathname || "/settings";
+    router.replace(`${basePath}?${params.toString()}`, { scroll: false });
+  }, [isLegacySettingsTab, pathname, router, searchParams]);
 
   const handleTabChange = useCallback((tabId: TabId) => {
     const params = new URLSearchParams(searchParams?.toString() ?? "");
@@ -78,7 +85,7 @@ export default function SettingsPage() {
     [activeTab, handleTabChange],
   );
 
-  if (tabParam === "integrations") {
+  if (tabParam === "integrations" || isLegacySettingsTab) {
     return null;
   }
 
@@ -90,7 +97,7 @@ export default function SettingsPage() {
           Settings
         </h1>
         <p className="text-xs text-muted-foreground">
-          Configure platform defaults, WIP policy, team setup, and operating guardrails.
+          Configure team access and analytics operating guardrails.
         </p>
       </div>
 
@@ -119,12 +126,6 @@ export default function SettingsPage() {
 
       {/* Tab content */}
       <div role="tabpanel" id={`tabpanel-${activeTab}`} aria-labelledby={`tab-${activeTab}`} className="flex-1 overflow-auto px-6 py-5">
-        {activeTab === "board" && <BoardSettingsTab />}
-        {activeTab === "sprints" && <SprintsTab />}
-        {activeTab === "projects" && <ProjectsTab />}
-        {activeTab === "departments" && <DepartmentsTab />}
-        {activeTab === "priorities" && <PrioritiesTab />}
-        {activeTab === "design-interview" && <DesignInterviewTab />}
         {activeTab === "team" && <TeamTab />}
         {activeTab === "operations" && <OperationsTab />}
       </div>

--- a/src/app/(dashboard)/standup/page.tsx
+++ b/src/app/(dashboard)/standup/page.tsx
@@ -1,5 +1,5 @@
-import { redirect } from "next/navigation";
+import { redirectToAnalyticsHome } from "@/app/(dashboard)/legacy-analytics-redirect";
 
 export default function StandupPage() {
-  redirect("/dashboard");
+  redirectToAnalyticsHome();
 }

--- a/src/app/(dashboard)/table/page.tsx
+++ b/src/app/(dashboard)/table/page.tsx
@@ -1,5 +1,5 @@
-import { redirect } from "next/navigation";
+import { redirectToAnalyticsHome } from "@/app/(dashboard)/legacy-analytics-redirect";
 
 export default function TablePage() {
-  redirect("/dashboard");
+  redirectToAnalyticsHome();
 }

--- a/src/app/(dashboard)/tasks/page.test.tsx
+++ b/src/app/(dashboard)/tasks/page.test.tsx
@@ -1,46 +1,22 @@
-import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import TasksPage from "@/app/(dashboard)/tasks/page";
-
-vi.mock("@/lib/auth", () => ({
-  auth: vi.fn(),
-}));
+import { ANALYTICS_HOME } from "@/lib/platform/routes";
 
 vi.mock("next/navigation", () => ({
-  redirect: vi.fn(),
-}));
-
-vi.mock("@/components/board/kanban-board", () => ({
-  KanbanBoard: () => <div>Kanban Board</div>,
+  redirect: vi.fn((target: string) => {
+    throw new Error(`NEXT_REDIRECT:${target}`);
+  }),
 }));
 
 describe("TasksPage", () => {
   beforeEach(() => {
-    vi.resetAllMocks();
+    vi.clearAllMocks();
   });
 
-  it("redirects unauthenticated visitors to /login", async () => {
-    const { auth } = await import("@/lib/auth");
+  it("redirects legacy task traffic to analytics", async () => {
     const { redirect } = await import("next/navigation");
 
-    vi.mocked(auth).mockResolvedValue(null as never);
-    vi.mocked(redirect).mockImplementation(() => {
-      throw new Error("NEXT_REDIRECT");
-    });
-
-    await expect(TasksPage()).rejects.toThrow("NEXT_REDIRECT");
-    expect(redirect).toHaveBeenCalledWith("/login");
-  });
-
-  it("renders the kanban board for authenticated users", async () => {
-    const { auth } = await import("@/lib/auth");
-
-    vi.mocked(auth).mockResolvedValue({ user: { id: "user_1" } } as never);
-
-    const page = await TasksPage();
-
-    render(page);
-
-    expect(screen.getByText("Kanban Board")).toBeTruthy();
+    await expect(async () => TasksPage()).rejects.toThrow(`NEXT_REDIRECT:${ANALYTICS_HOME}`);
+    expect(redirect).toHaveBeenCalledWith(ANALYTICS_HOME);
   });
 });

--- a/src/app/(dashboard)/tasks/page.tsx
+++ b/src/app/(dashboard)/tasks/page.tsx
@@ -1,13 +1,5 @@
-import { redirect } from "next/navigation";
-import { KanbanBoard } from "@/components/board/kanban-board";
-import { auth } from "@/lib/auth";
+import { redirectToAnalyticsHome } from "@/app/(dashboard)/legacy-analytics-redirect";
 
-export default async function TasksPage() {
-  const session = await auth();
-
-  if (!session?.user) {
-    redirect("/login");
-  }
-
-  return <KanbanBoard />;
+export default function TasksPage() {
+  redirectToAnalyticsHome();
 }

--- a/src/app/(dashboard)/today/page.tsx
+++ b/src/app/(dashboard)/today/page.tsx
@@ -1,5 +1,5 @@
-import { redirect } from "next/navigation";
+import { redirectToAnalyticsHome } from "@/app/(dashboard)/legacy-analytics-redirect";
 
 export default function TodayPage() {
-  redirect("/dashboard");
+  redirectToAnalyticsHome();
 }

--- a/src/app/(dashboard)/whip/page.tsx
+++ b/src/app/(dashboard)/whip/page.tsx
@@ -1,5 +1,5 @@
-import { redirect } from "next/navigation";
+import { redirectToAnalyticsHome } from "@/app/(dashboard)/legacy-analytics-redirect";
 
 export default function WhipPage() {
-  redirect("/dashboard");
+  redirectToAnalyticsHome();
 }

--- a/src/app/api/analytics/funnel/enrich/[provider]/route.test.ts
+++ b/src/app/api/analytics/funnel/enrich/[provider]/route.test.ts
@@ -220,14 +220,24 @@ describe("POST /api/analytics/funnel/enrich/[provider]", () => {
       disabled: boolean;
       reason: string;
       stored: number;
+      rows: Array<Record<string, unknown>>;
     };
 
     expect(response.status).toBe(202);
     expect(body).toMatchObject({
-      accepted: 0,
+      accepted: 1,
       disabled: true,
       reason: "Visitor funnel Prisma models are unavailable in this deployment.",
       stored: 0,
+    });
+    expect(body.rows).toHaveLength(1);
+    expect(body.rows[0]).toMatchObject({
+      row_id: "row-1",
+      email: "sample@example.com",
+      domain: "example.com",
+      company: "Example Co",
+      confidence: 0.9,
+      occurred_at: "2026-03-08T12:00:00.000Z",
     });
     expect(ingestVisitorEnrichmentSignals).not.toHaveBeenCalled();
   });

--- a/src/app/api/analytics/funnel/enrich/[provider]/route.ts
+++ b/src/app/api/analytics/funnel/enrich/[provider]/route.ts
@@ -128,6 +128,29 @@ function buildDryRunPreview(
   }));
 }
 
+function buildDisabledPreviewRows(signals: VisitorEnrichmentSignalInput[]): Record<string, unknown>[] {
+  return signals.map((signal) => {
+    const metadata = asObject(signal.metadata);
+    return {
+      row_id: trimOrNull(signal.signalKey),
+      email: trimOrNull(signal.email),
+      domain: trimOrNull(signal.domain),
+      full_name: trimOrNull(signal.fullName),
+      company: trimOrNull(signal.companyName),
+      title: trimOrNull(typeof metadata?.title === "string" ? metadata.title : null),
+      website: trimOrNull(typeof metadata?.website === "string" ? metadata.website : null),
+      linkedin_url: trimOrNull(typeof metadata?.linkedinUrl === "string" ? metadata.linkedinUrl : null),
+      captured_url: trimOrNull(typeof metadata?.capturedUrl === "string" ? metadata.capturedUrl : null),
+      referrer: trimOrNull(typeof metadata?.referrer === "string" ? metadata.referrer : null),
+      occurred_at: trimOrNull(signal.occurredAt),
+      confidence:
+        typeof signal.confidence === "number" && Number.isFinite(signal.confidence)
+          ? signal.confidence
+          : null,
+    };
+  });
+}
+
 export async function POST(
   request: NextRequest,
   context: { params: Promise<{ provider: string }> },
@@ -242,11 +265,12 @@ export async function POST(
     if (!funnelPrisma) {
       return NextResponse.json(
         {
-          accepted: 0,
+          accepted: signals.length,
           dryRun: false,
           disabled: true,
           mode,
           provider,
+          rows: buildDisabledPreviewRows(signals),
           received: signals.length,
           stored: 0,
           reason: VISITOR_FUNNEL_PRISMA_UNAVAILABLE_REASON,

--- a/src/app/api/analytics/route.test.ts
+++ b/src/app/api/analytics/route.test.ts
@@ -123,6 +123,24 @@ const HUBSPOT_DATA = {
       updatedAt: "2026-02-11T00:00:00.000Z",
     },
   ],
+  subscriptionDeals: [
+    {
+      dealId: "deal-subscription",
+      dealName: "Zaybra Subscription",
+      stageId: "2239936224",
+      stageLabel: "Subscriptions",
+      amount: 3598,
+      source: "HubSpot",
+      ownerId: "owner-3",
+      updatedAt: "2026-02-12T00:00:00.000Z",
+      createdAt: "2026-02-01T00:00:00.000Z",
+      stripeCustomerId: null,
+      pipelineId: "1390107368",
+      contactIds: [],
+      primaryContactId: null,
+      primaryContactEmail: "ops@example-subscription.com",
+    },
+  ],
   _meta: META,
 };
 
@@ -142,6 +160,9 @@ const STRIPE_DATA = {
     trialing: 2,
     churnRate: 0.02,
     recentChurnEvents: [],
+    activeCustomerRefs: [
+      { customerId: "cus_123", email: "billing@example.com", emailDomain: "example.com" },
+    ],
   },
   payments: {
     succeeded: 100,
@@ -168,6 +189,7 @@ const ZERO_STRIPE_DATA = {
     trialing: 0,
     churnRate: 0,
     recentChurnEvents: [],
+    activeCustomerRefs: [],
   },
   payments: {
     succeeded: 0,
@@ -525,6 +547,26 @@ describe("GET /api/analytics", () => {
     expect(deal.stripeCustomerId).toBe("cus_123");
     expect(prisma.stripeCustomerLink.findMany).toHaveBeenCalledWith({
       where: { userId: "user-1" },
+    });
+  });
+
+  it("builds finance-planning subscription overview from HubSpot subscription pipeline deals", async () => {
+    const { GET } = await import("@/app/api/analytics/route");
+    const response = await GET(new Request("http://localhost/api/analytics?section=finance-planning"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.hubspot.subscriptionDeals).toHaveLength(1);
+    expect(body.financialPlanning.subscriptionOverview).toEqual({
+      mergedActiveSubscriptions: 2,
+      stripeActiveSubscriptions: 20,
+      hubspotActiveSubscriptions: 1,
+      stripeMrr: 12000,
+      hubspotSubscriptionMrr: 3598,
+      hubspotOnlySubscriptionMrr: 3598,
+      excludedLinkedHubspotSubscriptionMrr: 0,
+      totalMrr: 15598,
+      totalArr: 187176,
     });
   });
 

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -25,6 +25,7 @@ import {
 import { buildAnalyticsRouteMeta } from "@/lib/analytics/route-meta";
 import { computeAnalyticsKpis } from "@/lib/analytics/kpis";
 import { computeKpiDelta } from "@/lib/analytics/kpi-deltas";
+import { buildSubscriptionMrrBreakdown } from "@/lib/analytics/subscription-mrr";
 import {
   buildVisitorFunnelData,
   parseVisitorFunnelFilters,
@@ -128,15 +129,23 @@ const SECTION_DOMAINS: Record<string, DomainKey[]> = {
     "distilledInsights",
   ],
   "ai-insights": [...ALL_DOMAINS],
-  "ads-traffic": [
+  "website-traffic": [
     "googleAnalytics",
-    "googleAds",
-    "metaAds",
-    "instagram",
-    "redditAds",
     "webflow",
     "semrush",
     "coda",
+    "lifecycleFunnel",
+    "funnelJourney",
+    "aiInsights",
+    "recommendations",
+    "distilledInsights",
+  ],
+  "social-media": [
+    "googleAds",
+    "metaAds",
+    "metaPage",
+    "instagram",
+    "redditAds",
     "lifecycleFunnel",
     "funnelJourney",
     "aiInsights",
@@ -154,7 +163,7 @@ const SECTION_DOMAINS: Record<string, DomainKey[]> = {
     "recommendations",
     "distilledInsights",
   ],
-  "finance-planning": ["stripe", "mercury"],
+  "finance-planning": ["stripe", "mercury", "hubspot"],
   "finance-forecast": ["stripe", "mercury"],
   "finance-pnl": ["stripe", "mercury"],
   "finance-unit-economics": ["stripe", "mercury", "hubspot"],
@@ -471,7 +480,7 @@ function buildRecommendations(data: AnalyticsDashboardData): AnalyticsRecommenda
   if ((data.googleAnalytics?.bounceRate ?? 0) > 0.55) {
     recommendations.push({
       id: "ads-bounce",
-      section: "ads-traffic",
+      section: "website-traffic",
       severity: "warning",
       title: "Reduce high bounce traffic",
       insight: `Bounce rate is ${((data.googleAnalytics?.bounceRate ?? 0) * 100).toFixed(1)}%, indicating weak landing relevance.`,
@@ -589,70 +598,21 @@ function stripePayloadHasSignal(data: StripeData | null | undefined): boolean {
   );
 }
 
-const GENERIC_EMAIL_DOMAINS = new Set([
-  "gmail.com",
-  "googlemail.com",
-  "yahoo.com",
-  "outlook.com",
-  "hotmail.com",
-  "icloud.com",
-  "me.com",
-  "proton.me",
-  "protonmail.com",
-]);
-
-function normalizeEmail(value: string | null | undefined): string | null {
-  const normalized = value?.trim().toLowerCase() ?? "";
-  return normalized.length > 0 ? normalized : null;
-}
-
-function normalizeEmailDomain(value: string | null | undefined): string | null {
-  const email = normalizeEmail(value);
-  if (!email || !email.includes("@")) return null;
-  const [, domain] = email.split("@");
-  const normalized = domain?.trim().toLowerCase() ?? "";
-  if (!normalized || GENERIC_EMAIL_DOMAINS.has(normalized)) {
-    return null;
-  }
-  return normalized;
-}
-
 function buildSubscriptionOverview(data: AnalyticsDashboardData): FinancialPlanningData["subscriptionOverview"] {
-  const stripeRefs = data.stripe?.subscriptions.activeCustomerRefs ?? [];
-  const hubspotDeals = (data.hubspot?.deals ?? []).filter(
-    (deal) => deal.stageLabel.trim().toLowerCase() === "subscription",
-  );
-
-  const stripeCustomerIds = new Set(
-    stripeRefs
-      .map((ref) => ref.customerId.trim())
-      .filter((customerId) => customerId.length > 0 && customerId !== "Unknown customer"),
-  );
-  const stripeEmails = new Set(
-    stripeRefs.map((ref) => normalizeEmail(ref.email)).filter(Boolean) as string[],
-  );
-  const stripeDomains = new Set(
-    stripeRefs.map((ref) => ref.emailDomain?.trim().toLowerCase() ?? null).filter(Boolean) as string[],
-  );
-
-  let hubspotOnlyCount = 0;
-
-  for (const deal of hubspotDeals) {
-    const customerId = deal.stripeCustomerId?.trim() || null;
-    const email = normalizeEmail(deal.primaryContactEmail);
-    const emailDomain = normalizeEmailDomain(deal.primaryContactEmail);
-
-    if (customerId && stripeCustomerIds.has(customerId)) continue;
-    if (email && stripeEmails.has(email)) continue;
-    if (emailDomain && stripeDomains.has(emailDomain)) continue;
-
-    hubspotOnlyCount += 1;
-  }
-
+  const breakdown = buildSubscriptionMrrBreakdown({
+    stripe: data.stripe,
+    hubspot: data.hubspot,
+  });
   return {
-    mergedActiveSubscriptions: stripeRefs.length + hubspotOnlyCount,
-    stripeActiveSubscriptions: data.stripe?.subscriptions.active ?? 0,
-    hubspotActiveSubscriptions: data.hubspot?.funnel.activeSubscriptions ?? hubspotDeals.length,
+    mergedActiveSubscriptions: breakdown.mergedActiveSubscriptions,
+    stripeActiveSubscriptions: breakdown.stripeActiveSubscriptions,
+    hubspotActiveSubscriptions: breakdown.hubspotActiveSubscriptions,
+    stripeMrr: breakdown.stripeMrr,
+    hubspotSubscriptionMrr: breakdown.hubspotSubscriptionMrr,
+    hubspotOnlySubscriptionMrr: breakdown.hubspotOnlySubscriptionMrr,
+    excludedLinkedHubspotSubscriptionMrr: breakdown.excludedLinkedHubspotSubscriptionMrr,
+    totalMrr: breakdown.totalMrr,
+    totalArr: breakdown.totalArr,
   };
 }
 
@@ -676,6 +636,7 @@ async function buildFinancialPlanningData(
   const mercury = data.mercury as MercuryData | null;
   const hubspot = data.hubspot as HubSpotData | null;
   const subscriptionOverview = buildSubscriptionOverview(data);
+  const totalMrr = subscriptionOverview?.totalMrr ?? stripe?.revenue.mrr ?? 0;
 
   const [dbBudgets, dbGoals, dbForecasts] = await Promise.all([
     prisma.budget.findMany({
@@ -748,8 +709,8 @@ async function buildFinancialPlanningData(
 
   // --- Goals with current progress ---
   const currentMetrics: Record<string, number> = {
-    mrr: stripe?.revenue.mrr ?? 0,
-    arr: (stripe?.revenue.mrr ?? 0) * 12,
+    mrr: totalMrr,
+    arr: totalMrr * 12,
     runway: mercury?.cashFlow.runway ?? 0,
     burn_rate: mercury?.cashFlow.burnRate ?? 0,
     net_cash_flow: mercury?.cashFlow.netCashFlow ?? 0,
@@ -1623,7 +1584,7 @@ export async function GET(request: Request) {
   }
 
   // Populate financial planning data when the finance section is requested
-  if (section === "finance" || section === null) {
+  if (section === "finance" || section === "finance-planning" || section === null) {
     try {
       result.financialPlanning = await buildFinancialPlanningData(userId, result);
     } catch (error) {

--- a/src/app/api/ceo/metrics/route.test.ts
+++ b/src/app/api/ceo/metrics/route.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/session-user", () => ({
+  getAuthenticatedUser: vi.fn(),
+}));
+
+vi.mock("@/lib/ceo/api-context", () => ({
+  CeoOrganizationContextError: class CeoOrganizationContextError extends Error {},
+  withCeoOrganizationContext: vi.fn(async (_session, _user, fn) => fn("org-1")),
+}));
+
+vi.mock("@/lib/ceo/service", () => ({
+  loadCeoMetricSnapshot: vi.fn(),
+}));
+
+describe("GET /api/ceo/metrics", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const { auth } = await import("@/lib/auth");
+    const { getAuthenticatedUser } = await import("@/lib/session-user");
+    const { GET } = await import("@/app/api/ceo/metrics/route");
+
+    vi.mocked(auth).mockResolvedValue(null as never);
+    vi.mocked(getAuthenticatedUser).mockReturnValue(null as never);
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("loads trusted CEO metrics for the authenticated organization", async () => {
+    const { auth } = await import("@/lib/auth");
+    const { getAuthenticatedUser } = await import("@/lib/session-user");
+    const { loadCeoMetricSnapshot } = await import("@/lib/ceo/service");
+    const { GET } = await import("@/app/api/ceo/metrics/route");
+
+    vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getAuthenticatedUser).mockReturnValue({
+      id: "user-1",
+      organizationId: "org-1",
+    } as never);
+    vi.mocked(loadCeoMetricSnapshot).mockResolvedValue({
+      generatedAt: "2026-05-01T12:00:00.000Z",
+      periodStart: "2026-04-01T00:00:00.000Z",
+      periodEnd: "2026-05-01T12:00:00.000Z",
+      metrics: [],
+      definitions: [],
+      reportPacks: [],
+      trustSummary: { fresh: 0, stale: 0, partial: 0, missing: 0, error: 0, conflicted: 0 },
+      readiness: {
+        status: "not_board_final",
+        ready: false,
+        summary: "Not board-final: no metrics are available.",
+        failingGates: [],
+      },
+    } as never);
+
+    const response = await GET();
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(loadCeoMetricSnapshot).toHaveBeenCalledWith({
+      userId: "user-1",
+      organizationId: "org-1",
+      persist: false,
+    });
+    expect(payload.generatedAt).toBe("2026-05-01T12:00:00.000Z");
+    expect(payload.readiness.status).toBe("not_board_final");
+  });
+});

--- a/src/app/api/ceo/metrics/route.ts
+++ b/src/app/api/ceo/metrics/route.ts
@@ -1,0 +1,40 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { CeoOrganizationContextError, withCeoOrganizationContext } from "@/lib/ceo/api-context";
+import { loadCeoMetricSnapshot } from "@/lib/ceo/service";
+import { getAuthenticatedUser } from "@/lib/session-user";
+
+export async function GET(): Promise<NextResponse> {
+  try {
+    const session = await auth();
+    const user = getAuthenticatedUser(session);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const payload = await withCeoOrganizationContext(session, user, (organizationId) =>
+      loadCeoMetricSnapshot({
+        userId: user.id,
+        organizationId,
+        persist: false,
+      })
+    );
+
+    return NextResponse.json(payload, {
+      headers: {
+        "Cache-Control": "private, max-age=30, stale-while-revalidate=120",
+      },
+    });
+  } catch (error) {
+    if (error instanceof CeoOrganizationContextError) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
+    }
+    console.error("GET /api/ceo/metrics error:", error);
+    return NextResponse.json(
+      { error: "Failed to load CEO metrics" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/ceo/reports/[runId]/route.ts
+++ b/src/app/api/ceo/reports/[runId]/route.ts
@@ -1,0 +1,43 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { CeoOrganizationContextError, withCeoOrganizationContext } from "@/lib/ceo/api-context";
+import { getCeoReportRun } from "@/lib/ceo/service";
+import { getAuthenticatedUser } from "@/lib/session-user";
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ runId: string }> }
+): Promise<NextResponse> {
+  try {
+    const session = await auth();
+    const user = getAuthenticatedUser(session);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { runId } = await context.params;
+    const run = await withCeoOrganizationContext(session, user, (organizationId) =>
+      getCeoReportRun({
+        userId: user.id,
+        organizationId,
+        runId,
+      })
+    );
+    if (!run) {
+      return NextResponse.json({ error: "Report run not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(run);
+  } catch (error) {
+    if (error instanceof CeoOrganizationContextError) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
+    }
+    console.error("GET /api/ceo/reports/[runId] error:", error);
+    return NextResponse.json(
+      { error: "Failed to load CEO report run" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/ceo/reports/route.test.ts
+++ b/src/app/api/ceo/reports/route.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/session-user", () => ({
+  getAuthenticatedUser: vi.fn(),
+}));
+
+vi.mock("@/lib/ceo/api-context", () => ({
+  CeoOrganizationContextError: class CeoOrganizationContextError extends Error {},
+  withCeoOrganizationContext: vi.fn(async (_session, _user, fn) => fn("org-1")),
+}));
+
+vi.mock("@/lib/ceo/service", () => ({
+  createCeoReportRun: vi.fn(),
+  listCeoReportPacks: vi.fn(),
+}));
+
+describe("/api/ceo/reports", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("lists default CEO report packs", async () => {
+    const { auth } = await import("@/lib/auth");
+    const { getAuthenticatedUser } = await import("@/lib/session-user");
+    const { listCeoReportPacks } = await import("@/lib/ceo/service");
+    const { GET } = await import("@/app/api/ceo/reports/route");
+
+    vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getAuthenticatedUser).mockReturnValue({ id: "user-1", organizationId: "org-1" } as never);
+    vi.mocked(listCeoReportPacks).mockResolvedValue([
+      { slug: "weekly-exec", name: "Weekly Exec", metricKeys: [], sections: [] },
+    ] as never);
+
+    const response = await GET();
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.reportPacks[0].slug).toBe("weekly-exec");
+  });
+
+  it("creates an immutable report run for the selected pack", async () => {
+    const { auth } = await import("@/lib/auth");
+    const { getAuthenticatedUser } = await import("@/lib/session-user");
+    const { createCeoReportRun } = await import("@/lib/ceo/service");
+    const { POST } = await import("@/app/api/ceo/reports/route");
+
+    vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getAuthenticatedUser).mockReturnValue({ id: "user-1", organizationId: "org-1" } as never);
+    vi.mocked(createCeoReportRun).mockResolvedValue({
+      id: "run-1",
+      packSlug: "weekly-exec",
+      packName: "Weekly Exec",
+      generatedAt: "2026-05-01T12:00:00.000Z",
+      metrics: [],
+      deterministicNotes: [],
+      markdown: "# Weekly Exec",
+      csv: "Metric,Value",
+      slideJson: {
+        title: "Weekly Exec",
+        generatedAt: "2026-05-01T12:00:00.000Z",
+        readiness: {
+          status: "not_board_final",
+          ready: false,
+          summary: "Not board-final: 1 readiness gate is failing.",
+          failingGates: [],
+        },
+        sections: [],
+        notes: [],
+      },
+    } as never);
+
+    const response = await POST(
+      new NextRequest("http://localhost/api/ceo/reports", {
+        method: "POST",
+        body: JSON.stringify({ packSlug: "weekly-exec" }),
+      })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(createCeoReportRun).toHaveBeenCalledWith({
+      userId: "user-1",
+      organizationId: "org-1",
+      packSlug: "weekly-exec",
+    });
+    expect(payload.markdown).toContain("Weekly Exec");
+    expect(payload.slideJson.readiness.status).toBe("not_board_final");
+  });
+});

--- a/src/app/api/ceo/reports/route.ts
+++ b/src/app/api/ceo/reports/route.ts
@@ -1,0 +1,65 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { CeoOrganizationContextError, withCeoOrganizationContext } from "@/lib/ceo/api-context";
+import { createCeoReportRun, listCeoReportPacks } from "@/lib/ceo/service";
+import { getAuthenticatedUser } from "@/lib/session-user";
+
+async function getUser() {
+  const session = await auth();
+  return getAuthenticatedUser(session);
+}
+
+export async function GET(): Promise<NextResponse> {
+  try {
+    const user = await getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const reportPacks = await listCeoReportPacks();
+    return NextResponse.json({ reportPacks });
+  } catch (error) {
+    console.error("GET /api/ceo/reports error:", error);
+    return NextResponse.json(
+      { error: "Failed to load CEO report packs" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const user = await getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = (await request.json().catch(() => null)) as { packSlug?: unknown } | null;
+    const packSlug = typeof body?.packSlug === "string" ? body.packSlug.trim() : "";
+    if (!packSlug) {
+      return NextResponse.json({ error: "packSlug is required" }, { status: 400 });
+    }
+
+    const run = await withCeoOrganizationContext(null, user, (organizationId) =>
+      createCeoReportRun({
+        userId: user.id,
+        organizationId,
+        packSlug,
+      })
+    );
+
+    return NextResponse.json(run, { status: 201 });
+  } catch (error) {
+    if (error instanceof CeoOrganizationContextError) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
+    }
+    const message = error instanceof Error ? error.message : "Failed to create CEO report run";
+    const status = message.startsWith("Unknown CEO report pack") ? 404 : 500;
+    if (status >= 500) {
+      console.error("POST /api/ceo/reports error:", error);
+    }
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/api/cron/sync/route.test.ts
+++ b/src/app/api/cron/sync/route.test.ts
@@ -50,10 +50,15 @@ vi.mock("@/lib/integrations/orchestrator", () => ({
 vi.mock("@/lib/integrations/ownership", () => ({
   bestEffortMigrateConnectionsToOwner: vi.fn(),
   bestEffortMigrateRulesToOwner: vi.fn(),
+  ensureIntegrationOwnerOrganizationId: vi.fn(),
 }));
 
 vi.mock("@/lib/integrations/health-checks", () => ({
   runIntegrationHealthChecks: vi.fn(),
+}));
+
+vi.mock("@/lib/retention/pipeline", () => ({
+  materializeRetentionCurrent: vi.fn(),
 }));
 
 vi.mock("@/lib/prisma", () => ({
@@ -91,10 +96,12 @@ describe("POST /api/cron/sync", () => {
     const {
       bestEffortMigrateConnectionsToOwner,
       bestEffortMigrateRulesToOwner,
+      ensureIntegrationOwnerOrganizationId,
     } = await import("@/lib/integrations/ownership");
     const { runIntegrationHealthChecks } = await import(
       "@/lib/integrations/health-checks"
     );
+    const { materializeRetentionCurrent } = await import("@/lib/retention/pipeline");
 
     vi.mocked(getVisitorFunnelPrisma).mockReturnValue(null);
     vi.mocked(bestEffortMigrateConnectionsToOwner).mockResolvedValue({
@@ -109,6 +116,8 @@ describe("POST /api/cron/sync", () => {
     vi.mocked(runRules).mockResolvedValue({ ok: true } as never);
     vi.mocked(runIntegrationHealthChecks).mockResolvedValue({ ok: true } as never);
     vi.mocked(pruneAnalyticsSnapshots).mockResolvedValue({ deleted: 0 } as never);
+    vi.mocked(ensureIntegrationOwnerOrganizationId).mockResolvedValue("org_1" as never);
+    vi.mocked(materializeRetentionCurrent).mockResolvedValue(undefined as never);
 
     const { POST } = await import("@/app/api/cron/sync/route");
     const request = new Request("http://localhost/api/cron/sync?wait=1", {
@@ -122,6 +131,7 @@ describe("POST /api/cron/sync", () => {
       visitorFunnelEnrichment: Array<{ skipped: boolean; reason: string | null }>;
       visitorFunnelEnrichmentHealth: { alerts: unknown[]; providers: unknown[] };
       visitorFunnelEnrichmentNotifications: { skippedReason: string | null };
+      retention: { attempted: number; materialized: number };
     };
 
     expect(response.status).toBe(200);
@@ -138,6 +148,11 @@ describe("POST /api/cron/sync", () => {
     expect(runVisitorFunnelEnrichmentSyncs).not.toHaveBeenCalled();
     expect(buildVisitorFunnelEnrichmentStatus).not.toHaveBeenCalled();
     expect(enqueueVisitorFunnelEnrichmentAlertNotifications).not.toHaveBeenCalled();
+    expect(body.retention).toMatchObject({ attempted: 1, materialized: 1 });
+    expect(materializeRetentionCurrent).toHaveBeenCalledWith({
+      id: "owner_1",
+      organizationId: "org_1",
+    });
   });
 
   it("queues heavy sync work in the background by default", async () => {
@@ -150,10 +165,12 @@ describe("POST /api/cron/sync", () => {
     const {
       bestEffortMigrateConnectionsToOwner,
       bestEffortMigrateRulesToOwner,
+      ensureIntegrationOwnerOrganizationId,
     } = await import("@/lib/integrations/ownership");
     const { runIntegrationHealthChecks } = await import(
       "@/lib/integrations/health-checks"
     );
+    const { materializeRetentionCurrent } = await import("@/lib/retention/pipeline");
 
     vi.mocked(getVisitorFunnelPrisma).mockReturnValue(null);
     vi.mocked(bestEffortMigrateConnectionsToOwner).mockResolvedValue({
@@ -168,6 +185,8 @@ describe("POST /api/cron/sync", () => {
     vi.mocked(runRules).mockResolvedValue({ ok: true } as never);
     vi.mocked(runIntegrationHealthChecks).mockResolvedValue({ ok: true } as never);
     vi.mocked(pruneAnalyticsSnapshots).mockResolvedValue({ deleted: 0 } as never);
+    vi.mocked(ensureIntegrationOwnerOrganizationId).mockResolvedValue("org_1" as never);
+    vi.mocked(materializeRetentionCurrent).mockResolvedValue(undefined as never);
 
     const { POST } = await import("@/app/api/cron/sync/route");
     const request = new Request("http://localhost/api/cron/sync", {
@@ -202,6 +221,7 @@ describe("POST /api/cron/sync", () => {
     expect(runRules).toHaveBeenCalledOnce();
     expect(runIntegrationHealthChecks).toHaveBeenCalledOnce();
     expect(pruneAnalyticsSnapshots).toHaveBeenCalledOnce();
+    expect(materializeRetentionCurrent).toHaveBeenCalledOnce();
   });
 
   afterEach(() => {

--- a/src/app/api/cron/sync/route.ts
+++ b/src/app/api/cron/sync/route.ts
@@ -15,9 +15,11 @@ import { runRules } from "@/lib/integrations/orchestrator";
 import {
   bestEffortMigrateConnectionsToOwner,
   bestEffortMigrateRulesToOwner,
+  ensureIntegrationOwnerOrganizationId,
 } from "@/lib/integrations/ownership";
 import { runIntegrationHealthChecks } from "@/lib/integrations/health-checks";
 import { prisma } from "@/lib/prisma";
+import { materializeRetentionCurrent } from "@/lib/retention/pipeline";
 
 function isAuthorized(request: NextRequest): boolean {
   const expected = process.env.CRON_SYNC_SECRET?.trim() || process.env.INTEGRATION_SYNC_SECRET?.trim();
@@ -39,6 +41,49 @@ function parseRetentionDays(): number {
 function shouldWaitForCompletion(request: NextRequest): boolean {
   const wait = new URL(request.url).searchParams.get("wait")?.trim().toLowerCase();
   return wait === "1" || wait === "true";
+}
+
+async function runRetentionMaterialization(input: {
+  ownerUserId: string | null;
+  userIds: string[];
+}): Promise<{
+  attempted: number;
+  materialized: number;
+  skipped: Array<{ userId: string; reason: string }>;
+}> {
+  const actorsByOrganizationId = new Map<string, { id: string; organizationId: string }>();
+  const skipped: Array<{ userId: string; reason: string }> = [];
+
+  for (const userId of input.userIds) {
+    const organizationId =
+      input.ownerUserId === userId
+        ? await ensureIntegrationOwnerOrganizationId(userId)
+        : (
+            await prisma.user.findUnique({
+              where: { id: userId },
+              select: { organizationId: true },
+            })
+          )?.organizationId;
+
+    if (!organizationId) {
+      skipped.push({ userId, reason: "Missing organizationId" });
+      continue;
+    }
+
+    if (!actorsByOrganizationId.has(organizationId)) {
+      actorsByOrganizationId.set(organizationId, { id: userId, organizationId });
+    }
+  }
+
+  for (const actor of actorsByOrganizationId.values()) {
+    await materializeRetentionCurrent(actor);
+  }
+
+  return {
+    attempted: input.userIds.length,
+    materialized: actorsByOrganizationId.size,
+    skipped,
+  };
 }
 
 async function executeCronSync(input: {
@@ -183,7 +228,7 @@ async function executeCronSync(input: {
       visitorFunnelEnrichmentStatus = [];
     }
 
-    const [analyticsResult, rulesResult, healthResult, pruningResult] = await Promise.allSettled([
+    const [analyticsResult, rulesResult, healthResult, pruningResult, retentionResult] = await Promise.allSettled([
       runAnalyticsRefresh({ userIds, rangePresets: ["7d", "30d"] }),
       runRules({
         mode: "incremental",
@@ -194,9 +239,16 @@ async function executeCronSync(input: {
       // Health checks run per-user; run for all discovered users.
       Promise.all(userIds.map((uid) => runIntegrationHealthChecks({ userId: uid }))),
       pruneAnalyticsSnapshots({ olderThanDays: parseRetentionDays() }),
+      runRetentionMaterialization({ ownerUserId, userIds }),
     ]);
 
-    const settled = { analytics: null as unknown, rules: null as unknown, health: null as unknown, pruning: null as unknown };
+    const settled = {
+      analytics: null as unknown,
+      rules: null as unknown,
+      health: null as unknown,
+      pruning: null as unknown,
+      retention: null as unknown,
+    };
 
     if (analyticsResult.status === "fulfilled") {
       settled.analytics = analyticsResult.value;
@@ -225,6 +277,13 @@ async function executeCronSync(input: {
       const msg = pruningResult.reason instanceof Error ? pruningResult.reason.message : String(pruningResult.reason);
       failures.push(`pruning: ${msg}`);
       console.error("POST /api/cron/sync pruning failed:", pruningResult.reason);
+    }
+    if (retentionResult.status === "fulfilled") {
+      settled.retention = retentionResult.value;
+    } else {
+      const msg = retentionResult.reason instanceof Error ? retentionResult.reason.message : String(retentionResult.reason);
+      failures.push(`retention: ${msg}`);
+      console.error("POST /api/cron/sync retention materialization failed:", retentionResult.reason);
     }
 
     return {

--- a/src/app/api/health/live/route.test.ts
+++ b/src/app/api/health/live/route.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import packageJson from "../../../../../package.json";
+
+describe("GET /api/health/live", () => {
+  it("returns liveness data without checking dependencies", async () => {
+    const { GET } = await import("@/app/api/health/live/route");
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      status: "ok",
+      version: packageJson.version,
+    });
+    expect(typeof body.timestamp).toBe("string");
+  });
+});

--- a/src/app/api/health/live/route.ts
+++ b/src/app/api/health/live/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import packageJson from "../../../../../package.json";
+
+const APP_VERSION = process.env.APP_VERSION?.trim() || packageJson.version;
+
+/**
+ * GET /api/health/live
+ *
+ * Liveness endpoint for platform health checks.
+ * Returns 200 when the app process is up and able to serve HTTP,
+ * without depending on downstream services like Postgres.
+ */
+export async function GET() {
+  return NextResponse.json(
+    {
+      status: "ok",
+      version: APP_VERSION,
+      timestamp: new Date().toISOString(),
+    },
+    {
+      status: 200,
+      headers: {
+        "Cache-Control": "no-store, no-cache, must-revalidate",
+      },
+    }
+  );
+}

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -8,7 +8,7 @@ const APP_VERSION = process.env.APP_VERSION?.trim() || packageJson.version;
 /**
  * GET /api/health
  *
- * Health check endpoint that verifies database connectivity
+ * Dependency health endpoint that verifies database connectivity
  * and reports pool status.
  *
  * Returns:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import { Providers } from "@/components/layout/providers";
 
 export const metadata: Metadata = {
   title: "WIPGuard",
-  description: "WIP-limited GTM operating system for revenue teams",
+  description: "Analytics API meeting place with governed metric trust for revenue teams",
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,13 @@
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { HomeLanding } from "@/components/marketing/home-landing";
+import { ANALYTICS_HOME } from "@/lib/platform/routes";
 
 export default async function Home() {
   const session = await auth();
 
   if (session?.user) {
-    redirect("/dashboard");
+    redirect(ANALYTICS_HOME);
   }
 
   return <HomeLanding />;

--- a/src/components/analytics/ai-insights-page.test.tsx
+++ b/src/components/analytics/ai-insights-page.test.tsx
@@ -6,7 +6,7 @@ import type { AiInsightsBundle, AnalyticsDashboardData } from "@/lib/analytics/t
 
 function makeInsights(count: number): AiInsightsBundle["global"] {
   const severities = ["critical", "warning", "info"] as const;
-  const sections = ["ads-traffic", "finance", "sales-pipeline", "customer-success"] as const;
+  const sections = ["website-traffic", "social-media", "finance", "sales-pipeline"] as const;
 
   return Array.from({ length: count }, (_, idx) => ({
     id: `insight-${idx + 1}`,
@@ -27,7 +27,8 @@ function writeCachedOverviewData(globalCount: number) {
     generatedAt: "2026-03-01T00:00:00.000Z",
     global: makeInsights(globalCount),
     bySection: {
-      "ads-traffic": [],
+      "website-traffic": [],
+      "social-media": [],
       finance: [],
       "sales-pipeline": [],
       retention: [],
@@ -170,6 +171,9 @@ describe("AiInsightsPage", () => {
       expect(screen.getByText("AI Insights")).toBeTruthy();
     });
 
-    expect(screen.queryByRole("button", { name: "Create task from this insight" })).toBeNull();
+    expect(screen.getByRole("heading", { name: "Recommended moves" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /create task/i })).toBeNull();
+    expect(screen.queryByText(/^Task$/)).toBeNull();
+    expect(screen.queryByText(/Creating\.\.\./)).toBeNull();
   });
 });

--- a/src/components/analytics/ai-insights-page.tsx
+++ b/src/components/analytics/ai-insights-page.tsx
@@ -40,7 +40,8 @@ const SEVERITY_ORDER: Record<AiInsight["severity"], number> = {
 const PAGE_SIZES = [10, 25, 50] as const;
 
 const SECTION_LABELS: Partial<Record<AnalyticsSectionId, string>> = {
-  "ads-traffic": "Ads & Traffic",
+  "website-traffic": "Website Traffic",
+  "social-media": "Social Media",
   finance: "Finance",
   "sales-pipeline": "Sales Pipeline",
   retention: "Retention",
@@ -158,7 +159,6 @@ export function AiInsightsPage() {
   const [autoRefresh, setAutoRefresh] = useState(true);
   const [showDismissed, setShowDismissed] = useState(false);
   const [recentlyDismissed, setRecentlyDismissed] = useState<{ id: string; title: string } | null>(null);
-  const [taskError, setTaskError] = useState<string | null>(null);
   const deferredSearchQuery = useDeferredValue(searchQuery);
 
   const {
@@ -167,8 +167,6 @@ export function AiInsightsPage() {
     togglePin,
     dismiss,
     undoDismiss,
-    createTaskFromInsight,
-    creatingTaskForId,
     sortAndFilter,
   } = useInsightPreferences();
 
@@ -422,18 +420,6 @@ export function AiInsightsPage() {
     setRecentlyDismissed(null);
   }, [recentlyDismissed, undoDismiss]);
 
-  const handleCreateTask = useCallback(
-    async (insight: AiInsight) => {
-      setTaskError(null);
-      try {
-        await createTaskFromInsight(insight);
-      } catch {
-        setTaskError(`Failed to create task for "${insight.title}". Please try again.`);
-      }
-    },
-    [createTaskFromInsight]
-  );
-
   const resetFilters = useCallback(() => {
     setSeverityFilter("all");
     setSectionFilter("all");
@@ -633,12 +619,6 @@ export function AiInsightsPage() {
           ) : null}
 
           {error ? <DashboardErrorBanner message={error} onRetry={resource.refresh} retryLabel="Rerun insights" /> : null}
-
-          {taskError ? (
-            <div className="rounded-2xl border border-red-200 bg-red-50 p-4 dark:border-red-900/50 dark:bg-red-900/10">
-              <p className="text-sm text-red-600 dark:text-red-400">{taskError}</p>
-            </div>
-          ) : null}
 
           <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
             <StatCard
@@ -997,8 +977,6 @@ export function AiInsightsPage() {
                       isPinned={isPinned(insight.id)}
                       onTogglePin={() => void togglePin(insight.id)}
                       onDismiss={() => handleDismiss(insight)}
-                      onCreateTask={() => void handleCreateTask(insight)}
-                      isCreatingTask={creatingTaskForId === insight.id}
                     />
                   ))
                 )}
@@ -1092,7 +1070,7 @@ export function AiInsightsPage() {
               <section className="rounded-3xl border border-border bg-card p-4">
                 <div className="flex items-start justify-between gap-3">
                   <div>
-                    <h2 className="text-base font-semibold text-foreground">Action queue</h2>
+                    <h2 className="text-base font-semibold text-foreground">Recommended moves</h2>
                     <p className="text-sm text-muted-foreground">Highest-leverage moves across the visible set.</p>
                   </div>
                   <ListTodo className="h-4 w-4 text-muted-foreground" />
@@ -1113,24 +1091,14 @@ export function AiInsightsPage() {
                         </div>
                         <div className="mt-3 flex items-center justify-between gap-3">
                           <p className="text-xs text-muted-foreground">{action.sectionLabel}</p>
-                          <div className="flex items-center gap-3">
-                            <button
-                              type="button"
-                              onClick={() => void handleCreateTask(action.insight)}
-                              disabled={creatingTaskForId === action.insight.id}
-                              className="text-xs font-medium text-foreground underline decoration-border underline-offset-4 hover:text-primary disabled:opacity-50"
+                          {action.destination ? (
+                            <Link
+                              href={action.destination.href}
+                              className="text-xs font-medium text-foreground underline decoration-border underline-offset-4 hover:text-primary"
                             >
-                              {creatingTaskForId === action.insight.id ? "Creating..." : "Create task"}
-                            </button>
-                            {action.destination ? (
-                              <Link
-                                href={action.destination.href}
-                                className="text-xs font-medium text-foreground underline decoration-border underline-offset-4 hover:text-primary"
-                              >
-                                Open {action.destination.label}
-                              </Link>
-                            ) : null}
-                          </div>
+                              Open {action.destination.label}
+                            </Link>
+                          ) : null}
                         </div>
                       </div>
                     ))

--- a/src/components/analytics/ai-insights-panel.test.tsx
+++ b/src/components/analytics/ai-insights-panel.test.tsx
@@ -9,7 +9,7 @@ function makeBundle(): AiInsightsBundle {
     global: [
       {
         id: "warn-ads",
-        section: "ads-traffic",
+        section: "website-traffic",
         severity: "warning",
         title: "Ads efficiency trending down",
         why: "Cost per conversion rising.",
@@ -61,7 +61,8 @@ function makeBundle(): AiInsightsBundle {
       },
     ],
     bySection: {
-      "ads-traffic": [],
+      "website-traffic": [],
+      "social-media": [],
       finance: [],
       "sales-pipeline": [],
       retention: [],
@@ -76,7 +77,7 @@ function makeBundle(): AiInsightsBundle {
 describe("AiInsightsPanel", () => {
   it("sorts by severity/confidence, supports filters, and shows stale badge", () => {
     const bundle = makeBundle();
-    bundle.bySection["ads-traffic"] = [bundle.global[0]];
+    bundle.bySection["website-traffic"] = [bundle.global[0]];
     bundle.bySection.finance = [bundle.global[2]];
     bundle.bySection["sales-pipeline"] = [bundle.global[1]];
     bundle.bySection.retention = [];
@@ -96,14 +97,14 @@ describe("AiInsightsPanel", () => {
     expect(screen.getByText("Runway stable")).toBeTruthy();
     expect(screen.queryByText("Pipeline conversion risk")).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Ads" }));
+    fireEvent.click(screen.getByRole("button", { name: "Web" }));
     expect(screen.getByText("Ads efficiency trending down")).toBeTruthy();
     expect(screen.queryByText("Refactor campaign targeting")).toBeNull();
   });
 
   it("resets filter when defaultFilter prop changes", () => {
     const bundle = makeBundle();
-    bundle.bySection["ads-traffic"] = [bundle.global[0]];
+    bundle.bySection["website-traffic"] = [bundle.global[0]];
     bundle.bySection.finance = [bundle.global[2]];
     bundle.bySection["sales-pipeline"] = [bundle.global[1]];
     bundle.bySection.retention = [];

--- a/src/components/analytics/ai-insights-panel.tsx
+++ b/src/components/analytics/ai-insights-panel.tsx
@@ -8,7 +8,8 @@ type InsightFilter = "all" | AnalyticsSectionId;
 
 const FILTERS: Array<{ id: InsightFilter; label: string }> = [
   { id: "all", label: "All" },
-  { id: "ads-traffic", label: "Ads" },
+  { id: "website-traffic", label: "Web" },
+  { id: "social-media", label: "Social" },
   { id: "finance", label: "Finance" },
   { id: "sales-pipeline", label: "Sales" },
   { id: "retention", label: "Retention" },

--- a/src/components/analytics/analytics-section-page.tsx
+++ b/src/components/analytics/analytics-section-page.tsx
@@ -137,7 +137,7 @@ const CHILD_ID_TO_RENDER_KIND = {
   "sales-performance": "sales-performance",
   "sales-google-workspace": "sales-google-workspace",
   "sales-slack": "sales-slack",
-  // Ads & Traffic
+  // Website traffic + social media children
   "ads-google-analytics": "ads-google-analytics",
   "ads-google-ads": "ads-google-ads",
   "ads-meta-ads": "ads-meta-ads",
@@ -344,7 +344,8 @@ export function AnalyticsSectionPage({ sectionId }: AnalyticsSectionPageProps) {
   const title = child?.label ?? primary?.label ?? "Analytics";
 
   const primaryContent = useMemo(() => {
-    if (sectionId === "ads-traffic") return <MarketingTabNew data={analyticsData} />;
+    if (sectionId === "website-traffic") return <MarketingTabNew data={analyticsData} variant="website-traffic" />;
+    if (sectionId === "social-media") return <MarketingTabNew data={analyticsData} variant="social-media" />;
     if (sectionId === "finance") return <FinanceTab data={analyticsData} />;
     if (sectionId === "sales-pipeline") return <SalesFunnelTab data={analyticsData} />;
     if (sectionId === "customer-success") return <CustomerSuccessTab data={analyticsData} />;
@@ -377,7 +378,7 @@ export function AnalyticsSectionPage({ sectionId }: AnalyticsSectionPageProps) {
     if (renderKind === "sales-performance") return <SalesPerformanceView pack={analyticsData?.salesPerformance ?? null} />;
     if (renderKind === "sales-google-workspace") return <GenericWorkspaceTab data={analyticsData} />;
     if (renderKind === "sales-slack") return <GenericSlackTab data={analyticsData} />;
-    // Ads & Traffic
+    // Website traffic + social media
     if (renderKind === "ads-google-analytics") return <AdsGoogleAnalyticsTab data={analyticsData} />;
     if (renderKind === "ads-google-ads") return <AdsGoogleAdsTab data={analyticsData} />;
     if (renderKind === "ads-meta-ads") return <AdsMetaAdsTab data={analyticsData} />;

--- a/src/components/analytics/analytics-summary-page.test.tsx
+++ b/src/components/analytics/analytics-summary-page.test.tsx
@@ -48,10 +48,10 @@ describe("AnalyticsSummaryPage", () => {
       },
       primarySections: [
         {
-          id: "ads-traffic",
-          label: "Ads & Traffic",
+          id: "website-traffic",
+          label: "Website Traffic",
           description: "desc",
-          href: "/analytics/ads-traffic",
+          href: "/analytics/website-traffic",
           status: "connected",
           integrationCount: 4,
           connectedCount: 4,

--- a/src/components/analytics/ceo-command-center.test.tsx
+++ b/src/components/analytics/ceo-command-center.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CeoCommandCenter } from "@/components/analytics/ceo-command-center";
+import { clearDashboardCache } from "@/lib/client/dashboard-cache-store";
+
+describe("CeoCommandCenter", () => {
+  beforeEach(() => {
+    clearDashboardCache();
+    vi.restoreAllMocks();
+  });
+
+  it("renders trusted metrics, trust labels, and report packs", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url === "/api/ceo/metrics") {
+          return Response.json({
+            generatedAt: "2026-05-01T12:00:00.000Z",
+            periodStart: "2026-04-01T00:00:00.000Z",
+            periodEnd: "2026-05-01T12:00:00.000Z",
+            trustSummary: { fresh: 1, stale: 1, partial: 0, missing: 0, error: 0, conflicted: 0 },
+            readiness: {
+              status: "not_board_final",
+              ready: false,
+              summary: "Not board-final: 1 readiness gate is failing.",
+              failingGates: [
+                {
+                  metricKey: "finance.cash_balance",
+                  label: "Cash Balance",
+                  reason: "Metric source trust is stale.",
+                },
+              ],
+            },
+            metrics: [
+              {
+                definition: {
+                  key: "ceo.flow_reliability_score",
+                  label: "Internal Execution Reliability",
+                  domain: "ceo",
+                  unit: "score",
+                  sourceDependencies: ["wipguard"],
+                },
+                value: 91,
+                delta: 4,
+                asOf: "2026-05-01T12:00:00.000Z",
+                trust: { status: "fresh", confidence: 1, warnings: [], sourceStates: [] },
+                lineage: [],
+              },
+              {
+                definition: {
+                  key: "finance.cash_balance",
+                  label: "Cash Balance",
+                  domain: "finance",
+                  unit: "currency",
+                  sourceDependencies: ["mercury"],
+                },
+                value: 100000,
+                delta: null,
+                asOf: "2026-05-01T11:00:00.000Z",
+                trust: {
+                  status: "stale",
+                  confidence: 0.7,
+                  warnings: ["Required source mercury is stale."],
+                  sourceStates: [],
+                },
+                lineage: [],
+              },
+            ],
+            reportPacks: [
+              {
+                slug: "weekly-exec",
+                name: "Weekly Exec",
+                description: "Weekly operating review.",
+                cadence: "weekly",
+                audience: "TEAM",
+                metricKeys: ["ceo.flow_reliability_score"],
+                sections: [],
+              },
+            ],
+            definitions: [],
+          });
+        }
+        return Response.json({ reportPacks: [] });
+      })
+    );
+
+    render(<CeoCommandCenter />);
+
+    await waitFor(() => {
+      expect(screen.getByText("CEO Command Center")).toBeTruthy();
+    });
+
+    expect(screen.getByText("Internal Execution Reliability")).toBeTruthy();
+    expect(screen.getByText("Not board-final")).toBeTruthy();
+    expect(screen.getByText("not board final")).toBeTruthy();
+    expect(screen.getByText("Cash Balance")).toBeTruthy();
+    expect(screen.getAllByText("fresh").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("stale").length).toBeGreaterThan(0);
+    expect(screen.getByText("Weekly Exec")).toBeTruthy();
+    expect(screen.getByText("Required source mercury is stale.")).toBeTruthy();
+  });
+});

--- a/src/components/analytics/ceo-command-center.tsx
+++ b/src/components/analytics/ceo-command-center.tsx
@@ -1,0 +1,393 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { AlertTriangle, FileText, RefreshCw, ShieldCheck } from "lucide-react";
+import { DashboardErrorBanner } from "@/components/dashboard/dashboard-error-banner";
+import { DashboardLoadingState } from "@/components/dashboard/dashboard-loading-state";
+import { DashboardStaleBanner } from "@/components/dashboard/dashboard-stale-banner";
+import { useDashboardResource } from "@/components/dashboard/use-dashboard-resource";
+
+type TrustStatus = "fresh" | "stale" | "partial" | "missing" | "error" | "conflicted";
+
+interface CeoMetric {
+  definition: {
+    key: string;
+    label: string;
+    domain: string;
+    unit: string;
+    sourceDependencies: string[];
+  };
+  value: number | string | null;
+  priorValue?: number | string | null;
+  delta: number | null;
+  details?: Array<{
+    key: string;
+    label: string;
+    value: number | string | null;
+    unit?: string;
+  }>;
+  asOf: string;
+  trust: {
+    status: TrustStatus;
+    confidence: number;
+    warnings: string[];
+  };
+}
+
+interface CeoReportPack {
+  slug: string;
+  name: string;
+  description: string;
+  cadence: string;
+  audience: string;
+  metricKeys: string[];
+}
+
+interface CeoReadiness {
+  status: "board_ready" | "not_board_final";
+  ready: boolean;
+  summary: string;
+  failingGates: Array<{
+    metricKey: string;
+    label: string;
+    reason: string;
+  }>;
+}
+
+interface CeoMetricsPayload {
+  generatedAt: string;
+  periodStart: string;
+  periodEnd: string;
+  trustSummary: Record<TrustStatus, number>;
+  metrics: CeoMetric[];
+  reportPacks: CeoReportPack[];
+  readiness: CeoReadiness;
+}
+
+interface ReportRunPayload {
+  id: string | null;
+  packSlug: string;
+  packName: string;
+  markdown: string;
+  csv: string;
+  slideJson: unknown;
+}
+
+const TRUST_CLASS: Record<TrustStatus, string> = {
+  fresh: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  stale: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  partial: "border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300",
+  missing: "border-zinc-500/30 bg-zinc-500/10 text-zinc-700 dark:text-zinc-300",
+  error: "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300",
+  conflicted: "border-purple-500/30 bg-purple-500/10 text-purple-700 dark:text-purple-300",
+};
+
+const DOMAIN_LABELS: Record<string, string> = {
+  ceo: "CEO",
+  finance: "Finance",
+  "sales-pipeline": "Sales",
+  retention: "Retention",
+  "customer-success": "Customer Success",
+  "website-traffic": "Website",
+  "social-media": "Social",
+  "customer-journey": "Customer Journey",
+  "demo-analytics": "Demo",
+  "process-analytics": "Process",
+};
+
+function formatMetricValue(metric: CeoMetric): string {
+  if (metric.value === null || metric.value === undefined || metric.value === "") return "Unavailable";
+  if (typeof metric.value === "string") return metric.value;
+  if (metric.definition.unit === "currency") {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 0,
+    }).format(metric.value);
+  }
+  if (metric.definition.unit === "percent") {
+    return `${(metric.value * 100).toFixed(1)}%`;
+  }
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(metric.value);
+}
+
+function formatDetailValue(detail: NonNullable<CeoMetric["details"]>[number]): string {
+  if (detail.value === null || detail.value === undefined || detail.value === "") return "Unavailable";
+  if (typeof detail.value === "string") return detail.value;
+  if (detail.unit === "currency") {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 0,
+    }).format(detail.value);
+  }
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(detail.value);
+}
+
+function formatDelta(delta: number | null): string | null {
+  if (delta === null || delta === 0) return null;
+  return `${delta > 0 ? "+" : ""}${delta.toFixed(1)}`;
+}
+
+function TrustBadge({ status }: { status: TrustStatus }) {
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${TRUST_CLASS[status]}`}>
+      {status}
+    </span>
+  );
+}
+
+function MetricTile({ metric }: { metric: CeoMetric }) {
+  const delta = formatDelta(metric.delta);
+  return (
+    <article className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium text-foreground">{metric.definition.label}</p>
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            {DOMAIN_LABELS[metric.definition.domain] ?? metric.definition.domain} · as of{" "}
+            {new Date(metric.asOf).toLocaleString()}
+          </p>
+        </div>
+        <TrustBadge status={metric.trust.status} />
+      </div>
+      <div className="mt-3 flex items-end gap-2">
+        <p className="text-2xl font-semibold text-foreground">{formatMetricValue(metric)}</p>
+        {delta ? <p className="pb-1 text-xs text-muted-foreground">{delta}</p> : null}
+      </div>
+      {metric.details && metric.details.length > 0 ? (
+        <dl className="mt-3 grid grid-cols-1 gap-2 border-t border-border pt-3 text-xs sm:grid-cols-3">
+          {metric.details.map((detail) => (
+            <div key={detail.key} className="min-w-0">
+              <dt className="truncate text-muted-foreground">{detail.label}</dt>
+              <dd className="mt-0.5 truncate font-medium tabular-nums text-foreground">
+                {formatDetailValue(detail)}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+      {metric.trust.warnings.length > 0 ? (
+        <div className="mt-3 space-y-1">
+          {metric.trust.warnings.slice(0, 2).map((warning) => (
+            <p key={warning} className="flex gap-1.5 text-xs text-amber-700 dark:text-amber-300">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              <span>{warning}</span>
+            </p>
+          ))}
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+export function CeoCommandCenter() {
+  const [reportRun, setReportRun] = useState<ReportRunPayload | null>(null);
+  const [reportError, setReportError] = useState<string | null>(null);
+  const [creatingPack, setCreatingPack] = useState<string | null>(null);
+
+  const resource = useDashboardResource<CeoMetricsPayload>({
+    cacheKey: "ceo:metric-snapshot:v1",
+    deps: [],
+    load: async ({ signal }) => {
+      const response = await fetch("/api/ceo/metrics", { signal, cache: "no-store" });
+      if (!response.ok) {
+        throw new Error(`CEO metrics request failed (${response.status})`);
+      }
+      return (await response.json()) as CeoMetricsPayload;
+    },
+    getLastUpdatedAt: (payload) => payload.generatedAt,
+    mapError: (error) => {
+      if (error instanceof Error && error.message) return error.message;
+      return "Could not load CEO metrics.";
+    },
+  });
+
+  const metricsByDomain = useMemo(() => {
+    const groups = new Map<string, CeoMetric[]>();
+    for (const metric of resource.data?.metrics ?? []) {
+      if (!metric.definition.key.startsWith("ceo.") && !["finance", "sales-pipeline", "retention", "customer-success", "website-traffic", "social-media"].includes(metric.definition.domain)) {
+        continue;
+      }
+      const domain = metric.definition.domain;
+      groups.set(domain, [...(groups.get(domain) ?? []), metric]);
+    }
+    return Array.from(groups.entries()).sort(([a], [b]) => a.localeCompare(b));
+  }, [resource.data]);
+
+  async function createReport(packSlug: string) {
+    setCreatingPack(packSlug);
+    setReportError(null);
+    try {
+      const response = await fetch("/api/ceo/reports", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ packSlug }),
+      });
+      const payload = (await response.json().catch(() => null)) as ReportRunPayload | { error?: string } | null;
+      if (!response.ok) {
+        throw new Error((payload as { error?: string } | null)?.error ?? `Report run failed (${response.status})`);
+      }
+      setReportRun(payload as ReportRunPayload);
+    } catch (error) {
+      setReportError(error instanceof Error ? error.message : "Could not create report run.");
+    } finally {
+      setCreatingPack(null);
+    }
+  }
+
+  if (resource.loading && !resource.data) {
+    return <DashboardLoadingState message="Loading CEO command center..." />;
+  }
+
+  if (!resource.data) {
+    return (
+      <div className="p-4">
+        <DashboardErrorBanner message={resource.error ?? "CEO metrics are unavailable."} onRetry={resource.refresh} />
+      </div>
+    );
+  }
+
+  const trustSummary = resource.data.trustSummary;
+  const readiness = resource.data.readiness;
+
+  return (
+    <div className="h-full space-y-4 overflow-y-auto p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold text-foreground">CEO Command Center</h1>
+          <p className="text-xs text-muted-foreground">
+            Trusted operating metrics with source freshness, confidence, and report-pack exports.
+          </p>
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            Last computed: {new Date(resource.data.generatedAt).toLocaleString()}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={resource.refresh}
+          disabled={resource.refreshing}
+          className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm text-muted-foreground hover:text-foreground disabled:opacity-60"
+        >
+          <RefreshCw className="h-4 w-4" aria-hidden="true" />
+          {resource.refreshing ? "Refreshing" : "Refresh"}
+        </button>
+      </div>
+
+      {(resource.error || resource.stale) && (
+        <DashboardStaleBanner
+          lastUpdatedAt={resource.lastUpdatedAt}
+          refreshing={resource.refreshing}
+          onRefresh={resource.refresh}
+          label="Showing cached CEO metrics while the latest snapshot refreshes."
+        />
+      )}
+
+      <section
+        className={`rounded-lg border p-4 ${
+          readiness.ready
+            ? "border-emerald-500/30 bg-emerald-500/10"
+            : "border-amber-500/30 bg-amber-500/10"
+        }`}
+        aria-label="Board readiness"
+      >
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Production readiness
+            </p>
+            <h2 className="mt-1 text-base font-semibold text-foreground">
+              {readiness.ready ? "Board-ready" : "Not board-final"}
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">{readiness.summary}</p>
+          </div>
+          <span
+            className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${
+              readiness.ready
+                ? "border-emerald-500/30 text-emerald-700 dark:text-emerald-300"
+                : "border-amber-500/30 text-amber-700 dark:text-amber-300"
+            }`}
+          >
+            {readiness.status.replaceAll("_", " ")}
+          </span>
+        </div>
+        {readiness.failingGates.length > 0 ? (
+          <div className="mt-3 grid gap-2 md:grid-cols-2">
+            {readiness.failingGates.slice(0, 6).map((gate) => (
+              <p key={`${gate.metricKey}:${gate.reason}`} className="flex gap-2 text-xs text-amber-800 dark:text-amber-200">
+                <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                <span>
+                  <span className="font-medium">{gate.label}:</span> {gate.reason}
+                </span>
+              </p>
+            ))}
+          </div>
+        ) : null}
+      </section>
+
+      <section className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-6" aria-label="Trust summary">
+        {Object.entries(trustSummary).map(([status, count]) => (
+          <div key={status} className="rounded-lg border border-border bg-card p-3">
+            <p className="text-[11px] uppercase tracking-wide text-muted-foreground">{status}</p>
+            <p className="mt-1 text-2xl font-semibold text-foreground">{count}</p>
+          </div>
+        ))}
+      </section>
+
+      <section className="grid gap-3 lg:grid-cols-4" aria-label="Report packs">
+        {resource.data.reportPacks.map((pack) => (
+          <article key={pack.slug} className="rounded-lg border border-border bg-card p-4">
+            <div className="flex items-start gap-2">
+              <FileText className="mt-0.5 h-4 w-4 text-primary" aria-hidden="true" />
+              <div className="min-w-0">
+                <h2 className="text-sm font-semibold text-foreground">{pack.name}</h2>
+                <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{pack.description}</p>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => void createReport(pack.slug)}
+              disabled={creatingPack !== null}
+              className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground hover:bg-muted disabled:opacity-60"
+            >
+              <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+              {creatingPack === pack.slug ? "Generating" : "Generate"}
+            </button>
+          </article>
+        ))}
+      </section>
+
+      {reportError ? <DashboardErrorBanner message={reportError} onRetry={() => setReportError(null)} retryLabel="Dismiss" /> : null}
+
+      {reportRun ? (
+        <section className="rounded-lg border border-border bg-card p-4" aria-label="Latest report run">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <h2 className="text-sm font-semibold text-foreground">{reportRun.packName}</h2>
+              <p className="text-xs text-muted-foreground">Generated report run {reportRun.id ?? "not persisted"}</p>
+            </div>
+          </div>
+          <pre className="mt-3 max-h-72 overflow-auto rounded-md border border-border bg-background p-3 text-xs text-muted-foreground">
+            {reportRun.markdown}
+          </pre>
+        </section>
+      ) : null}
+
+      <div className="space-y-4">
+        {metricsByDomain.map(([domain, metrics]) => (
+          <section key={domain} className="space-y-3" aria-label={`${DOMAIN_LABELS[domain] ?? domain} metrics`}>
+            <div className="flex items-center justify-between">
+              <h2 className="text-sm font-semibold text-foreground">{DOMAIN_LABELS[domain] ?? domain}</h2>
+              <p className="text-xs text-muted-foreground">{metrics.length} metrics</p>
+            </div>
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+              {metrics.map((metric) => (
+                <MetricTile key={metric.definition.key} metric={metric} />
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/analytics/cross-domain-insights.tsx
+++ b/src/components/analytics/cross-domain-insights.tsx
@@ -3,7 +3,8 @@
 import type { AnalyticsSectionId, CrossDomainInsights } from "@/lib/analytics/types";
 
 const SECTION_LABELS: Record<AnalyticsSectionId, string> = {
-  "ads-traffic": "Ads & Traffic",
+  "website-traffic": "Website Traffic",
+  "social-media": "Social Media",
   finance: "Finance",
   "sales-pipeline": "Sales & Pipeline",
   retention: "Retention",
@@ -34,7 +35,7 @@ export function CrossDomainInsightsPanel({ data }: CrossDomainInsightsPanelProps
     );
   }
 
-  const sections: AnalyticsSectionId[] = ["ads-traffic", "finance", "sales-pipeline", "customer-success"];
+  const sections: AnalyticsSectionId[] = ["website-traffic", "social-media", "finance", "sales-pipeline"];
 
   return (
     <section className="rounded-xl border border-border bg-card p-4 space-y-4">

--- a/src/components/analytics/customer-success-operational-view-model.ts
+++ b/src/components/analytics/customer-success-operational-view-model.ts
@@ -179,7 +179,7 @@ export function deriveCustomerSuccessOperationalView(data: AnalyticsDashboardDat
     },
     {
       id: "overdue",
-      label: "Overdue Open Tasks",
+      label: "Legacy Open Execution Items",
       value: product?.overdueOpenTasks ?? 0,
       threshold: 5,
       description: "Overdue execution creates retention delays.",

--- a/src/components/analytics/finance-mercury-tab.tsx
+++ b/src/components/analytics/finance-mercury-tab.tsx
@@ -56,6 +56,15 @@ export function FinanceMercuryTab({ data }: FinanceMercuryTabProps) {
   }
 
   const { accounts, cashFlow } = mercury;
+  const bankCash = cashFlow.bankCash ?? accounts
+    .filter((account) => account.type.toLowerCase() !== "treasury")
+    .reduce((sum, account) => sum + account.balance, 0);
+  const treasuryCash = cashFlow.treasuryCash ?? accounts
+    .filter((account) => account.type.toLowerCase() === "treasury")
+    .reduce((sum, account) => sum + account.balance, 0);
+  const totalBalanceSubtitle = treasuryCash > 0
+    ? `${fmt$(bankCash)} bank · ${fmt$(treasuryCash)} Treasury`
+    : undefined;
 
   if (accounts.length === 0 && cashFlow.totalBalance === 0) {
     return (
@@ -158,6 +167,7 @@ export function FinanceMercuryTab({ data }: FinanceMercuryTabProps) {
         <StatCard
           label="Total Balance"
           value={fmt$(cashFlow.totalBalance)}
+          subtitle={totalBalanceSubtitle}
           icon={Landmark}
         />
         <StatCard
@@ -333,7 +343,12 @@ export function FinanceMercuryTab({ data }: FinanceMercuryTabProps) {
                 })}
               {/* Total row */}
               <div className="flex items-center justify-between border-t border-border pt-3">
-                <span className="text-sm font-semibold text-foreground">Total Balance</span>
+                <div>
+                  <span className="text-sm font-semibold text-foreground">Total Balance</span>
+                  {totalBalanceSubtitle ? (
+                    <p className="text-[11px] text-muted-foreground">{totalBalanceSubtitle}</p>
+                  ) : null}
+                </div>
                 <span className="text-lg font-bold tabular-nums text-foreground">{fmt$(cashFlow.totalBalance)}</span>
               </div>
             </div>

--- a/src/components/analytics/finance-tab.test.tsx
+++ b/src/components/analytics/finance-tab.test.tsx
@@ -85,6 +85,7 @@ function makeFinancialPlanning(
     goals: [],
     pnl: null,
     unitEconomics: null,
+    subscriptionOverview: null,
     ...overrides,
   };
 }
@@ -225,4 +226,3 @@ describe("FinanceTab", () => {
     expect(screen.getByText("Operating")).toBeTruthy();
   });
 });
-

--- a/src/components/analytics/finance-tab.tsx
+++ b/src/components/analytics/finance-tab.tsx
@@ -179,15 +179,17 @@ export function FinanceTab({ data }: FinanceTabProps) {
   }
 
   // Extract metrics with fallbacks
-  const mrr = stripe?.revenue?.mrr ?? 0;
-  const mrrChange = stripe?.revenue?.mrrChange ?? 0;
   const subscriptionOverview = fp?.subscriptionOverview ?? null;
+  const mrr = subscriptionOverview?.totalMrr ?? (stripe?.revenue?.mrr ?? 0);
+  const mrrChange = stripe?.revenue?.mrrChange ?? 0;
   const activeSubs = subscriptionOverview?.mergedActiveSubscriptions ?? (stripe?.subscriptions?.active ?? 0);
   const stripeSubs = subscriptionOverview?.stripeActiveSubscriptions ?? (stripe?.subscriptions?.active ?? 0);
   const hubspotSubs = subscriptionOverview?.hubspotActiveSubscriptions ?? 0;
   const pastDue = stripe?.subscriptions?.pastDue ?? 0;
   const trialing = stripe?.subscriptions?.trialing ?? 0;
   const cashBalance = mercury?.cashFlow?.totalBalance ?? 0;
+  const bankCash = mercury?.cashFlow?.bankCash ?? null;
+  const treasuryCash = mercury?.cashFlow?.treasuryCash ?? null;
   const runway = mercury?.cashFlow?.runway ?? 0;
   const netCashFlow = mercury?.cashFlow?.netCashFlow ?? 0;
   const successRate = normalizePercentValue(stripe?.payments?.successRate ?? 0);
@@ -216,7 +218,12 @@ export function FinanceTab({ data }: FinanceTabProps) {
         <StatCard
           label="Cash Balance"
           value={fmt$(cashBalance)}
-          subtitle={runway > 0 ? `${runway.toFixed(1)} months runway` : undefined}
+          subtitle={[
+            bankCash !== null && treasuryCash !== null
+              ? `${fmt$(bankCash)} bank · ${fmt$(treasuryCash)} Treasury`
+              : null,
+            runway > 0 ? `${runway.toFixed(1)} months runway` : null,
+          ].filter(Boolean).join(" · ") || undefined}
           icon={Wallet}
         />
         <StatCard

--- a/src/components/analytics/insight-card-full.tsx
+++ b/src/components/analytics/insight-card-full.tsx
@@ -32,8 +32,10 @@ const SEVERITY_CONFIG = {
 
 function formatSectionLabel(section: AiInsight["section"]): string {
   switch (section) {
-    case "ads-traffic":
-      return "Ads & Traffic";
+    case "website-traffic":
+      return "Website Traffic";
+    case "social-media":
+      return "Social Media";
     case "sales-pipeline":
       return "Sales Pipeline";
     case "customer-success":
@@ -57,8 +59,6 @@ interface InsightCardFullProps {
   isPinned?: boolean;
   onTogglePin?: () => void;
   onDismiss?: () => void;
-  onCreateTask?: () => void;
-  isCreatingTask?: boolean;
 }
 
 export function InsightCardFull({
@@ -69,12 +69,10 @@ export function InsightCardFull({
   isPinned = false,
   onTogglePin,
   onDismiss,
-  onCreateTask,
-  isCreatingTask = false,
 }: InsightCardFullProps) {
   const config = SEVERITY_CONFIG[insight.severity];
   const Icon = config.icon;
-  const showActions = onTogglePin != null && onDismiss != null && onCreateTask != null;
+  const showActions = onTogglePin != null && onDismiss != null;
 
   return (
     <article
@@ -134,8 +132,6 @@ export function InsightCardFull({
                 isPinned={isPinned}
                 onTogglePin={onTogglePin!}
                 onDismiss={onDismiss!}
-                onCreateTask={onCreateTask!}
-                isCreatingTask={isCreatingTask}
               />
             </div>
           ) : null}

--- a/src/components/analytics/integration-child-dashboards.tsx
+++ b/src/components/analytics/integration-child-dashboards.tsx
@@ -730,12 +730,20 @@ export function FinanceMercuryDashboard({ data }: IntegrationChildDashboardProps
   if (!mercury) {
     return <EmptyProviderState title="Mercury data is unavailable" description="Connect Mercury to inspect cash position and runway." reasons={reasons} />;
   }
+  const bankCash = mercury.cashFlow.bankCash ?? mercury.accounts
+    .filter((account) => account.type.toLowerCase() !== "treasury")
+    .reduce((sum, account) => sum + account.balance, 0);
+  const treasuryCash = mercury.cashFlow.treasuryCash ?? mercury.accounts
+    .filter((account) => account.type.toLowerCase() === "treasury")
+    .reduce((sum, account) => sum + account.balance, 0);
 
   return (
     <DashboardShell title="Mercury" subtitle="Cash position, burn profile, and account-level liquidity.">
       <MetricGrid
         metrics={[
           { label: "Total Balance", value: fmtCurrency(mercury.cashFlow.totalBalance) },
+          { label: "Bank Cash", value: fmtCurrency(bankCash) },
+          { label: "Treasury Cash", value: fmtCurrency(treasuryCash) },
           { label: "Inflows (30d)", value: fmtCurrency(mercury.cashFlow.inflows30d) },
           { label: "Outflows (30d)", value: fmtCurrency(mercury.cashFlow.outflows30d) },
           { label: "Net Cash Flow", value: fmtCurrency(mercury.cashFlow.netCashFlow) },

--- a/src/components/analytics/lifecycle-funnel-panel.test.tsx
+++ b/src/components/analytics/lifecycle-funnel-panel.test.tsx
@@ -14,7 +14,7 @@ function makeLifecycle(): LifecycleFunnelData {
         conversionFromPrevious: null,
         trendDeltaPct: 10,
         confidence: 0.91,
-        section: "ads-traffic",
+        section: "website-traffic",
         evidence: [
           {
             source: "Google Analytics",
@@ -33,7 +33,7 @@ function makeLifecycle(): LifecycleFunnelData {
         conversionFromPrevious: 50,
         trendDeltaPct: 7,
         confidence: 0.85,
-        section: "ads-traffic",
+        section: "website-traffic",
         evidence: [
           {
             source: "Google Ads",
@@ -155,7 +155,7 @@ function makeInsights(): AiInsight[] {
   return [
     {
       id: "ai-ads",
-      section: "ads-traffic",
+      section: "website-traffic",
       severity: "warning",
       title: "Improve paid traffic quality",
       why: "Bounce rising.",

--- a/src/components/analytics/marketing-tab-new.test.tsx
+++ b/src/components/analytics/marketing-tab-new.test.tsx
@@ -21,7 +21,7 @@ describe("MarketingTabNew provider states", () => {
     const data = makeData();
     data.errors.push({ source: "googleAds", message: "Google Ads API quota exceeded" });
 
-    render(<MarketingTabNew data={data} />);
+    render(<MarketingTabNew data={data} variant="social-media" />);
 
     expect(screen.getAllByText("Configured but failing").length).toBeGreaterThan(0);
     expect(screen.getByText("Configured but failing: Google Ads API quota exceeded")).toBeTruthy();
@@ -56,7 +56,7 @@ describe("MarketingTabNew provider states", () => {
       },
     };
 
-    render(<MarketingTabNew data={data} />);
+    render(<MarketingTabNew data={data} variant="social-media" />);
 
     expect(screen.getByText("No Google Ads data in selected range")).toBeTruthy();
   });
@@ -380,7 +380,7 @@ describe("MarketingTabNew provider states", () => {
       },
     };
 
-    render(<MarketingTabNew data={data} />);
+    render(<MarketingTabNew data={data} variant="social-media" />);
 
     expect(
       screen.getByText(

--- a/src/components/analytics/marketing-tab-new.tsx
+++ b/src/components/analytics/marketing-tab-new.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import React, { useState } from 'react';
 import { AnalyticsDashboardData } from '@/lib/analytics/types';
 import { StatCard } from './stat-card';
@@ -25,6 +26,7 @@ import {
 
 interface MarketingTabNewProps {
   data: AnalyticsDashboardData | null;
+  variant?: 'website-traffic' | 'social-media';
 }
 
 // Helper functions
@@ -83,7 +85,7 @@ function resolveProviderState(input: {
   return { state: 'healthy', error: null };
 }
 
-export function MarketingTabNew({ data }: MarketingTabNewProps) {
+export function MarketingTabNew({ data, variant = 'website-traffic' }: MarketingTabNewProps) {
   const [expandedPlatforms, setExpandedPlatforms] = useState<Record<string, boolean>>({
     googleAds: true,
     metaAds: true,
@@ -353,112 +355,170 @@ export function MarketingTabNew({ data }: MarketingTabNewProps) {
   const igAttributeCorrelations = data.instagram?.attributeCorrelations || [];
   const igWinningPatterns = data.instagram?.winningPatterns || [];
   const igLosingPatterns = data.instagram?.losingPatterns || [];
+  const isWebsiteTraffic = variant === 'website-traffic';
+  const companionRoute = isWebsiteTraffic ? '/analytics/social-media' : '/analytics/website-traffic';
+  const companionLabel = isWebsiteTraffic ? 'Social Media' : 'Website Traffic';
+  const insightFilter = isWebsiteTraffic ? 'website-traffic' : 'social-media';
+  const gaUsers30d = data.googleAnalytics?.users30d || 0;
+  const webflowSubmissions = data.webflow?.totalFormSubmissions ?? 0;
+  const semrushOrganicTraffic = data.semrush?.organicTraffic ?? 0;
 
   return (
     <div className="space-y-6">
-      <AiInsightsPanel bundle={data.aiInsights || null} defaultFilter="ads-traffic" />
+      <div className="flex flex-wrap items-start justify-between gap-3 rounded-xl border border-border bg-card p-4">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">
+            {isWebsiteTraffic ? 'Website Traffic' : 'Social Media'}
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {isWebsiteTraffic
+              ? 'Website acquisition, content performance, and onsite conversion health.'
+              : 'Paid and organic social performance across campaigns, pages, and Instagram content.'}
+          </p>
+        </div>
+        <Link
+          href={companionRoute}
+          className="rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground hover:bg-secondary/50"
+        >
+          Open {companionLabel}
+        </Link>
+      </div>
+
+      <AiInsightsPanel bundle={data.aiInsights || null} defaultFilter={insightFilter} />
 
       {/* Top KPI Row */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <StatCard
-          label="Sessions (30d)"
-          value={
-            gaStatus.state === 'not_configured'
-              ? "Not configured"
-              : gaStatus.state === 'failing'
-                ? "Configured but failing"
-                : gaStatus.state === 'no_data'
-                  ? "No data"
-                  : fmtNum(sessions30d)
-          }
-          change={gaStatus.state === 'healthy' && sessionsChange != null ? fmtPct(sessionsChange) : undefined}
-          changeType={
-            sessionsChange == null
-              ? 'neutral'
-              : sessionsChange > 0
-                ? 'positive'
-                : 'negative'
-          }
-          subtitle={
-            gaStatus.state === 'failing'
-              ? gaStatus.error || "Google Analytics request failed"
-              : gaStatus.state === 'not_configured'
-                ? "Google Analytics"
-                : gaStatus.state === 'no_data'
-                  ? "No GA data in selected range"
-                  : undefined
-          }
-          icon={TrendingUp}
-        />
-        <StatCard
-          label="Total Ad Spend"
-          value={
-            !paidConfigured
-              ? "Not configured"
-              : paidFailure
-                ? "Configured but failing"
-                : paidHealthy
-                  ? fmtCurrency(totalAdSpend)
-                  : "No data"
-          }
-          subtitle={
-            !paidConfigured
-              ? "Google Ads, Meta Ads, Reddit Ads"
-              : paidFailure
-                ? paidFailure.error || "One or more ad providers failed"
-                : paidHealthy
-                  ? "Google + Meta + Reddit"
-                  : "No ad spend in selected range"
-          }
-          icon={DollarSign}
-        />
-        <StatCard
-          label="Total Conversions"
-          value={
-            !conversionConfigured
-              ? "Not configured"
-              : conversionFailure
-                ? "Configured but failing"
-                : conversionHealthy
-                  ? fmtNum(totalConversions)
-                  : "No data"
-          }
-          subtitle={
-            !conversionConfigured
-              ? "Google Ads, Meta Ads"
-              : conversionFailure
-                ? conversionFailure.error || "Conversion providers failed"
-                : conversionHealthy
-                  ? "Google + Meta"
-                  : "No conversion data in selected range"
-          }
-          icon={MousePointerClick}
-        />
-        <StatCard
-          label="Page Followers"
-          value={
-            metaPageStatus.state === 'not_configured'
-              ? "Not configured"
-              : metaPageStatus.state === 'failing'
-                ? "Configured but failing"
-                : metaPageStatus.state === 'no_data'
-                  ? "No data"
-                  : fmtNum(pageFollowers)
-          }
-          subtitle={
-            metaPageStatus.state === 'failing'
-              ? metaPageStatus.error || "Meta Page request failed"
-              : metaPageStatus.state === 'not_configured'
-                ? "Meta Page"
-                : metaPageStatus.state === 'no_data'
-                  ? "Configured, but no Meta Page signals were returned in this range"
-                  : "Meta Page connected"
-          }
-          icon={Facebook}
-        />
+        {isWebsiteTraffic ? (
+          <>
+            <StatCard
+              label="Sessions (30d)"
+              value={
+                gaStatus.state === 'not_configured'
+                  ? "Not configured"
+                  : gaStatus.state === 'failing'
+                    ? "Configured but failing"
+                    : gaStatus.state === 'no_data'
+                      ? "No data"
+                      : fmtNum(sessions30d)
+              }
+              change={gaStatus.state === 'healthy' && sessionsChange != null ? fmtPct(sessionsChange) : undefined}
+              changeType={
+                sessionsChange == null
+                  ? 'neutral'
+                  : sessionsChange > 0
+                    ? 'positive'
+                    : 'negative'
+              }
+              subtitle={
+                gaStatus.state === 'failing'
+                  ? gaStatus.error || "Google Analytics request failed"
+                  : gaStatus.state === 'not_configured'
+                    ? "Google Analytics"
+                    : gaStatus.state === 'no_data'
+                      ? "No GA data in selected range"
+                      : undefined
+              }
+              icon={TrendingUp}
+            />
+            <StatCard
+              label="Users (30d)"
+              value={gaStatus.state === 'healthy' ? fmtNum(gaUsers30d) : gaStatus.state === 'no_data' ? "No data" : "Not configured"}
+              subtitle="Google Analytics"
+              icon={Globe}
+            />
+            <StatCard
+              label="Organic Traffic"
+              value={semrushStatus.state === 'healthy' ? fmtNum(semrushOrganicTraffic) : semrushStatus.state === 'no_data' ? "No data" : "Not configured"}
+              subtitle={semrushStatus.state === 'failing' ? semrushStatus.error || "SEMrush request failed" : "SEMrush"}
+              icon={Search}
+            />
+            <StatCard
+              label="Form Submissions"
+              value={webflowStatus.state === 'healthy' ? fmtNum(webflowSubmissions) : webflowStatus.state === 'no_data' ? "No data" : "Not configured"}
+              subtitle={webflowStatus.state === 'failing' ? webflowStatus.error || "Webflow request failed" : "Webflow"}
+              icon={Layout}
+            />
+          </>
+        ) : (
+          <>
+            <StatCard
+              label="Total Ad Spend"
+              value={
+                !paidConfigured
+                  ? "Not configured"
+                  : paidFailure
+                    ? "Configured but failing"
+                    : paidHealthy
+                      ? fmtCurrency(totalAdSpend)
+                      : "No data"
+              }
+              subtitle={
+                !paidConfigured
+                  ? "Google Ads, Meta Ads, Reddit Ads"
+                  : paidFailure
+                    ? paidFailure.error || "One or more ad providers failed"
+                    : paidHealthy
+                      ? "Google + Meta + Reddit"
+                      : "No ad spend in selected range"
+              }
+              icon={DollarSign}
+            />
+            <StatCard
+              label="Total Conversions"
+              value={
+                !conversionConfigured
+                  ? "Not configured"
+                  : conversionFailure
+                    ? "Configured but failing"
+                    : conversionHealthy
+                      ? fmtNum(totalConversions)
+                      : "No data"
+              }
+              subtitle={
+                !conversionConfigured
+                  ? "Google Ads, Meta Ads"
+                  : conversionFailure
+                    ? conversionFailure.error || "Conversion providers failed"
+                    : conversionHealthy
+                      ? "Google + Meta"
+                      : "No conversion data in selected range"
+              }
+              icon={MousePointerClick}
+            />
+            <StatCard
+              label="Page Followers"
+              value={
+                metaPageStatus.state === 'not_configured'
+                  ? "Not configured"
+                  : metaPageStatus.state === 'failing'
+                    ? "Configured but failing"
+                    : metaPageStatus.state === 'no_data'
+                      ? "No data"
+                      : fmtNum(pageFollowers)
+              }
+              subtitle={
+                metaPageStatus.state === 'failing'
+                  ? metaPageStatus.error || "Meta Page request failed"
+                  : metaPageStatus.state === 'not_configured'
+                    ? "Meta Page"
+                    : metaPageStatus.state === 'no_data'
+                      ? "Configured, but no Meta Page signals were returned in this range"
+                      : "Meta Page connected"
+              }
+              icon={Facebook}
+            />
+            <StatCard
+              label="Instagram Followers"
+              value={instagramStatus.state === 'healthy' ? fmtNum(igFollowers) : instagramStatus.state === 'no_data' ? "No data" : "Not configured"}
+              subtitle={instagramStatus.state === 'failing' ? instagramStatus.error || "Instagram request failed" : "Instagram"}
+              icon={Instagram}
+            />
+          </>
+        )}
       </div>
 
-      {/* Traffic Section */}
+      {/* Website Traffic Section */}
+      {isWebsiteTraffic ? (
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Traffic by Channel */}
         <div className="bg-card border border-border rounded-xl p-6">
@@ -509,9 +569,10 @@ export function MarketingTabNew({ data }: MarketingTabNewProps) {
           )}
         </div>
       </div>
-      
-      {/* Channel Comparison */}
-      {paidConfigured && paidHealthy ? (
+      ) : null}
+
+      {/* Social Media comparison */}
+      {!isWebsiteTraffic && paidConfigured && paidHealthy ? (
         <div className="bg-card border border-border rounded-xl p-6">
           <h3 className="text-lg font-semibold text-foreground mb-4">Channel Comparison</h3>
           <ChannelTable byPlatform={byPlatform} />
@@ -519,6 +580,7 @@ export function MarketingTabNew({ data }: MarketingTabNewProps) {
       ) : null}
 
       {/* Ad Performance Section */}
+      {!isWebsiteTraffic ? (
       <div className="space-y-4">
         <h2 className="text-xl font-semibold text-foreground">Ad Performance</h2>
 
@@ -773,8 +835,10 @@ export function MarketingTabNew({ data }: MarketingTabNewProps) {
           )}
         </div>
       </div>
+      ) : null}
 
-      {/* Social & Web Section */}
+      {/* Social Section */}
+      {!isWebsiteTraffic ? (
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Meta Page Insights */}
         <div className="bg-card border border-border rounded-xl p-6">
@@ -1172,6 +1236,12 @@ export function MarketingTabNew({ data }: MarketingTabNewProps) {
           )}
         </div>
 
+      </div>
+      ) : null}
+
+      {/* Website Section */}
+      {isWebsiteTraffic ? (
+      <div className="grid grid-cols-1 gap-6">
         {/* Webflow Site Info */}
         <div className="bg-card border border-border rounded-xl p-6">
           <h3 className="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
@@ -1261,8 +1331,10 @@ export function MarketingTabNew({ data }: MarketingTabNewProps) {
           )}
         </div>
       </div>
+      ) : null}
 
       {/* -- SEMrush SEO Intelligence -- */}
+      {isWebsiteTraffic ? (
       <div className="mt-6">
         <h3 className="text-lg font-bold text-foreground mb-4 flex items-center gap-2">
           <Search className="w-5 h-5 text-[#fc5a29]" />
@@ -1354,6 +1426,7 @@ export function MarketingTabNew({ data }: MarketingTabNewProps) {
           </div>
         )}
       </div>
+      ) : null}
     </div>
   );
 }

--- a/src/components/analytics/ops-insights.tsx
+++ b/src/components/analytics/ops-insights.tsx
@@ -7,10 +7,10 @@ export function DecisionDashboardView({ payload }: { payload: Record<string, unk
 
   return (
     <div className="grid grid-cols-1 gap-3 lg:grid-cols-4">
-      <MetricCard label="Flow Reliability" value={northStar.flowReliabilityScore} />
+      <MetricCard label="Internal Execution Reliability" value={northStar.flowReliabilityScore} />
       <MetricCard label="Throughput (30d)" value={northStar.throughput30d} />
       <MetricCard label="On-Time Completion" value={northStar.onTimeCompletionRate} suffix="%" />
-      <MetricCard label="Overdue Open Tasks" value={supporting.overdueOpenTasks} />
+      <MetricCard label="Legacy Open Execution Items" value={supporting.overdueOpenTasks} />
     </div>
   );
 }
@@ -112,4 +112,3 @@ function MetricCard({
     </div>
   );
 }
-

--- a/src/components/analytics/overview-tab.tsx
+++ b/src/components/analytics/overview-tab.tsx
@@ -74,6 +74,11 @@ export function OverviewTab({ data }: { data: AnalyticsDashboardData | null }) {
           label="Cash Balance"
           value={cash ? fmt$(cash.totalBalance) : "—"}
           change={cash ? `${cash.runway.toFixed(1)} months runway` : undefined}
+          subtitle={
+            cash && cash.bankCash !== undefined && cash.treasuryCash !== undefined
+              ? `${fmt$(cash.bankCash)} bank · ${fmt$(cash.treasuryCash)} Treasury`
+              : undefined
+          }
           changeType={cash && cash.runway > 6 ? "positive" : cash && cash.runway > 3 ? "neutral" : "negative"}
           icon={Wallet}
         />

--- a/src/components/customer-success/account-workspace.test.tsx
+++ b/src/components/customer-success/account-workspace.test.tsx
@@ -289,12 +289,10 @@ describe("CustomerSuccessAccountWorkspace", () => {
       tasks: [
         {
           id: "task_1",
-          accountId: "acct_1",
           title: "Call champion about rollout",
           status: "ACTIVE",
           priority: "P1",
           dueDate: "2026-03-12T00:00:00.000Z",
-          notes: "Confirm blocker owners",
         },
       ],
     });
@@ -537,7 +535,7 @@ describe("CustomerSuccessAccountWorkspace", () => {
           severity: "medium",
           status: "open",
           slaStatus: "at_risk",
-          source: "implementation",
+          source: "workflow",
           evidence: ["Milestone completion slipped"],
           suggestedAction: "Coordinate unblock with implementation lead",
           createdAt: "2026-03-09T10:00:00.000Z",
@@ -555,7 +553,7 @@ describe("CustomerSuccessAccountWorkspace", () => {
           severity: "medium",
           status: "in_progress",
           slaStatus: "on_track",
-          source: "implementation",
+          source: "workflow",
           evidence: ["Owner assigned and recovery plan in motion"],
           suggestedAction: "Track weekly until the milestone is back on plan",
           createdAt: "2026-03-09T10:00:00.000Z",

--- a/src/components/dashboard/executive-overview-dashboard.tsx
+++ b/src/components/dashboard/executive-overview-dashboard.tsx
@@ -270,7 +270,7 @@ function TrafficSection({ data }: { data: ExecutiveOverviewPayload["traffic"] })
           </div>
         )}
 
-        <SectionFooter href="/analytics/ads-traffic" label="View full traffic dashboard" />
+        <SectionFooter href="/analytics/website-traffic" label="View full traffic dashboard" />
       </div>
     </SectionCard>
   );
@@ -585,7 +585,7 @@ export function ExecutiveOverviewDashboard() {
               <p className="text-lg font-bold tabular-nums">{fmt$(data.adSpend.blendedCpa)}</p>
             </div>
           </div>
-          <SectionFooter href="/analytics/ads-traffic" label="View full ad performance" />
+          <SectionFooter href="/analytics/social-media" label="View full social media performance" />
         </SectionCard>
       )}
 

--- a/src/components/dashboard/workspace-badge.tsx
+++ b/src/components/dashboard/workspace-badge.tsx
@@ -4,8 +4,6 @@ import { clsx } from "clsx";
 import { getWorkspaceLabel, type WorkspaceId } from "@/lib/platform/workspaces";
 
 const BADGE_STYLES: Record<WorkspaceId, string> = {
-  dashboard: "bg-slate-100 text-slate-700",
-  work: "bg-amber-100 text-amber-800",
   deals: "bg-emerald-100 text-emerald-800",
   analytics: "bg-sky-100 text-sky-800",
   integrations: "bg-violet-100 text-violet-800",

--- a/src/components/layout/sidebar-nav-config.ts
+++ b/src/components/layout/sidebar-nav-config.ts
@@ -1,8 +1,7 @@
 import {
   Activity,
-  Cable,
-  LayoutDashboard,
   Bot,
+  Cable,
   Handshake,
   type LucideIcon,
 } from "lucide-react";
@@ -26,10 +25,9 @@ export interface NavItem {
 }
 
 const WORKSPACE_ICONS: Record<WorkspaceId, LucideIcon> = {
-  dashboard: LayoutDashboard,
-  deals: Handshake,
   analytics: Activity,
   integrations: Cable,
+  deals: Handshake,
   automations: Bot,
 };
 

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { clsx } from "clsx";
-import { LayoutDashboard, Settings } from "lucide-react";
+import { Activity, Settings } from "lucide-react";
 import { buildNavItems } from "./sidebar-nav-config";
 import { SidebarNavGroup } from "./sidebar-nav-group";
 
@@ -23,8 +23,8 @@ export function Sidebar() {
   return (
     <aside className="flex h-screen w-56 flex-col border-r border-sidebar-border bg-sidebar-bg text-sm text-sidebar-foreground">
       <div className="flex items-center gap-2 border-b border-sidebar-border px-4 py-4">
-        <LayoutDashboard className="h-6 w-6 text-primary" aria-hidden="true" />
-        <span className="text-lg font-bold text-foreground">WIPGuard</span>
+        <Activity className="h-6 w-6 text-primary" aria-hidden="true" />
+        <span className="text-lg font-bold text-foreground">WIPGuard Analytics</span>
       </div>
 
       <nav aria-label="Main navigation" className="flex-1 space-y-0.5 overflow-y-auto px-2 py-3">

--- a/src/components/marketing/home-landing.test.tsx
+++ b/src/components/marketing/home-landing.test.tsx
@@ -8,10 +8,10 @@ describe("HomeLanding", () => {
 
     expect(
       screen.getByRole("heading", {
-        name: /stop starting\. start finishing revenue work\./i,
+        name: /make every business metric traceable\./i,
       })
     ).toBeTruthy();
     expect(screen.getAllByRole("link", { name: /access workspace/i }).length).toBeGreaterThan(0);
-    expect(screen.getByRole("link", { name: /see the flow/i })).toBeTruthy();
+    expect(screen.getByRole("link", { name: /see the metric layer/i })).toBeTruthy();
   });
 });

--- a/src/components/marketing/home-landing.tsx
+++ b/src/components/marketing/home-landing.tsx
@@ -12,83 +12,83 @@ import {
 
 const metrics = [
   {
-    label: "One surface",
-    value: "Pipeline, campaigns, CS, and ops work",
+    label: "Source trust",
+    value: "Freshness, lineage, and warnings stay attached to every number",
   },
   {
-    label: "One rule",
-    value: "Treat WIP like a budget, not a suggestion",
+    label: "Board packs",
+    value: "Weekly exec, board, investor, and custom snapshots reuse the same facts",
   },
   {
-    label: "One record",
-    value: "Board movement leaves the audit trail behind it",
+    label: "Live integrations",
+    value: "Finance, CRM, ads, web, CS, and workspace systems meet in one API layer",
   },
 ];
 
 const painPoints = [
   {
     icon: Gauge,
-    title: "Invisible overload",
+    title: "Metric drift",
     body:
-      "Teams look busy while queue depth climbs, cycle time stretches, and the real bottleneck stays hidden.",
+      "The same number changes across dashboards, exports, and meetings because every surface recalculates it differently.",
   },
   {
     icon: Workflow,
-    title: "Broken handoffs",
+    title: "Disconnected sources",
     body:
-      "Marketing, sales, customer success, and ops all update different systems, so the customer path stops making sense.",
+      "Finance, CRM, ads, customer success, and workspace systems each hold part of the story with different timestamps.",
   },
   {
     icon: Cable,
-    title: "Manual record tax",
+    title: "Manual board prep",
     body:
-      "Every deal stage, follow-up, and support signal asks the team to do the same admin twice.",
+      "Weekly meetings and board packets become spreadsheet archaeology when freshness, lineage, and warnings are detached.",
   },
 ];
 
 const operatingModel = [
   {
     step: "01",
-    title: "See the actual work mix",
+    title: "Ingest source snapshots",
     body:
-      "Board, deals, demos, automations, and analytics sit in one operating surface instead of five tabs and a spreadsheet.",
+      "Each provider lands in one analytics API layer with source timestamps, sync health, and raw snapshot lineage.",
   },
   {
     step: "02",
-    title: "Limit concurrent work",
+    title: "Compute canonical metrics",
     body:
-      "WIP policies make overcommitment obvious before another task gets pulled into motion.",
+      "Reusable calculators produce one governed value for dashboards, exports, investor updates, and board materials.",
   },
   {
     step: "03",
-    title: "Move work, update systems",
+    title: "Label trust state",
     body:
-      "Status changes generate the CRM, calendar, Slack, and reporting artifacts the team would usually forget to log.",
+      "Every metric carries freshness, confidence, warnings, calculation version, and cited source snapshots.",
   },
   {
     step: "04",
-    title: "Orient before acting",
+    title: "Reuse locked facts",
     body:
-      "Signed-in users land on a dashboard first so they understand the constraint, risk, and next action before touching the board.",
+      "The CEO command center and report packs use the same locked values so meeting narratives do not diverge.",
   },
 ];
 
 const roleCards = [
   {
     title: "CEO / Founder",
-    body: "See where the quarter is actually stuck without running another status meeting.",
+    body: "Walk into weekly and board conversations with current numbers, visible caveats, and cited sources.",
   },
   {
     title: "Marketing",
-    body: "Tie traffic, campaigns, and conference work back to real demo and revenue flow.",
+    body: "Tie traffic, campaigns, and conference signals back to demo and revenue motion without copy-paste reporting.",
   },
   {
     title: "Sales",
-    body: "Work the pipeline without losing the thread between outreach, demos, and close motion.",
+    body: "Read pipeline metrics beside revenue, source health, and customer journey context.",
   },
   {
     title: "Customer Success / Ops",
-    body: "Spot risk early, route follow-ups, and keep the operating record clean as accounts evolve.",
+    body: "Surface account risk and source gaps before they distort executive reporting.",
   },
 ];
 
@@ -128,15 +128,15 @@ export function HomeLanding() {
 
               <div className="space-y-5">
                 <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-black/45">
-                  WIP-limited GTM operating system
+                  Analytics API meeting place
                 </p>
                 <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-[#080808] sm:text-5xl lg:text-6xl">
-                  Stop starting. Start finishing revenue work.
+                  Make every business metric traceable.
                 </h1>
                 <p className="max-w-2xl text-base leading-7 text-black/65 sm:text-lg">
-                  WIPGuard gives GTM teams one place to run campaigns, deals,
-                  demos, follow-ups, and customer handoffs without losing the
-                  thread of the customer journey.
+                  WIPGuard brings finance, sales, marketing, customer success,
+                  and internal execution sources into one governed metric layer
+                  with freshness, lineage, and board-ready exports.
                 </p>
               </div>
 
@@ -152,7 +152,7 @@ export function HomeLanding() {
                   href="#how-it-works"
                   className="rounded-full border border-black/15 bg-white px-5 py-3 text-sm font-medium text-black transition hover:border-black/30 hover:bg-white/70"
                 >
-                  See the flow
+                  See the metric layer
                 </Link>
               </div>
 
@@ -176,9 +176,9 @@ export function HomeLanding() {
                 <div className="flex items-center justify-between rounded-[24px] bg-black px-5 py-4 text-white">
                   <div>
                     <p className="text-xs uppercase tracking-[0.18em] text-white/55">
-                      Today&apos;s operating view
+                      Today&apos;s metric trust view
                     </p>
-                    <p className="mt-1 text-lg font-semibold">Orient before you pull more work</p>
+                    <p className="mt-1 text-lg font-semibold">One value, with sources attached</p>
                   </div>
                   <ShieldCheck className="h-5 w-5 text-[#fc5a29]" aria-hidden="true" />
                 </div>
@@ -186,21 +186,21 @@ export function HomeLanding() {
                 <div className="mt-5 grid gap-4 md:grid-cols-[1.1fr_0.9fr]">
                   <div className="rounded-[24px] bg-[#f5f5f5] p-4">
                     <div className="flex items-center justify-between">
-                      <p className="text-sm font-semibold">Queue pressure</p>
+                      <p className="text-sm font-semibold">Source health</p>
                       <span className="rounded-full bg-[#fc5a29]/10 px-3 py-1 text-xs font-medium text-[#fc5a29]">
-                        WIP at limit
+                        Trust labeled
                       </span>
                     </div>
                     <div className="mt-4 space-y-3">
                       {[
-                        { lane: "Queued", count: "06", fill: "bg-[#1d1d1d]", width: "w-[78%]" },
-                        { lane: "Active", count: "03", fill: "bg-[#fc5a29]", width: "w-[54%]" },
-                        { lane: "Blocked", count: "02", fill: "bg-[#f2b3a0]", width: "w-[36%]" },
+                        { lane: "Fresh", count: "18", fill: "bg-[#1d1d1d]", width: "w-[78%]" },
+                        { lane: "Partial", count: "03", fill: "bg-[#fc5a29]", width: "w-[54%]" },
+                        { lane: "Missing", count: "02", fill: "bg-[#f2b3a0]", width: "w-[36%]" },
                       ].map((lane) => (
                         <div key={lane.lane} className="rounded-2xl bg-white p-3">
                           <div className="flex items-center justify-between text-sm">
                             <span className="font-medium">{lane.lane}</span>
-                            <span className="text-black/55">{lane.count} cards</span>
+                            <span className="text-black/55">{lane.count} metrics</span>
                           </div>
                           <div className="mt-3 h-2 rounded-full bg-black/8">
                             <div className={`h-2 rounded-full ${lane.fill} ${lane.width}`} />
@@ -217,7 +217,7 @@ export function HomeLanding() {
                         <div>
                           <p className="text-sm font-semibold">Upcoming customer load</p>
                           <p className="text-sm text-black/65">
-                            4 demos and 2 follow-ups are driving today&apos;s constraints.
+                            Demo, pipeline, and retention signals share one customer timeline.
                           </p>
                         </div>
                       </div>
@@ -241,7 +241,7 @@ export function HomeLanding() {
                         <div>
                           <p className="text-sm font-semibold">Record-keeping on movement</p>
                           <p className="text-sm text-white/65">
-                            Moving the work updates the system of record instead of asking the rep to do it twice.
+                            Report exports cite the same locked facts that power the command center.
                           </p>
                         </div>
                       </div>
@@ -257,10 +257,10 @@ export function HomeLanding() {
           <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
             <div className="max-w-2xl">
               <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-black/45">
-                Why the customer journey gets distorted
+                Why executive reporting gets distorted
               </p>
               <h2 className="mt-4 text-3xl font-semibold tracking-tight sm:text-4xl">
-                The journey breaks the moment each team owns a different truth.
+                The meeting breaks the moment each team owns a different truth.
               </h2>
             </div>
 
@@ -291,9 +291,9 @@ export function HomeLanding() {
                 </h2>
               </div>
               <p className="max-w-xl text-sm leading-6 text-black/65">
-                The first touch should explain the system, the sign-in step should
-                clarify access, and the first authenticated screen should orient
-                the user before they jump into execution.
+                Source snapshots enter once, canonical calculators create the metric,
+                and every dashboard or export reuses that value with the same trust
+                state and citations.
               </p>
             </div>
 
@@ -315,10 +315,10 @@ export function HomeLanding() {
           <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
             <div className="max-w-2xl">
               <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-black/45">
-                Built for the full GTM loop
+                Built for the operating meeting loop
               </p>
               <h2 className="mt-4 text-3xl font-semibold tracking-tight sm:text-4xl">
-                One operating surface for the people who actually move revenue.
+                One metric surface for the people accountable for the business.
               </h2>
             </div>
             <div className="mt-10 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
@@ -344,7 +344,7 @@ export function HomeLanding() {
               <p className="mt-4 text-sm leading-7 text-white/65 sm:text-base">
                 Existing team members and beta operators can sign in to their
                 workspace. Everyone else should start by understanding the
-                operating model, not by getting dumped into an internal dashboard.
+                metric trust model, not by getting dropped into an internal source map.
               </p>
             </div>
             <Link

--- a/src/lib/__tests__/analytics-ai-insights.test.ts
+++ b/src/lib/__tests__/analytics-ai-insights.test.ts
@@ -34,7 +34,8 @@ function baseData(): AnalyticsDashboardData {
       generatedAt: "2026-01-01T00:00:00.000Z",
       global: [],
       bySection: {
-        "ads-traffic": [],
+        "website-traffic": [],
+        "social-media": [],
         finance: [],
         "sales-pipeline": [],
         retention: [],
@@ -226,7 +227,7 @@ describe("analytics AI insights bundle", () => {
   });
 });
 
-// ── Ads & Traffic insights ──────────────────────────────
+// ── Website traffic + social media insights ─────────────
 
 describe("ads insights", () => {
   it("fires bounce rate alarm when above 55%", () => {
@@ -277,7 +278,7 @@ describe("ads insights", () => {
     const bundle = buildAiInsightsBundle(data);
     const convInsight = bundle.global.find((i) => i.id === "ai-ads-click-conv");
     expect(convInsight).toBeDefined();
-    expect(convInsight!.section).toBe("ads-traffic");
+    expect(convInsight!.section).toBe("social-media");
   });
 
   it("fires declining sessions alert when >15% drop", () => {
@@ -326,7 +327,8 @@ describe("ads insights", () => {
   it("does not fire ads insights when no ads data present", () => {
     const data = baseData();
     const bundle = buildAiInsightsBundle(data);
-    expect(bundle.bySection["ads-traffic"].length).toBe(0);
+    expect(bundle.bySection["website-traffic"].length).toBe(0);
+    expect(bundle.bySection["social-media"].length).toBe(0);
   });
 });
 

--- a/src/lib/__tests__/analytics-demo-analytics.test.ts
+++ b/src/lib/__tests__/analytics-demo-analytics.test.ts
@@ -221,6 +221,62 @@ describe("buildDemoAnalyticsData", () => {
     ]);
   });
 
+  it("includes uncovered post-demo HubSpot deals in the scheduling records", () => {
+    const data = baseData();
+    data.hubspot = {
+      funnel: {
+        totalDeals: 2,
+        closedWon: 1,
+        closedLost: 0,
+        unlikely: 0,
+        churn: 0,
+        activeSubscriptions: 0,
+        noShows: 0,
+        demoScheduled: 2,
+        demoFollowUp: 1,
+        avgDealSize: 4500,
+        winRate: 50,
+        effectiveWinRate: 50,
+        noShowRate: 0,
+        stages: [],
+        dealsBySource: [],
+      },
+      contacts: { totalContacts: 0, recentContacts: 0, bySource: [] },
+      deals: [
+        makeDeal({
+          dealId: "follow-up-deal",
+          dealName: "Follow Up Co",
+          stageId: "follow",
+          stageLabel: "Demo Follow-Up",
+          amount: 4000,
+          source: "Organic",
+          ownerId: null,
+          updatedAt: "2026-02-12T00:00:00.000Z",
+          createdAt: "2026-01-10T00:00:00.000Z",
+        }),
+        makeDeal({
+          dealId: "won-deal",
+          dealName: "Won Co",
+          stageId: "won",
+          stageLabel: "Closed Won",
+          amount: 5000,
+          source: "Paid",
+          ownerId: null,
+          updatedAt: "2026-02-15T00:00:00.000Z",
+          createdAt: "2026-01-12T00:00:00.000Z",
+        }),
+      ],
+      _meta: META,
+    };
+
+    const demo = buildDemoAnalyticsData(data);
+
+    expect(demo.totalScheduled).toBe(2);
+    expect(demo.demos.map((record) => record.dealId)).toEqual(["follow-up-deal", "won-deal"]);
+    expect(demo.demos.every((record) => record.isUpcoming === false)).toBe(true);
+    expect(demo.demos.every((record) => record.outcome === "completed")).toBe(true);
+  });
+
   it("builds journey path analysis across full lifecycle", () => {
     const data = baseData();
     data.hubspot = {

--- a/src/lib/__tests__/analytics-fetchers-hubspot.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-hubspot.test.ts
@@ -95,7 +95,7 @@ describe("analytics hubspot fetcher", () => {
     expect(data.pipelineDetected).toEqual({ pipelineId: "default", dealCount: 0 });
   });
 
-  it("filters non-default pipelines and resolves contractsent to Ping Later from live metadata", async () => {
+  it("keeps subscription pipeline deals out of main deals while exposing active subscriptions", async () => {
     const fetchMock = createHubSpotFetchMock({
       activeDeals: [
         {
@@ -134,8 +134,12 @@ describe("analytics hubspot fetcher", () => {
 
     expect(data.deals?.map((deal) => deal.dealId)).toEqual(["deal-default"]);
     expect(data.deals?.[0]?.stageLabel).toBe("Ping Later");
+    expect(data.subscriptionDeals?.map((deal) => deal.dealId)).toEqual(["deal-subscription"]);
+    expect(data.subscriptionDeals?.[0]?.stageLabel).toBe("Subscriptions");
+    expect(data.subscriptionPipelineDetected).toEqual({ pipelineId: "1390107368", dealCount: 1 });
     expect(data.pipelineStages?.find((stage) => stage.stageId === "contractsent")?.label).toBe("Ping Later");
-    expect(data.funnel.activeSubscriptions).toBe(0);
+    expect(data.funnel.activeSubscriptions).toBe(1);
+    expect(data._meta.diagnostics?.subscriptionDealsFetched).toBe(1);
   });
 
   it("keeps funnel metrics activity-based but builds display deals from last-modified recency", async () => {

--- a/src/lib/__tests__/analytics-fetchers-mercury.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-mercury.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchMercuryData } from "@/lib/analytics/fetchers";
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("Mercury analytics fetcher", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("includes Mercury Treasury in cash balance and excludes Treasury sweeps from cash flow", async () => {
+    const fetchMock = vi.fn();
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          accounts: [
+            {
+              id: "checking-1",
+              name: "Mercury Checking",
+              currentBalance: 79_717.54,
+              type: "mercury",
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          accounts: [
+            {
+              id: "treasury-1",
+              status: "active",
+              currentBalance: 2_478_334.94,
+              availableBalance: 2_478_334.94,
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          transactions: [
+            { id: "sweep-out", status: "sent", kind: "treasuryTransfer", amount: -425_000 },
+            { id: "sweep-in", status: "sent", kind: "treasuryTransfer", amount: 425_000 },
+            { id: "internal-out", status: "sent", kind: "internalTransfer", amount: -10_000 },
+            { id: "internal-in", status: "sent", kind: "internalTransfer", amount: 10_000 },
+            { id: "wire-in", status: "sent", kind: "incomingDomesticWire", amount: 500 },
+            { id: "vendor", status: "sent", kind: "outgoingPayment", amount: -2_000 },
+            { id: "card", status: "sent", kind: "debitCardTransaction", amount: -100 },
+            { id: "pending", status: "pending", kind: "outgoingPayment", amount: -999 },
+          ],
+        })
+      );
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const data = await fetchMercuryData("token", {
+      fromDate: new Date("2026-04-01T00:00:00.000Z"),
+      toDate: new Date("2026-04-30T23:59:59.999Z"),
+    });
+
+    expect(data.accounts).toEqual([
+      {
+        accountId: "checking-1",
+        accountName: "Mercury Checking",
+        balance: 79_717.54,
+        type: "mercury",
+      },
+      {
+        accountId: "treasury-1",
+        accountName: "Mercury Treasury",
+        balance: 2_478_334.94,
+        type: "treasury",
+      },
+    ]);
+    expect(data.cashFlow.totalBalance).toBeCloseTo(2_558_052.48);
+    expect(data.cashFlow.bankCash).toBeCloseTo(79_717.54);
+    expect(data.cashFlow.treasuryCash).toBeCloseTo(2_478_334.94);
+    expect(data.cashFlow.totalCash).toBeCloseTo(2_558_052.48);
+    expect(data.cashFlow.inflows30d).toBe(500);
+    expect(data.cashFlow.outflows30d).toBe(2_100);
+    expect(data.cashFlow.netCashFlow).toBe(-1_600);
+    expect(data.cashFlow.burnRate).toBe(1_600);
+
+    const transactionsUrl = String(fetchMock.mock.calls[2]?.[0] ?? "");
+    expect(transactionsUrl).toContain("/transactions?");
+    expect(transactionsUrl).toContain("postedStart=2026-04-01");
+    expect(transactionsUrl).toContain("postedEnd=2026-04-30");
+    expect(transactionsUrl).toContain("status=sent");
+  });
+
+  it("falls back to account transactions when the global transactions endpoint is unavailable", async () => {
+    const fetchMock = vi.fn();
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          accounts: [
+            {
+              id: "checking-1",
+              name: "Mercury Checking",
+              currentBalance: 10_000,
+              type: "mercury",
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ accounts: [] }, 403))
+      .mockResolvedValueOnce(jsonResponse({ error: "unavailable" }, 500))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          transactions: [
+            { status: "sent", kind: "treasuryTransfer", amount: 5_000 },
+            { status: "sent", kind: "outgoingPayment", amount: -1_250 },
+          ],
+        })
+      );
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const data = await fetchMercuryData("token", {
+      fromDate: new Date("2026-04-01T00:00:00.000Z"),
+      toDate: new Date("2026-04-30T23:59:59.999Z"),
+    });
+
+    expect(data.cashFlow.totalBalance).toBe(10_000);
+    expect(data.cashFlow.bankCash).toBe(10_000);
+    expect(data.cashFlow.treasuryCash).toBe(0);
+    expect(data.cashFlow.totalCash).toBe(10_000);
+    expect(data.cashFlow.inflows30d).toBe(0);
+    expect(data.cashFlow.outflows30d).toBe(1_250);
+    expect(data.cashFlow.burnRate).toBe(1_250);
+    expect(String(fetchMock.mock.calls[3]?.[0] ?? "")).toContain(
+      "/account/checking-1/transactions"
+    );
+  });
+});

--- a/src/lib/__tests__/analytics-funnel-lifecycle.test.ts
+++ b/src/lib/__tests__/analytics-funnel-lifecycle.test.ts
@@ -32,7 +32,8 @@ function baseData(): AnalyticsDashboardData {
       generatedAt: "2026-01-01T00:00:00.000Z",
       global: [],
       bySection: {
-        "ads-traffic": [],
+        "website-traffic": [],
+        "social-media": [],
         finance: [],
         "sales-pipeline": [],
         retention: [],

--- a/src/lib/__tests__/analytics-route-ai-lifecycle.test.ts
+++ b/src/lib/__tests__/analytics-route-ai-lifecycle.test.ts
@@ -60,7 +60,8 @@ describe("analytics API response shape helpers", () => {
   it("initializes empty AI insights bundle with all sections", () => {
     const bundle = createEmptyAiInsightsBundle("2026-01-31T00:00:00.000Z");
     expect(bundle.generatedAt).toBe("2026-01-31T00:00:00.000Z");
-    expect(bundle.bySection["ads-traffic"]).toEqual([]);
+    expect(bundle.bySection["website-traffic"]).toEqual([]);
+    expect(bundle.bySection["social-media"]).toEqual([]);
     expect(bundle.bySection["sales-pipeline"]).toEqual([]);
   });
 });

--- a/src/lib/__tests__/analytics-section-registry.test.ts
+++ b/src/lib/__tests__/analytics-section-registry.test.ts
@@ -11,7 +11,8 @@ import {
 describe("analytics section registry", () => {
   it("includes required primary sections", () => {
     const ids = new Set(ANALYTICS_PRIMARY_SECTIONS.map((section) => section.id));
-    expect(ids.has("ads-traffic")).toBe(true);
+    expect(ids.has("website-traffic")).toBe(true);
+    expect(ids.has("social-media")).toBe(true);
     expect(ids.has("finance")).toBe(true);
     expect(ids.has("sales-pipeline")).toBe(true);
     expect(ids.has("retention")).toBe(true);
@@ -42,7 +43,7 @@ describe("analytics section registry", () => {
     expect(LEGACY_ANALYTICS_TAB_REDIRECTS.overview).toBe("/analytics");
     expect(LEGACY_ANALYTICS_TAB_REDIRECTS.sales).toBe("/analytics/sales-pipeline");
     expect(LEGACY_ANALYTICS_TAB_REDIRECTS.finance).toBe("/analytics/finance");
-    expect(LEGACY_ANALYTICS_TAB_REDIRECTS.marketing).toBe("/analytics/ads-traffic");
+    expect(LEGACY_ANALYTICS_TAB_REDIRECTS.marketing).toBe("/analytics/website-traffic");
     expect(LEGACY_ANALYTICS_TAB_REDIRECTS.tasks).toBe("/analytics/customer-success");
     expect(LEGACY_ANALYTICS_TAB_REDIRECTS.journey).toBe("/analytics/customer-journey");
     expect(LEGACY_ANALYTICS_TAB_REDIRECTS.demos).toBe("/analytics/demo-analytics");
@@ -50,6 +51,7 @@ describe("analytics section registry", () => {
   });
 
   it("redirects removed customer-success ops routes to the parent dashboard", () => {
+    expect(LEGACY_ANALYTICS_ROUTE_REDIRECTS.tasks).toBe("/analytics/customer-success");
     expect(LEGACY_ANALYTICS_ROUTE_REDIRECTS["decision-dashboard"]).toBe("/analytics/customer-success");
     expect(LEGACY_ANALYTICS_ROUTE_REDIRECTS["flow-metrics"]).toBe("/analytics/customer-success");
     expect(LEGACY_ANALYTICS_ROUTE_REDIRECTS["flow-risk"]).toBe("/analytics/customer-success");
@@ -61,7 +63,11 @@ describe("analytics section registry", () => {
   });
 
   it("returns the owning primary section for child routes", () => {
-    expect(getAnalyticsPrimaryForSection("ads-google-ads")?.id).toBe("ads-traffic");
+    expect(ANALYTICS_SUB_SECTIONS.find((section) => section.id === "ads-coda-kanban")?.label).toBe(
+      "Coda Lead Magnet (Whitepaper)",
+    );
+    expect(getAnalyticsPrimaryForSection("ads-google-ads")?.id).toBe("social-media");
+    expect(getAnalyticsPrimaryForSection("ads-google-analytics")?.id).toBe("website-traffic");
     expect(getAnalyticsPrimaryForSection("finance-stripe")?.id).toBe("finance");
     expect(getAnalyticsPrimaryForSection("sales-hubspot")?.id).toBe("sales-pipeline");
     expect(getAnalyticsPrimaryForSection("cs-pylon")?.id).toBe("customer-success");
@@ -73,7 +79,8 @@ describe("analytics section registry", () => {
   });
 
   it("ensures each tier-1 dashboard has integration sub-tabs", () => {
-    expect(getAnalyticsSecondaryForPrimary("ads-traffic").length).toBeGreaterThan(0);
+    expect(getAnalyticsSecondaryForPrimary("website-traffic").length).toBeGreaterThan(0);
+    expect(getAnalyticsSecondaryForPrimary("social-media").length).toBeGreaterThan(0);
     expect(getAnalyticsSecondaryForPrimary("finance").length).toBeGreaterThan(0);
     expect(getAnalyticsSecondaryForPrimary("sales-pipeline").length).toBeGreaterThan(0);
     expect(getAnalyticsSecondaryForPrimary("customer-success").length).toBeGreaterThan(0);

--- a/src/lib/__tests__/sidebar-analytics-nav.test.ts
+++ b/src/lib/__tests__/sidebar-analytics-nav.test.ts
@@ -4,14 +4,14 @@ import { buildNavItems } from "@/components/layout/sidebar-nav-config";
 describe("sidebar workspace navigation", () => {
   const navItems = buildNavItems();
 
-  it("builds the five top-level product pillars", () => {
+  it("builds the analytics-first workspace pillars", () => {
     expect(navItems.map((item) => item.id)).toEqual([
-      "dashboard",
-      "deals",
       "analytics",
       "integrations",
+      "deals",
       "automations",
     ]);
+    expect(navItems.some((item) => item.href === "/dashboard")).toBe(false);
   });
 
   it("groups analytics and automations as nested workspace entries", () => {

--- a/src/lib/analytics/demo-analytics.ts
+++ b/src/lib/analytics/demo-analytics.ts
@@ -792,8 +792,12 @@ export function buildDemoAnalyticsData(
   );
 
   const hubSpotFallbacks = deals
-    .filter((deal) => deal.stageLabel === "Demo Scheduled" && !coveredHubSpotDealIds.has(deal.dealId))
-    .map((deal) => buildUnscheduledFallbackRecord({ deal }));
+    .filter((deal) => DEMO_ENTRY_STAGES.has(deal.stageLabel) && !coveredHubSpotDealIds.has(deal.dealId))
+    .map((deal) => (
+      deal.stageLabel === "Demo Scheduled"
+        ? buildUnscheduledFallbackRecord({ deal })
+        : buildDealAggregateRecord({ now, deal })
+    ));
 
   const demos = [...meetingBackedDemos, ...hubSpotFallbacks].sort((a, b) => {
     const timeDiff = new Date(a.scheduledAt).getTime() - new Date(b.scheduledAt).getTime();

--- a/src/lib/analytics/fetchers.ts
+++ b/src/lib/analytics/fetchers.ts
@@ -160,6 +160,10 @@ function isMainHubSpotPipeline(pipelineId: string | null | undefined): boolean {
   return !normalized || normalized === HUBSPOT_MAIN_PIPELINE_ID;
 }
 
+function isHubSpotSubscriptionPipeline(pipelineId: string | null | undefined): boolean {
+  return pipelineId?.trim() === HUBSPOT_SUBSCRIPTION_PIPELINE_ID;
+}
+
 function compareHubSpotDealsByRecency(
   a: { dealId: string; updatedAt: string | null; createdAt: string | null },
   b: { dealId: string; updatedAt: string | null; createdAt: string | null },
@@ -476,6 +480,11 @@ export async function fetchHubSpotData(
 
   const mainPipeline = pipelineResult.pipelines.find((pipeline) => pipeline.id === HUBSPOT_MAIN_PIPELINE_ID) ?? null;
   const stageLabelById = new Map(
+    pipelineResult.pipelines.flatMap((pipeline) =>
+      pipeline.stages.map((stage) => [stage.id, stage.label] as const),
+    ),
+  );
+  const mainStageLabelById = new Map(
     (mainPipeline?.stages ?? []).map((stage) => [stage.id, stage.label]),
   );
 
@@ -489,8 +498,14 @@ export async function fetchHubSpotData(
   const allMainPipelineDeals = allDeals.filter((deal) =>
     isMainHubSpotPipeline(deal.properties?.pipeline ?? null),
   );
+  const allSubscriptionPipelineDeals = allDeals.filter((deal) =>
+    isHubSpotSubscriptionPipeline(deal.properties?.pipeline ?? null),
+  );
   const activeDeals = activeDealsResult.deals.filter((deal) =>
     isMainHubSpotPipeline(deal.properties?.pipeline ?? null),
+  );
+  const activeSubscriptionPipelineDeals = activeDealsResult.deals.filter((deal) =>
+    isHubSpotSubscriptionPipeline(deal.properties?.pipeline ?? null),
   );
   const dealsFetched = allMainPipelineDeals.length;
 
@@ -525,7 +540,7 @@ export async function fetchHubSpotData(
     const props = deal.properties || {};
 
     const stage = props.dealstage || "unknown";
-    const mappedLabel = resolveHubSpotStageLabel(stage, stageLabelById);
+    const mappedLabel = resolveHubSpotStageLabel(stage, mainStageLabelById);
     const amount = parseFloat(props.amount) || 0;
     const source = props.hs_analytics_source || "Unknown";
 
@@ -563,6 +578,30 @@ export async function fetchHubSpotData(
       dealId: String((deal as { id?: string }).id ?? ""),
       dealName: props.dealname || "Untitled deal",
       stageId,
+      stageLabel: resolveHubSpotStageLabel(stageId, mainStageLabelById),
+      amount: parseFloat(props.amount) || 0,
+      source: props.hs_analytics_source || "Unknown",
+      ownerId,
+      repName: resolveOwnerName(ownerId),
+      updatedAt: props.hs_lastmodifieddate ? new Date(props.hs_lastmodifieddate).toISOString() : null,
+      createdAt: props.createdate ? new Date(props.createdate).toISOString() : null,
+      closedAt: props.closedate ? new Date(props.closedate).toISOString() : null,
+      stripeCustomerId: props.stripe_customer_id || props.stripe_customer || null,
+      pipelineId: props.pipeline || null,
+      contactIds: [] as string[],
+      primaryContactId: null as string | null,
+      primaryContactEmail: null as string | null,
+    };
+  });
+
+  const subscriptionDeals = activeSubscriptionPipelineDeals.map((deal) => {
+    const props = deal.properties || {};
+    const stageId = props.dealstage || "unknown";
+    const ownerId = props.hubspot_owner_id || null;
+    return {
+      dealId: String((deal as { id?: string }).id ?? ""),
+      dealName: props.dealname || "Untitled subscription",
+      stageId,
       stageLabel: resolveHubSpotStageLabel(stageId, stageLabelById),
       amount: parseFloat(props.amount) || 0,
       source: props.hs_analytics_source || "Unknown",
@@ -598,10 +637,7 @@ export async function fetchHubSpotData(
   let closedLost = stageAgg[STAGE_CLOSED_LOST]?.count || 0;
   let unlikely = stageAgg[STAGE_UNLIKELY]?.count || 0;
   let churn = stageAgg[STAGE_CHURN]?.count || 0;
-  let subscriptions = allMainPipelineDeals.filter((deal) => {
-    const label = resolveHubSpotStageLabel(deal.properties?.dealstage || "", stageLabelById).toLowerCase();
-    return label === "subscription";
-  }).length;
+  let subscriptions = activeSubscriptionPipelineDeals.length;
   let noShows = stageAgg[STAGE_NO_SHOW]?.count || 0;
   let demoScheduled = stageAgg[STAGE_DEMO_SCHEDULED]?.count || 0;
   let demoFollowUp = stageAgg[STAGE_DEMO_FOLLOW_UP]?.count || 0;
@@ -652,10 +688,7 @@ export async function fetchHubSpotData(
     closedLost = stageEntryAgg[STAGE_CLOSED_LOST]?.count || 0;
     unlikely = stageEntryAgg[STAGE_UNLIKELY]?.count || 0;
     churn = stageEntryAgg[STAGE_CHURN]?.count || 0;
-    subscriptions = eventsInRange.filter((event) => {
-      const label = resolveHubSpotStageLabel(event.toStage, stageLabelById).toLowerCase();
-      return label === "subscription";
-    }).length;
+    subscriptions = activeSubscriptionPipelineDeals.length;
     noShows = stageEntryAgg[STAGE_NO_SHOW]?.count || 0;
     demoScheduled = stageEntryAgg[STAGE_DEMO_SCHEDULED]?.count || 0;
     demoFollowUp = stageEntryAgg[STAGE_DEMO_FOLLOW_UP]?.count || 0;
@@ -776,6 +809,7 @@ export async function fetchHubSpotData(
   }
 
   deals.sort(compareHubSpotDealsByRecency);
+  subscriptionDeals.sort(compareHubSpotDealsByRecency);
 
   let displayDeals = [...deals];
   if (useActivityInRange && rangeFrom && rangeTo) {
@@ -811,9 +845,9 @@ export async function fetchHubSpotData(
 
   // ── Enrich deals with contact analytics for attribution ──
   try {
-    const dealIdsForContacts = deals.map((d) => d.dealId).filter(Boolean);
+    const dealIdsForContacts = [...deals, ...subscriptionDeals].map((d) => d.dealId).filter(Boolean);
     const contactAnalytics = await fetchDealContactAnalytics(baseUrl, headers, dealIdsForContacts);
-    for (const deal of deals) {
+    for (const deal of [...deals, ...subscriptionDeals]) {
       const analytics = contactAnalytics.get(deal.dealId);
       if (analytics) {
         deal.contactIds = analytics.contactIds;
@@ -838,8 +872,13 @@ export async function fetchHubSpotData(
     activeDealsRaw: activeDealsResult.deals.length,
     archivedDealsRaw: archivedDealsResult.deals.length,
     includedPipelineId: HUBSPOT_MAIN_PIPELINE_ID,
-    excludedPipelineIds: [HUBSPOT_SUBSCRIPTION_PIPELINE_ID],
-    excludedDeals: allDeals.length - allMainPipelineDeals.length,
+    subscriptionPipelineId: HUBSPOT_SUBSCRIPTION_PIPELINE_ID,
+    subscriptionDealsFetched: allSubscriptionPipelineDeals.length,
+    subscriptionActiveDealsFetched: activeSubscriptionPipelineDeals.length,
+    excludedPipelineIds: pipelineResult.pipelines
+      .map((pipeline) => pipeline.id)
+      .filter((pipelineId) => pipelineId !== HUBSPOT_MAIN_PIPELINE_ID && pipelineId !== HUBSPOT_SUBSCRIPTION_PIPELINE_ID),
+    excludedDeals: allDeals.length - allMainPipelineDeals.length - allSubscriptionPipelineDeals.length,
     lastAfter: {
       active: activeDealsResult.lastAfter,
       archived: archivedDealsResult.lastAfter,
@@ -881,6 +920,10 @@ export async function fetchHubSpotData(
       pipelineId: HUBSPOT_MAIN_PIPELINE_ID,
       dealCount: deals.length,
     },
+    subscriptionPipelineDetected: {
+      pipelineId: HUBSPOT_SUBSCRIPTION_PIPELINE_ID,
+      dealCount: subscriptionDeals.length,
+    },
     pipelineStageLabelsSource: pipelineResult.source,
     pipelineStages: (mainPipeline?.stages ?? []).map((stage) => ({
       stageId: stage.id,
@@ -888,6 +931,7 @@ export async function fetchHubSpotData(
     })),
     repScoreboard,
     deals,
+    subscriptionDeals,
     displayDeals,
     _meta: meta,
   };
@@ -1572,15 +1616,20 @@ export async function fetchMercuryData(
     id?: string;
     name?: string;
     currentBalance?: number;
+    availableBalance?: number;
     type?: string;
+    status?: string;
   };
 
   type MercuryTransaction = {
+    id?: string;
     postedAt?: string;
     createdAt?: string;
     timestamp?: string;
     status?: string;
     amount?: number;
+    kind?: string | null;
+    mercuryCategory?: string | null;
   };
 
   const headers: Record<string, string> = {
@@ -1602,7 +1651,34 @@ export async function fetchMercuryData(
     type: account.type ?? "checking",
   }));
 
-  const totalBalance = accounts.reduce((s: number, a: { balance: number }) => s + a.balance, 0);
+  try {
+    const treasuryRes = await fetch(`${baseUrl}/treasury?limit=1000`, { headers });
+    if (treasuryRes.ok) {
+      const treasuryData = await safeJson<{ accounts?: MercuryAccount[] }>(treasuryRes, "mercury treasury");
+      const treasuryAccounts = (treasuryData.accounts ?? [])
+        .filter((account) => account.status !== "deleted" && account.status !== "archived")
+        .map((account, index) => ({
+          accountId: account.id ?? `treasury-${index}`,
+          accountName: account.name ?? `Mercury Treasury${index > 0 ? ` ${index + 1}` : ""}`,
+          balance: account.currentBalance ?? 0,
+          type: "treasury",
+        }));
+      accounts.push(...treasuryAccounts);
+    }
+  } catch {
+    // Older Mercury tokens/accounts may not expose Treasury. Keep bank cash available.
+  }
+
+  const isTreasuryAccount = (account: { type?: string | null }): boolean =>
+    (account.type ?? "").toLowerCase() === "treasury";
+  const bankCash = accounts
+    .filter((account) => !isTreasuryAccount(account))
+    .reduce((sum: number, account: { balance: number }) => sum + account.balance, 0);
+  const treasuryCash = accounts
+    .filter(isTreasuryAccount)
+    .reduce((sum: number, account: { balance: number }) => sum + account.balance, 0);
+  const totalCash = bankCash + treasuryCash;
+  const totalBalance = totalCash;
 
   // Fetch recent transactions for cash flow
   const rangeFrom = options?.fromDate ?? null;
@@ -1617,32 +1693,79 @@ export async function fetchMercuryData(
     .toISOString()
     .split("T")[0];
 
+  const endKey = (useRange ? rangeTo! : new Date()).toISOString().split("T")[0];
+  const shouldCountCashFlow = (tx: MercuryTransaction): boolean => {
+    if (tx.status !== "sent") return false;
+    if (typeof tx.amount !== "number" || !Number.isFinite(tx.amount) || tx.amount === 0) return false;
+    const kind = (tx.kind ?? "").toLowerCase();
+    const mercuryCategory = (tx.mercuryCategory ?? "").toLowerCase();
+    return !(
+      kind === "internaltransfer" ||
+      kind === "treasurytransfer" ||
+      mercuryCategory === "treasurytransfer"
+    );
+  };
+  const addCashFlow = (tx: MercuryTransaction): void => {
+    if (!shouldCountCashFlow(tx)) return;
+    const amount = tx.amount ?? 0;
+    const amt = Math.abs(amount);
+    if (amount > 0) inflows += amt;
+    else outflows += amt;
+  };
+
   let inflows = 0, outflows = 0;
-  for (const account of accounts) {
-    try {
-      const txRes = await fetch(
-        `${baseUrl}/account/${account.accountId}/transactions?start=${startKey}&limit=500`,
-        { headers }
-      );
-      if (!txRes.ok) continue;
+  let usedGlobalTransactions = false;
+  try {
+    let startAfter: string | null = null;
+    for (let page = 0; page < 10; page += 1) {
+      const params = new URLSearchParams({
+        postedStart: startKey,
+        postedEnd: endKey,
+        status: "sent",
+        limit: "1000",
+        order: "desc",
+      });
+      if (startAfter) params.set("start_after", startAfter);
+      const txRes = await fetch(`${baseUrl}/transactions?${params.toString()}`, { headers });
+      if (!txRes.ok) break;
+      usedGlobalTransactions = true;
       const txData = await safeJson<{ transactions?: MercuryTransaction[] }>(txRes, "mercury transactions");
-      for (const tx of txData.transactions ?? []) {
-        if (useRange && rangeTo) {
-          const postedAt = tx.postedAt || tx.createdAt || tx.timestamp || "";
-          if (postedAt) {
-            const postedMs = Date.parse(postedAt);
-            if (Number.isFinite(postedMs) && postedMs > rangeTo.getTime()) continue;
+      const txs = txData.transactions ?? [];
+      for (const tx of txs) addCashFlow(tx);
+      if (txs.length < 1000) break;
+      const lastId = txs[txs.length - 1]?.id;
+      if (!lastId || lastId === startAfter) break;
+      startAfter = lastId;
+    }
+  } catch {
+    usedGlobalTransactions = false;
+    inflows = 0;
+    outflows = 0;
+  }
+
+  const bankAccounts = accounts.filter((account) => !isTreasuryAccount(account));
+  if (!usedGlobalTransactions) {
+    for (const account of bankAccounts) {
+      try {
+        const txRes = await fetch(
+          `${baseUrl}/account/${account.accountId}/transactions?start=${startKey}&limit=500`,
+          { headers }
+        );
+        if (!txRes.ok) continue;
+        const txData = await safeJson<{ transactions?: MercuryTransaction[] }>(txRes, "mercury transactions");
+        for (const tx of txData.transactions ?? []) {
+          if (useRange && rangeTo) {
+            const postedAt = tx.postedAt || tx.createdAt || tx.timestamp || "";
+            if (postedAt) {
+              const postedMs = Date.parse(postedAt);
+              if (Number.isFinite(postedMs) && postedMs > rangeTo.getTime()) continue;
+            }
           }
+          addCashFlow(tx);
         }
-        if (tx.status === "sent") {
-          const amount = tx.amount ?? 0;
-          const amt = Math.abs(amount);
-          if (amount > 0) inflows += amt;
-          else outflows += amt;
-        }
+      } catch {
+        // Skip account on error
       }
-    } catch {
-      // Skip account on error
     }
   }
 
@@ -1653,6 +1776,9 @@ export async function fetchMercuryData(
     accounts,
     cashFlow: {
       totalBalance,
+      bankCash,
+      treasuryCash,
+      totalCash,
       inflows30d: inflows,
       outflows30d: outflows,
       netCashFlow: inflows - outflows,

--- a/src/lib/analytics/funnel.ts
+++ b/src/lib/analytics/funnel.ts
@@ -71,7 +71,7 @@ function lifecycleStageDefinitions(): StageDefinition[] {
     {
       id: "awareness",
       label: "Awareness",
-      section: "ads-traffic",
+      section: "website-traffic",
       rawVolume: (data) =>
         data.googleAnalytics?.users30d ??
         data.googleAnalytics?.sessions30d ??

--- a/src/lib/analytics/insight-engine.ts
+++ b/src/lib/analytics/insight-engine.ts
@@ -12,7 +12,8 @@ import { buildProfitAndLoss } from "./pnl-builder";
 import { computeUnitEconomics } from "./unit-economics";
 
 const SECTION_ORDER: AnalyticsSectionId[] = [
-  "ads-traffic",
+  "website-traffic",
+  "social-media",
   "finance",
   "sales-pipeline",
   "customer-success",
@@ -51,7 +52,7 @@ function sortInsights(items: AiInsight[]): AiInsight[] {
   });
 }
 
-// ── Ads & Traffic ────────────────────────────────────────
+// ── Website Traffic + Social Media ───────────────────────
 
 function buildAdsInsights(data: AnalyticsDashboardData): AiInsight[] {
   const insights: AiInsight[] = [];
@@ -75,7 +76,7 @@ function buildAdsInsights(data: AnalyticsDashboardData): AiInsight[] {
   if (bounce > 0.55) {
     insights.push({
       id: "ai-ads-bounce-rate",
-      section: "ads-traffic",
+      section: "website-traffic",
       subsectionId: "ads-google-analytics",
       severity: bounce > 0.65 ? "critical" : "warning",
       title: "High bounce rate signals landing page mismatch",
@@ -107,7 +108,7 @@ function buildAdsInsights(data: AnalyticsDashboardData): AiInsight[] {
   if (totalClicks > 100 && clickToConv < 0.02) {
     insights.push({
       id: "ai-ads-click-conv",
-      section: "ads-traffic",
+      section: "social-media",
       severity: clickToConv < 0.015 ? "critical" : "warning",
       title: "Click-to-conversion rate below efficient threshold",
       why: `Across all paid channels: ${(clickToConv * 100).toFixed(2)}% conversion rate on ${totalClicks.toLocaleString()} clicks.`,
@@ -143,7 +144,7 @@ function buildAdsInsights(data: AnalyticsDashboardData): AiInsight[] {
     const dropPct = ((sessionsPrev - sessionsCurrent) / sessionsPrev * 100).toFixed(1);
     insights.push({
       id: "ai-ads-session-decline",
-      section: "ads-traffic",
+      section: "website-traffic",
       subsectionId: "ads-google-analytics",
       severity: sessionsCurrent < sessionsPrev * 0.7 ? "critical" : "warning",
       title: "Session volume declining period-over-period",
@@ -185,7 +186,7 @@ function buildAdsInsights(data: AnalyticsDashboardData): AiInsight[] {
     const cheapCPA = gCPA > mCPA ? mCPA : gCPA;
     insights.push({
       id: "ai-ads-cpa-disparity",
-      section: "ads-traffic",
+      section: "social-media",
       severity: "warning",
       title: `${expensive} CPA is ${(expCPA / cheapCPA).toFixed(1)}x higher than ${cheap}`,
       why: `${expensive} CPA: $${expCPA.toFixed(0)} vs ${cheap} CPA: $${cheapCPA.toFixed(0)}. Budget reallocation could improve overall efficiency.`,
@@ -226,7 +227,7 @@ function buildAdsInsights(data: AnalyticsDashboardData): AiInsight[] {
   if (organicTraffic > 100 && organicTraffic < sessionsCurrent * 0.1) {
     insights.push({
       id: "ai-ads-seo-underperforming",
-      section: "ads-traffic",
+      section: "website-traffic",
       severity: "warning",
       title: "Organic search heavily underperforming relative to overall traffic",
       why: `Organic traffic is only ${toPct(organicTraffic / sessionsCurrent)} of total sessions (${organicTraffic} out of ${sessionsCurrent}). High paid dependency.`,
@@ -253,7 +254,7 @@ function buildAdsInsights(data: AnalyticsDashboardData): AiInsight[] {
   } else if (organicKw > 0 && paidKw > organicKw * 2) {
     insights.push({
       id: "ai-ads-paid-heavy",
-      section: "ads-traffic",
+      section: "website-traffic",
       severity: "warning",
       title: "Over-reliance on Paid Keywords vs Organic",
       why: `Bidding on ${paidKw} keywords but only ranking organically for ${organicKw}. Missing opportunity to capture free traffic for proven terms.`,
@@ -285,7 +286,7 @@ function buildAdsInsights(data: AnalyticsDashboardData): AiInsight[] {
   if (sessionsCurrent > 500 && submissions === 0 && pages > 0) {
     insights.push({
       id: "ai-ads-webflow-zero-conv",
-      section: "ads-traffic",
+      section: "website-traffic",
       severity: "critical",
       title: "0 form submissions despite meaningful traffic",
       why: `The site generated ${sessionsCurrent} sessions but recorded 0 form submissions in Webflow.`,
@@ -1322,7 +1323,7 @@ function buildCrossdomainInsights(data: AnalyticsDashboardData): AiInsight[] {
   if (totalAdSpend > 1000 && pipelineValue > 0 && closedWonValue < totalAdSpend * 0.5) {
     insights.push({
       id: "ai-xd-spend-vs-pipeline",
-      section: "ads-traffic",
+      section: "social-media",
       severity: closedWonValue < totalAdSpend * 0.25 ? "critical" : "warning",
       title: "Ad spend not translating to pipeline value",
       why: `$${totalAdSpend.toLocaleString()} ad spend but only $${closedWonValue.toLocaleString()} closed won — pipeline ROI is ${pipelineValue > 0 ? (closedWonValue / totalAdSpend * 100).toFixed(0) : 0}%.`,
@@ -1743,7 +1744,8 @@ export function buildAiInsightsBundle(data: AnalyticsDashboardData): AiInsightsB
       return acc;
     },
     {
-      "ads-traffic": [],
+      "website-traffic": [],
+      "social-media": [],
       finance: [],
       "sales-pipeline": [],
       retention: [],

--- a/src/lib/analytics/kpis.ts
+++ b/src/lib/analytics/kpis.ts
@@ -1,5 +1,6 @@
 import type { AnalyticsDashboardData } from "./types";
 import { normalizePercentValue } from "./percentage-utils";
+import { buildSubscriptionMrrBreakdown } from "./subscription-mrr";
 
 /**
  * Compute fallback KPIs from raw provider data when `data.kpis` is not
@@ -25,7 +26,7 @@ export function computeAnalyticsKpis(data: AnalyticsDashboardData) {
 
   // ── Finance KPIs ──
   const stripe = data.stripe;
-  const mrr = stripe?.revenue.mrr ?? 0;
+  const mrr = buildSubscriptionMrrBreakdown({ stripe, hubspot: data.hubspot }).totalMrr;
   const paymentSuccessPct = normalizePercentValue(stripe?.payments.successRate ?? 0);
 
   return {

--- a/src/lib/analytics/metric-history.ts
+++ b/src/lib/analytics/metric-history.ts
@@ -11,18 +11,18 @@ interface MetricDefinition {
 }
 
 const METRIC_REGISTRY: MetricDefinition[] = [
-  // Ads & Traffic
-  { key: "ga.sessions30d", section: "ads-traffic", label: "Sessions (30d)", extract: (d) => d.googleAnalytics?.sessions30d ?? null },
-  { key: "ga.bounceRate", section: "ads-traffic", label: "Bounce Rate", extract: (d) => d.googleAnalytics?.bounceRate ?? null },
-  { key: "ga.users30d", section: "ads-traffic", label: "Users (30d)", extract: (d) => d.googleAnalytics?.users30d ?? null },
-  { key: "ga.pageviews30d", section: "ads-traffic", label: "Pageviews (30d)", extract: (d) => d.googleAnalytics?.pageviews30d ?? null },
-  { key: "ga.avgSessionDuration", section: "ads-traffic", label: "Avg Session Duration", extract: (d) => d.googleAnalytics?.avgSessionDuration ?? null },
-  { key: "googleAds.spend", section: "ads-traffic", label: "Google Ads Spend", extract: (d) => d.googleAds?.totalSpend30d ?? null },
-  { key: "googleAds.clicks", section: "ads-traffic", label: "Google Ads Clicks", extract: (d) => d.googleAds?.totalClicks ?? null },
-  { key: "googleAds.conversions", section: "ads-traffic", label: "Google Ads Conversions", extract: (d) => d.googleAds?.totalConversions ?? null },
-  { key: "googleAds.roas", section: "ads-traffic", label: "Google Ads ROAS", extract: (d) => d.googleAds?.roas ?? null },
-  { key: "metaAds.spend", section: "ads-traffic", label: "Meta Ads Spend", extract: (d) => d.metaAds?.totalSpend30d ?? null },
-  { key: "metaAds.clicks", section: "ads-traffic", label: "Meta Ads Clicks", extract: (d) => d.metaAds?.totalClicks ?? null },
+  // Website traffic + social media
+  { key: "ga.sessions30d", section: "website-traffic", label: "Sessions (30d)", extract: (d) => d.googleAnalytics?.sessions30d ?? null },
+  { key: "ga.bounceRate", section: "website-traffic", label: "Bounce Rate", extract: (d) => d.googleAnalytics?.bounceRate ?? null },
+  { key: "ga.users30d", section: "website-traffic", label: "Users (30d)", extract: (d) => d.googleAnalytics?.users30d ?? null },
+  { key: "ga.pageviews30d", section: "website-traffic", label: "Pageviews (30d)", extract: (d) => d.googleAnalytics?.pageviews30d ?? null },
+  { key: "ga.avgSessionDuration", section: "website-traffic", label: "Avg Session Duration", extract: (d) => d.googleAnalytics?.avgSessionDuration ?? null },
+  { key: "googleAds.spend", section: "social-media", label: "Google Ads Spend", extract: (d) => d.googleAds?.totalSpend30d ?? null },
+  { key: "googleAds.clicks", section: "social-media", label: "Google Ads Clicks", extract: (d) => d.googleAds?.totalClicks ?? null },
+  { key: "googleAds.conversions", section: "social-media", label: "Google Ads Conversions", extract: (d) => d.googleAds?.totalConversions ?? null },
+  { key: "googleAds.roas", section: "social-media", label: "Google Ads ROAS", extract: (d) => d.googleAds?.roas ?? null },
+  { key: "metaAds.spend", section: "social-media", label: "Meta Ads Spend", extract: (d) => d.metaAds?.totalSpend30d ?? null },
+  { key: "metaAds.clicks", section: "social-media", label: "Meta Ads Clicks", extract: (d) => d.metaAds?.totalClicks ?? null },
 
   // Finance
   { key: "stripe.mrr", section: "finance", label: "MRR", extract: (d) => d.stripe?.revenue?.mrr ?? null },

--- a/src/lib/analytics/response-shape.ts
+++ b/src/lib/analytics/response-shape.ts
@@ -5,7 +5,8 @@ export function createEmptyAiInsightsBundle(generatedAt: string = new Date().toI
     generatedAt,
     global: [],
     bySection: {
-      "ads-traffic": [],
+      "website-traffic": [],
+      "social-media": [],
       finance: [],
       "sales-pipeline": [],
       retention: [],

--- a/src/lib/analytics/section-registry.ts
+++ b/src/lib/analytics/section-registry.ts
@@ -1,5 +1,6 @@
 export type AnalyticsPrimarySectionId =
-  | "ads-traffic"
+  | "website-traffic"
+  | "social-media"
   | "finance"
   | "sales-pipeline"
   | "retention"
@@ -59,10 +60,16 @@ export interface AnalyticsSubSection {
 
 export const ANALYTICS_PRIMARY_SECTIONS: AnalyticsPrimarySection[] = [
   {
-    id: "ads-traffic",
-    label: "Ads & Traffic",
-    path: "/analytics/ads-traffic",
-    description: "Campaigns, traffic, and content performance.",
+    id: "website-traffic",
+    label: "Website Traffic",
+    path: "/analytics/website-traffic",
+    description: "Site traffic, content performance, and web conversions.",
+  },
+  {
+    id: "social-media",
+    label: "Social Media",
+    path: "/analytics/social-media",
+    description: "Paid and organic social platform performance.",
   },
   {
     id: "finance",
@@ -109,13 +116,13 @@ export const ANALYTICS_PRIMARY_SECTIONS: AnalyticsPrimarySection[] = [
 ];
 
 export const ANALYTICS_SUB_SECTIONS: AnalyticsSubSection[] = [
-  { id: "ads-google-analytics", label: "Google Analytics", path: "/analytics/ads-google-analytics", parentId: "ads-traffic", dataDomain: "googleAnalytics" },
-  { id: "ads-google-ads", label: "Google Ads", path: "/analytics/ads-google-ads", parentId: "ads-traffic", dataDomain: "googleAds" },
-  { id: "ads-meta-ads", label: "Meta Ads", path: "/analytics/ads-meta-ads", parentId: "ads-traffic", dataDomain: "metaAds" },
-  { id: "ads-reddit-ads", label: "Reddit Ads", path: "/analytics/ads-reddit-ads", parentId: "ads-traffic", dataDomain: "redditAds" },
-  { id: "ads-webflow", label: "Webflow", path: "/analytics/ads-webflow", parentId: "ads-traffic", dataDomain: "webflow" },
-  { id: "ads-semrush", label: "SEMrush", path: "/analytics/ads-semrush", parentId: "ads-traffic", dataDomain: "semrush" },
-  { id: "ads-coda-kanban", label: "Free Kanban Generator (Whitepaper)", path: "/analytics/ads-coda-kanban", parentId: "ads-traffic", dataDomain: "coda" },
+  { id: "ads-google-analytics", label: "Google Analytics", path: "/analytics/ads-google-analytics", parentId: "website-traffic", dataDomain: "googleAnalytics" },
+  { id: "ads-google-ads", label: "Google Ads", path: "/analytics/ads-google-ads", parentId: "social-media", dataDomain: "googleAds" },
+  { id: "ads-meta-ads", label: "Meta Ads", path: "/analytics/ads-meta-ads", parentId: "social-media", dataDomain: "metaAds" },
+  { id: "ads-reddit-ads", label: "Reddit Ads", path: "/analytics/ads-reddit-ads", parentId: "social-media", dataDomain: "redditAds" },
+  { id: "ads-webflow", label: "Webflow", path: "/analytics/ads-webflow", parentId: "website-traffic", dataDomain: "webflow" },
+  { id: "ads-semrush", label: "SEMrush", path: "/analytics/ads-semrush", parentId: "website-traffic", dataDomain: "semrush" },
+  { id: "ads-coda-kanban", label: "Coda Lead Magnet (Whitepaper)", path: "/analytics/ads-coda-kanban", parentId: "website-traffic", dataDomain: "coda" },
 
   { id: "finance-mercury", label: "Mercury", path: "/analytics/finance-mercury", parentId: "finance", dataDomain: "mercury" },
   { id: "finance-stripe", label: "Stripe", path: "/analytics/finance-stripe", parentId: "finance", dataDomain: "stripe" },
@@ -178,7 +185,7 @@ export const LEGACY_ANALYTICS_TAB_REDIRECTS: Record<string, string> = {
   overview: "/analytics",
   sales: "/analytics/sales-pipeline",
   finance: "/analytics/finance",
-  marketing: "/analytics/ads-traffic",
+  marketing: "/analytics/website-traffic",
   tasks: "/analytics/customer-success",
   journey: "/analytics/customer-journey",
   demos: "/analytics/demo-analytics",
@@ -189,8 +196,9 @@ export const LEGACY_ANALYTICS_ROUTE_REDIRECTS: Record<string, string> = {
   overview: "/analytics",
   sales: "/analytics/sales-pipeline",
   finance: "/analytics/finance",
-  marketing: "/analytics/ads-traffic",
-  tasks: "/dashboard",
+  marketing: "/analytics/website-traffic",
+  "ads-traffic": "/analytics/website-traffic",
+  tasks: "/analytics/customer-success",
   hubspot: "/analytics/sales-hubspot",
   stripe: "/analytics/finance-stripe",
   mercury: "/analytics/finance-mercury",

--- a/src/lib/analytics/subscription-mrr.test.ts
+++ b/src/lib/analytics/subscription-mrr.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { buildSubscriptionMrrBreakdown } from "@/lib/analytics/subscription-mrr";
+
+describe("buildSubscriptionMrrBreakdown", () => {
+  it("adds HubSpot-only subscription revenue to Stripe MRR", () => {
+    const breakdown = buildSubscriptionMrrBreakdown({
+      stripe: {
+        revenue: { mrr: 12000, mrrChange: 500 },
+        subscriptions: {
+          active: 1,
+          activeCustomerRefs: [{ customerId: "cus_123", email: "billing@example.com", emailDomain: "example.com" }],
+        },
+      },
+      hubspot: {
+        subscriptionDeals: [
+          {
+            dealId: "hs-only",
+            dealName: "HubSpot Only",
+            stageLabel: "Subscriptions",
+            amount: 3598,
+            stripeCustomerId: null,
+            primaryContactEmail: "ops@example-subscription.com",
+          },
+        ],
+      },
+    });
+
+    expect(breakdown.totalMrr).toBe(15598);
+    expect(breakdown.totalArr).toBe(187176);
+    expect(breakdown.stripeMrr).toBe(12000);
+    expect(breakdown.hubspotOnlySubscriptionMrr).toBe(3598);
+    expect(breakdown.mergedActiveSubscriptions).toBe(2);
+  });
+
+  it("excludes HubSpot subscription revenue linked to active Stripe customers", () => {
+    const breakdown = buildSubscriptionMrrBreakdown({
+      stripe: {
+        revenue: { mrr: 12000, mrrChange: 500 },
+        subscriptions: {
+          active: 1,
+          activeCustomerRefs: [{ customerId: "cus_123", email: "billing@example.com", emailDomain: "example.com" }],
+        },
+      },
+      hubspot: {
+        subscriptionDeals: [
+          {
+            dealId: "linked-by-customer",
+            dealName: "Linked Customer",
+            stageLabel: "Subscriptions",
+            amount: 4000,
+            stripeCustomerId: "cus_123",
+            primaryContactEmail: null,
+          },
+          {
+            dealId: "linked-by-email",
+            dealName: "Linked Email",
+            stageLabel: "Subscriptions",
+            amount: 3000,
+            stripeCustomerId: null,
+            primaryContactEmail: "billing@example.com",
+          },
+        ],
+      },
+    });
+
+    expect(breakdown.totalMrr).toBe(12000);
+    expect(breakdown.hubspotOnlySubscriptionMrr).toBe(0);
+    expect(breakdown.excludedLinkedHubspotSubscriptionMrr).toBe(7000);
+    expect(breakdown.mergedActiveSubscriptions).toBe(1);
+  });
+});

--- a/src/lib/analytics/subscription-mrr.ts
+++ b/src/lib/analytics/subscription-mrr.ts
@@ -1,0 +1,161 @@
+type StripeCustomerRef = {
+  customerId?: string | null;
+  email?: string | null;
+  emailDomain?: string | null;
+};
+
+type StripeLike = {
+  revenue?: {
+    mrr?: number | null;
+    mrrChange?: number | null;
+  } | null;
+  subscriptions?: {
+    active?: number | null;
+    activeCustomerRefs?: StripeCustomerRef[] | null;
+  } | null;
+} | null | undefined;
+
+type HubSpotSubscriptionDealLike = {
+  dealId?: string | null;
+  dealName?: string | null;
+  stageLabel?: string | null;
+  amount?: number | string | null;
+  stripeCustomerId?: string | null;
+  primaryContactEmail?: string | null;
+};
+
+type HubSpotLike = {
+  subscriptionDeals?: HubSpotSubscriptionDealLike[] | null;
+  deals?: HubSpotSubscriptionDealLike[] | null;
+} | null | undefined;
+
+const GENERIC_EMAIL_DOMAINS = new Set([
+  "gmail.com",
+  "googlemail.com",
+  "yahoo.com",
+  "outlook.com",
+  "hotmail.com",
+  "icloud.com",
+  "me.com",
+  "proton.me",
+  "protonmail.com",
+]);
+
+function normalizeLookup(value: string | null | undefined): string | null {
+  const normalized = value?.trim().toLowerCase() ?? "";
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeEmailDomain(value: string | null | undefined): string | null {
+  const email = normalizeLookup(value);
+  if (!email || !email.includes("@")) return null;
+  const [, domain] = email.split("@");
+  const normalized = normalizeLookup(domain);
+  if (!normalized || GENERIC_EMAIL_DOMAINS.has(normalized)) return null;
+  return normalized;
+}
+
+function toNumber(value: number | string | null | undefined): number {
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function asStripeLike(value: unknown): StripeLike {
+  return typeof value === "object" && value !== null ? (value as StripeLike) : null;
+}
+
+function asHubSpotLike(value: unknown): HubSpotLike {
+  return typeof value === "object" && value !== null ? (value as HubSpotLike) : null;
+}
+
+function getHubSpotSubscriptionDeals(hubspot: HubSpotLike): HubSpotSubscriptionDealLike[] {
+  if (Array.isArray(hubspot?.subscriptionDeals)) return hubspot.subscriptionDeals;
+  return (hubspot?.deals ?? []).filter(
+    (deal) => deal.stageLabel?.trim().toLowerCase() === "subscription",
+  );
+}
+
+export type SubscriptionMrrBreakdown = {
+  stripeMrr: number;
+  stripeMrrChange: number | null;
+  hubspotSubscriptionMrr: number;
+  hubspotOnlySubscriptionMrr: number;
+  excludedLinkedHubspotSubscriptionMrr: number;
+  totalMrr: number;
+  totalArr: number;
+  stripeActiveSubscriptions: number;
+  hubspotActiveSubscriptions: number;
+  hubspotOnlyActiveSubscriptions: number;
+  mergedActiveSubscriptions: number;
+};
+
+export function buildSubscriptionMrrBreakdown(input: {
+  stripe: unknown;
+  hubspot: unknown;
+}): SubscriptionMrrBreakdown {
+  const stripe = asStripeLike(input.stripe);
+  const hubspot = asHubSpotLike(input.hubspot);
+  const stripeRefs = stripe?.subscriptions?.activeCustomerRefs ?? [];
+  const hubspotDeals = getHubSpotSubscriptionDeals(hubspot);
+
+  const stripeCustomerIds = new Set(
+    stripeRefs
+      .map((ref) => ref.customerId?.trim() ?? "")
+      .filter((customerId) => customerId.length > 0 && customerId !== "Unknown customer"),
+  );
+  const stripeEmails = new Set(
+    stripeRefs.map((ref) => normalizeLookup(ref.email)).filter(Boolean) as string[],
+  );
+  const stripeDomains = new Set(
+    stripeRefs.map((ref) => normalizeLookup(ref.emailDomain)).filter(Boolean) as string[],
+  );
+
+  let hubspotOnlyActiveSubscriptions = 0;
+  let hubspotOnlySubscriptionMrr = 0;
+  let excludedLinkedHubspotSubscriptionMrr = 0;
+  let hubspotSubscriptionMrr = 0;
+
+  for (const deal of hubspotDeals) {
+    const amount = Math.max(0, toNumber(deal.amount));
+    const customerId = deal.stripeCustomerId?.trim() || null;
+    const email = normalizeLookup(deal.primaryContactEmail);
+    const emailDomain = normalizeEmailDomain(deal.primaryContactEmail);
+    const linkedToStripe =
+      Boolean(customerId && stripeCustomerIds.has(customerId)) ||
+      Boolean(email && stripeEmails.has(email)) ||
+      Boolean(emailDomain && stripeDomains.has(emailDomain));
+
+    hubspotSubscriptionMrr += amount;
+    if (linkedToStripe) {
+      excludedLinkedHubspotSubscriptionMrr += amount;
+      continue;
+    }
+
+    hubspotOnlyActiveSubscriptions += 1;
+    hubspotOnlySubscriptionMrr += amount;
+  }
+
+  const stripeMrr = Math.max(0, toNumber(stripe?.revenue?.mrr));
+  const totalMrr = stripeMrr + hubspotOnlySubscriptionMrr;
+
+  return {
+    stripeMrr,
+    stripeMrrChange:
+      stripe?.revenue?.mrrChange === null || stripe?.revenue?.mrrChange === undefined
+        ? null
+        : toNumber(stripe.revenue.mrrChange),
+    hubspotSubscriptionMrr,
+    hubspotOnlySubscriptionMrr,
+    excludedLinkedHubspotSubscriptionMrr,
+    totalMrr,
+    totalArr: totalMrr * 12,
+    stripeActiveSubscriptions: stripe?.subscriptions?.active ?? stripeRefs.length,
+    hubspotActiveSubscriptions: hubspotDeals.length,
+    hubspotOnlyActiveSubscriptions,
+    mergedActiveSubscriptions: stripeRefs.length + hubspotOnlyActiveSubscriptions,
+  };
+}

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -123,9 +123,44 @@ export interface HubSpotData {
   contacts: ContactMetrics;
   repScoreboard?: HubSpotRepScoreboardRow[];
   pipelineDetected?: { pipelineId: string; dealCount: number };
+  subscriptionPipelineDetected?: { pipelineId: string; dealCount: number };
   pipelineStageLabelsSource?: "api" | "fallback";
   pipelineStages?: Array<{ stageId: string; label: string }>;
   deals?: Array<{
+    dealId: string;
+    dealName: string;
+    stageId: string;
+    stageLabel: string;
+    amount: number;
+    source: string;
+    ownerId: string | null;
+    repName?: string;
+    updatedAt: string | null;
+    createdAt: string | null;
+    closedAt?: string | null;
+    stripeCustomerId?: string | null;
+    pipelineId: string | null;
+    contactIds: string[];
+    primaryContactId: string | null;
+    primaryContactEmail: string | null;
+    primaryContactAnalytics?: {
+      createdAt?: string | null;
+      source: string | null;
+      sourceData1: string | null;
+      sourceData2: string | null;
+      firstSeenAt: string | null;
+      lastSeenAt: string | null;
+      firstUrl: string | null;
+      lastUrl: string | null;
+      numVisits: number | null;
+      numPageViews: number | null;
+      utmSource: string | null;
+      utmMedium: string | null;
+      utmCampaign: string | null;
+    };
+    stageHistory?: Array<{ occurredAt: string; stageId: string; stageLabel: string }>;
+  }>;
+  subscriptionDeals?: Array<{
     dealId: string;
     dealName: string;
     stageId: string;
@@ -354,6 +389,9 @@ export interface AccountBalance {
 
 export interface CashFlowMetrics {
   totalBalance: number;
+  bankCash?: number;
+  treasuryCash?: number;
+  totalCash?: number;
   inflows30d: number;
   outflows30d: number;
   netCashFlow: number;
@@ -985,7 +1023,8 @@ export interface CrossFunnelData {
 }
 
 export type AnalyticsSectionId =
-  | "ads-traffic"
+  | "website-traffic"
+  | "social-media"
   | "finance"
   | "sales-pipeline"
   | "retention"
@@ -1681,6 +1720,12 @@ export interface FinancialPlanningData {
     mergedActiveSubscriptions: number;
     stripeActiveSubscriptions: number;
     hubspotActiveSubscriptions: number;
+    stripeMrr: number;
+    hubspotSubscriptionMrr: number;
+    hubspotOnlySubscriptionMrr: number;
+    excludedLinkedHubspotSubscriptionMrr: number;
+    totalMrr: number;
+    totalArr: number;
   } | null;
 }
 
@@ -1820,5 +1865,5 @@ export const ANALYTICS_TABS: TabConfig[] = [
   { id: "overview", label: "Overview", description: "Key metrics at a glance" },
   { id: "sales", label: "Sales & Pipeline", description: "HubSpot deals & conversions" },
   { id: "finance", label: "Revenue & Finance", description: "Stripe MRR & Mercury cash" },
-  { id: "marketing", label: "Ads & Traffic", description: "Google Analytics, Ads, Meta & Reddit" },
+  { id: "marketing", label: "Website Traffic", description: "Legacy alias that redirects to website traffic analytics" },
 ];

--- a/src/lib/ceo/api-context.ts
+++ b/src/lib/ceo/api-context.ts
@@ -1,0 +1,27 @@
+import { resolveDashboardOrganizationId, tenantBypassEnabled } from "@/lib/platform/dashboard/context";
+import { runWithContextAsync } from "@/lib/request-context";
+import type { AuthenticatedUser } from "@/lib/session-user";
+
+export class CeoOrganizationContextError extends Error {
+  constructor() {
+    super("Organization context required for CEO metrics");
+    this.name = "CeoOrganizationContextError";
+  }
+}
+
+export async function withCeoOrganizationContext<T>(
+  session: unknown,
+  user: AuthenticatedUser,
+  fn: (organizationId: string | null) => Promise<T>
+): Promise<T> {
+  const organizationId = await resolveDashboardOrganizationId(session, user.id);
+  if (!organizationId && !tenantBypassEnabled) {
+    throw new CeoOrganizationContextError();
+  }
+
+  if (!organizationId) {
+    return fn(null);
+  }
+
+  return runWithContextAsync({ organizationId, userId: user.id }, () => fn(organizationId));
+}

--- a/src/lib/ceo/metric-trust.test.ts
+++ b/src/lib/ceo/metric-trust.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDefaultCeoReportPacks,
+  buildMetricReportRun,
+  computeCeoReadiness,
+  evaluateMetricTrust,
+  getDefaultCeoMetricDefinitions,
+  type CeoMetricValue,
+} from "@/lib/ceo/metric-trust";
+
+const AS_OF = new Date("2026-05-01T12:00:00.000Z");
+
+describe("CEO metric trust layer", () => {
+  it("marks metrics stale when the best source is older than its freshness SLA", () => {
+    const trust = evaluateMetricTrust({
+      asOf: AS_OF,
+      freshnessSlaHours: 6,
+      requiredSourceKeys: ["stripe"],
+      sources: [
+        {
+          sourceKey: "stripe",
+          status: "SUCCESS",
+          capturedAt: "2026-05-01T00:00:00.000Z",
+          expiresAt: "2026-05-01T01:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(trust.status).toBe("stale");
+    expect(trust.confidence).toBeLessThan(1);
+    expect(trust.warnings.join(" ")).toContain("stale");
+  });
+
+  it("marks metrics partial when at least one required source is missing", () => {
+    const trust = evaluateMetricTrust({
+      asOf: AS_OF,
+      freshnessSlaHours: 24,
+      requiredSourceKeys: ["hubspot", "stripe"],
+      sources: [
+        {
+          sourceKey: "hubspot",
+          status: "SUCCESS",
+          capturedAt: "2026-05-01T10:00:00.000Z",
+          expiresAt: "2026-05-01T13:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(trust.status).toBe("partial");
+    expect(trust.warnings.join(" ")).toContain("stripe");
+  });
+
+  it("registers default metric definitions across every existing analytics domain", () => {
+    const definitions = getDefaultCeoMetricDefinitions();
+    const domains = new Set(definitions.map((definition) => definition.domain));
+
+    expect(domains).toContain("finance");
+    expect(domains).toContain("sales-pipeline");
+    expect(domains).toContain("customer-success");
+    expect(domains).toContain("process-analytics");
+    expect(domains).toContain("website-traffic");
+    expect(domains).toContain("social-media");
+    expect(domains).toContain("ceo");
+    expect(definitions.every((definition) => definition.sourceDependencies.length > 0)).toBe(true);
+  });
+
+  it("builds deterministic markdown, csv, and slide-ready JSON for a report pack", () => {
+    const definitions = getDefaultCeoMetricDefinitions();
+    const packs = buildDefaultCeoReportPacks(definitions);
+    const weeklyPack = packs.find((pack) => pack.slug === "weekly-exec");
+    expect(weeklyPack).toBeDefined();
+
+    const run = buildMetricReportRun({
+      pack: weeklyPack!,
+      metrics: weeklyPack!.metricKeys.map((metricKey, index) => ({
+        definition: definitions.find((definition) => definition.key === metricKey)!,
+        value: index + 1,
+        priorValue: index,
+        delta: 1,
+        details: metricKey === "finance.cash_balance"
+          ? [
+              { key: "bankCash", label: "Bank cash", value: 10, unit: "currency" },
+              { key: "treasuryCash", label: "Treasury cash", value: 20, unit: "currency" },
+              { key: "totalCash", label: "Total cash", value: 30, unit: "currency" },
+            ]
+          : undefined,
+        periodStart: "2026-04-24T00:00:00.000Z",
+        periodEnd: "2026-05-01T12:00:00.000Z",
+        asOf: "2026-05-01T12:00:00.000Z",
+        computedAt: "2026-05-01T12:01:00.000Z",
+        trust: {
+          status: index === 0 ? "fresh" : "stale",
+          confidence: index === 0 ? 1 : 0.7,
+          warnings: index === 0 ? [] : ["Source snapshot is stale."],
+          sourceStates: [],
+        },
+        lineage: [],
+      })),
+      generatedAt: "2026-05-01T12:02:00.000Z",
+    });
+
+    expect(run.markdown).toContain("# Weekly Exec");
+    expect(run.markdown).toContain("Trust");
+    expect(run.markdown).toContain("Bank cash: 10; Treasury cash: 20; Total cash: 30");
+    expect(run.csv).toContain("Metric,Value,Prior Value,Delta,Trust,As Of,Sources,Details");
+    expect(run.csv).toContain("Bank cash: 10; Treasury cash: 20; Total cash: 30");
+    expect(run.slideJson.sections.length).toBeGreaterThan(0);
+    expect(
+      run.slideJson.sections
+        .flatMap((section) => section.metrics)
+        .find((metric) => metric.key === "finance.cash_balance")?.details
+    ).toEqual([
+      { key: "bankCash", label: "Bank cash", value: 10, unit: "currency" },
+      { key: "treasuryCash", label: "Treasury cash", value: 20, unit: "currency" },
+      { key: "totalCash", label: "Total cash", value: 30, unit: "currency" },
+    ]);
+    expect(run.deterministicNotes.some((note) => note.includes("stale"))).toBe(true);
+  });
+
+  it("marks reports not board-final when any required metric is stale, missing, or unverified", () => {
+    const definitions = getDefaultCeoMetricDefinitions();
+    const packs = buildDefaultCeoReportPacks(definitions);
+    const boardPack = packs.find((pack) => pack.slug === "board-meeting")!;
+    const metrics: CeoMetricValue[] = boardPack.metricKeys.map((metricKey, index) => ({
+      definition: definitions.find((definition) => definition.key === metricKey)!,
+      value: index === 1 ? null : index + 1,
+      priorValue: null,
+      delta: null,
+      periodStart: "2026-04-01T00:00:00.000Z",
+      periodEnd: "2026-05-01T00:00:00.000Z",
+      asOf: "2026-05-01T00:00:00.000Z",
+      computedAt: "2026-05-01T00:01:00.000Z",
+      trust: {
+        status: index === 0 ? "fresh" : "stale",
+        confidence: index === 0 ? 1 : 0.7,
+        warnings: index === 0 ? [] : ["Source snapshot is stale."],
+        sourceStates: [],
+      },
+      lineage: index === 2 ? [] : [{ sourceKey: "test-source", sourceId: "snap-1", capturedAt: "2026-05-01T00:00:00.000Z" }],
+    }));
+
+    const readiness = computeCeoReadiness({
+      reportPacks: [boardPack],
+      metrics,
+      verifiedMetricKeys: new Set(boardPack.metricKeys.filter((key) => key !== boardPack.metricKeys[3])),
+    });
+
+    expect(readiness.status).toBe("not_board_final");
+    expect(readiness.ready).toBe(false);
+    expect(readiness.failingGates.some((gate) => gate.reason.includes("stale"))).toBe(true);
+    expect(readiness.failingGates.some((gate) => gate.reason.includes("lineage"))).toBe(true);
+    expect(readiness.failingGates.some((gate) => gate.reason.includes("verified"))).toBe(true);
+    expect(readiness.failingGates.some((gate) => gate.reason.includes("value"))).toBe(true);
+  });
+
+  it("embeds board-readiness warnings into markdown, csv, and slide-ready JSON exports", () => {
+    const definitions = getDefaultCeoMetricDefinitions();
+    const pack = buildDefaultCeoReportPacks(definitions).find((candidate) => candidate.slug === "weekly-exec")!;
+    const metrics: CeoMetricValue[] = pack.metricKeys.map((metricKey) => ({
+      definition: definitions.find((definition) => definition.key === metricKey)!,
+      value: 1,
+      priorValue: null,
+      delta: null,
+      periodStart: "2026-04-01T00:00:00.000Z",
+      periodEnd: "2026-05-01T00:00:00.000Z",
+      asOf: "2026-05-01T00:00:00.000Z",
+      computedAt: "2026-05-01T00:01:00.000Z",
+      trust: { status: "fresh", confidence: 1, warnings: [], sourceStates: [] },
+      lineage: [{ sourceKey: "test-source", sourceId: "snap-1", capturedAt: "2026-05-01T00:00:00.000Z" }],
+    }));
+    const readiness = {
+      status: "not_board_final" as const,
+      ready: false,
+      summary: "Not board-final: 1 readiness gate is failing.",
+      failingGates: [
+        {
+          metricKey: "finance.mrr",
+          label: "MRR",
+          reason: "Metric source snapshot is stale.",
+        },
+      ],
+    };
+
+    const run = buildMetricReportRun({ pack, metrics, readiness });
+
+    expect(run.markdown).toContain("Board Readiness");
+    expect(run.markdown).toContain("Not board-final");
+    expect(run.csv).toContain("Readiness Status,not_board_final");
+    expect(run.slideJson.readiness.status).toBe("not_board_final");
+    expect(run.slideJson.readiness.failingGates[0]?.metricKey).toBe("finance.mrr");
+  });
+});

--- a/src/lib/ceo/metric-trust.ts
+++ b/src/lib/ceo/metric-trust.ts
@@ -1,0 +1,746 @@
+import {
+  ANALYTICS_PRIMARY_SECTIONS,
+  ANALYTICS_SUB_SECTIONS,
+  type AnalyticsPrimarySectionId,
+} from "@/lib/analytics/section-registry";
+
+export type CeoMetricDomain = AnalyticsPrimarySectionId | "ceo";
+
+export type CeoMetricUnit =
+  | "count"
+  | "currency"
+  | "days"
+  | "percent"
+  | "ratio"
+  | "score"
+  | "text";
+
+export type CeoMetricTrustStatus =
+  | "fresh"
+  | "stale"
+  | "partial"
+  | "missing"
+  | "error"
+  | "conflicted";
+
+export interface CeoMetricDefinition {
+  key: string;
+  label: string;
+  domain: CeoMetricDomain;
+  ownerAudience: "CEO" | "BOARD" | "TEAM" | "INVESTOR";
+  unit: CeoMetricUnit;
+  calculationVersion: string;
+  sourceDependencies: string[];
+  freshnessSlaHours: number;
+  boardEligible: boolean;
+  weeklyEligible: boolean;
+  description: string;
+}
+
+export interface CeoSourceSample {
+  sourceKey: string;
+  sourceId?: string | null;
+  status: "SUCCESS" | "ERROR" | "MISSING" | "PARTIAL";
+  capturedAt?: string | Date | null;
+  expiresAt?: string | Date | null;
+  lastError?: string | null;
+}
+
+export interface CeoMetricSourceState {
+  sourceKey: string;
+  sourceId: string | null;
+  status: CeoSourceSample["status"];
+  capturedAt: string | null;
+  expiresAt: string | null;
+  ageHours: number | null;
+  fresh: boolean;
+  lastError: string | null;
+}
+
+export interface CeoMetricTrust {
+  status: CeoMetricTrustStatus;
+  confidence: number;
+  warnings: string[];
+  sourceStates: CeoMetricSourceState[];
+}
+
+export interface CeoMetricValue {
+  definition: CeoMetricDefinition;
+  value: number | string | null;
+  priorValue: number | string | null;
+  delta: number | null;
+  details?: Array<{
+    key: string;
+    label: string;
+    value: number | string | null;
+    unit?: CeoMetricUnit;
+  }>;
+  periodStart: string;
+  periodEnd: string;
+  asOf: string;
+  computedAt: string;
+  trust: CeoMetricTrust;
+  lineage: Array<{
+    sourceKey: string;
+    sourceId: string | null;
+    capturedAt: string | null;
+  }>;
+}
+
+export interface CeoReadinessGate {
+  metricKey: string;
+  label: string;
+  reason: string;
+}
+
+export interface CeoReadiness {
+  status: "board_ready" | "not_board_final";
+  ready: boolean;
+  summary: string;
+  failingGates: CeoReadinessGate[];
+}
+
+export interface CeoReportPackSection {
+  title: string;
+  metricKeys: string[];
+}
+
+export interface CeoReportPack {
+  slug: string;
+  name: string;
+  description: string;
+  cadence: "weekly" | "monthly" | "quarterly" | "ad_hoc";
+  audience: "CEO" | "BOARD" | "TEAM" | "INVESTOR";
+  metricKeys: string[];
+  sections: CeoReportPackSection[];
+}
+
+export interface CeoReportRun {
+  packSlug: string;
+  packName: string;
+  generatedAt: string;
+  metrics: CeoMetricValue[];
+  deterministicNotes: string[];
+  markdown: string;
+  csv: string;
+  slideJson: {
+    title: string;
+    generatedAt: string;
+    readiness: CeoReadiness;
+    sections: Array<{
+      title: string;
+      metrics: Array<{
+        key: string;
+        label: string;
+        value: number | string | null;
+        priorValue: number | string | null;
+        delta: number | null;
+        unit: CeoMetricUnit;
+        trust: CeoMetricTrustStatus;
+        asOf: string;
+        warnings: string[];
+        details?: CeoMetricValue["details"];
+      }>;
+    }>;
+    notes: string[];
+  };
+}
+
+const CALCULATION_VERSION = "ceo-metric-trust-v1";
+const BOARD_GRADE_CORE_KEYS = new Set<string>([
+  "ceo.flow_reliability_score",
+  "ceo.throughput_30d",
+  "ceo.overdue_open_tasks",
+  "finance.cash_balance",
+  "finance.mrr",
+  "sales.open_pipeline_value",
+  "retention.at_risk_accounts",
+  "customer_success.support_load",
+  "website.sessions",
+  "social.paid_spend",
+]);
+
+const CORE_METRICS: CeoMetricDefinition[] = [
+  {
+    key: "ceo.flow_reliability_score",
+    label: "Internal Execution Reliability",
+    domain: "ceo",
+    ownerAudience: "CEO",
+    unit: "score",
+    calculationVersion: CALCULATION_VERSION,
+    sourceDependencies: ["wipguard"],
+    freshnessSlaHours: 1,
+    boardEligible: true,
+    weeklyEligible: true,
+    description: "Composite legacy internal execution reliability score from overdue, stale, blocker, throughput, and work-in-progress signals.",
+  },
+  {
+    key: "ceo.throughput_30d",
+    label: "Internal Execution Throughput 30d",
+    domain: "ceo",
+    ownerAudience: "TEAM",
+    unit: "count",
+    calculationVersion: CALCULATION_VERSION,
+    sourceDependencies: ["wipguard"],
+    freshnessSlaHours: 1,
+    boardEligible: true,
+    weeklyEligible: true,
+    description: "Completed legacy internal execution items over the trailing 30 days.",
+  },
+  {
+    key: "ceo.overdue_open_tasks",
+    label: "Legacy Open Execution Items",
+    domain: "ceo",
+    ownerAudience: "TEAM",
+    unit: "count",
+    calculationVersion: CALCULATION_VERSION,
+    sourceDependencies: ["wipguard"],
+    freshnessSlaHours: 1,
+    boardEligible: true,
+    weeklyEligible: true,
+    description: "Open legacy internal execution items past their expected date.",
+  },
+  {
+    key: "finance.cash_balance",
+    label: "Cash Balance",
+    domain: "finance",
+    ownerAudience: "BOARD",
+    unit: "currency",
+    calculationVersion: CALCULATION_VERSION,
+    sourceDependencies: ["mercury"],
+    freshnessSlaHours: 24,
+    boardEligible: true,
+    weeklyEligible: true,
+    description: "Latest cash balance from financial source systems.",
+  },
+  {
+    key: "finance.mrr",
+    label: "MRR",
+    domain: "finance",
+    ownerAudience: "BOARD",
+    unit: "currency",
+    calculationVersion: CALCULATION_VERSION,
+    sourceDependencies: ["stripe", "hubspot"],
+    freshnessSlaHours: 24,
+    boardEligible: true,
+    weeklyEligible: true,
+    description: "Current monthly recurring revenue from Stripe plus unmatched HubSpot subscription deals.",
+  },
+  {
+    key: "sales.open_pipeline_value",
+    label: "Open Pipeline Value",
+    domain: "sales-pipeline",
+    ownerAudience: "BOARD",
+    unit: "currency",
+    calculationVersion: CALCULATION_VERSION,
+    sourceDependencies: ["hubspot"],
+    freshnessSlaHours: 6,
+    boardEligible: true,
+    weeklyEligible: true,
+    description: "Total value of open sales pipeline.",
+  },
+  {
+    key: "retention.at_risk_accounts",
+    label: "At-Risk Accounts",
+    domain: "retention",
+    ownerAudience: "CEO",
+    unit: "count",
+    calculationVersion: CALCULATION_VERSION,
+    sourceDependencies: ["retention"],
+    freshnessSlaHours: 24,
+    boardEligible: true,
+    weeklyEligible: true,
+    description: "Current accounts classified as retention risk.",
+  },
+  {
+    key: "customer_success.support_load",
+    label: "Support Load",
+    domain: "customer-success",
+    ownerAudience: "TEAM",
+    unit: "count",
+    calculationVersion: CALCULATION_VERSION,
+    sourceDependencies: ["pylon"],
+    freshnessSlaHours: 6,
+    boardEligible: true,
+    weeklyEligible: true,
+    description: "Open customer-support workload from customer-success systems.",
+  },
+  {
+    key: "website.sessions",
+    label: "Website Sessions",
+    domain: "website-traffic",
+    ownerAudience: "CEO",
+    unit: "count",
+    calculationVersion: CALCULATION_VERSION,
+    sourceDependencies: ["googleAnalytics", "webflow"],
+    freshnessSlaHours: 24,
+    boardEligible: true,
+    weeklyEligible: true,
+    description: "Top-of-funnel website traffic from analytics and site systems.",
+  },
+  {
+    key: "social.paid_spend",
+    label: "Paid Media Spend",
+    domain: "social-media",
+    ownerAudience: "CEO",
+    unit: "currency",
+    calculationVersion: CALCULATION_VERSION,
+    sourceDependencies: ["googleAds", "metaAds", "redditAds"],
+    freshnessSlaHours: 24,
+    boardEligible: true,
+    weeklyEligible: true,
+    description: "Paid acquisition spend across connected ad platforms.",
+  },
+];
+
+function toIso(value: string | Date | null | undefined): string | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function hoursBetween(fromIso: string | null, to: Date): number | null {
+  if (!fromIso) return null;
+  const from = new Date(fromIso);
+  if (Number.isNaN(from.getTime())) return null;
+  return Math.max(0, (to.getTime() - from.getTime()) / (60 * 60 * 1000));
+}
+
+function sourceKeyForPrimary(primaryId: AnalyticsPrimarySectionId): string[] {
+  const boardGradeSources: Partial<Record<AnalyticsPrimarySectionId, string[]>> = {
+    "website-traffic": ["googleAnalytics", "webflow"],
+    "social-media": ["googleAds", "metaAds", "redditAds"],
+    finance: ["mercury", "stripe", "hubspot"],
+    "sales-pipeline": ["hubspot"],
+    retention: ["retention"],
+    "customer-success": ["pylon", "googleWorkspace", "slack"],
+    "customer-journey": ["customerJourney"],
+    "demo-analytics": ["demoAnalytics"],
+    "process-analytics": ["processAnalytics"],
+  };
+  if (boardGradeSources[primaryId]) {
+    return boardGradeSources[primaryId];
+  }
+
+  const keys = ANALYTICS_SUB_SECTIONS.filter((section) => section.parentId === primaryId).map(
+    (section) => section.dataDomain
+  );
+  return Array.from(new Set(keys.length > 0 ? keys : [primaryId]));
+}
+
+export function getDefaultCeoMetricDefinitions(): CeoMetricDefinition[] {
+  const domainDefinitions = ANALYTICS_PRIMARY_SECTIONS.map((section) => ({
+    key: `domain.${section.id}.health`,
+    label: `${section.label} Health`,
+    domain: section.id,
+    ownerAudience: "CEO" as const,
+    unit: "score" as const,
+    calculationVersion: CALCULATION_VERSION,
+    sourceDependencies: sourceKeyForPrimary(section.id),
+    freshnessSlaHours: section.id === "process-analytics" ? 1 : 24,
+    boardEligible: true,
+    weeklyEligible: true,
+    description: `Trust-weighted health metric for ${section.description.toLowerCase()}`,
+  }));
+
+  const subSectionDefinitions = ANALYTICS_SUB_SECTIONS.map((section) => ({
+    key: `source.${section.id}.health`,
+    label: `${section.label} Source Health`,
+    domain: section.parentId,
+    ownerAudience: "CEO" as const,
+    unit: "score" as const,
+    calculationVersion: CALCULATION_VERSION,
+    sourceDependencies: [section.dataDomain],
+    freshnessSlaHours: section.parentId === "process-analytics" ? 1 : 24,
+    boardEligible: false,
+    weeklyEligible: false,
+    description: `Trust state for the ${section.label} source used by CEO reports.`,
+  }));
+
+  return [...CORE_METRICS, ...domainDefinitions, ...subSectionDefinitions].sort((a, b) =>
+    a.key.localeCompare(b.key)
+  );
+}
+
+export function getDefaultBoardGradeMetricKeys(
+  definitions = getDefaultCeoMetricDefinitions()
+): Set<string> {
+  return new Set(
+    definitions
+      .filter((definition) => BOARD_GRADE_CORE_KEYS.has(definition.key) || definition.key.startsWith("domain."))
+      .map((definition) => definition.key)
+  );
+}
+
+export function evaluateMetricTrust(input: {
+  asOf: Date;
+  freshnessSlaHours: number;
+  requiredSourceKeys: string[];
+  sources: CeoSourceSample[];
+}): CeoMetricTrust {
+  const required = Array.from(new Set(input.requiredSourceKeys));
+  const warnings: string[] = [];
+  const sourceStates: CeoMetricSourceState[] = [];
+
+  for (const key of required) {
+    const candidates = input.sources
+      .filter((source) => source.sourceKey === key)
+      .sort((a, b) => {
+        const aTime = toIso(a.capturedAt) ? new Date(toIso(a.capturedAt)!).getTime() : 0;
+        const bTime = toIso(b.capturedAt) ? new Date(toIso(b.capturedAt)!).getTime() : 0;
+        return bTime - aTime;
+      });
+    const latest = candidates[0] ?? null;
+    const capturedAt = toIso(latest?.capturedAt);
+    const expiresAt = toIso(latest?.expiresAt);
+    const ageHours = hoursBetween(capturedAt, input.asOf);
+    const fresh =
+      latest?.status === "SUCCESS" &&
+      ageHours !== null &&
+      ageHours <= input.freshnessSlaHours &&
+      (!expiresAt || new Date(expiresAt).getTime() >= input.asOf.getTime());
+
+    sourceStates.push({
+      sourceKey: key,
+      sourceId: latest?.sourceId ?? null,
+      status: latest?.status ?? "MISSING",
+      capturedAt,
+      expiresAt,
+      ageHours,
+      fresh,
+      lastError: latest?.lastError ?? null,
+    });
+  }
+
+  const missing = sourceStates.filter((state) => state.status === "MISSING");
+  const errored = sourceStates.filter((state) => state.status === "ERROR");
+  const partial = sourceStates.filter((state) => state.status === "PARTIAL");
+  const successful = sourceStates.filter((state) => state.status === "SUCCESS");
+  const stale = successful.filter((state) => !state.fresh);
+
+  for (const state of missing) {
+    warnings.push(`Required source ${state.sourceKey} is missing.`);
+  }
+  for (const state of errored) {
+    warnings.push(
+      `Required source ${state.sourceKey} errored${state.lastError ? `: ${state.lastError}` : "."}`
+    );
+  }
+  for (const state of partial) {
+    warnings.push(`Required source ${state.sourceKey} is partial.`);
+  }
+  for (const state of stale) {
+    warnings.push(`Required source ${state.sourceKey} is stale.`);
+  }
+
+  let status: CeoMetricTrustStatus = "fresh";
+  if (successful.length === 0 && errored.length > 0) {
+    status = "error";
+  } else if (successful.length === 0) {
+    status = "missing";
+  } else if (missing.length > 0 || errored.length > 0 || partial.length > 0) {
+    status = "partial";
+  } else if (stale.length > 0) {
+    status = "stale";
+  }
+
+  const confidenceByStatus: Record<CeoMetricTrustStatus, number> = {
+    fresh: 1,
+    stale: 0.7,
+    partial: 0.55,
+    missing: 0,
+    error: 0,
+    conflicted: 0.35,
+  };
+
+  return {
+    status,
+    confidence: confidenceByStatus[status],
+    warnings,
+    sourceStates,
+  };
+}
+
+export function buildDefaultCeoReportPacks(definitions = getDefaultCeoMetricDefinitions()): CeoReportPack[] {
+  const available = new Set(definitions.map((definition) => definition.key));
+  const boardGradeKeys = getDefaultBoardGradeMetricKeys(definitions);
+  const pick = (keys: string[]) => keys.filter((key) => available.has(key));
+
+  const weeklyKeys = pick([
+    "ceo.flow_reliability_score",
+    "ceo.throughput_30d",
+    "ceo.overdue_open_tasks",
+    "sales.open_pipeline_value",
+    "finance.cash_balance",
+    "finance.mrr",
+    "retention.at_risk_accounts",
+    "domain.social-media.health",
+    "domain.website-traffic.health",
+  ]);
+  const boardKeys = pick([
+    "finance.cash_balance",
+    "finance.mrr",
+    "sales.open_pipeline_value",
+    "retention.at_risk_accounts",
+    "ceo.flow_reliability_score",
+    "domain.customer-journey.health",
+    "domain.demo-analytics.health",
+    "domain.customer-success.health",
+  ]);
+  const investorKeys = pick([
+    "finance.mrr",
+    "sales.open_pipeline_value",
+    "website.sessions",
+    "social.paid_spend",
+    "ceo.throughput_30d",
+    "domain.retention.health",
+  ]);
+  const customKeys = definitions
+    .filter((definition) => definition.boardEligible && boardGradeKeys.has(definition.key))
+    .map((definition) => definition.key);
+
+  return [
+    {
+      slug: "weekly-exec",
+      name: "Weekly Exec",
+      description: "Recurring weekly operating review for the CEO and leadership team.",
+      cadence: "weekly",
+      audience: "TEAM",
+      metricKeys: weeklyKeys,
+      sections: [
+        { title: "Internal Execution", metricKeys: pick(["ceo.flow_reliability_score", "ceo.throughput_30d", "ceo.overdue_open_tasks"]) },
+        { title: "Revenue", metricKeys: pick(["sales.open_pipeline_value", "finance.mrr", "finance.cash_balance"]) },
+        { title: "Growth and Retention", metricKeys: pick(["retention.at_risk_accounts", "domain.social-media.health", "domain.website-traffic.health"]) },
+      ],
+    },
+    {
+      slug: "board-meeting",
+      name: "Board Meeting",
+      description: "Board-ready monthly or quarterly operating snapshot with metric trust labels.",
+      cadence: "quarterly",
+      audience: "BOARD",
+      metricKeys: boardKeys,
+      sections: [
+        { title: "Financials", metricKeys: pick(["finance.cash_balance", "finance.mrr"]) },
+        { title: "Revenue and Retention", metricKeys: pick(["sales.open_pipeline_value", "retention.at_risk_accounts"]) },
+        { title: "Operational Signals", metricKeys: pick(["ceo.flow_reliability_score", "domain.customer-journey.health", "domain.demo-analytics.health", "domain.customer-success.health"]) },
+      ],
+    },
+    {
+      slug: "investor-update",
+      name: "Investor Update",
+      description: "Concise investor update metric pack for recurring stakeholder communication.",
+      cadence: "monthly",
+      audience: "INVESTOR",
+      metricKeys: investorKeys,
+      sections: [
+        { title: "Traction", metricKeys: pick(["finance.mrr", "sales.open_pipeline_value", "website.sessions"]) },
+        { title: "Efficiency", metricKeys: pick(["social.paid_spend", "ceo.throughput_30d", "domain.retention.health"]) },
+      ],
+    },
+    {
+      slug: "custom-metric-snapshot",
+      name: "Custom Metric Snapshot",
+      description: "Ad hoc metric snapshot across all board-eligible CEO metrics.",
+      cadence: "ad_hoc",
+      audience: "CEO",
+      metricKeys: customKeys,
+      sections: [{ title: "Selected Metrics", metricKeys: customKeys }],
+    },
+  ];
+}
+
+export function computeCeoReadiness(input: {
+  reportPacks: CeoReportPack[];
+  metrics: CeoMetricValue[];
+  verifiedMetricKeys: Set<string>;
+}): CeoReadiness {
+  const metricByKey = new Map(input.metrics.map((metric) => [metric.definition.key, metric]));
+  const requiredKeys = Array.from(new Set(input.reportPacks.flatMap((pack) => pack.metricKeys)));
+  const failingGates: CeoReadinessGate[] = [];
+
+  for (const key of requiredKeys) {
+    const metric = metricByKey.get(key);
+    const label = metric?.definition.label ?? key;
+    if (!metric) {
+      failingGates.push({ metricKey: key, label, reason: "Metric is missing from the CEO snapshot." });
+      continue;
+    }
+    if (!input.verifiedMetricKeys.has(key)) {
+      failingGates.push({ metricKey: key, label, reason: "Metric calculator has not been verified for board use." });
+    }
+    if (metric.value === null || metric.value === undefined || metric.value === "") {
+      failingGates.push({ metricKey: key, label, reason: "Metric value is unavailable." });
+    }
+    if (metric.trust.status !== "fresh") {
+      failingGates.push({ metricKey: key, label, reason: `Metric source trust is ${metric.trust.status}.` });
+    }
+    if (metric.lineage.length === 0) {
+      failingGates.push({ metricKey: key, label, reason: "Metric has no source lineage citation." });
+    }
+  }
+
+  if (failingGates.length === 0) {
+    return {
+      status: "board_ready",
+      ready: true,
+      summary: "Board-ready: all required metrics have verified calculators, fresh sources, values, and lineage.",
+      failingGates,
+    };
+  }
+
+  return {
+    status: "not_board_final",
+    ready: false,
+    summary: `Not board-final: ${failingGates.length} readiness gate${failingGates.length === 1 ? " is" : "s are"} failing.`,
+    failingGates,
+  };
+}
+
+function formatValue(value: number | string | null): string {
+  if (value === null || value === undefined) return "";
+  return String(value);
+}
+
+function formatMetricDetails(metric: CeoMetricValue): string {
+  if (!metric.details || metric.details.length === 0) return "";
+  return metric.details
+    .map((detail) => `${detail.label}: ${formatValue(detail.value)}`)
+    .join("; ");
+}
+
+function csvCell(value: number | string | null): string {
+  const raw = formatValue(value);
+  if (!/[",\n]/.test(raw)) return raw;
+  return `"${raw.replaceAll('"', '""')}"`;
+}
+
+function buildDeterministicNotes(metrics: CeoMetricValue[]): string[] {
+  const notes: string[] = [];
+  const weakMetrics = metrics.filter((metric) => metric.trust.status !== "fresh");
+  if (weakMetrics.length > 0) {
+    notes.push(`${weakMetrics.length} metric(s) are stale, partial, missing, errored, or conflicted.`);
+  }
+
+  for (const metric of metrics) {
+    if (typeof metric.delta !== "number" || metric.delta === 0) continue;
+    const direction = metric.delta > 0 ? "increased" : "decreased";
+    notes.push(`${metric.definition.label} ${direction} by ${Math.abs(metric.delta)} versus the prior period.`);
+  }
+
+  if (notes.length === 0) {
+    notes.push("No material metric variances were detected.");
+  }
+  return notes;
+}
+
+export function buildMetricReportRun(input: {
+  pack: CeoReportPack;
+  metrics: CeoMetricValue[];
+  generatedAt?: string;
+  readiness?: CeoReadiness;
+}): CeoReportRun {
+  const generatedAt = input.generatedAt ?? new Date().toISOString();
+  const metricByKey = new Map(input.metrics.map((metric) => [metric.definition.key, metric]));
+  const orderedMetrics = input.pack.metricKeys
+    .map((key) => metricByKey.get(key))
+    .filter((metric): metric is CeoMetricValue => Boolean(metric));
+  const deterministicNotes = buildDeterministicNotes(orderedMetrics);
+  const readiness = input.readiness ?? {
+    status: "board_ready" as const,
+    ready: true,
+    summary: "Board-ready: readiness was not constrained by an external gate.",
+    failingGates: [],
+  };
+
+  const markdownLines = [
+    `# ${input.pack.name}`,
+    "",
+    `Generated: ${generatedAt}`,
+    "",
+    "## Board Readiness",
+    readiness.summary,
+    ...(readiness.failingGates.length > 0
+      ? ["", ...readiness.failingGates.map((gate) => `- ${gate.label}: ${gate.reason}`)]
+      : []),
+    "",
+    "| Metric | Value | Prior | Delta | Trust | As Of | Sources | Details |",
+    "| --- | ---: | ---: | ---: | --- | --- | --- | --- |",
+    ...orderedMetrics.map((metric) =>
+      [
+        metric.definition.label,
+        formatValue(metric.value),
+        formatValue(metric.priorValue),
+        formatValue(metric.delta),
+        metric.trust.status,
+        metric.asOf,
+        metric.lineage.map((lineage) => lineage.sourceKey).join("; "),
+        formatMetricDetails(metric),
+      ]
+        .map((value) => String(value).replaceAll("|", "\\|"))
+        .join(" | ")
+        .replace(/^/, "| ")
+        .replace(/$/, " |")
+    ),
+    "",
+    "## Deterministic Notes",
+    ...deterministicNotes.map((note) => `- ${note}`),
+  ];
+
+  const csvRows = [
+    ["Readiness Status", readiness.status],
+    ["Readiness Summary", readiness.summary],
+    ...readiness.failingGates.map((gate) => [
+      "Readiness Gate",
+      `${gate.metricKey}: ${gate.reason}`,
+    ]),
+    [],
+    ["Metric", "Value", "Prior Value", "Delta", "Trust", "As Of", "Sources", "Details"],
+    ...orderedMetrics.map((metric) => [
+      metric.definition.label,
+      formatValue(metric.value),
+      formatValue(metric.priorValue),
+      formatValue(metric.delta),
+      metric.trust.status,
+      metric.asOf,
+      metric.lineage.map((lineage) => lineage.sourceKey).join("; "),
+      formatMetricDetails(metric),
+    ]),
+  ];
+
+  const sections = input.pack.sections.map((section) => ({
+    title: section.title,
+    metrics: section.metricKeys
+      .map((key) => metricByKey.get(key))
+      .filter((metric): metric is CeoMetricValue => Boolean(metric))
+      .map((metric) => ({
+        key: metric.definition.key,
+        label: metric.definition.label,
+        value: metric.value,
+        priorValue: metric.priorValue,
+        delta: metric.delta,
+        unit: metric.definition.unit,
+        trust: metric.trust.status,
+        asOf: metric.asOf,
+        warnings: metric.trust.warnings,
+        details: metric.details,
+      })),
+  }));
+
+  return {
+    packSlug: input.pack.slug,
+    packName: input.pack.name,
+    generatedAt,
+    metrics: orderedMetrics,
+    deterministicNotes,
+    markdown: markdownLines.join("\n"),
+    csv: csvRows.map((row) => row.map(csvCell).join(",")).join("\n"),
+    slideJson: {
+      title: input.pack.name,
+      generatedAt,
+      readiness,
+      sections,
+      notes: deterministicNotes,
+    },
+  };
+}

--- a/src/lib/ceo/service.test.ts
+++ b/src/lib/ceo/service.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AnalyticsSnapshotStatus } from "@/generated/prisma/client";
+import { loadCeoMetricSnapshot } from "@/lib/ceo/service";
+import { computeDecisionDashboard } from "@/lib/analytics/decision-dashboard";
+import { prisma } from "@/lib/prisma";
+
+vi.mock("@/lib/analytics/decision-dashboard", () => ({
+  computeDecisionDashboard: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    analyticsSnapshot: {
+      findMany: vi.fn(),
+    },
+    ceoMetricDefinition: {
+      upsert: vi.fn(),
+    },
+    ceoMetricValueSnapshot: {
+      create: vi.fn(),
+    },
+    ceoMetricSourceLineage: {
+      createMany: vi.fn(),
+    },
+    retentionTenantCurrent: {
+      count: vi.fn(),
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+function snapshot(providerKey: string, payload: unknown) {
+  return {
+    id: `${providerKey}-snapshot`,
+    providerKey,
+    status: AnalyticsSnapshotStatus.SUCCESS,
+    capturedAt: new Date("2026-05-01T11:30:00.000Z"),
+    expiresAt: new Date("2026-05-02T11:30:00.000Z"),
+    lastError: null,
+    payload,
+  };
+}
+
+describe("loadCeoMetricSnapshot", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(prisma.ceoMetricDefinition.upsert).mockImplementation(((input: { where: { key: string } }) =>
+      Promise.resolve({
+        id: `definition-${input.where.key}`,
+        key: input.where.key,
+      })) as never);
+    vi.mocked(computeDecisionDashboard).mockResolvedValue({
+      asOf: "2026-05-01T12:00:00.000Z",
+      northStar: {
+        flowReliabilityScore: 87,
+        throughput30d: 12,
+        throughputTrendPct: 25,
+      },
+      supportingMetrics: {
+        overdueOpenTasks: 3,
+      },
+    } as never);
+    vi.mocked(prisma.retentionTenantCurrent.count).mockResolvedValue(4 as never);
+    vi.mocked(prisma.retentionTenantCurrent.findFirst).mockResolvedValue({
+      id: "retention-current-1",
+      lastMaterializedAt: new Date("2026-05-01T11:30:00.000Z"),
+      updatedAt: new Date("2026-05-01T11:30:00.000Z"),
+    } as never);
+  });
+
+  it("computes every default-pack core metric through explicit calculators with lineage", async () => {
+    vi.mocked(prisma.analyticsSnapshot.findMany).mockResolvedValue([
+      snapshot("mercury", {
+        cashFlow: {
+          bankCash: 23456,
+          treasuryCash: 100000,
+          totalCash: 123456,
+          totalBalance: 123456,
+        },
+      }),
+      snapshot("stripe", {
+        revenue: { mrr: 20000, mrrChange: 1500 },
+        subscriptions: {
+          active: 1,
+          activeCustomerRefs: [{ customerId: "cus_linked", email: "finance@example.com", emailDomain: "example.com" }],
+        },
+      }),
+      snapshot("hubspot", {
+        repScoreboard: [{ totalPipeline: 90000 }, { totalPipeline: 10000 }],
+        subscriptionDeals: [
+          {
+            dealId: "hs-only",
+            dealName: "HubSpot Only",
+            stageLabel: "Subscriptions",
+            amount: 5000,
+            stripeCustomerId: null,
+            primaryContactEmail: "ops@example-subscription.com",
+          },
+          {
+            dealId: "hs-linked",
+            dealName: "HubSpot Linked",
+            stageLabel: "Subscriptions",
+            amount: 3000,
+            stripeCustomerId: "cus_linked",
+            primaryContactEmail: "finance@example.com",
+          },
+        ],
+      }),
+      snapshot("pylon", { openIssues: 7 }),
+      snapshot("googleAnalytics", { sessions30d: 5432 }),
+      snapshot("webflow", { site: "connected" }),
+      snapshot("googleAds", { totalSpend30d: 400 }),
+      snapshot("metaAds", { totalSpend30d: 700 }),
+      snapshot("redditAds", { totalSpend30d: 200 }),
+      snapshot("googleWorkspace", { enabledRules: 4 }),
+      snapshot("slack", { enabledRules: 4 }),
+    ] as never);
+
+    const payload = await loadCeoMetricSnapshot({
+      userId: "user-1",
+      organizationId: "org-1",
+      persist: false,
+    });
+
+    const metricByKey = new Map(payload.metrics.map((metric) => [metric.definition.key, metric]));
+    expect(metricByKey.get("ceo.flow_reliability_score")?.value).toBe(87);
+    expect(metricByKey.get("ceo.flow_reliability_score")?.lineage[0]?.sourceKey).toBe("wipguard");
+    expect(metricByKey.get("ceo.throughput_30d")?.value).toBe(12);
+    expect(metricByKey.get("ceo.throughput_30d")?.delta).toBe(25);
+    expect(metricByKey.get("ceo.overdue_open_tasks")?.value).toBe(3);
+    expect(metricByKey.get("finance.cash_balance")?.value).toBe(123456);
+    expect(metricByKey.get("finance.cash_balance")?.details).toEqual([
+      { key: "bankCash", label: "Bank cash", value: 23456, unit: "currency" },
+      { key: "treasuryCash", label: "Treasury cash", value: 100000, unit: "currency" },
+      { key: "totalCash", label: "Total cash", value: 123456, unit: "currency" },
+    ]);
+    expect(metricByKey.get("finance.mrr")?.value).toBe(25000);
+    expect(metricByKey.get("finance.mrr")?.delta).toBe(1500);
+    expect(metricByKey.get("finance.mrr")?.details).toEqual([
+      { key: "stripeMrr", label: "Stripe MRR", value: 20000, unit: "currency" },
+      { key: "hubspotOnlySubscriptionMrr", label: "HubSpot-only subscription MRR", value: 5000, unit: "currency" },
+      {
+        key: "excludedLinkedHubspotSubscriptionMrr",
+        label: "Linked HubSpot subscription MRR excluded",
+        value: 3000,
+        unit: "currency",
+      },
+      { key: "totalMrr", label: "Total MRR", value: 25000, unit: "currency" },
+    ]);
+    expect(metricByKey.get("sales.open_pipeline_value")?.value).toBe(100000);
+    expect(metricByKey.get("retention.at_risk_accounts")?.value).toBe(4);
+    expect(metricByKey.get("customer_success.support_load")?.value).toBe(7);
+    expect(metricByKey.get("website.sessions")?.value).toBe(5432);
+    expect(metricByKey.get("social.paid_spend")?.value).toBe(1300);
+    expect(payload.readiness.status).toBe("board_ready");
+    expect(payload.reportPacks.map((pack) => pack.slug)).toEqual([
+      "weekly-exec",
+      "board-meeting",
+      "investor-update",
+      "custom-metric-snapshot",
+    ]);
+  });
+});

--- a/src/lib/ceo/service.ts
+++ b/src/lib/ceo/service.ts
@@ -1,0 +1,760 @@
+import { AnalyticsSnapshotStatus, Prisma, RetentionTenantStatus } from "@/generated/prisma/client";
+import { computeDecisionDashboard } from "@/lib/analytics/decision-dashboard";
+import { buildSubscriptionMrrBreakdown } from "@/lib/analytics/subscription-mrr";
+import { prisma } from "@/lib/prisma";
+import {
+  buildDefaultCeoReportPacks,
+  buildMetricReportRun,
+  computeCeoReadiness,
+  evaluateMetricTrust,
+  getDefaultCeoMetricDefinitions,
+  getDefaultBoardGradeMetricKeys,
+  type CeoMetricDefinition,
+  type CeoReadiness,
+  type CeoMetricTrustStatus,
+  type CeoMetricValue,
+  type CeoReportPack,
+  type CeoReportRun,
+  type CeoSourceSample,
+} from "@/lib/ceo/metric-trust";
+
+export interface CeoMetricSnapshotPayload {
+  generatedAt: string;
+  periodStart: string;
+  periodEnd: string;
+  definitions: CeoMetricDefinition[];
+  metrics: CeoMetricValue[];
+  reportPacks: CeoReportPack[];
+  trustSummary: Record<CeoMetricTrustStatus, number>;
+  readiness: CeoReadiness;
+}
+
+export interface CreateCeoReportRunResult extends CeoReportRun {
+  id: string | null;
+}
+
+const TRUST_SUMMARY_KEYS: CeoMetricTrustStatus[] = [
+  "fresh",
+  "stale",
+  "partial",
+  "missing",
+  "error",
+  "conflicted",
+];
+
+type AnalyticsSnapshotSample = {
+  id: string;
+  providerKey: string;
+  status: AnalyticsSnapshotStatus;
+  capturedAt: Date;
+  expiresAt: Date;
+  lastError: string | null;
+  payload: Prisma.JsonValue | null;
+};
+
+type MetricCalculatorInput = {
+  definition: CeoMetricDefinition;
+  decisionDashboard: Awaited<ReturnType<typeof computeDecisionDashboard>>;
+  latestSnapshots: Map<string, AnalyticsSnapshotSample>;
+  retentionMetric: RetentionMetricSource;
+  sourceSamples: CeoSourceSample[];
+  asOf: Date;
+};
+
+type MetricCalculation = {
+  value: number | string | null;
+  priorValue: number | string | null;
+  delta: number | null;
+  details?: CeoMetricValue["details"];
+};
+
+type CeoMetricCalculator = (input: MetricCalculatorInput) => MetricCalculation;
+
+type RetentionMetricSource = {
+  atRiskAccounts: number | null;
+  source: CeoSourceSample;
+};
+
+function toPrismaJson(value: unknown): Prisma.InputJsonValue {
+  if (value === null || value === undefined) return Prisma.JsonNull as unknown as Prisma.InputJsonValue;
+  return JSON.parse(JSON.stringify(value)) as Prisma.InputJsonValue;
+}
+
+function metricUnitToDb(unit: CeoMetricDefinition["unit"]) {
+  return unit.toUpperCase() as Uppercase<CeoMetricDefinition["unit"]>;
+}
+
+function metricTrustToDb(status: CeoMetricTrustStatus) {
+  return status.toUpperCase() as Uppercase<CeoMetricTrustStatus>;
+}
+
+function audienceToDb(audience: CeoMetricDefinition["ownerAudience"] | CeoReportPack["audience"]) {
+  return audience;
+}
+
+function sourceSampleFromSnapshot(snapshot: AnalyticsSnapshotSample): CeoSourceSample {
+  return {
+    sourceKey: snapshot.providerKey,
+    sourceId: snapshot.id,
+    status: snapshot.status === AnalyticsSnapshotStatus.SUCCESS ? "SUCCESS" : "ERROR",
+    capturedAt: snapshot.capturedAt,
+    expiresAt: snapshot.expiresAt,
+    lastError: snapshot.lastError,
+  };
+}
+
+function latestSnapshotByProvider(snapshots: AnalyticsSnapshotSample[]): Map<string, AnalyticsSnapshotSample> {
+  const latest = new Map<string, AnalyticsSnapshotSample>();
+  for (const snapshot of snapshots) {
+    const existing = latest.get(snapshot.providerKey);
+    if (!existing || snapshot.capturedAt > existing.capturedAt) {
+      latest.set(snapshot.providerKey, snapshot);
+    }
+  }
+  return latest;
+}
+
+function decisionDashboardSourceSample(
+  dashboard: Awaited<ReturnType<typeof computeDecisionDashboard>>
+): CeoSourceSample {
+  const capturedAt = new Date(dashboard.asOf);
+  return {
+    sourceKey: "wipguard",
+    sourceId: "decision-dashboard",
+    status: "SUCCESS",
+    capturedAt,
+    expiresAt: new Date(capturedAt.getTime() + 60 * 60 * 1000),
+  };
+}
+
+function getPathNumber(payload: unknown, path: string[]): number | null {
+  let current = payload;
+  for (const key of path) {
+    if (!current || typeof current !== "object" || Array.isArray(current)) return null;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return typeof current === "number" && Number.isFinite(current) ? current : null;
+}
+
+function getFirstNumber(payload: unknown, paths: string[][]): number | null {
+  for (const path of paths) {
+    const value = getPathNumber(payload, path);
+    if (value !== null) return value;
+  }
+  return null;
+}
+
+function getPathArray(payload: unknown, path: string[]): unknown[] {
+  let current = payload;
+  for (const key of path) {
+    if (!current || typeof current !== "object" || Array.isArray(current)) return [];
+    current = (current as Record<string, unknown>)[key];
+  }
+  return Array.isArray(current) ? current : [];
+}
+
+function sumArrayNumber(payload: unknown, path: string[], key: string): number | null {
+  const values = getPathArray(payload, path)
+    .map((item) => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) return null;
+      const value = (item as Record<string, unknown>)[key];
+      return typeof value === "number" && Number.isFinite(value) ? value : null;
+    })
+    .filter((value): value is number => value !== null);
+  if (values.length === 0) return null;
+  return values.reduce((sum, value) => sum + value, 0);
+}
+
+function cashBreakdownFromMercury(payload: unknown): {
+  bankCash: number | null;
+  treasuryCash: number | null;
+  totalCash: number | null;
+} {
+  const bankCashFromPayload = getFirstNumber(payload, [["cashFlow", "bankCash"], ["bankCash"]]);
+  const treasuryCashFromPayload = getFirstNumber(payload, [["cashFlow", "treasuryCash"], ["treasuryCash"]]);
+  const totalCashFromPayload = getFirstNumber(payload, [
+    ["cashFlow", "totalCash"],
+    ["cashFlow", "totalBalance"],
+    ["totalCash"],
+    ["totalBalance"],
+    ["cashBalance"],
+  ]);
+  const accounts = getPathArray(payload, ["accounts"]);
+  const accountTotals = accounts.reduce<{
+    bankCash: number;
+    treasuryCash: number;
+    hasAccounts: boolean;
+  }>(
+    (totals, account) => {
+      if (!account || typeof account !== "object" || Array.isArray(account)) return totals;
+      const record = account as Record<string, unknown>;
+      const balance = record.balance;
+      if (typeof balance !== "number" || !Number.isFinite(balance)) return totals;
+      const type = typeof record.type === "string" ? record.type.toLowerCase() : "";
+      if (type === "treasury") totals.treasuryCash += balance;
+      else totals.bankCash += balance;
+      totals.hasAccounts = true;
+      return totals;
+    },
+    { bankCash: 0, treasuryCash: 0, hasAccounts: false }
+  );
+  const bankCash = bankCashFromPayload ?? (accountTotals.hasAccounts ? accountTotals.bankCash : null);
+  const treasuryCash =
+    treasuryCashFromPayload ?? (accountTotals.hasAccounts ? accountTotals.treasuryCash : null);
+  const totalCash = totalCashFromPayload ?? (
+    bankCash !== null || treasuryCash !== null ? (bankCash ?? 0) + (treasuryCash ?? 0) : null
+  );
+
+  return { bankCash, treasuryCash, totalCash };
+}
+
+function derivedSourceSample(input: {
+  sourceKey: string;
+  sourceId: string;
+  asOf: Date;
+  freshnessSlaHours: number;
+  requiredSourceKeys: string[];
+  sources: CeoSourceSample[];
+}): CeoSourceSample {
+  const trust = evaluateMetricTrust({
+    asOf: input.asOf,
+    freshnessSlaHours: input.freshnessSlaHours,
+    requiredSourceKeys: input.requiredSourceKeys,
+    sources: input.sources,
+  });
+  const citedStates = trust.sourceStates.filter((state) => state.sourceId || state.capturedAt);
+  if (trust.status !== "fresh") {
+    const capturedAt = citedStates
+      .map((state) => state.capturedAt)
+      .filter((value): value is string => Boolean(value))
+      .map((value) => new Date(value))
+      .reduce<Date | null>(
+        (latest, date) => (!latest || date.getTime() > latest.getTime() ? date : latest),
+        null
+      );
+    return {
+      sourceKey: input.sourceKey,
+      sourceId: citedStates.length > 0 ? input.sourceId : null,
+      status: citedStates.length > 0 ? "PARTIAL" : "MISSING",
+      capturedAt,
+      expiresAt: null,
+      lastError: trust.warnings.join(" "),
+    };
+  }
+
+  const capturedAt = citedStates
+    .map((state) => state.capturedAt)
+    .filter((value): value is string => Boolean(value))
+    .map((value) => new Date(value))
+    .reduce<Date | null>(
+      (latest, date) => (!latest || date.getTime() > latest.getTime() ? date : latest),
+      null
+    );
+  const expiresAt = citedStates
+    .map((state) => state.expiresAt)
+    .filter((value): value is string => Boolean(value))
+    .map((value) => new Date(value))
+    .reduce<Date | null>(
+      (earliest, date) => (!earliest || date.getTime() < earliest.getTime() ? date : earliest),
+      null
+    );
+
+  return {
+    sourceKey: input.sourceKey,
+    sourceId: input.sourceId,
+    status: "SUCCESS",
+    capturedAt: capturedAt ?? input.asOf,
+    expiresAt: expiresAt ?? new Date(input.asOf.getTime() + input.freshnessSlaHours * 60 * 60 * 1000),
+  };
+}
+
+const CEO_METRIC_CALCULATORS: Record<string, CeoMetricCalculator> = {
+  "ceo.flow_reliability_score": ({ decisionDashboard }) => ({
+    value: decisionDashboard.northStar.flowReliabilityScore,
+    priorValue: null,
+    delta: null,
+  }),
+  "ceo.throughput_30d": ({ decisionDashboard }) => ({
+    value: decisionDashboard.northStar.throughput30d,
+    priorValue: null,
+    delta: decisionDashboard.northStar.throughputTrendPct,
+  }),
+  "ceo.overdue_open_tasks": ({ decisionDashboard }) => ({
+    value: decisionDashboard.supportingMetrics.overdueOpenTasks,
+    priorValue: null,
+    delta: null,
+  }),
+  "finance.cash_balance": ({ latestSnapshots }) => {
+    const mercury = latestSnapshots.get("mercury")?.payload;
+    const cash = cashBreakdownFromMercury(mercury);
+    return {
+      value: cash.totalCash,
+      priorValue: null,
+      delta: null,
+      details: [
+        { key: "bankCash", label: "Bank cash", value: cash.bankCash, unit: "currency" },
+        { key: "treasuryCash", label: "Treasury cash", value: cash.treasuryCash, unit: "currency" },
+        { key: "totalCash", label: "Total cash", value: cash.totalCash, unit: "currency" },
+      ],
+    };
+  },
+  "finance.mrr": ({ latestSnapshots }) => {
+    const stripe = latestSnapshots.get("stripe")?.payload;
+    const hubspot = latestSnapshots.get("hubspot")?.payload;
+    const breakdown = buildSubscriptionMrrBreakdown({ stripe, hubspot });
+    return {
+      value: breakdown.totalMrr,
+      priorValue: null,
+      delta: breakdown.stripeMrrChange,
+      details: [
+        { key: "stripeMrr", label: "Stripe MRR", value: breakdown.stripeMrr, unit: "currency" },
+        {
+          key: "hubspotOnlySubscriptionMrr",
+          label: "HubSpot-only subscription MRR",
+          value: breakdown.hubspotOnlySubscriptionMrr,
+          unit: "currency",
+        },
+        {
+          key: "excludedLinkedHubspotSubscriptionMrr",
+          label: "Linked HubSpot subscription MRR excluded",
+          value: breakdown.excludedLinkedHubspotSubscriptionMrr,
+          unit: "currency",
+        },
+        { key: "totalMrr", label: "Total MRR", value: breakdown.totalMrr, unit: "currency" },
+      ],
+    };
+  },
+  "sales.open_pipeline_value": ({ latestSnapshots }) => {
+    const hubspot = latestSnapshots.get("hubspot")?.payload;
+    const scoreboardPipeline = sumArrayNumber(hubspot, ["repScoreboard"], "totalPipeline");
+    return {
+      value:
+        scoreboardPipeline ??
+        getFirstNumber(hubspot, [
+          ["pipeline", "totalValue"],
+          ["totalPipelineValue"],
+          ["totalValue"],
+        ]),
+      priorValue: null,
+      delta: null,
+    };
+  },
+  "retention.at_risk_accounts": ({ retentionMetric }) => ({
+    value: retentionMetric.atRiskAccounts,
+    priorValue: null,
+    delta: null,
+  }),
+  "customer_success.support_load": ({ latestSnapshots }) => {
+    const pylon = latestSnapshots.get("pylon")?.payload;
+    return {
+      value: getFirstNumber(pylon, [["openIssues"], ["openConversations"], ["summary", "openIssues"]]),
+      priorValue: null,
+      delta: null,
+    };
+  },
+  "website.sessions": ({ latestSnapshots }) => {
+    const googleAnalytics = latestSnapshots.get("googleAnalytics")?.payload;
+    return {
+      value: getFirstNumber(googleAnalytics, [
+        ["sessions30d"],
+        ["overview", "sessions"],
+        ["sessions"],
+        ["traffic", "sessions"],
+      ]),
+      priorValue: null,
+      delta: null,
+    };
+  },
+  "social.paid_spend": ({ latestSnapshots }) => {
+    const spend = ["googleAds", "metaAds", "redditAds"].reduce((sum, key) => {
+      const value = getFirstNumber(latestSnapshots.get(key)?.payload, [
+        ["totalSpend30d"],
+        ["spend"],
+        ["cost"],
+        ["summary", "spend"],
+      ]);
+      return sum + (value ?? 0);
+    }, 0);
+    return { value: spend > 0 ? spend : null, priorValue: null, delta: null };
+  },
+};
+
+function healthScoreForDefinition(input: MetricCalculatorInput): MetricCalculation {
+  const trust = evaluateMetricTrust({
+    asOf: input.asOf,
+    freshnessSlaHours: input.definition.freshnessSlaHours,
+    requiredSourceKeys: input.definition.sourceDependencies,
+    sources: input.sourceSamples,
+  });
+  const scoreByStatus: Record<CeoMetricTrustStatus, number> = {
+    fresh: 100,
+    stale: 70,
+    partial: 55,
+    conflicted: 35,
+    missing: 0,
+    error: 0,
+  };
+  return { value: scoreByStatus[trust.status], priorValue: null, delta: null };
+}
+
+async function loadRetentionMetricSource(input: {
+  organizationId: string | null;
+  asOf: Date;
+}): Promise<RetentionMetricSource> {
+  if (!input.organizationId) {
+    return {
+      atRiskAccounts: null,
+      source: { sourceKey: "retention", sourceId: null, status: "MISSING" },
+    };
+  }
+
+  const [atRiskAccounts, latest] = await Promise.all([
+    prisma.retentionTenantCurrent.count({
+      where: {
+        organizationId: input.organizationId,
+        status: RetentionTenantStatus.AT_RISK,
+      },
+    }),
+    prisma.retentionTenantCurrent.findFirst({
+      where: { organizationId: input.organizationId },
+      orderBy: [{ lastMaterializedAt: "desc" }, { updatedAt: "desc" }],
+      select: { id: true, lastMaterializedAt: true, updatedAt: true },
+    }),
+  ]);
+
+  if (!latest) {
+    return {
+      atRiskAccounts: null,
+      source: { sourceKey: "retention", sourceId: null, status: "MISSING" },
+    };
+  }
+
+  const capturedAt = latest.lastMaterializedAt ?? latest.updatedAt ?? input.asOf;
+  return {
+    atRiskAccounts,
+    source: {
+      sourceKey: "retention",
+      sourceId: latest.id,
+      status: "SUCCESS",
+      capturedAt,
+      expiresAt: new Date(capturedAt.getTime() + 24 * 60 * 60 * 1000),
+    },
+  };
+}
+
+function valueForDefinition(input: MetricCalculatorInput): MetricCalculation {
+  const calculator = CEO_METRIC_CALCULATORS[input.definition.key];
+  if (calculator) return calculator(input);
+  if (input.definition.key.startsWith("domain.") || input.definition.key.startsWith("source.")) {
+    return healthScoreForDefinition(input);
+  }
+  return { value: null, priorValue: null, delta: null };
+}
+
+function verifiedMetricKeysForDefinitions(definitions: CeoMetricDefinition[]): Set<string> {
+  const boardGradeKeys = getDefaultBoardGradeMetricKeys(definitions);
+  return new Set(
+    definitions
+      .filter((definition) => definition.key in CEO_METRIC_CALCULATORS || definition.key.startsWith("domain."))
+      .map((definition) => definition.key)
+      .filter((key) => boardGradeKeys.has(key))
+  );
+}
+
+async function loadLatestAnalyticsSnapshots(input: {
+  userId: string;
+  sourceKeys: string[];
+}): Promise<AnalyticsSnapshotSample[]> {
+  return prisma.analyticsSnapshot.findMany({
+    where: {
+      userId: input.userId,
+      providerKey: { in: Array.from(new Set(input.sourceKeys)) },
+    },
+    orderBy: [{ capturedAt: "desc" }],
+    select: {
+      id: true,
+      providerKey: true,
+      status: true,
+      capturedAt: true,
+      expiresAt: true,
+      lastError: true,
+      payload: true,
+    },
+  });
+}
+
+async function upsertMetricDefinitions(definitions: CeoMetricDefinition[]): Promise<Map<string, string>> {
+  const entries = await Promise.all(
+    definitions.map((definition) =>
+      prisma.ceoMetricDefinition.upsert({
+        where: { key: definition.key },
+        create: {
+          key: definition.key,
+          label: definition.label,
+          domain: definition.domain,
+          ownerAudience: audienceToDb(definition.ownerAudience),
+          unit: metricUnitToDb(definition.unit),
+          calculationVersion: definition.calculationVersion,
+          sourceDependencies: definition.sourceDependencies,
+          freshnessSlaHours: definition.freshnessSlaHours,
+          boardEligible: definition.boardEligible,
+          weeklyEligible: definition.weeklyEligible,
+          description: definition.description,
+        },
+        update: {
+          label: definition.label,
+          domain: definition.domain,
+          ownerAudience: audienceToDb(definition.ownerAudience),
+          unit: metricUnitToDb(definition.unit),
+          calculationVersion: definition.calculationVersion,
+          sourceDependencies: definition.sourceDependencies,
+          freshnessSlaHours: definition.freshnessSlaHours,
+          boardEligible: definition.boardEligible,
+          weeklyEligible: definition.weeklyEligible,
+          description: definition.description,
+        },
+        select: { id: true, key: true },
+      })
+    )
+  );
+
+  return new Map(entries.map((entry) => [entry.key, entry.id]));
+}
+
+async function persistMetricSnapshots(input: {
+  metrics: CeoMetricValue[];
+  definitionIds: Map<string, string>;
+  userId: string;
+  organizationId: string | null;
+}): Promise<void> {
+  for (const metric of input.metrics) {
+    const valueSnapshot = await prisma.ceoMetricValueSnapshot.create({
+      data: {
+        metricKey: metric.definition.key,
+        definitionId: input.definitionIds.get(metric.definition.key) ?? null,
+        userId: input.userId,
+        organizationId: input.organizationId,
+        periodStart: new Date(metric.periodStart),
+        periodEnd: new Date(metric.periodEnd),
+        value: toPrismaJson(metric.value),
+        priorValue: toPrismaJson(metric.priorValue),
+        delta: metric.delta,
+        asOf: new Date(metric.asOf),
+        computedAt: new Date(metric.computedAt),
+        trustStatus: metricTrustToDb(metric.trust.status),
+        confidence: metric.trust.confidence,
+        warnings: metric.trust.warnings,
+        sourceState: toPrismaJson(metric.trust.sourceStates),
+      },
+      select: { id: true },
+    });
+
+    if (metric.lineage.length > 0) {
+      await prisma.ceoMetricSourceLineage.createMany({
+        data: metric.lineage.map((lineage) => ({
+          valueSnapshotId: valueSnapshot.id,
+          sourceKey: lineage.sourceKey,
+          sourceType: "analytics_snapshot",
+          sourceId: lineage.sourceId,
+          capturedAt: lineage.capturedAt ? new Date(lineage.capturedAt) : null,
+          metadata: Prisma.JsonNull,
+        })),
+      });
+    }
+  }
+}
+
+export async function loadCeoMetricSnapshot(input: {
+  userId: string;
+  organizationId?: string | null;
+  persist?: boolean;
+}): Promise<CeoMetricSnapshotPayload> {
+  const definitions = getDefaultCeoMetricDefinitions();
+  const sourceKeys = definitions.flatMap((definition) => definition.sourceDependencies);
+  const [decisionDashboard, snapshots] = await Promise.all([
+    computeDecisionDashboard(),
+    loadLatestAnalyticsSnapshots({ userId: input.userId, sourceKeys }),
+  ]);
+  const latestSnapshots = latestSnapshotByProvider(snapshots);
+  const asOf = new Date(decisionDashboard.asOf);
+  const snapshotSourceSamples = snapshots.map(sourceSampleFromSnapshot);
+  const retentionMetric = await loadRetentionMetricSource({
+    organizationId: input.organizationId ?? null,
+    asOf,
+  });
+  const sourceSamples = [
+    decisionDashboardSourceSample(decisionDashboard),
+    ...snapshotSourceSamples,
+    derivedSourceSample({
+      sourceKey: "customerJourney",
+      sourceId: "derived:customerJourney",
+      asOf,
+      freshnessSlaHours: 24,
+      requiredSourceKeys: ["hubspot"],
+      sources: snapshotSourceSamples,
+    }),
+    derivedSourceSample({
+      sourceKey: "demoAnalytics",
+      sourceId: "derived:demoAnalytics",
+      asOf,
+      freshnessSlaHours: 24,
+      requiredSourceKeys: ["hubspot"],
+      sources: snapshotSourceSamples,
+    }),
+    derivedSourceSample({
+      sourceKey: "processAnalytics",
+      sourceId: "derived:processAnalytics",
+      asOf,
+      freshnessSlaHours: 1,
+      requiredSourceKeys: ["hubspot"],
+      sources: snapshotSourceSamples,
+    }),
+    retentionMetric.source,
+  ];
+  const computedAt = new Date().toISOString();
+  const periodEnd = asOf.toISOString();
+  const periodStart = new Date(asOf.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const reportPacks = buildDefaultCeoReportPacks(definitions);
+
+  const metrics: CeoMetricValue[] = definitions.map((definition) => {
+    const trust = evaluateMetricTrust({
+      asOf,
+      freshnessSlaHours: definition.freshnessSlaHours,
+      requiredSourceKeys: definition.sourceDependencies,
+      sources: sourceSamples,
+    });
+    const value = valueForDefinition({
+      definition,
+      decisionDashboard,
+      latestSnapshots,
+      retentionMetric,
+      sourceSamples,
+      asOf,
+    });
+
+    return {
+      definition,
+      value: value.value,
+      priorValue: value.priorValue,
+      delta: value.delta,
+      details: value.details,
+      periodStart,
+      periodEnd,
+      asOf: periodEnd,
+      computedAt,
+      trust,
+      lineage: trust.sourceStates
+        .filter((state) => state.sourceId || state.capturedAt)
+        .map((state) => ({
+          sourceKey: state.sourceKey,
+          sourceId: state.sourceId,
+          capturedAt: state.capturedAt,
+        })),
+    };
+  });
+
+  const trustSummary = TRUST_SUMMARY_KEYS.reduce(
+    (summary, key) => {
+      summary[key] = metrics.filter((metric) => metric.trust.status === key).length;
+      return summary;
+    },
+    {} as Record<CeoMetricTrustStatus, number>
+  );
+
+  const definitionIds = await upsertMetricDefinitions(definitions);
+  if (input.persist) {
+    await persistMetricSnapshots({
+      metrics,
+      definitionIds,
+      userId: input.userId,
+      organizationId: input.organizationId ?? null,
+    });
+  }
+  const readiness = computeCeoReadiness({
+    reportPacks,
+    metrics,
+    verifiedMetricKeys: verifiedMetricKeysForDefinitions(definitions),
+  });
+
+  return {
+    generatedAt: computedAt,
+    periodStart,
+    periodEnd,
+    definitions,
+    metrics,
+    reportPacks,
+    trustSummary,
+    readiness,
+  };
+}
+
+export async function listCeoReportPacks(): Promise<CeoReportPack[]> {
+  return buildDefaultCeoReportPacks(getDefaultCeoMetricDefinitions());
+}
+
+export async function createCeoReportRun(input: {
+  userId: string;
+  organizationId?: string | null;
+  packSlug: string;
+}): Promise<CreateCeoReportRunResult> {
+  const snapshot = await loadCeoMetricSnapshot({
+    userId: input.userId,
+    organizationId: input.organizationId,
+    persist: true,
+  });
+  const pack = snapshot.reportPacks.find((candidate) => candidate.slug === input.packSlug);
+  if (!pack) {
+    throw new Error(`Unknown CEO report pack: ${input.packSlug}`);
+  }
+
+  const run = buildMetricReportRun({ pack, metrics: snapshot.metrics, readiness: snapshot.readiness });
+  const persisted = await prisma.ceoReportRun.create({
+    data: {
+      packSlug: run.packSlug,
+      packName: run.packName,
+      userId: input.userId,
+      organizationId: input.organizationId ?? null,
+      generatedAt: new Date(run.generatedAt),
+      metricPayload: toPrismaJson(run.metrics),
+      deterministicNotes: run.deterministicNotes,
+      markdown: run.markdown,
+      csv: run.csv,
+      slideJson: toPrismaJson(run.slideJson),
+    },
+    select: { id: true },
+  });
+
+  return {
+    ...run,
+    id: persisted.id,
+  };
+}
+
+export async function getCeoReportRun(input: {
+  userId: string;
+  organizationId?: string | null;
+  runId: string;
+}): Promise<CreateCeoReportRunResult | null> {
+  const row = await prisma.ceoReportRun.findFirst({
+    where: {
+      id: input.runId,
+      OR: [
+        { userId: input.userId },
+        ...(input.organizationId ? [{ organizationId: input.organizationId }] : []),
+      ],
+    },
+  });
+  if (!row) return null;
+
+  return {
+    id: row.id,
+    packSlug: row.packSlug,
+    packName: row.packName,
+    generatedAt: row.generatedAt.toISOString(),
+    metrics: row.metricPayload as unknown as CeoMetricValue[],
+    deterministicNotes: row.deterministicNotes,
+    markdown: row.markdown,
+    csv: row.csv,
+    slideJson: row.slideJson as unknown as CeoReportRun["slideJson"],
+  };
+}

--- a/src/lib/hooks/use-insight-preferences.ts
+++ b/src/lib/hooks/use-insight-preferences.ts
@@ -18,6 +18,8 @@ interface UseInsightPreferencesReturn {
   togglePin: (id: string) => Promise<void>;
   dismiss: (id: string) => Promise<void>;
   undoDismiss: (id: string) => Promise<void>;
+  createTaskFromInsight: (insight: AiInsight) => Promise<void>;
+  creatingTaskForId: string | null;
   sortAndFilter: (insights: AiInsight[], showDismissed?: boolean) => AiInsight[];
   loading: boolean;
 }
@@ -36,6 +38,7 @@ async function setPreference(insightId: string, status: InsightStatus): Promise<
 export function useInsightPreferences(): UseInsightPreferencesReturn {
   const [pinnedIds, setPinnedIds] = useState<Set<string>>(new Set());
   const [dismissedIds, setDismissedIds] = useState<Set<string>>(new Set());
+  const [creatingTaskForId, setCreatingTaskForId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
   // Load preferences from API on mount
@@ -138,6 +141,28 @@ export function useInsightPreferences(): UseInsightPreferencesReturn {
     [pinnedIds, dismissedIds]
   );
 
+  const createTaskFromInsight = useCallback(async (insight: AiInsight) => {
+    const taskAction = insight.actions.find((action) => action.type === "create_task");
+    if (!taskAction) {
+      throw new Error("No create_task action available for insight");
+    }
+
+    setCreatingTaskForId(insight.id);
+    try {
+      const response = await fetch("/api/tasks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(taskAction.payload),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to create task (${response.status})`);
+      }
+    } finally {
+      setCreatingTaskForId((current) => (current === insight.id ? null : current));
+    }
+  }, []);
+
   return {
     pinnedIds,
     dismissedIds,
@@ -146,6 +171,8 @@ export function useInsightPreferences(): UseInsightPreferencesReturn {
     togglePin,
     dismiss,
     undoDismiss,
+    createTaskFromInsight,
+    creatingTaskForId,
     sortAndFilter,
     loading,
   };

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -116,7 +116,7 @@ export function workspaceIdForPermissionAction(
     case "priority.write":
     case "policy.write":
     case "policy.override":
-      return "dashboard";
+      return "analytics";
     case "conference.write":
     case "deals.read":
     case "deals.write":
@@ -133,7 +133,7 @@ export function workspaceIdForPermissionAction(
     case "team.invite":
     case "team.role.write":
     case "profile.write":
-      return "dashboard";
+      return "analytics";
     default:
       return null;
   }

--- a/src/lib/platform/routes.ts
+++ b/src/lib/platform/routes.ts
@@ -1,0 +1,1 @@
+export const ANALYTICS_HOME = "/analytics" as const;

--- a/src/lib/platform/workspaces.ts
+++ b/src/lib/platform/workspaces.ts
@@ -4,7 +4,6 @@ import {
 } from "@/lib/analytics/section-registry";
 
 export type WorkspaceId =
-  | "dashboard"
   | "deals"
   | "analytics"
   | "integrations"
@@ -28,10 +27,36 @@ export interface WorkspaceNavItem {
 
 export const WORKSPACE_NAV_ITEMS: WorkspaceNavItem[] = [
   {
-    id: "dashboard",
-    label: "Dashboard",
-    href: "/dashboard",
-    description: "Cross-platform GTM operating view.",
+    id: "analytics",
+    label: "Analytics",
+    href: "/analytics",
+    description: "Metric trust, source health, customer journey, and operating intelligence.",
+    children: [
+      {
+        id: "ceo-command-center",
+        label: "CEO Command Center",
+        href: "/analytics/ceo",
+        workspaceId: "analytics",
+      },
+      ...ANALYTICS_PRIMARY_SECTIONS.map((section) => ({
+        id: section.id,
+        label: section.label,
+        href: section.path,
+        workspaceId: "analytics" as const,
+      })),
+      {
+        id: "ai-insights",
+        label: "AI Insights",
+        href: "/analytics/ai-insights",
+        workspaceId: "analytics",
+      },
+    ],
+  },
+  {
+    id: "integrations",
+    label: "Integrations",
+    href: "/integrations",
+    description: "Connections, sync health, and provider operations.",
   },
   {
     id: "deals",
@@ -52,32 +77,6 @@ export const WORKSPACE_NAV_ITEMS: WorkspaceNavItem[] = [
         workspaceId: "deals",
       },
     ],
-  },
-  {
-    id: "analytics",
-    label: "Analytics",
-    href: "/analytics",
-    description: "Performance, customer journey, and operational intelligence.",
-    children: [
-      ...ANALYTICS_PRIMARY_SECTIONS.map((section) => ({
-        id: section.id,
-        label: section.label,
-        href: section.path,
-        workspaceId: "analytics" as const,
-      })),
-      {
-        id: "ai-insights",
-        label: "AI Insights",
-        href: "/analytics/ai-insights",
-        workspaceId: "analytics",
-      },
-    ],
-  },
-  {
-    id: "integrations",
-    label: "Integrations",
-    href: "/integrations",
-    description: "Connections, sync health, and provider operations.",
   },
   {
     id: "automations",

--- a/tests/e2e/board.spec.ts
+++ b/tests/e2e/board.spec.ts
@@ -1,145 +1,40 @@
 /**
- * E2E Tests: Kanban Board
+ * E2E Tests: Retired task management routes
  *
- * Critical user journeys:
- * - Board loads with expected columns
- * - Create a new task
- * - Task appears in the correct column
- * - Drag task between columns
- * - WIP limit enforcement
+ * The product surface is analytics-first. Legacy task, board, and operating
+ * routes should stay authenticated and land users in the analytics command
+ * center instead of rendering retired task-management UI.
  */
-import { test, expect } from '@playwright/test';
-import { BoardPage } from './helpers/pages';
-import { uniqueTaskTitle, BOARD_COLUMNS } from './helpers/test-data';
+import { expect, test } from '@playwright/test';
 
-test.describe('Kanban Board', () => {
-  let boardPage: BoardPage;
+const LEGACY_PRODUCT_ROUTES = [
+  '/dashboard',
+  '/tasks',
+  '/board',
+  '/my-tasks',
+  '/projects',
+  '/standup',
+  '/today',
+  '/whip',
+  '/table',
+  '/logbook',
+] as const;
 
-  test.beforeEach(async ({ page }) => {
-    boardPage = new BoardPage(page);
-    await boardPage.goto();
-  });
+test.describe('Retired task management routes', () => {
+  for (const route of LEGACY_PRODUCT_ROUTES) {
+    test(`redirects ${route} to analytics`, async ({ page }) => {
+      await page.goto(route);
 
-  test('should display the board with expected columns', async ({ page }) => {
-    // Verify board page loaded (not redirected to login)
-    await expect(page).not.toHaveURL(/\/login/i);
+      await expect(page).toHaveURL(/\/analytics(?:[/?#]|$)/, { timeout: 15_000 });
+      await expect(page).not.toHaveURL(/\/login/i);
+      await expect(page.locator('[data-testid="authenticated-layout"], nav').first()).toBeVisible();
+    });
+  }
 
-    // Verify expected columns exist (may be horizontally scrollable).
-    for (const columnName of BOARD_COLUMNS) {
-      const column = boardPage.getColumn(columnName);
-      await expect(column).toHaveCount(1);
-    }
-  });
+  test('does not expose legacy task creation controls after redirect', async ({ page }) => {
+    await page.goto('/tasks');
 
-  test('should create a new task', async ({ page }) => {
-    const taskTitle = uniqueTaskTitle('Board');
-
-    await boardPage.createTask(taskTitle);
-
-    // Verify the task appears on the board
-    await expect(boardPage.getTask(taskTitle)).toBeVisible({ timeout: 10_000 });
-  });
-
-  test('should show newly created task in the first column', async ({ page }) => {
-    const taskTitle = uniqueTaskTitle('Column');
-
-    await boardPage.createTask(taskTitle);
-
-    // Task should be visible
-    await expect(boardPage.getTask(taskTitle)).toBeVisible({ timeout: 10_000 });
-
-    // Check it's in the first column (To Do)
-    const firstColumn = boardPage.getColumn(BOARD_COLUMNS[0]);
-    const taskInColumn = firstColumn.getByText(taskTitle);
-
-    // Try to verify column placement; if column selector doesn't match,
-    // at least verify the task exists on the page
-    const isInColumn = await taskInColumn.isVisible().catch(() => false);
-    if (!isInColumn) {
-      // Fallback: just verify task is on the page
-      await expect(boardPage.getTask(taskTitle)).toBeVisible();
-    }
-  });
-
-  test('should move a task between columns via drag and drop', async ({ page }) => {
-    const taskTitle = uniqueTaskTitle('DragDrop');
-
-    // Create task first
-    await boardPage.createTask(taskTitle);
-    await expect(boardPage.getTask(taskTitle)).toBeVisible({ timeout: 10_000 });
-
-    // Drag task to "In Progress" column
-    const targetColumn = BOARD_COLUMNS[1]; // "In Progress"
-    await boardPage.dragTaskToColumn(taskTitle, targetColumn);
-
-    // Allow time for the UI to update after drag
-    await page.waitForLoadState('networkidle');
-
-    // Verify the task is now visible (it should still be on the board)
-    await expect(boardPage.getTask(taskTitle)).toBeVisible({ timeout: 10_000 });
-  });
-
-  test('should enforce WIP limits when moving tasks', async ({ page }) => {
-    // This test verifies that WIP limit enforcement is visible to the user.
-    // We attempt to move tasks to a column until the limit is hit.
-
-    const targetColumn = BOARD_COLUMNS[1]; // "In Progress" typically has WIP limits
-
-    // Create multiple tasks
-    const tasks: string[] = [];
-    for (let i = 0; i < 5; i++) {
-      const title = uniqueTaskTitle(`WIP-${i}`);
-      tasks.push(title);
-      await boardPage.createTask(title);
-      await expect(boardPage.getTask(title)).toBeVisible({ timeout: 10_000 });
-    }
-
-    // Try moving all tasks to In Progress
-    for (const title of tasks) {
-      try {
-        await boardPage.dragTaskToColumn(title, targetColumn);
-        // Small wait to allow any warning to appear
-        await page.waitForLoadState('networkidle');
-      } catch {
-        // Drag might fail if WIP limit blocks it - that's expected
-      }
-    }
-
-    // After attempting to exceed WIP limit, check for a warning or that
-    // not all tasks made it to the target column
-    const wipWarning = boardPage.getWipLimitWarning();
-    const warningVisible = await wipWarning.isVisible().catch(() => false);
-
-    // The test passes if either:
-    // 1. A WIP limit warning is shown, OR
-    // 2. The page still shows all tasks (some may have been blocked from moving)
-    if (warningVisible) {
-      await expect(wipWarning).toBeVisible();
-    } else {
-      // Verify the board is still functional
-      for (const title of tasks) {
-        await expect(boardPage.getTask(title)).toBeVisible();
-      }
-    }
-  });
-
-  test('should allow creating multiple tasks', async ({ page }) => {
-    const task1 = uniqueTaskTitle('Multi-1');
-    const task2 = uniqueTaskTitle('Multi-2');
-    const task3 = uniqueTaskTitle('Multi-3');
-
-    await boardPage.createTask(task1);
-    await expect(boardPage.getTask(task1)).toBeVisible({ timeout: 10_000 });
-
-    await boardPage.createTask(task2);
-    await expect(boardPage.getTask(task2)).toBeVisible({ timeout: 10_000 });
-
-    await boardPage.createTask(task3);
-    await expect(boardPage.getTask(task3)).toBeVisible({ timeout: 10_000 });
-
-    // All three should be visible
-    await expect(boardPage.getTask(task1)).toBeVisible();
-    await expect(boardPage.getTask(task2)).toBeVisible();
-    await expect(boardPage.getTask(task3)).toBeVisible();
+    await expect(page).toHaveURL(/\/analytics(?:[/?#]|$)/, { timeout: 15_000 });
+    await expect(page.getByRole('button', { name: /add.*task|create.*task|new.*task/i })).toHaveCount(0);
   });
 });

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -1,198 +1,54 @@
 /**
- * E2E Tests: Settings & WIP Policy Configuration
+ * E2E Tests: Settings
  *
- * Critical user journeys:
- * - Settings page loads
- * - Update WIP limit for a column
- * - Save settings successfully
- * - WIP limit changes are enforced on the board
- * - Settings persist after page reload
+ * WIP policy, board, and sprint configuration moved out of the primary product
+ * surface. Settings now covers team access and analytics operating guardrails.
  */
-import { test, expect } from '@playwright/test';
-import { SettingsPage, BoardPage } from './helpers/pages';
-import { uniqueTaskTitle, BOARD_COLUMNS } from './helpers/test-data';
+import { expect, test } from '@playwright/test';
 
-test.describe('Settings & WIP Policy', () => {
-  let settingsPage: SettingsPage;
+const LEGACY_SETTINGS_TABS = [
+  'board',
+  'sprints',
+  'projects',
+  'departments',
+  'priorities',
+  'design-interview',
+] as const;
 
-  test.beforeEach(async ({ page }) => {
-    settingsPage = new SettingsPage(page);
-  });
+test.describe('Settings', () => {
+  test('loads the analytics-first settings tabs', async ({ page }) => {
+    await page.goto('/settings');
 
-  test('should load the settings page', async ({ page }) => {
-    await settingsPage.goto();
-
-    // Verify page loaded (not redirected to login)
     await expect(page).not.toHaveURL(/\/login/i);
-
-    // Page should contain settings-related content
-    const pageContent = await page.textContent('body');
-    const hasSettingsContent =
-      pageContent?.toLowerCase().includes('settings') ||
-      pageContent?.toLowerCase().includes('configuration') ||
-      pageContent?.toLowerCase().includes('preferences') ||
-      pageContent?.toLowerCase().includes('wip') ||
-      pageContent?.toLowerCase().includes('limit');
-
-    expect(hasSettingsContent).toBe(true);
+    await expect(page.getByRole('heading', { name: /^settings$/i })).toBeVisible();
+    await expect(page.getByRole('tab', { name: /^team$/i })).toBeVisible();
+    await expect(page.getByRole('tab', { name: /^operations$/i })).toBeVisible();
+    await expect(page.getByRole('tab', { name: /board|sprint|project|department|priority/i })).toHaveCount(0);
   });
 
-  test('should display WIP limit controls', async ({ page }) => {
-    await settingsPage.goto();
+  test('switches between Team and Operations without exposing WIP controls', async ({ page }) => {
+    await page.goto('/settings');
 
-    // Check that WIP limit content is present on the page
-    const pageContent = await page.textContent('body') || '';
-    const lowerContent = pageContent.toLowerCase();
+    const operationsTab = page.getByRole('tab', { name: /^operations$/i });
+    await operationsTab.click();
 
-    const hasWipContent =
-      lowerContent.includes('wip') ||
-      lowerContent.includes('work in progress') ||
-      lowerContent.includes('limit') ||
-      lowerContent.includes('column');
-
-    expect(hasWipContent).toBe(true);
+    await expect(page).toHaveURL(/\/settings\?tab=operations/i);
+    await expect(operationsTab).toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByText(/wip limit|work in progress|create sprint|new sprint/i)).toHaveCount(0);
   });
 
-  test('should update WIP limit for Active column', async ({ page }) => {
-    await settingsPage.goto();
+  for (const tab of LEGACY_SETTINGS_TABS) {
+    test(`redirects legacy ${tab} settings to Team`, async ({ page }) => {
+      await page.goto(`/settings?tab=${tab}`);
 
-    const columnName = 'Active';
-    const newLimit = 5;
+      await expect(page).toHaveURL(/\/settings\?tab=team/i, { timeout: 15_000 });
+      await expect(page.getByRole('tab', { name: /^team$/i })).toHaveAttribute('aria-selected', 'true');
+    });
+  }
 
-    const wipInput = settingsPage.getWipLimitInput(columnName);
-    const inputVisible = await wipInput.isVisible().catch(() => false);
+  test('moves the legacy integrations tab to the integrations page', async ({ page }) => {
+    await page.goto('/settings?tab=integrations');
 
-    if (inputVisible) {
-      await settingsPage.setWipLimit(columnName, newLimit);
-      await settingsPage.save();
-
-      // Wait for save confirmation
-      const successMsg = settingsPage.getSuccessMessage();
-      const successVisible = await successMsg.isVisible().catch(() => false);
-
-      if (successVisible) {
-        await expect(successMsg).toBeVisible();
-      } else {
-        // Verify the page didn't show an error
-        await page.waitForLoadState('networkidle');
-        await expect(page).not.toHaveURL(/\/error/i);
-      }
-    } else {
-      // WIP limit inputs may be in a different format
-      // Check that the settings page is still functional
-      await expect(page).not.toHaveURL(/\/login/i);
-    }
-  });
-
-  test('should save settings and show confirmation', async ({ page }) => {
-    await settingsPage.goto();
-
-    const saveButton = settingsPage.getSaveButton();
-    const saveVisible = await saveButton.isVisible().catch(() => false);
-
-    if (saveVisible) {
-      await saveButton.click();
-
-      // Should show success or at least not error
-      await page.waitForLoadState('networkidle');
-
-      const successMsg = settingsPage.getSuccessMessage();
-      const errorOnPage = page.getByText(/error|failed/i);
-
-      const hasSuccess = await successMsg.isVisible().catch(() => false);
-      const hasError = await errorOnPage.isVisible().catch(() => false);
-
-      // Either success is shown, or at minimum no error occurred
-      if (!hasSuccess) {
-        // It's acceptable if no explicit success message, as long as no error
-        // Some UIs use subtle indicators
-        expect(true).toBe(true); // Save didn't crash
-      }
-    }
-  });
-
-  test('should persist settings after page reload', async ({ page }) => {
-    await settingsPage.goto();
-
-    const columnName = 'Active';
-    const newLimit = 7;
-
-    const wipInput = settingsPage.getWipLimitInput(columnName);
-    const inputVisible = await wipInput.isVisible().catch(() => false);
-
-    if (inputVisible) {
-      // Set a new value
-      await settingsPage.setWipLimit(columnName, newLimit);
-      await settingsPage.save();
-      await page.waitForLoadState('networkidle');
-
-      // Reload the page
-      await page.reload();
-      await page.waitForLoadState('domcontentloaded');
-
-      // Verify the value persisted
-      const updatedInput = settingsPage.getWipLimitInput(columnName);
-      const updatedInputVisible = await updatedInput.isVisible().catch(() => false);
-
-      if (updatedInputVisible) {
-        const value = await updatedInput.inputValue();
-        expect(value).toBe(String(newLimit));
-      }
-    } else {
-      // Settings page loaded without WIP inputs in expected format
-      await expect(page).not.toHaveURL(/\/login/i);
-    }
-  });
-
-  test('should enforce updated WIP limits on the board', async ({ page }) => {
-    // First, set a low WIP limit
-    await settingsPage.goto();
-
-    const columnName = 'Active';
-    const lowLimit = 2;
-
-    const wipInput = settingsPage.getWipLimitInput(columnName);
-    const inputVisible = await wipInput.isVisible().catch(() => false);
-
-    if (inputVisible) {
-      await settingsPage.setWipLimit(columnName, lowLimit);
-      await settingsPage.save();
-      await page.waitForLoadState('networkidle');
-    }
-
-    // Now go to the board and try to exceed the limit
-    const boardPage = new BoardPage(page);
-    await boardPage.goto();
-
-    // Create tasks and try to move them all to Active
-    const tasks: string[] = [];
-    for (let i = 0; i < lowLimit + 2; i++) {
-      const title = uniqueTaskTitle(`WIPEnforce-${i}`);
-      tasks.push(title);
-      await boardPage.createTask(title);
-      await expect(boardPage.getTask(title)).toBeVisible({ timeout: 10_000 });
-    }
-
-    // Move tasks to Active one by one
-    for (const title of tasks) {
-      try {
-        await boardPage.dragTaskToColumn(title, 'Active');
-        await page.waitForLoadState('networkidle');
-      } catch {
-        // Expected to fail once WIP limit is reached
-      }
-    }
-
-    // Check that WIP limit was enforced
-    const wipWarning = boardPage.getWipLimitWarning();
-    const warningVisible = await wipWarning.isVisible().catch(() => false);
-
-    // The board should still be functional regardless
-    for (const title of tasks) {
-      await expect(boardPage.getTask(title)).toBeVisible();
-    }
-
-    // WIP enforcement is verified if a warning appeared or if some tasks
-    // couldn't be moved (both are valid enforcement patterns)
+    await expect(page).toHaveURL(/\/integrations(?:[/?#]|$)/i, { timeout: 15_000 });
   });
 });

--- a/tests/e2e/sprint.spec.ts
+++ b/tests/e2e/sprint.spec.ts
@@ -1,43 +1,24 @@
 /**
- * E2E Tests: Sprint Management (Settings → Sprints tab)
+ * E2E Tests: Retired sprint settings
  *
- * Covers:
- * - Sprints tab loads
- * - Create a sprint (date-based label)
- * - Toggle active sprint
+ * Sprint management is no longer part of the primary product surface. The
+ * legacy settings entry point should route users back to the supported Team tab.
  */
-import { test, expect } from '@playwright/test';
-import { SprintPage } from './helpers/pages';
+import { expect, test } from '@playwright/test';
 
-test.describe('Sprint Management', () => {
-  let sprintPage: SprintPage;
+test.describe('Retired sprint settings', () => {
+  test('redirects the legacy sprints tab to Team settings', async ({ page }) => {
+    await page.goto('/settings?tab=sprints');
 
-  test.beforeEach(async ({ page }) => {
-    sprintPage = new SprintPage(page);
+    await expect(page).toHaveURL(/\/settings\?tab=team/i, { timeout: 15_000 });
+    await expect(page.getByRole('tab', { name: /^team$/i })).toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByText(/sprint management|create sprint|new sprint/i)).toHaveCount(0);
   });
 
-  test('should load the sprints page', async ({ page }) => {
-    await sprintPage.goto();
+  test('keeps users authenticated while retiring sprint UI', async ({ page }) => {
+    await page.goto('/settings?tab=sprints');
 
-    // Verify page loaded (not redirected to login)
     await expect(page).not.toHaveURL(/\/login/i);
-
-    await expect(page.getByText(/sprint management/i)).toBeVisible();
-  });
-
-  test('should create a new sprint', async ({ page }) => {
-    await sprintPage.goto();
-    const createdLabel = await sprintPage.createSprint('ignored');
-
-    // Verify the sprint appears on the page
-    await expect(page.getByText(createdLabel).first()).toBeVisible({ timeout: 10_000 });
-  });
-
-  test('should mark created sprint as active', async ({ page }) => {
-    await sprintPage.goto();
-    const createdLabel = await sprintPage.createSprint('ignored');
-
-    await expect(page.getByText(createdLabel).first()).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByRole('button', { name: /deactivate sprint/i })).toBeVisible();
+    await expect(page.locator('[data-testid="authenticated-layout"], nav').first()).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- Ships the CEO Metric Trust Layer: canonical CEO metrics, trust/freshness/readiness labels, source lineage, report packs, report-run APIs, and `/analytics/ceo`.
- Makes the app surface analytics-first: authenticated users land on `/analytics`, legacy task/board routes redirect there, Settings hides task/board/project/sprint tabs, and AI Insights no longer exposes create-task UI.
- Hardens production rollout: strict CEO schema migration behavior, `/api/health/live`, Railway healthcheck wiring, production smoke runbook, Treasury-inclusive cash handling, and HubSpot subscription MRR support.
- Keeps legacy task/project APIs and schemas in place for compatibility while removing them from the primary product surface.

## Test plan

- [x] `npm test` — 272 files / 2,404 tests passing
- [x] `npx tsc --noEmit --pretty false`
- [x] `npm run lint` — exits 0 with existing warnings
- [x] `npm run build`
- [x] Focused CEO/API/UI route tests pass via full suite
- [ ] CI green
- [ ] After merge/deploy, smoke `/api/health/live`, `/api/ceo/metrics`, `/api/ceo/reports`, `/analytics`, `/analytics/ceo`, and a Board Meeting report export

## Deployment notes

- Deploy from the merged PR, not from local dirty state.
- Railway is configured to use `/api/health/live` for healthchecks.
- CEO metric migrations run in strict mode when the CEO migration is present, so production should fail fast rather than booting without required schema.
- `output/` remains intentionally untracked and was not included in this PR.
