### PR TITLE
fix(analytics): count demos from meeting records

### DIFF
--- a/src/app/api/analytics/route.test.ts
+++ b/src/app/api/analytics/route.test.ts
@@ -537,6 +537,24 @@ describe("GET /api/analytics", () => {
     expect(body.demoAnalytics.totalScheduled).toBeGreaterThan(0);
   });
 
+  it("loads unlinked HubSpot meetings for demo analytics instead of only deal-linked meetings", async () => {
+    const { prisma } = await import("@/lib/prisma");
+    const { GET } = await import("@/app/api/analytics/route");
+    await GET(new Request("http://localhost/api/analytics?section=demo-analytics"));
+
+    expect(prisma.dealMeeting.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          OR: [
+            { deal: { organizationId: "org-1" } },
+            { customerRecord: { organizationId: "org-1" } },
+            { dealId: null, customerRecordId: null },
+          ],
+        },
+      }),
+    );
+  });
+
   it("hydrates stripe customer links onto hubspot deals", async () => {
     const { prisma } = await import("@/lib/prisma");
     const { GET } = await import("@/app/api/analytics/route");

--- a/src/lib/__tests__/analytics-demo-analytics.test.ts
+++ b/src/lib/__tests__/analytics-demo-analytics.test.ts
@@ -338,15 +338,15 @@ describe("buildDemoAnalyticsData", () => {
     expect(paid.demoNoShow).toBe(1);
     expect(paid.closedLost).toBe(1);
     expect(paid.onboarding).toBe(0); // No Subscription/Closed Won deals
-    expect(paid.churned).toBe(1);
-    expect(paid.notActivated).toBe(1);
+    expect(paid.churned).toBe(0); // Closed Lost is a sales loss, not customer churn
+    expect(paid.notActivated).toBe(0);
   });
 
   it("includes Stripe churn events in churned count", () => {
     const data = baseData();
     data.hubspot = {
       funnel: {
-        totalDeals: 2, closedWon: 1, closedLost: 0, unlikely: 0, churn: 0,
+        totalDeals: 3, closedWon: 1, closedLost: 1, unlikely: 0, churn: 0,
         activeSubscriptions: 1, noShows: 0, demoScheduled: 1, demoFollowUp: 0,
         avgDealSize: 5000, winRate: 100, effectiveWinRate: 100, noShowRate: 0,
         stages: [], dealsBySource: [],
@@ -355,6 +355,7 @@ describe("buildDemoAnalyticsData", () => {
       deals: [
         makeDeal({ dealId: "cus_stripe1", dealName: "Stripe Customer", stageId: "w", stageLabel: "Closed Won", amount: 5000, source: "Organic", ownerId: null, updatedAt: "2026-03-05T00:00:00.000Z", createdAt: "2026-01-01T00:00:00.000Z" }),
         makeDeal({ dealId: "d2", dealName: "Active Deal", stageId: "s", stageLabel: "Subscription", amount: 3000, source: "Organic", ownerId: null, updatedAt: "2026-02-01T00:00:00.000Z", createdAt: "2026-01-10T00:00:00.000Z" }),
+        makeDeal({ dealId: "cus_lost", dealName: "Lost Deal", stageId: "l", stageLabel: "Closed Lost", amount: 2000, source: "Organic", ownerId: null, updatedAt: "2026-02-12T00:00:00.000Z", createdAt: "2026-01-15T00:00:00.000Z" }),
       ],
       _meta: META,
     };
@@ -365,6 +366,7 @@ describe("buildDemoAnalyticsData", () => {
         active: 1, pastDue: 0, canceled: 1, trialing: 0, churnRate: 50,
         recentChurnEvents: [
           { customer: "cus_stripe1", canceledAt: "2026-01-20T00:00:00.000Z", amount: 5000 },
+          { customer: "cus_lost", canceledAt: "2026-01-25T00:00:00.000Z", amount: 2000 },
         ],
       },
       payments: { succeeded: 2, failed: 0, successRate: 100 },
@@ -375,7 +377,7 @@ describe("buildDemoAnalyticsData", () => {
     const demo = buildDemoAnalyticsData(data);
     const organic = demo.journeyPaths.find((p) => p.source === "Organic")!;
 
-    // Stripe churn event matched by dealId → customer ID
+    // Stripe churn event matched by dealId → customer ID, but only for activated customer stages
     expect(organic.churned).toBe(1);
     expect(organic.onboarding).toBe(2); // Both Closed Won and Subscription
     expect(organic.notActivated).toBe(1);
@@ -445,14 +447,24 @@ describe("buildDemoAnalyticsData", () => {
       meetings: [
         makeMeeting({
           id: "meeting-upcoming",
-          title: "Upcoming Demo",
+          title: "Field Fastener & Arda Cards",
           status: "SCHEDULED",
           startAt: "2026-03-15T18:00:00.000Z",
           endAt: "2026-03-15T18:30:00.000Z",
+          notes: "A Sales Engineer will walk you through how Arda can eliminate stockouts and make ordering 10x faster. What are you most interested in learning about Arda?: Let's start the conversation.",
           dealId: "local-upcoming",
           dealName: "Upcoming Deal",
           hubspotDealId: "hs-upcoming",
           attendeeEmails: ["future@example.com"],
+        }),
+        makeMeeting({
+          id: "meeting-internal",
+          title: "Arda Sync",
+          status: "COMPLETED",
+          startAt: "2026-03-12T18:00:00.000Z",
+          endAt: "2026-03-12T18:30:00.000Z",
+          notes: "Internal operating sync.",
+          attendeeEmails: ["team@example.com"],
         }),
         makeMeeting({
           id: "meeting-historical",
@@ -518,6 +530,12 @@ describe("buildDemoAnalyticsData", () => {
       ],
     });
 
+    expect(demo.totalScheduled).toBe(2);
+    expect(demo.totalCompleted).toBe(1);
+    expect(demo.weeklyTrend).toEqual([
+      { week: "2026-03-01", scheduled: 1, completed: 1, noShows: 0 },
+      { week: "2026-03-15", scheduled: 1, completed: 0, noShows: 0 },
+    ]);
     expect(demo.upcomingCount).toBe(2);
     expect(demo.meetingBackedUpcomingCount).toBe(1);
     expect(demo.unscheduledDemoCount).toBe(1);

--- a/src/lib/__tests__/hubspot-deals-sync.test.ts
+++ b/src/lib/__tests__/hubspot-deals-sync.test.ts
@@ -149,10 +149,26 @@ describe("HubSpot local deal sync", () => {
 
       if (
         parsed.pathname === "/crm/v3/objects/contacts" ||
-        parsed.pathname === "/crm/v3/objects/companies" ||
-        parsed.pathname === "/crm/v3/objects/meetings"
+        parsed.pathname === "/crm/v3/objects/companies"
       ) {
         return jsonResponse({ results: [] });
+      }
+
+      if (parsed.pathname === "/crm/v3/objects/meetings") {
+        return jsonResponse({
+          results: [
+            {
+              id: "meeting-demo",
+              properties: {
+                hs_meeting_title: "Field Fastener & Arda Cards",
+                hs_meeting_body: "A Sales Engineer will walk you through how Arda can eliminate stockouts and make ordering 10x faster.",
+                hs_meeting_start_time: "2026-03-04T15:00:00.000Z",
+                hs_meeting_end_time: "2026-03-04T15:45:00.000Z",
+                hs_meeting_outcome: "COMPLETED",
+              },
+            },
+          ],
+        });
       }
 
       if (parsed.pathname === "/crm/v3/owners") {
@@ -171,7 +187,18 @@ describe("HubSpot local deal sync", () => {
     const result = await syncDealsFromHubSpot("user-1");
 
     expect(result.deals).toBe(3);
+    expect(result.meetings).toBe(1);
     expect(vi.mocked(prisma.deal.upsert).mock.calls).toHaveLength(3);
+    expect(vi.mocked(prisma.dealMeeting.upsert).mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          notes: "A Sales Engineer will walk you through how Arda can eliminate stockouts and make ordering 10x faster.",
+        }),
+        update: expect.objectContaining({
+          notes: "A Sales Engineer will walk you through how Arda can eliminate stockouts and make ordering 10x faster.",
+        }),
+      }),
+    );
     expect(
       vi.mocked(prisma.deal.upsert).mock.calls.map((call) => call[0].create.stage),
     ).toEqual([

--- a/src/lib/analytics/demo-analytics.ts
+++ b/src/lib/analytics/demo-analytics.ts
@@ -32,6 +32,12 @@ const DEMO_ANALYSIS_ARTIFACT_TYPES = new Set([
   "demo_coaching_memo",
   "deal_next_step_memo",
 ]);
+const DEMO_MEETING_TEXT_MARKERS = [
+  "sales engineer will walk you through",
+  "what are you most interested in learning about arda",
+  "make ordering 10x faster",
+  "& arda cards",
+];
 
 type HubSpotDeal = NonNullable<NonNullable<AnalyticsDashboardData["hubspot"]>["deals"]>[number];
 
@@ -218,6 +224,23 @@ function findHubSpotDealForMeeting(
   }
 
   return null;
+}
+
+function isDemoMeeting(meeting: DemoMeetingContext, deal: HubSpotDeal | null): boolean {
+  if (deal && DEMO_ENTRY_STAGES.has(deal.stageLabel)) return true;
+
+  const text = [
+    meeting.title,
+    meeting.notes,
+    meeting.dealName,
+    meeting.companyName,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  if (/\bdemo\b/.test(text)) return true;
+  return DEMO_MEETING_TEXT_MARKERS.some((marker) => text.includes(marker));
 }
 
 function buildDemoRecordFromMeeting(input: {
@@ -462,10 +485,9 @@ function buildConversionFunnel(demos: DemoRecord[]): DemoConversionStep[] {
 }
 
 function buildWeeklyTrend(demos: DemoRecord[]): DemoWeeklyTrend[] {
-  const historical = cohortDemos(demos);
   const byWeek = new Map<string, { scheduled: number; completed: number; noShows: number }>();
 
-  for (const demo of historical) {
+  for (const demo of demos) {
     const date = new Date(demo.scheduledAt);
     const weekStart = new Date(date);
     weekStart.setDate(date.getDate() - date.getDay());
@@ -495,7 +517,7 @@ const DEMO_ENTRY_STAGES = new Set([
   ...POST_DEMO_STAGES,
 ]);
 const ONBOARDED_STAGES = new Set(["Subscription", "Closed Won"]);
-const HUBSPOT_CHURN_STAGES = new Set(["Churn", "Closed Lost"]);
+const HUBSPOT_CHURN_STAGES = new Set(["Churn"]);
 
 type StripeChurnEvent = NonNullable<
   AnalyticsDashboardData["stripe"]
@@ -577,7 +599,8 @@ function buildJourneyPathAnalysis(data: AnalyticsDashboardData): JourneyPathRow[
     const churnedDeals = sourceDeals.flatMap((deal) => {
       const stripeEvent = resolveStripeChurnEvent(deal, stripeChurnLookup);
       const hubspotChurned = HUBSPOT_CHURN_STAGES.has(deal.stageLabel);
-      if (!hubspotChurned && !stripeEvent) return [];
+      const stripeChurned = Boolean(stripeEvent && ONBOARDED_STAGES.has(deal.stageLabel));
+      if (!hubspotChurned && !stripeChurned) return [];
       return [{
         deal,
         churnedAt: stripeEvent?.canceledAt ?? deal.updatedAt ?? null,
@@ -621,9 +644,11 @@ export async function listDemoAnalyticsMeetings(): Promise<DemoMeetingContext[]>
   const organizationId = getRequiredOrganizationId();
   const meetings = await prisma.dealMeeting.findMany({
     where: {
-      deal: {
-        organizationId,
-      },
+      OR: [
+        { deal: { organizationId } },
+        { customerRecord: { organizationId } },
+        { dealId: null, customerRecordId: null },
+      ],
     },
     include: {
       deal: {
@@ -777,13 +802,15 @@ export function buildDemoAnalyticsData(
     deal: findHubSpotDealForMeeting(meeting, dealsByHubspotId, dealsByName),
   }));
 
-  const meetingBackedDemos = meetingPairs.map(({ meeting, deal }) =>
-    buildDemoRecordFromMeeting({
-      now,
-      meeting,
-      deal,
-    }),
-  );
+  const meetingBackedDemos = meetingPairs
+    .filter(({ meeting, deal }) => isDemoMeeting(meeting, deal))
+    .map(({ meeting, deal }) =>
+      buildDemoRecordFromMeeting({
+        now,
+        meeting,
+        deal,
+      }),
+    );
 
   const coveredHubSpotDealIds = new Set(
     meetingPairs
@@ -805,7 +832,7 @@ export function buildDemoAnalyticsData(
     return a.dealName.localeCompare(b.dealName);
   });
 
-  const cohort = aggregateDemos;
+  const cohort = meetingBackedDemos.length > 0 ? meetingBackedDemos : aggregateDemos;
   const historical = historicalAnalysisDemos(demos);
   const totalScheduled = cohort.length;
   const totalCompleted = cohort.filter((demo) => demo.outcome === "completed").length;

--- a/src/lib/deals/hubspot-sync.ts
+++ b/src/lib/deals/hubspot-sync.ts
@@ -227,7 +227,7 @@ export async function syncDealsFromHubSpot(userId: string): Promise<SyncResult> 
     fetchAllPaginated(accessToken, "deals", "dealname,dealstage,amount,closedate,createdate,hs_analytics_source,hubspot_owner_id,hs_lastmodifieddate,pipeline"),
     fetchAllPaginated(accessToken, "contacts", "firstname,lastname,email,phone,jobtitle"),
     fetchAllPaginated(accessToken, "companies", "name,domain,industry"),
-    fetchAllPaginated(accessToken, "meetings", "hs_meeting_title,hs_meeting_start_time,hs_meeting_end_time,hs_meeting_location,hs_meeting_outcome,hs_meeting_external_url"),
+    fetchAllPaginated(accessToken, "meetings", "hs_meeting_title,hs_meeting_body,hs_meeting_start_time,hs_meeting_end_time,hs_meeting_location,hs_meeting_outcome,hs_meeting_external_url"),
     fetchOwnerMap(accessToken),
   ]);
 
@@ -394,6 +394,7 @@ export async function syncDealsFromHubSpot(userId: string): Promise<SyncResult> 
     const endAt = endTime ? new Date(endTime) : null;
 
     const outcome = hm.properties.hs_meeting_outcome || "";
+    const notes = hm.properties.hs_meeting_body?.trim() || null;
     let status: MeetingStatus = MeetingStatus.SCHEDULED;
     if (outcome === "COMPLETED") status = MeetingStatus.COMPLETED;
     else if (outcome === "CANCELED" || outcome === "CANCELLED") status = MeetingStatus.CANCELED;
@@ -427,6 +428,7 @@ export async function syncDealsFromHubSpot(userId: string): Promise<SyncResult> 
         startAt,
         endAt: endAt && !isNaN(endAt.getTime()) ? endAt : null,
         location: hm.properties.hs_meeting_location || null,
+        notes,
         dealId: localDealId,
         companyId: localCompanyId,
         expectedAttendees: localAttendeeIds.length,
@@ -440,6 +442,7 @@ export async function syncDealsFromHubSpot(userId: string): Promise<SyncResult> 
         startAt,
         endAt: endAt && !isNaN(endAt.getTime()) ? endAt : null,
         location: hm.properties.hs_meeting_location || null,
+        notes,
         dealId: localDealId,
         companyId: localCompanyId,
         expectedAttendees: localAttendeeIds.length,


### PR DESCRIPTION
## Summary
- Count demo analytics from meeting-backed demo records when HubSpot/calendar meetings exist
- Filter meeting-backed analytics to demo meetings instead of every internal meeting
- Persist HubSpot meeting body text so booking-style "Company & Arda Cards" events classify correctly
- Keep churn counts limited to activated/customer churn, not closed-lost prospects

## Verification
- npx prisma generate --schema prisma/schema.prisma
- npx vitest run src/lib/__tests__/analytics-demo-analytics.test.ts src/app/api/analytics/route.test.ts src/lib/__tests__/hubspot-deals-sync.test.ts
- npx eslint src/lib/analytics/demo-analytics.ts src/lib/__tests__/analytics-demo-analytics.test.ts src/app/api/analytics/route.test.ts src/lib/deals/hubspot-sync.ts src/lib/__tests__/hubspot-deals-sync.test.ts

## Production
Already deployed to Railway production as deployment 4cebd0a6-f967-404f-a70f-cd788b47fc4e; health check returned 200 OK.