### PR TITLE
Use liveness checks for Railway deploy health

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,6 @@ USER nextjs
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
-  CMD node -e "fetch('http://127.0.0.1:3000/api/health').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))"
+  CMD node -e "fetch('http://127.0.0.1:3000/api/health/live').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))"
 
 ENTRYPOINT ["sh", "/app/docker-entrypoint.sh"]

--- a/railway.json
+++ b/railway.json
@@ -6,7 +6,7 @@
   "deploy": {
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10,
-    "healthcheckPath": "/api/health",
+    "healthcheckPath": "/api/health/live",
     "healthcheckTimeout": 120
   }
 }

--- a/src/app/api/health/live/route.test.ts
+++ b/src/app/api/health/live/route.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import packageJson from "../../../../../package.json";
+
+describe("GET /api/health/live", () => {
+  it("returns liveness data without checking dependencies", async () => {
+    const { GET } = await import("@/app/api/health/live/route");
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      status: "ok",
+      version: packageJson.version,
+    });
+    expect(typeof body.timestamp).toBe("string");
+  });
+});

--- a/src/app/api/health/live/route.ts
+++ b/src/app/api/health/live/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import packageJson from "../../../../../package.json";
+
+const APP_VERSION = process.env.APP_VERSION?.trim() || packageJson.version;
+
+/**
+ * GET /api/health/live
+ *
+ * Liveness endpoint for platform health checks.
+ * Returns 200 when the app process is up and able to serve HTTP,
+ * without depending on downstream services like Postgres.
+ */
+export async function GET() {
+  return NextResponse.json(
+    {
+      status: "ok",
+      version: APP_VERSION,
+      timestamp: new Date().toISOString(),
+    },
+    {
+      status: 200,
+      headers: {
+        "Cache-Control": "no-store, no-cache, must-revalidate",
+      },
+    }
+  );
+}

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -8,7 +8,7 @@ const APP_VERSION = process.env.APP_VERSION?.trim() || packageJson.version;
 /**
  * GET /api/health
  *
- * Health check endpoint that verifies database connectivity
+ * Dependency health endpoint that verifies database connectivity
  * and reports pool status.
  *
  * Returns:


### PR DESCRIPTION
## Summary
- add a dedicated `/api/health/live` endpoint for liveness checks
- keep `/api/health` as the DB-aware dependency health endpoint
- point Railway and the container healthcheck at the liveness endpoint so DB outages do not make the whole service unroutable

## Verification
- `npx vitest run src/app/api/health/route.test.ts src/app/api/health/live/route.test.ts`
- `npm run build` in `/Users/kylehenson/WIPGuard`

## Context
Railway went hard down because the deploy healthcheck used `/api/health`, which returns `503` whenever Postgres is unavailable. Separating liveness from dependency health keeps the app routable while preserving DB diagnostics.