### PR TITLE
fix: gate legacy product APIs in production

### DIFF
--- a/src/__tests__/security-headers.test.ts
+++ b/src/__tests__/security-headers.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
+import { NextRequest } from "next/server";
 
 // We test the next.config.ts headers configuration by importing and invoking it
 describe("Security Headers Configuration", () => {
@@ -130,6 +131,16 @@ describe("Security Headers Configuration", () => {
 });
 
 describe("Middleware", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const setNodeEnv = (value: string | undefined) => {
+    (process.env as Record<string, string | undefined>).NODE_ENV = value;
+  };
+
+  afterEach(() => {
+    delete process.env.ENABLE_LEGACY_PRODUCT_APIS;
+    setNodeEnv(originalNodeEnv);
+  });
+
   it("should export a middleware function", async () => {
     const middlewareModule = await import("../middleware");
     expect(typeof middlewareModule.middleware).toBe("function");
@@ -140,5 +151,62 @@ describe("Middleware", () => {
     expect(middlewareModule.config).toBeDefined();
     expect(middlewareModule.config.matcher).toBeDefined();
     expect(Array.isArray(middlewareModule.config.matcher)).toBe(true);
+  });
+
+  it("returns 410 for legacy product APIs when disabled", async () => {
+    process.env.ENABLE_LEGACY_PRODUCT_APIS = "false";
+    const { middleware } = await import("../middleware");
+
+    const response = middleware(
+      new NextRequest("http://localhost:3000/api/tasks?status=ACTIVE")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(410);
+    expect(response.headers.get("API-Version")).toBe("v1");
+    expect(body).toEqual({
+      error: "Legacy product API disabled",
+      replacement: "/api/analytics",
+      dashboard: "/analytics",
+    });
+  });
+
+  it("returns 410 for versioned legacy product APIs when disabled", async () => {
+    process.env.ENABLE_LEGACY_PRODUCT_APIS = "false";
+    const { middleware } = await import("../middleware");
+
+    const response = middleware(
+      new NextRequest("http://localhost:3000/api/v1/tasks")
+    );
+
+    expect(response.status).toBe(410);
+    expect(response.headers.get("API-Version")).toBe("v1");
+  });
+
+  it("disables legacy product APIs by default in production", async () => {
+    delete process.env.ENABLE_LEGACY_PRODUCT_APIS;
+    setNodeEnv("production");
+    const { middleware } = await import("../middleware");
+
+    const response = middleware(
+      new NextRequest("http://localhost:3000/api/projects")
+    );
+
+    expect(response.status).toBe(410);
+  });
+
+  it("does not block analytics or customer-success APIs", async () => {
+    process.env.ENABLE_LEGACY_PRODUCT_APIS = "false";
+    const { middleware } = await import("../middleware");
+
+    const analyticsResponse = middleware(
+      new NextRequest("http://localhost:3000/api/analytics")
+    );
+    const customerSuccessResponse = middleware(
+      new NextRequest("http://localhost:3000/api/customer-success/accounts/acct_1/tasks")
+    );
+
+    expect(analyticsResponse.status).toBe(200);
+    expect(customerSuccessResponse.status).toBe(200);
   });
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,6 +8,18 @@ import {
   VERSION_SUNSET_DATES,
 } from "@/lib/api/versioning";
 
+const LEGACY_PRODUCT_API_PREFIXES = [
+  "/api/board-settings",
+  "/api/logbook",
+  "/api/priorities",
+  "/api/projects",
+  "/api/sprints",
+  "/api/standup",
+  "/api/tasks",
+  "/api/v1/projects",
+  "/api/v1/tasks",
+] as const;
+
 /**
  * Next.js Middleware
  *
@@ -52,6 +64,9 @@ export function middleware(request: NextRequest) {
       );
     }
 
+    const legacyProductApiResponse = maybeRejectLegacyProductApi(pathname);
+    if (legacyProductApiResponse) return legacyProductApiResponse;
+
     // Add version headers to versioned requests
     const response = NextResponse.next();
     const version = extractVersionFromPath(pathname);
@@ -69,11 +84,51 @@ export function middleware(request: NextRequest) {
     return response;
   }
 
+  const legacyProductApiResponse = maybeRejectLegacyProductApi(pathname);
+  if (legacyProductApiResponse) return legacyProductApiResponse;
+
   // Unversioned API request — add version header indicating current version
   const response = NextResponse.next();
   response.headers.set("API-Version", CURRENT_API_VERSION);
   addSecurityHeaders(response);
   return response;
+}
+
+function maybeRejectLegacyProductApi(pathname: string): NextResponse | null {
+  if (legacyProductApisEnabled()) {
+    return null;
+  }
+
+  const isLegacyProductApi = LEGACY_PRODUCT_API_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+  );
+  if (!isLegacyProductApi) {
+    return null;
+  }
+
+  const response = NextResponse.json(
+    {
+      error: "Legacy product API disabled",
+      replacement: "/api/analytics",
+      dashboard: "/analytics",
+    },
+    { status: 410 }
+  );
+  response.headers.set("API-Version", CURRENT_API_VERSION);
+  addSecurityHeaders(response);
+  return response;
+}
+
+function legacyProductApisEnabled(): boolean {
+  const flag = process.env.ENABLE_LEGACY_PRODUCT_APIS?.trim().toLowerCase();
+  if (flag === "1" || flag === "true" || flag === "yes" || flag === "on") {
+    return true;
+  }
+  if (flag === "0" || flag === "false" || flag === "no" || flag === "off") {
+    return false;
+  }
+
+  return process.env.NODE_ENV !== "production";
 }
 
 function maybeRedirectToCanonicalHost(


### PR DESCRIPTION
## Summary
- return 410 for legacy task-management APIs in production unless ENABLE_LEGACY_PRODUCT_APIS is explicitly enabled
- keep analytics and customer-success task APIs passing through
- cover unversioned and v1 legacy task/project API paths in middleware tests

## Verification
- npm test
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build
- railway run --service WIPGuard-app npx prisma migrate status --schema prisma/schema.prisma (blocked locally because Railway injects the private database hostname; no Prisma schema files changed in this PR)