### PR TITLE
feat: add canonical analytics metrics layer

### DIFF
--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -23,7 +23,7 @@ import {
   storeAnalyticsSnapshotFailure,
 } from "@/lib/analytics/snapshots";
 import { buildAnalyticsRouteMeta } from "@/lib/analytics/route-meta";
-import { computeAnalyticsKpis } from "@/lib/analytics/kpis";
+import { buildAnalyticsMetricsLayer, computeAnalyticsKpis } from "@/lib/analytics/kpis";
 import { computeKpiDelta } from "@/lib/analytics/kpi-deltas";
 import { buildSubscriptionMrrBreakdown } from "@/lib/analytics/subscription-mrr";
 import {
@@ -690,9 +690,7 @@ async function buildFinancialPlanningData(
       totalActual: null,
       totalVariance: null,
     };
-    const lineItems: BudgetLineItemData[] = mercury?.cashFlow
-      ? budgetDraft.lineItems
-      : computeBudgetActuals(budgetDraft, mercury);
+    const lineItems: BudgetLineItemData[] = computeBudgetActuals(budgetDraft, mercury);
     const summary = computeBudgetSummary(lineItems);
     return {
       id: b.id,
@@ -1593,6 +1591,10 @@ export async function GET(request: Request) {
     }
   }
 
+  const metrics = buildAnalyticsMetricsLayer(result);
+  result.metrics = metrics;
+  result.kpis = metrics.kpis;
+
   if (section === "overview") {
     try {
       const prevToDate = new Date(fromDate.getTime() - 1);
@@ -1621,8 +1623,8 @@ export async function GET(request: Request) {
       ]);
 
       const currentTraffic =
-        result.googleAnalytics || result.ga ? computeAnalyticsKpis(result).traffic : null;
-      const currentFinance = result.stripe ? computeAnalyticsKpis(result).finance : null;
+        result.googleAnalytics || result.ga ? metrics.kpis.traffic : null;
+      const currentFinance = result.stripe ? metrics.kpis.finance : null;
 
       const prevTraffic = prevGa.payload
         ? computeAnalyticsKpis(

--- a/src/app/api/cron/sync/route.ts
+++ b/src/app/api/cron/sync/route.ts
@@ -229,7 +229,11 @@ async function executeCronSync(input: {
     }
 
     const [analyticsResult, rulesResult, healthResult, pruningResult, retentionResult] = await Promise.allSettled([
-      runAnalyticsRefresh({ userIds, rangePresets: ["7d", "30d"] }),
+      runAnalyticsRefresh({
+        userIds,
+        rangePresets: ["7d", "30d"],
+        includeMonthlyFinancialHistory: true,
+      }),
       runRules({
         mode: "incremental",
         dryRun: false,

--- a/src/app/api/financial-planning/ai-analysis/route.ts
+++ b/src/app/api/financial-planning/ai-analysis/route.ts
@@ -15,7 +15,7 @@ export async function GET(): Promise<NextResponse> {
     const userId = (session.user as { id: string }).id;
 
     // Build the monthly history, then generate AI analysis from it
-    const history = await buildMonthlyPnLHistory(userId, 12);
+    const history = await buildMonthlyPnLHistory(userId);
 
     if (history.months.length === 0) {
       return NextResponse.json(

--- a/src/app/api/financial-planning/monthly-history/route.ts
+++ b/src/app/api/financial-planning/monthly-history/route.ts
@@ -13,9 +13,16 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     const userId = (session.user as { id: string }).id;
     const monthsParam = request.nextUrl.searchParams.get("months");
-    const monthsBack = monthsParam ? Math.min(Math.max(parseInt(monthsParam, 10) || 12, 1), 24) : 12;
+    const monthsBack = monthsParam ? Math.min(Math.max(parseInt(monthsParam, 10) || 12, 1), 24) : null;
+    const now = new Date();
+    const options =
+      monthsBack == null
+        ? undefined
+        : {
+            startDate: new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - monthsBack, 1)),
+          };
 
-    const history = await buildMonthlyPnLHistory(userId, monthsBack);
+    const history = await buildMonthlyPnLHistory(userId, options);
 
     return NextResponse.json(history, {
       headers: {

--- a/src/components/analytics/ads-google-analytics-tab.tsx
+++ b/src/components/analytics/ads-google-analytics-tab.tsx
@@ -59,11 +59,11 @@ export function AdsGoogleAnalyticsTab({ data }: AdsGoogleAnalyticsTabProps) {
     sessions30d, sessionsPrev30d,
     users30d, usersPrev30d,
     pageviews30d, pageviewsPrev30d,
-    bounceRate, avgSessionDuration,
+    avgSessionDuration,
     trafficByChannel, topPages, dailyTrend,
   } = ga;
 
-  const kpis = data.kpis ?? computeAnalyticsKpis(data);
+  const kpis = data.metrics?.kpis ?? data.kpis ?? computeAnalyticsKpis(data);
   const bounceRatePct = kpis.traffic.bounceRatePct ?? 0;
   const pagesPerSession = kpis.traffic.pagesPerSession ?? (sessions30d > 0 ? pageviews30d / sessions30d : 0);
   const engagementScore = kpis.traffic.engagementScore ?? Math.round(100 - bounceRatePct);

--- a/src/components/analytics/finance-monthly-history-tab.tsx
+++ b/src/components/analytics/finance-monthly-history-tab.tsx
@@ -104,7 +104,7 @@ export function FinanceMonthlyHistoryTab() {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch("/api/financial-planning/monthly-history?months=12");
+      const res = await fetch("/api/financial-planning/monthly-history");
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const json = await res.json();
       setData(json);

--- a/src/components/analytics/finance-planning-tab.test.tsx
+++ b/src/components/analytics/finance-planning-tab.test.tsx
@@ -2,7 +2,12 @@ import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FinancePlanningTab } from "@/components/analytics/finance-planning-tab";
 import { createEmptyAnalyticsDashboardData } from "@/lib/analytics/response-shape";
-import type { AnalyticsDashboardData, StripeData, MercuryData } from "@/lib/analytics/types";
+import type {
+  AnalyticsDashboardData,
+  MercuryData,
+  StripeData,
+} from "@/lib/analytics/types";
+import type { AnalyticsMetricsLayer } from "@/lib/analytics/kpis";
 
 /* ── Mock lucide-react icons as plain function components ── */
 
@@ -161,6 +166,85 @@ describe("FinancePlanningTab", () => {
       render(<FinancePlanningTab data={makePayload()} />);
       expect(screen.getAllByText("Cost of Goods Sold").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("Payroll & Benefits").length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("renders planned and actual values from the canonical metrics layer", () => {
+      const data = makePayload({
+        mercury: makeMercury({
+          transactions: [
+            {
+              id: "stripe-fee",
+              postedAt: "2026-01-15T00:00:00.000Z",
+              amount: -1234,
+              kind: "outgoingPayment",
+              mercuryCategory: null,
+              description: "Stripe fee",
+              counterpartyName: "Stripe",
+            },
+          ],
+        }),
+      }) as AnalyticsDashboardData & { metrics: AnalyticsMetricsLayer };
+      data.metrics = {
+        kpis: {
+          traffic: {
+            bounceRatePct: 0,
+            pagesPerSession: 0,
+            engagementScore: 100,
+            pageDepthScore: 0,
+          },
+          finance: {
+            mrr: 15000,
+            paymentSuccessPct: 98.7,
+          },
+        },
+        finance: {
+          budgetActuals: {
+            budgetId: "budget-1",
+            budgetName: "Baseline Budget",
+            totalBudget: 1000,
+            totalActual: 1234,
+            totalVariance: 234,
+            totalVariancePct: 23.4,
+            overspendCategories: ["Cost of Goods Sold"],
+            items: [
+              {
+                category: "Cost of Goods Sold",
+                budgeted: 1000,
+                actual: 1234,
+                variance: 234,
+                variancePct: 23.4,
+                status: "over",
+              },
+            ],
+          },
+        },
+      };
+      data.financialPlanning = {
+        budgets: [
+          {
+            id: "budget-1",
+            name: "Baseline Budget",
+            period: "monthly",
+            startDate: "2026-01-01T00:00:00.000Z",
+            endDate: "2026-01-31T23:59:59.999Z",
+            lineItems: [],
+            totalPlanned: 1000,
+            totalActual: 1234,
+            totalVariance: 234,
+          },
+        ],
+        activeBudget: null,
+        forecasts: [],
+        goals: [],
+        pnl: null,
+        unitEconomics: null,
+        subscriptionOverview: null,
+      };
+
+      render(<FinancePlanningTab data={data} />);
+
+      expect(screen.getAllByText("Cost of Goods Sold").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("$1.2K").length).toBeGreaterThanOrEqual(1);
     });
   });
 

--- a/src/components/analytics/finance-planning-tab.tsx
+++ b/src/components/analytics/finance-planning-tab.tsx
@@ -2,7 +2,11 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Target, Wallet, AlertTriangle, TrendingDown } from "lucide-react";
-import type { AnalyticsDashboardData } from "@/lib/analytics/types";
+import type {
+  AnalyticsDashboardData,
+  FinanceBudgetActualMetric,
+  FinanceBudgetActualsMetric,
+} from "@/lib/analytics/types";
 import { FinanceDataEmptyState } from "@/components/analytics/finance-empty-state";
 import { StatCard } from "@/components/analytics/stat-card";
 import { BarDisplay } from "@/components/analytics/bar-display";
@@ -15,10 +19,6 @@ import {
   AlertBanner,
   type DataTableColumn,
 } from "./dashboard-primitives";
-import {
-  computeBudgetSummary,
-  type BudgetActualItem,
-} from "@/lib/analytics/budget-variance";
 import {
   defaultDateRange,
   endDateForPeriod,
@@ -57,6 +57,16 @@ const CATEGORY_CONFIG: Array<{ key: BudgetCategoryApi; label: string }> = [
   { key: "OTHER", label: "Other" },
 ];
 
+const EMPTY_BUDGET_METRIC: FinanceBudgetActualsMetric = {
+  budgetId: "",
+  budgetName: "",
+  totalBudget: 0,
+  totalActual: 0,
+  totalVariance: 0,
+  totalVariancePct: 0,
+  overspendCategories: [],
+  items: [],
+};
 
 function emptyAmounts(): Record<BudgetCategoryApi, string> {
   return {
@@ -192,40 +202,15 @@ export function FinancePlanningTab({ data }: FinancePlanningTabProps) {
     seedFormFromBudget,
   ]);
 
-  const activeBudgetWithActuals = useMemo(() => {
-    if (!activeBudget) return data?.financialPlanning?.activeBudget ?? null;
-    const serverBudget = data?.financialPlanning?.budgets.find((budget) => budget.id === activeBudget.id);
-    return serverBudget ?? data?.financialPlanning?.activeBudget ?? null;
-  }, [activeBudget, data?.financialPlanning]);
-
   /* ── Computed data ────────────────────────────────── */
 
-  const budgetItems = useMemo(
-    () =>
-      (activeBudgetWithActuals?.lineItems ?? []).map((item) => ({
-        category: item.category,
-        budgeted: item.plannedAmount,
-        actual: item.actualAmount ?? 0,
-        variance: item.variance ?? 0,
-        variancePct: item.variancePct ?? 0,
-        status:
-          item.variance == null || item.variancePct == null
-            ? "on_track"
-            : item.variance > 0
-              ? "over"
-              : item.variance < 0
-                ? "under"
-                : "on_track",
-      })) satisfies BudgetActualItem[],
-    [activeBudgetWithActuals],
-  );
+  const budgetSummary =
+    data?.metrics?.finance.budgetActuals ?? EMPTY_BUDGET_METRIC;
+  const budgetItems = budgetSummary.items;
 
-  const budgetSummary = useMemo(
-    () => computeBudgetSummary(budgetItems),
-    [budgetItems],
+  const hasBudgetBaseline = Boolean(
+    budgetSummary.budgetId || (activeBudget && activeBudget.lineItems?.length),
   );
-
-  const hasBudgetBaseline = Boolean(activeBudget && activeBudget.lineItems?.length);
 
   const goals = useMemo<FinancialGoal[]>(
     () => (data ? computeFinancialGoals(data) : []),
@@ -363,7 +348,7 @@ export function FinancePlanningTab({ data }: FinancePlanningTabProps) {
 
   /* ── Budget variance table columns ────────────────── */
 
-  const budgetColumns: DataTableColumn<BudgetActualItem>[] = useMemo(
+  const budgetColumns: DataTableColumn<FinanceBudgetActualMetric>[] = useMemo(
     () => [
       {
         key: "category",

--- a/src/components/analytics/finance-tab.test.tsx
+++ b/src/components/analytics/finance-tab.test.tsx
@@ -4,6 +4,7 @@ import { FinanceTab } from "@/components/analytics/finance-tab";
 import { createEmptyAnalyticsDashboardData } from "@/lib/analytics/response-shape";
 import { buildProfitAndLossCore } from "@/lib/analytics/pnl-builder";
 import { buildDefaultScenarios } from "@/lib/analytics/forecast-engine";
+import { buildAnalyticsMetricsLayer } from "@/lib/analytics/kpis";
 import type {
   AnalyticsDashboardData,
   FinancialPlanningData,
@@ -104,6 +105,8 @@ function makePayload(
   data.stripe = opts.stripe !== undefined ? opts.stripe : makeStripe();
   data.mercury = opts.mercury !== undefined ? opts.mercury : makeMercury();
   data.financialPlanning = opts.financialPlanning !== undefined ? opts.financialPlanning : null;
+  data.metrics = buildAnalyticsMetricsLayer(data);
+  data.kpis = data.metrics.kpis;
   return data;
 }
 

--- a/src/components/analytics/finance-tab.tsx
+++ b/src/components/analytics/finance-tab.tsx
@@ -160,6 +160,7 @@ export function FinanceTab({ data }: FinanceTabProps) {
   const stripe = data.stripe;
   const mercury = data.mercury;
   const fp = data.financialPlanning;
+  const budgetActuals = data.metrics?.finance.budgetActuals ?? null;
   const financeErrors = data.errors
     .filter((entry) => entry.source === "stripe" || entry.source === "mercury")
     .map((entry) => `${entry.source}: ${entry.message}`);
@@ -467,44 +468,36 @@ export function FinanceTab({ data }: FinanceTabProps) {
       {/* ═══════════════════════════════════════════════════════════ */}
       {/* BUDGET VARIANCE                                           */}
       {/* ═══════════════════════════════════════════════════════════ */}
-      {fp?.activeBudget && (
+      {budgetActuals && (
         <div className="bg-card border border-border rounded-xl p-6">
           <div className="flex items-center gap-2 mb-6">
             <AlertTriangle className="w-5 h-5 text-muted-foreground" />
             <h3 className="text-foreground font-semibold">Budget vs Actual</h3>
-            <span className="text-xs text-muted-foreground ml-auto">{fp.activeBudget.name}</span>
+            <span className="text-xs text-muted-foreground ml-auto">{budgetActuals.budgetName}</span>
           </div>
-
-          {fp.activeBudget.totalActual == null ? (
-            <div className="mb-4 rounded-lg border border-amber-500/20 bg-amber-500/5 px-4 py-3 text-sm text-muted-foreground">
-              Actuals are hidden until transaction categories are mapped to budget lines.
-            </div>
-          ) : null}
 
           {/* Summary row */}
           <div className="grid grid-cols-3 gap-4 mb-6">
             <div className="bg-secondary/40 rounded-lg p-4">
               <p className="text-xs text-muted-foreground uppercase mb-1">Planned</p>
-              <p className="text-lg font-bold text-foreground tabular-nums">{fmt$(fp.activeBudget.totalPlanned)}</p>
+              <p className="text-lg font-bold text-foreground tabular-nums">{fmt$(budgetActuals.totalBudget)}</p>
             </div>
             <div className="bg-secondary/40 rounded-lg p-4">
               <p className="text-xs text-muted-foreground uppercase mb-1">Actual</p>
               <p className="text-lg font-bold text-foreground tabular-nums">
-                {fp.activeBudget.totalActual != null ? fmt$(fp.activeBudget.totalActual) : "—"}
+                {fmt$(budgetActuals.totalActual)}
               </p>
             </div>
             <div className="bg-secondary/40 rounded-lg p-4">
               <p className="text-xs text-muted-foreground uppercase mb-1">Variance</p>
               <p className={`text-lg font-bold tabular-nums ${
-                fp.activeBudget.totalVariance != null
-                  ? fp.activeBudget.totalVariance > 0
+                budgetActuals.totalVariance > 0
                     ? "text-red-500"
-                    : fp.activeBudget.totalVariance < 0
+                    : budgetActuals.totalVariance < 0
                     ? "text-emerald-500"
                     : "text-foreground"
-                  : "text-muted-foreground"
               }`}>
-                {fp.activeBudget.totalVariance != null ? fmtDelta(fp.activeBudget.totalVariance) : "—"}
+                {fmtDelta(budgetActuals.totalVariance)}
               </p>
             </div>
           </div>
@@ -517,26 +510,24 @@ export function FinanceTab({ data }: FinanceTabProps) {
             <span className="text-xs font-semibold text-muted-foreground uppercase text-right">Variance</span>
             <span className="text-xs font-semibold text-muted-foreground uppercase text-right">Var %</span>
           </div>
-          {fp.activeBudget.lineItems.map((item) => {
-            const overBudget = (item.variancePct ?? 0) > 15;
+          {budgetActuals.items.map((item) => {
+            const overBudget = item.status === "over";
             return (
-              <div key={item.id} className={`grid grid-cols-5 gap-4 py-2.5 ${overBudget ? "bg-red-500/5 -mx-2 px-2 rounded" : ""}`}>
-                <span className="text-sm text-muted-foreground capitalize">{item.category}</span>
-                <span className="text-sm text-foreground text-right tabular-nums">{fmt$(item.plannedAmount)}</span>
+              <div key={item.category} className={`grid grid-cols-5 gap-4 py-2.5 ${overBudget ? "bg-red-500/5 -mx-2 px-2 rounded" : ""}`}>
+                <span className="text-sm text-muted-foreground">{item.category}</span>
+                <span className="text-sm text-foreground text-right tabular-nums">{fmt$(item.budgeted)}</span>
                 <span className="text-sm text-foreground text-right tabular-nums">
-                  {item.actualAmount != null ? fmt$(item.actualAmount) : "—"}
+                  {fmt$(item.actual)}
                 </span>
                 <span className={`text-sm text-right tabular-nums ${
-                  item.variance != null
-                    ? item.variance > 0 ? "text-red-500" : item.variance < 0 ? "text-emerald-500" : "text-muted-foreground"
-                    : "text-muted-foreground"
+                  item.variance > 0 ? "text-red-500" : item.variance < 0 ? "text-emerald-500" : "text-muted-foreground"
                 }`}>
-                  {item.variance != null ? fmtDelta(item.variance) : "—"}
+                  {fmtDelta(item.variance)}
                 </span>
                 <span className={`text-sm text-right tabular-nums ${
                   overBudget ? "text-red-500 font-medium" : "text-muted-foreground"
                 }`}>
-                  {item.variancePct != null ? `${item.variancePct > 0 ? "+" : ""}${item.variancePct.toFixed(1)}%` : "—"}
+                  {item.variancePct > 0 ? "+" : ""}{item.variancePct.toFixed(1)}%
                 </span>
               </div>
             );

--- a/src/components/analytics/sub-dashboards/google-analytics-dashboard.tsx
+++ b/src/components/analytics/sub-dashboards/google-analytics-dashboard.tsx
@@ -70,7 +70,7 @@ export function GoogleAnalyticsDashboard({ data }: GoogleAnalyticsDashboardProps
     );
   }
 
-  const kpis = data.kpis ?? computeAnalyticsKpis(data);
+  const kpis = data.metrics?.kpis ?? data.kpis ?? computeAnalyticsKpis(data);
   const bounceRatePct = kpis.traffic.bounceRatePct ?? 0;
 
   const sessionsChange = calculateChange(ga.sessions30d, ga.sessionsPrev30d);

--- a/src/components/analytics/sub-dashboards/stripe-dashboard.tsx
+++ b/src/components/analytics/sub-dashboards/stripe-dashboard.tsx
@@ -42,7 +42,7 @@ export function StripeDashboard({ data }: StripeDashboardProps) {
   }
 
   const { revenue, subscriptions, payments, revenueTrend } = stripe;
-  const kpis = data.kpis ?? computeAnalyticsKpis(data);
+  const kpis = data.metrics?.kpis ?? data.kpis ?? computeAnalyticsKpis(data);
   const mrr = kpis.finance.mrr ?? revenue.mrr;
   const paymentSuccessPct = kpis.finance.paymentSuccessPct ?? payments.successRate;
 

--- a/src/lib/__tests__/analytics-ai-insights.test.ts
+++ b/src/lib/__tests__/analytics-ai-insights.test.ts
@@ -30,6 +30,7 @@ function baseData(): AnalyticsDashboardData {
     visitorFunnel: null,
     recommendations: [],
     distilledInsights: [],
+    metrics: null,
     aiInsights: {
       generatedAt: "2026-01-01T00:00:00.000Z",
       global: [],

--- a/src/lib/__tests__/analytics-fetchers-mercury.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-mercury.test.ts
@@ -48,8 +48,21 @@ describe("Mercury analytics fetcher", () => {
             { id: "internal-out", status: "sent", kind: "internalTransfer", amount: -10_000 },
             { id: "internal-in", status: "sent", kind: "internalTransfer", amount: 10_000 },
             { id: "wire-in", status: "sent", kind: "incomingDomesticWire", amount: 500 },
-            { id: "vendor", status: "sent", kind: "outgoingPayment", amount: -2_000 },
-            { id: "card", status: "sent", kind: "debitCardTransaction", amount: -100 },
+            {
+              id: "vendor",
+              status: "sent",
+              kind: "outgoingPayment",
+              amount: -2_000,
+              description: "Gusto payroll",
+              counterpartyName: "Gusto",
+            },
+            {
+              id: "card",
+              status: "sent",
+              kind: "debitCardTransaction",
+              amount: -100,
+              bankDescription: "Vercel",
+            },
             { id: "pending", status: "pending", kind: "outgoingPayment", amount: -999 },
           ],
         })
@@ -84,6 +97,20 @@ describe("Mercury analytics fetcher", () => {
     expect(data.cashFlow.outflows30d).toBe(2_100);
     expect(data.cashFlow.netCashFlow).toBe(-1_600);
     expect(data.cashFlow.burnRate).toBe(1_600);
+    expect(data.transactions).toEqual([
+      expect.objectContaining({ id: "wire-in", amount: 500 }),
+      expect.objectContaining({
+        id: "vendor",
+        amount: -2_000,
+        description: "Gusto payroll",
+        counterpartyName: "Gusto",
+      }),
+      expect.objectContaining({
+        id: "card",
+        amount: -100,
+        bankDescription: "Vercel",
+      }),
+    ]);
 
     const transactionsUrl = String(fetchMock.mock.calls[2]?.[0] ?? "");
     expect(transactionsUrl).toContain("/transactions?");

--- a/src/lib/__tests__/analytics-financial-planning.test.ts
+++ b/src/lib/__tests__/analytics-financial-planning.test.ts
@@ -94,4 +94,113 @@ describe("financial planning helpers", () => {
 
     expect(item.actualAmount).toBeCloseTo(expected, 2);
   });
+
+  it("maps Mercury transaction detail to budget categories when available", () => {
+    const budget: BudgetData = {
+      id: "budget-2",
+      name: "Monthly Budget",
+      period: "monthly",
+      startDate: "2026-02-01T00:00:00.000Z",
+      endDate: "2026-03-01T00:00:00.000Z",
+      lineItems: [
+        {
+          id: "payroll",
+          category: "payroll",
+          plannedAmount: 1000,
+          actualAmount: null,
+          variance: null,
+          variancePct: null,
+        },
+        {
+          id: "marketing",
+          category: "marketing",
+          plannedAmount: 1000,
+          actualAmount: null,
+          variance: null,
+          variancePct: null,
+        },
+        {
+          id: "infrastructure",
+          category: "infrastructure",
+          plannedAmount: 1000,
+          actualAmount: null,
+          variance: null,
+          variancePct: null,
+        },
+        {
+          id: "other",
+          category: "other",
+          plannedAmount: 1000,
+          actualAmount: null,
+          variance: null,
+          variancePct: null,
+        },
+      ],
+      totalPlanned: 4000,
+      totalActual: null,
+      totalVariance: null,
+    };
+
+    const mercuryWithTransactions: MercuryData = {
+      ...mercuryFixture,
+      cashFlow: {
+        ...mercuryFixture.cashFlow,
+        outflows30d: 99_999,
+      },
+      transactions: [
+        {
+          id: "gusto",
+          postedAt: "2026-02-10T00:00:00.000Z",
+          amount: -1200,
+          kind: "outgoingPayment",
+          mercuryCategory: null,
+          description: "Gusto payroll",
+          counterpartyName: "Gusto",
+        },
+        {
+          id: "linkedin",
+          postedAt: "2026-02-11T00:00:00.000Z",
+          amount: -450,
+          kind: "debitCardTransaction",
+          mercuryCategory: null,
+          description: "LinkedIn Ads",
+          counterpartyName: "LinkedIn",
+        },
+        {
+          id: "vercel",
+          postedAt: "2026-02-12T00:00:00.000Z",
+          amount: -125,
+          kind: "debitCardTransaction",
+          mercuryCategory: null,
+          description: "Vercel hosting",
+          counterpartyName: "Vercel",
+        },
+        {
+          id: "unknown",
+          postedAt: "2026-02-13T00:00:00.000Z",
+          amount: -75,
+          kind: "outgoingPayment",
+          mercuryCategory: null,
+          description: "Unmapped vendor",
+          counterpartyName: "Vendor",
+        },
+        {
+          id: "old",
+          postedAt: "2026-01-13T00:00:00.000Z",
+          amount: -999,
+          kind: "outgoingPayment",
+          mercuryCategory: null,
+          description: "Gusto payroll",
+          counterpartyName: "Gusto",
+        },
+      ],
+    };
+
+    const items = computeBudgetActuals(budget, mercuryWithTransactions);
+
+    expect(items.find((item) => item.category === "payroll")?.actualAmount).toBe(1200);
+    expect(items.find((item) => item.category === "marketing")?.actualAmount).toBe(450);
+    expect(items.find((item) => item.category === "infrastructure")?.actualAmount).toBe(125);
+    expect(items.find((item) => item.category === "other")?.actualAmount).toBe(75);
+  });
 });

--- a/src/lib/__tests__/analytics-funnel-lifecycle.test.ts
+++ b/src/lib/__tests__/analytics-funnel-lifecycle.test.ts
@@ -28,6 +28,7 @@ function baseData(): AnalyticsDashboardData {
     visitorFunnel: null,
     recommendations: [],
     distilledInsights: [],
+    metrics: null,
     aiInsights: {
       generatedAt: "2026-01-01T00:00:00.000Z",
       global: [],

--- a/src/lib/__tests__/analytics-kpis.test.ts
+++ b/src/lib/__tests__/analytics-kpis.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { AnalyticsDashboardData } from "@/lib/analytics/types";
-import { computeAnalyticsKpis } from "@/lib/analytics/kpis";
+import type { AnalyticsDashboardData, BudgetData } from "@/lib/analytics/types";
+import { buildAnalyticsMetricsLayer, computeAnalyticsKpis } from "@/lib/analytics/kpis";
 
 function makeData(successRate: number): AnalyticsDashboardData {
   return {
@@ -26,5 +26,66 @@ describe("computeAnalyticsKpis (finance)", () => {
 
   it("treats a 1.0 ratio as 100%", () => {
     expect(computeAnalyticsKpis(makeData(1)).finance.paymentSuccessPct).toBe(100);
+  });
+});
+
+describe("buildAnalyticsMetricsLayer", () => {
+  it("publishes canonical finance budget planned and actual metrics", () => {
+    const activeBudget: BudgetData = {
+      id: "budget-1",
+      name: "May Budget",
+      period: "monthly",
+      startDate: "2026-05-01T00:00:00.000Z",
+      endDate: "2026-05-31T23:59:59.999Z",
+      totalPlanned: 1000,
+      totalActual: 1234,
+      totalVariance: 234,
+      lineItems: [
+        {
+          id: "line-1",
+          category: "cogs",
+          plannedAmount: 1000,
+          actualAmount: 1234,
+          variance: 234,
+          variancePct: 23.4,
+        },
+      ],
+    };
+    const data = {
+      financialPlanning: {
+        activeBudget,
+        budgets: [activeBudget],
+      },
+    } as unknown as AnalyticsDashboardData;
+
+    const metrics = buildAnalyticsMetricsLayer(data);
+
+    expect(metrics.finance.budgetActuals).toMatchObject({
+      budgetId: "budget-1",
+      budgetName: "May Budget",
+      totalBudget: 1000,
+      totalActual: 1234,
+      totalVariance: 234,
+      totalVariancePct: 23.4,
+      overspendCategories: ["Cost of Goods Sold"],
+      items: [
+        {
+          category: "Cost of Goods Sold",
+          budgeted: 1000,
+          actual: 1234,
+          variance: 234,
+          variancePct: 23.4,
+          status: "over",
+        },
+      ],
+    });
+  });
+
+  it("returns null budget actuals when no active budget exists", () => {
+    const metrics = buildAnalyticsMetricsLayer({
+      financialPlanning: { activeBudget: null, budgets: [] },
+    } as unknown as AnalyticsDashboardData);
+
+    expect(metrics.finance.budgetActuals).toBeNull();
   });
 });

--- a/src/lib/__tests__/analytics-refresh-runner-monthly-history.test.ts
+++ b/src/lib/__tests__/analytics-refresh-runner-monthly-history.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runAnalyticsRefresh } from "@/lib/analytics/refresh-runner";
+import { fetchMercuryData, fetchStripeData } from "@/lib/analytics/fetchers";
+import { getCredentials } from "@/lib/analytics/credentials";
+import { storeAnalyticsSnapshot } from "@/lib/analytics/snapshots";
+import { prisma } from "@/lib/prisma";
+
+vi.mock("@/lib/analytics/credentials", () => ({
+  getCredentials: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/fetchers", () => ({
+  fetchHubSpotData: vi.fn(),
+  fetchMercuryData: vi.fn(),
+  fetchStripeData: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/fetchers-ads", () => ({
+  fetchGoogleAdsData: vi.fn(),
+  fetchMetaAdsData: vi.fn(),
+  fetchMetaPageData: vi.fn(),
+  fetchRedditAdsData: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/fetchers-coda", () => ({
+  fetchCodaData: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/fetchers-ga-webflow", () => ({
+  fetchGAData: vi.fn(),
+  fetchWebflowData: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/fetchers-integrations", () => ({
+  fetchIntegrationTelemetryData: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/fetchers-pylon", () => ({
+  fetchPylonData: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/fetchers-semrush", () => ({
+  fetchSemrushData: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/snapshots", () => ({
+  snapshotExpiryFromNow: vi.fn(() => new Date("2025-03-15T13:00:00.000Z")),
+  storeAnalyticsSnapshot: vi.fn(),
+  storeAnalyticsSnapshotFailure: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    integrationConnection: {
+      findMany: vi.fn(),
+    },
+    analyticsSnapshot: {
+      findMany: vi.fn(),
+    },
+    task: {
+      count: vi.fn(),
+    },
+    statusHistory: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+describe("analytics monthly financial history refresh", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-03-15T12:00:00.000Z"));
+    vi.mocked(getCredentials).mockResolvedValue({
+      stripeKey: "stripe-key",
+      mercuryKey: "mercury-key",
+    } as never);
+    vi.mocked(fetchStripeData).mockResolvedValue({ provider: "stripe" } as never);
+    vi.mocked(fetchMercuryData).mockResolvedValue({ provider: "mercury" } as never);
+    vi.mocked(prisma.analyticsSnapshot.findMany).mockResolvedValue([]);
+    vi.mocked(storeAnalyticsSnapshot).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetAllMocks();
+  });
+
+  it("pulls and stores one finance snapshot per month starting January 2025", async () => {
+    await runAnalyticsRefresh({
+      userIds: ["user-1"],
+      rangePresets: [],
+      includeMonthlyFinancialHistory: true,
+    });
+
+    expect(fetchStripeData).toHaveBeenCalledTimes(3);
+    expect(fetchMercuryData).toHaveBeenCalledTimes(3);
+    expect(fetchStripeData).toHaveBeenNthCalledWith(1, "stripe-key", {
+      fromDate: new Date("2025-01-01T00:00:00.000Z"),
+      toDate: new Date("2025-01-31T23:59:59.999Z"),
+    });
+    expect(fetchStripeData).toHaveBeenNthCalledWith(2, "stripe-key", {
+      fromDate: new Date("2025-02-01T00:00:00.000Z"),
+      toDate: new Date("2025-02-28T23:59:59.999Z"),
+    });
+    expect(fetchStripeData).toHaveBeenNthCalledWith(3, "stripe-key", {
+      fromDate: new Date("2025-03-01T00:00:00.000Z"),
+      toDate: new Date("2025-03-31T23:59:59.999Z"),
+    });
+
+    expect(storeAnalyticsSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        providerKey: "stripe",
+        contextKey: "financial-planning",
+        rangePreset: "monthly",
+        fromDate: new Date("2025-01-01T00:00:00.000Z"),
+        toDate: new Date("2025-01-31T23:59:59.999Z"),
+      }),
+    );
+    expect(storeAnalyticsSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        providerKey: "mercury",
+        contextKey: "financial-planning",
+        rangePreset: "monthly",
+        fromDate: new Date("2025-03-01T00:00:00.000Z"),
+        toDate: new Date("2025-03-31T23:59:59.999Z"),
+      }),
+    );
+  });
+
+  it("skips already-stored closed months and refreshes the current month", async () => {
+    vi.mocked(prisma.analyticsSnapshot.findMany).mockResolvedValue([
+      {
+        providerKey: "stripe",
+        fromDate: new Date("2025-01-01T00:00:00.000Z"),
+      },
+      {
+        providerKey: "mercury",
+        fromDate: new Date("2025-01-01T00:00:00.000Z"),
+      },
+      {
+        providerKey: "stripe",
+        fromDate: new Date("2025-02-01T00:00:00.000Z"),
+      },
+      {
+        providerKey: "mercury",
+        fromDate: new Date("2025-02-01T00:00:00.000Z"),
+      },
+      {
+        providerKey: "stripe",
+        fromDate: new Date("2025-03-01T00:00:00.000Z"),
+      },
+      {
+        providerKey: "mercury",
+        fromDate: new Date("2025-03-01T00:00:00.000Z"),
+      },
+    ] as never);
+
+    await runAnalyticsRefresh({
+      userIds: ["user-1"],
+      rangePresets: [],
+      includeMonthlyFinancialHistory: true,
+    });
+
+    expect(fetchStripeData).toHaveBeenCalledOnce();
+    expect(fetchMercuryData).toHaveBeenCalledOnce();
+    expect(fetchStripeData).toHaveBeenCalledWith("stripe-key", {
+      fromDate: new Date("2025-03-01T00:00:00.000Z"),
+      toDate: new Date("2025-03-31T23:59:59.999Z"),
+    });
+    expect(fetchMercuryData).toHaveBeenCalledWith("mercury-key", {
+      fromDate: new Date("2025-03-01T00:00:00.000Z"),
+      toDate: new Date("2025-03-31T23:59:59.999Z"),
+    });
+  });
+});

--- a/src/lib/__tests__/budget-variance.test.ts
+++ b/src/lib/__tests__/budget-variance.test.ts
@@ -263,6 +263,44 @@ describe("computeBudgetActuals", () => {
       expect(item.status).toBe("on_track");
     }
   });
+
+  it("uses Mercury transaction categories when transaction detail is available", () => {
+    const items = computeBudgetActuals(makeMercury({
+      transactions: [
+        {
+          id: "payroll",
+          postedAt: "2026-01-10T00:00:00.000Z",
+          amount: -500,
+          kind: "outgoingPayment",
+          mercuryCategory: null,
+          description: "Gusto payroll",
+          counterpartyName: "Gusto",
+        },
+        {
+          id: "infra",
+          postedAt: "2026-01-11T00:00:00.000Z",
+          amount: -125,
+          kind: "debitCardTransaction",
+          mercuryCategory: null,
+          description: "Vercel hosting",
+          counterpartyName: "Vercel",
+        },
+        {
+          id: "other",
+          postedAt: "2026-01-12T00:00:00.000Z",
+          amount: -75,
+          kind: "debitCardTransaction",
+          mercuryCategory: null,
+          description: "Unmapped vendor",
+          counterpartyName: "Vendor",
+        },
+      ],
+    }));
+
+    expect(items.find((item) => item.category === "Payroll & Benefits")?.actual).toBe(500);
+    expect(items.find((item) => item.category === "Infrastructure & Hosting")?.actual).toBe(125);
+    expect(items.find((item) => item.category === "Other")?.actual).toBe(75);
+  });
 });
 
 /* ═══════════════════════════════════════════════════════════

--- a/src/lib/__tests__/monthly-pnl-history.test.ts
+++ b/src/lib/__tests__/monthly-pnl-history.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { prisma } from "@/lib/prisma";
+import { buildMonthlyPnLHistory } from "@/lib/analytics/monthly-pnl-history";
+import type { MercuryData, StripeData } from "@/lib/analytics/types";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    analyticsSnapshot: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/integrations/ownership", () => ({
+  resolveIntegrationOwnerUserId: vi.fn((userId: string) => `owner:${userId}`),
+}));
+
+const meta = {
+  fetchedAt: "2025-01-31T23:59:59.999Z",
+  nextRefresh: "2025-02-01T00:59:59.999Z",
+  source: "cached" as const,
+};
+
+function makeStripe(revenue: number): StripeData {
+  return {
+    revenue: {
+      mrr: revenue / 10,
+      mrrChange: 0,
+      totalRevenue30d: revenue,
+      totalRevenuePrev30d: revenue,
+      revenueGrowth: 0,
+      avgRevenuePerCustomer: revenue / 100,
+    },
+    subscriptions: {
+      active: 10,
+      pastDue: 0,
+      canceled: 0,
+      trialing: 0,
+      churnRate: 0,
+      recentChurnEvents: [],
+    },
+    payments: {
+      succeeded: 1,
+      failed: 0,
+      successRate: 100,
+    },
+    revenueTrend: [],
+    _meta: meta,
+  };
+}
+
+function makeMercury(balance: number, outflows: number): MercuryData {
+  return {
+    accounts: [],
+    cashFlow: {
+      totalBalance: balance,
+      inflows30d: 0,
+      outflows30d: outflows,
+      netCashFlow: -outflows,
+      runway: 1,
+      burnRate: outflows,
+    },
+    _meta: meta,
+  };
+}
+
+describe("buildMonthlyPnLHistory", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-03-15T12:00:00.000Z"));
+    vi.mocked(prisma.analyticsSnapshot.findMany).mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("loads and exposes every reporting month starting January 2025", async () => {
+    vi.mocked(prisma.analyticsSnapshot.findMany).mockResolvedValue([
+      {
+        providerKey: "stripe",
+        payload: makeStripe(10_000),
+        fromDate: new Date("2025-01-01T00:00:00.000Z"),
+        toDate: new Date("2025-01-31T23:59:59.999Z"),
+        capturedAt: new Date("2025-03-15T00:00:00.000Z"),
+      },
+      {
+        providerKey: "mercury",
+        payload: makeMercury(50_000, 2_000),
+        fromDate: new Date("2025-03-01T00:00:00.000Z"),
+        toDate: new Date("2025-03-31T23:59:59.999Z"),
+        capturedAt: new Date("2025-03-15T00:00:00.000Z"),
+      },
+    ] as never);
+
+    const history = await buildMonthlyPnLHistory("user-1");
+
+    expect(prisma.analyticsSnapshot.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          userId: "owner:user-1",
+          contextKey: "financial-planning",
+          rangePreset: "monthly",
+          fromDate: { gte: new Date("2025-01-01T00:00:00.000Z") },
+        }),
+      }),
+    );
+    expect(history.months.map((month) => month.month)).toEqual([
+      "2025-01",
+      "2025-02",
+      "2025-03",
+    ]);
+    expect(history.months[0]?.revenue).toBe(10_000);
+    expect(history.months[1]?.revenue).toBe(0);
+    expect(history.months[2]?.cashBalance).toBe(50_000);
+  });
+});

--- a/src/lib/__tests__/snapshots.test.ts
+++ b/src/lib/__tests__/snapshots.test.ts
@@ -1,11 +1,16 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
-import { storeAnalyticsSnapshot, storeAnalyticsSnapshotFailure } from "@/lib/analytics/snapshots";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import {
+  pruneAnalyticsSnapshots,
+  storeAnalyticsSnapshot,
+  storeAnalyticsSnapshotFailure,
+} from "@/lib/analytics/snapshots";
 import { prisma } from "@/lib/prisma";
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     analyticsSnapshot: {
       upsert: vi.fn(),
+      deleteMany: vi.fn(),
     },
   },
 }));
@@ -13,6 +18,10 @@ vi.mock("@/lib/prisma", () => ({
 describe("analytics snapshots", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("upserts SUCCESS snapshots by composite key", async () => {
@@ -72,5 +81,23 @@ describe("analytics snapshots", () => {
       })
     );
   });
-});
 
+  it("prunes old rolling snapshots without deleting monthly financial history", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-04-15T00:00:00.000Z"));
+    vi.mocked(prisma.analyticsSnapshot.deleteMany).mockResolvedValueOnce({ count: 3 } as never);
+
+    const result = await pruneAnalyticsSnapshots({ olderThanDays: 30 });
+
+    expect(result.deleted).toBe(3);
+    expect(prisma.analyticsSnapshot.deleteMany).toHaveBeenCalledWith({
+      where: {
+        capturedAt: { lt: new Date("2025-03-16T00:00:00.000Z") },
+        NOT: {
+          contextKey: "financial-planning",
+          rangePreset: "monthly",
+        },
+      },
+    });
+  });
+});

--- a/src/lib/analytics/budget-variance.ts
+++ b/src/lib/analytics/budget-variance.ts
@@ -1,11 +1,6 @@
-// Budget-vs-actual variance analysis — computes estimated actuals per budget
-// line item using Mercury aggregate outflow data.
-//
-// Mercury data only provides aggregate inflows/outflows totals (no transaction-
-// level detail such as merchant names, categories, or descriptions). Therefore,
-// actual expenses per category are **estimated** using the same SaaS-standard
-// ratios defined in pnl-builder.ts. The "other" category absorbs any remainder
-// not covered by the known ratios.
+// Budget-vs-actual variance analysis — computes actuals per budget line item
+// using Mercury transactions when available, with aggregate outflow ratios as a
+// fallback for older snapshots.
 //
 // This module is pure computation — no database calls, no side effects.
 
@@ -14,6 +9,7 @@ import type {
   BudgetLineItemData,
   ExpenseCategory,
   MercuryData,
+  MercuryTransactionData,
 } from "@/lib/analytics/types";
 import { computeVariance } from "@/lib/analytics/finance-utils";
 
@@ -29,6 +25,107 @@ const CATEGORY_RATIOS: Record<ExpenseCategory, number> = {
   infrastructure: 0.10,
   ops: 0.15,
   other: 0, // "other" is a catch-all not covered by standard ratios
+};
+
+const EXPENSE_CATEGORIES: ExpenseCategory[] = [
+  "cogs",
+  "payroll",
+  "marketing",
+  "infrastructure",
+  "ops",
+  "other",
+];
+
+const CATEGORY_KEYWORDS: Record<ExpenseCategory, string[]> = {
+  payroll: [
+    "payroll",
+    "salary",
+    "wage",
+    "gusto",
+    "rippling",
+    "adp",
+    "justworks",
+    "deel",
+    "remote.com",
+    "benefit",
+    "health insurance",
+    "dental",
+    "workers comp",
+    "payroll tax",
+  ],
+  marketing: [
+    "marketing",
+    "advertising",
+    "google ads",
+    "adwords",
+    "facebook ads",
+    "meta ads",
+    "linkedin ads",
+    "reddit ads",
+    "tiktok ads",
+    "x ads",
+    "twitter ads",
+    "semrush",
+    "sponsorship",
+    "conference booth",
+    "campaign",
+  ],
+  infrastructure: [
+    "aws",
+    "amazon web services",
+    "google cloud",
+    "gcp",
+    "azure",
+    "vercel",
+    "railway",
+    "render",
+    "cloudflare",
+    "datadog",
+    "sentry",
+    "supabase",
+    "neon",
+    "planetscale",
+    "github",
+    "twilio",
+    "domain",
+    "dns",
+  ],
+  cogs: [
+    "stripe fee",
+    "payment processing",
+    "processor fee",
+    "fulfillment",
+    "hosting usage",
+    "openai api",
+    "anthropic",
+    "pinecone",
+    "replicate",
+    "customer support",
+    "support seat",
+  ],
+  ops: [
+    "rent",
+    "office",
+    "legal",
+    "attorney",
+    "accounting",
+    "bookkeeping",
+    "insurance",
+    "tax",
+    "bank fee",
+    "mercury fee",
+    "travel",
+    "airline",
+    "hotel",
+    "meal",
+    "restaurant",
+    "notion",
+    "slack",
+    "zoom",
+    "google workspace",
+    "quickbooks",
+  ],
+  other: [],
 };
 
 // ---------------------------------------------------------------------------
@@ -54,19 +151,107 @@ function estimateOutflowMultiplier(budget: BudgetData): number {
   return Math.max(days / 30, 0);
 }
 
+function txSearchText(tx: MercuryTransactionData): string {
+  return [
+    tx.mercuryCategory,
+    tx.kind,
+    tx.description,
+    tx.counterpartyName,
+    tx.bankDescription,
+    tx.note,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function transactionInBudgetRange(
+  tx: MercuryTransactionData,
+  budget: BudgetData | null,
+): boolean {
+  if (!budget || !tx.postedAt) return true;
+  const postedAt = Date.parse(tx.postedAt);
+  const start = Date.parse(budget.startDate);
+  const end = Date.parse(budget.endDate);
+  if (!Number.isFinite(postedAt) || !Number.isFinite(start) || !Number.isFinite(end)) {
+    return true;
+  }
+  return postedAt >= start && postedAt <= end;
+}
+
+export function categorizeMercuryTransaction(
+  tx: MercuryTransactionData,
+): ExpenseCategory {
+  const text = txSearchText(tx);
+  for (const category of EXPENSE_CATEGORIES) {
+    if (category === "other") continue;
+    if (CATEGORY_KEYWORDS[category].some((keyword) => text.includes(keyword))) {
+      return category;
+    }
+  }
+  return "other";
+}
+
+function hasTransactionDetail(mercury: MercuryData | null): boolean {
+  return Boolean(mercury?.transactions && mercury.transactions.length > 0);
+}
+
+function actualsFromTransactions(
+  mercury: MercuryData,
+  budget: BudgetData | null,
+): Record<ExpenseCategory, number> {
+  const totals = Object.fromEntries(
+    EXPENSE_CATEGORIES.map((category) => [category, 0]),
+  ) as Record<ExpenseCategory, number>;
+
+  for (const tx of mercury.transactions ?? []) {
+    if (typeof tx.amount !== "number" || !Number.isFinite(tx.amount) || tx.amount >= 0) {
+      continue;
+    }
+    if (!transactionInBudgetRange(tx, budget)) continue;
+    const category = categorizeMercuryTransaction(tx);
+    totals[category] = round2(totals[category] + Math.abs(tx.amount));
+  }
+
+  return totals;
+}
+
+function actualsFromRatios(totalOutflows: number): Record<ExpenseCategory, number> {
+  const totals = Object.fromEntries(
+    EXPENSE_CATEGORIES.map((category) => [category, 0]),
+  ) as Record<ExpenseCategory, number>;
+  let knownCategoryActualsSum = 0;
+
+  for (const category of EXPENSE_CATEGORIES) {
+    if (category === "other") continue;
+    const actualAmount = round2(totalOutflows * CATEGORY_RATIOS[category]);
+    totals[category] = actualAmount;
+    knownCategoryActualsSum += actualAmount;
+  }
+
+  totals.other = round2(Math.max(totalOutflows - knownCategoryActualsSum, 0));
+  return totals;
+}
+
+function actualsByCategory(
+  mercury: MercuryData,
+  budget: BudgetData | null,
+): Record<ExpenseCategory, number> {
+  if (hasTransactionDetail(mercury)) {
+    return actualsFromTransactions(mercury, budget);
+  }
+  const totalOutflows = mercury.cashFlow.outflows30d * (budget ? estimateOutflowMultiplier(budget) : 1);
+  return actualsFromRatios(totalOutflows);
+}
+
 // ---------------------------------------------------------------------------
 // computeBudgetActuals
 // ---------------------------------------------------------------------------
 
 /**
- * Estimate actual amounts for each budget line item using Mercury's total
+ * Compute actual amounts for each budget line item from Mercury transactions
+ * when snapshots include them. Older snapshots fall back to Mercury's total
  * outflows and the SaaS-standard category ratios.
- *
- * For every line item, `actualAmount` is derived from:
- *   `mercury.cashFlow.outflows30d * outflowMultiplier * CATEGORY_RATIOS[category]`
- *
- * The "other" category receives whatever is left after all known-ratio
- * categories have been allocated.
  *
  * When `mercury` is null (disconnected / unavailable), all actuals fields
  * are returned as null.
@@ -84,44 +269,18 @@ function computeBudgetActualsCore(
     }));
   }
 
-  const totalOutflows =
-    mercury.cashFlow.outflows30d * estimateOutflowMultiplier(budget);
+  const totals = actualsByCategory(mercury, budget);
 
-  // First pass: compute actuals for all known-ratio categories and track the
-  // sum so we can derive the "other" remainder.
-  let knownCategoryActualsSum = 0;
-
-  const withActuals: BudgetLineItemData[] = budget.lineItems.map((item) => {
-    if (item.category !== "other") {
-      const actualAmount = round2(totalOutflows * CATEGORY_RATIOS[item.category]);
-      knownCategoryActualsSum += actualAmount;
-      const { variance, variancePct } = computeVariance(item.plannedAmount, actualAmount);
-      return {
-        ...item,
-        actualAmount,
-        variance: variance != null ? round2(variance) : null,
-        variancePct: variancePct != null ? round2(variancePct) : null,
-      };
-    }
-    // Placeholder for "other" — filled in the second pass below.
-    return { ...item };
+  return budget.lineItems.map((item) => {
+    const actualAmount = round2(totals[item.category] ?? 0);
+    const { variance, variancePct } = computeVariance(item.plannedAmount, actualAmount);
+    return {
+      ...item,
+      actualAmount,
+      variance: variance != null ? round2(variance) : null,
+      variancePct: variancePct != null ? round2(variancePct) : null,
+    };
   });
-
-  // Second pass: assign "other" category the remainder.
-  for (let i = 0; i < withActuals.length; i++) {
-    if (withActuals[i].category === "other") {
-      const actualAmount = round2(totalOutflows - knownCategoryActualsSum);
-      const { variance, variancePct } = computeVariance(withActuals[i].plannedAmount, actualAmount);
-      withActuals[i] = {
-        ...withActuals[i],
-        actualAmount,
-        variance: variance != null ? round2(variance) : null,
-        variancePct: variancePct != null ? round2(variancePct) : null,
-      };
-    }
-  }
-
-  return withActuals;
 }
 
 // ---------------------------------------------------------------------------
@@ -218,6 +377,15 @@ export const EXPENSE_LABEL_RATIOS: Record<string, number> = {
   "General & Administrative": 0.15,
 };
 
+const LABEL_TO_CATEGORY: Record<string, ExpenseCategory> = {
+  "Cost of Goods Sold": "cogs",
+  "Payroll & Benefits": "payroll",
+  "Sales & Marketing": "marketing",
+  "Infrastructure & Hosting": "infrastructure",
+  "General & Administrative": "ops",
+  Other: "other",
+};
+
 const DEFAULT_LABELS = Object.keys(EXPENSE_LABEL_RATIOS);
 
 /** Determine status from variancePct using a 10% threshold. */
@@ -232,7 +400,9 @@ function toBudgetActualItems(
   mercury: MercuryData | null,
   budgetAmounts?: Record<string, number>,
 ): BudgetActualItem[] {
-  const totalOutflows = mercury?.cashFlow.outflows30d ?? 0;
+  const totals = mercury
+    ? actualsByCategory(mercury, null)
+    : actualsFromRatios(0);
 
   // When explicit budgets are provided, treat them as overrides. We still emit
   // the default label set so partially-specified budgets fall back to derived
@@ -242,11 +412,13 @@ function toBudgetActualItems(
         ...DEFAULT_LABELS,
         ...Object.keys(budgetAmounts).filter((label) => !DEFAULT_LABELS.includes(label)),
       ]
-    : DEFAULT_LABELS;
+    : hasTransactionDetail(mercury) && totals.other > 0
+      ? [...DEFAULT_LABELS, "Other"]
+      : DEFAULT_LABELS;
 
   const items: BudgetActualItem[] = labels.map((label) => {
-    const ratio = EXPENSE_LABEL_RATIOS[label] ?? 0;
-    const actual = round2(totalOutflows * ratio);
+    const category = LABEL_TO_CATEGORY[label] ?? "other";
+    const actual = round2(totals[category] ?? 0);
     const planned = budgetAmounts?.[label] ?? round2(actual * 1.1);
     const variance = round2(actual - planned);
     const variancePct = planned === 0 ? (actual === 0 ? 0 : 100) : round2((variance / planned) * 100);

--- a/src/lib/analytics/fetchers.ts
+++ b/src/lib/analytics/fetchers.ts
@@ -12,6 +12,7 @@ import type {
   SalesPerformanceRepMonthRow,
   StripeData,
   MercuryData,
+  MercuryTransactionData,
   AnalyticsTimestamp,
   DealStage,
 } from "./types";
@@ -1630,6 +1631,18 @@ export async function fetchMercuryData(
     amount?: number;
     kind?: string | null;
     mercuryCategory?: string | null;
+    description?: string | null;
+    bankDescription?: string | null;
+    note?: string | null;
+    counterpartyName?: string | null;
+    merchantName?: string | null;
+    externalMemo?: string | null;
+    memo?: string | null;
+    details?: {
+      counterpartyName?: string | null;
+      merchantName?: string | null;
+      description?: string | null;
+    } | null;
   };
 
   const headers: Record<string, string> = {
@@ -1705,12 +1718,37 @@ export async function fetchMercuryData(
       mercuryCategory === "treasurytransfer"
     );
   };
+  const toTransactionData = (tx: MercuryTransaction): MercuryTransactionData => ({
+    id: tx.id ?? "",
+    postedAt: tx.postedAt ?? tx.createdAt ?? tx.timestamp ?? null,
+    amount: tx.amount ?? 0,
+    kind: tx.kind ?? null,
+    mercuryCategory: tx.mercuryCategory ?? null,
+    description:
+      tx.description ??
+      tx.details?.description ??
+      tx.externalMemo ??
+      tx.memo ??
+      null,
+    counterpartyName:
+      tx.counterpartyName ??
+      tx.merchantName ??
+      tx.details?.counterpartyName ??
+      tx.details?.merchantName ??
+      null,
+    bankDescription: tx.bankDescription ?? null,
+    note: tx.note ?? null,
+  });
+
+  const transactions: MercuryTransactionData[] = [];
+
   const addCashFlow = (tx: MercuryTransaction): void => {
     if (!shouldCountCashFlow(tx)) return;
     const amount = tx.amount ?? 0;
     const amt = Math.abs(amount);
     if (amount > 0) inflows += amt;
     else outflows += amt;
+    transactions.push(toTransactionData(tx));
   };
 
   let inflows = 0, outflows = 0;
@@ -1785,6 +1823,7 @@ export async function fetchMercuryData(
       runway: Math.round(runway * 10) / 10,
       burnRate,
     },
+    transactions,
     _meta: makeMeta(),
   };
 }

--- a/src/lib/analytics/kpis.ts
+++ b/src/lib/analytics/kpis.ts
@@ -1,6 +1,105 @@
-import type { AnalyticsDashboardData } from "./types";
+import type {
+  AnalyticsDashboardData,
+  AnalyticsMetricsLayer,
+  BudgetData,
+  FinanceBudgetActualMetric,
+  FinanceBudgetActualsMetric,
+} from "./types";
 import { normalizePercentValue } from "./percentage-utils";
 import { buildSubscriptionMrrBreakdown } from "./subscription-mrr";
+
+export type {
+  AnalyticsMetricsLayer,
+  FinanceBudgetActualMetric,
+  FinanceBudgetActualsMetric,
+} from "./types";
+
+const CATEGORY_LABELS: Record<string, string> = {
+  cogs: "Cost of Goods Sold",
+  payroll: "Payroll & Benefits",
+  marketing: "Sales & Marketing",
+  infrastructure: "Infrastructure & Hosting",
+  ops: "General & Administrative",
+  other: "Other",
+};
+
+function roundMetric(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function metricVariancePct(budgeted: number, actual: number): number {
+  if (budgeted === 0) return actual === 0 ? 0 : 100;
+  return roundMetric(((actual - budgeted) / budgeted) * 100);
+}
+
+function statusFromVariance(
+  variance: number | null,
+): FinanceBudgetActualMetric["status"] {
+  if (variance == null || variance === 0) return "on_track";
+  return variance > 0 ? "over" : "under";
+}
+
+function buildFinanceBudgetActualsMetric(
+  activeBudget: BudgetData | null | undefined,
+): FinanceBudgetActualsMetric | null {
+  if (!activeBudget) return null;
+
+  const items = activeBudget.lineItems.map((item) => {
+    const budgeted = roundMetric(item.plannedAmount);
+    const actual = roundMetric(item.actualAmount ?? 0);
+    const variance = roundMetric(item.variance ?? actual - budgeted);
+    const variancePct = roundMetric(
+      item.variancePct ?? metricVariancePct(budgeted, actual),
+    );
+
+    return {
+      category: CATEGORY_LABELS[item.category] ?? item.category,
+      budgeted,
+      actual,
+      variance,
+      variancePct,
+      status: statusFromVariance(item.variance ?? variance),
+    };
+  });
+
+  const totalBudget = roundMetric(activeBudget.totalPlanned);
+  const totalActual = roundMetric(
+    activeBudget.totalActual ??
+      items.reduce((sum, item) => sum + item.actual, 0),
+  );
+  const totalVariance = roundMetric(
+    activeBudget.totalVariance ?? totalActual - totalBudget,
+  );
+  const totalVariancePct = metricVariancePct(totalBudget, totalActual);
+
+  return {
+    budgetId: activeBudget.id,
+    budgetName: activeBudget.name,
+    totalBudget,
+    totalActual,
+    totalVariance,
+    totalVariancePct,
+    overspendCategories: items
+      .filter((item) => item.status === "over")
+      .map((item) => item.category),
+    items,
+  };
+}
+
+export function buildAnalyticsMetricsLayer(
+  data: AnalyticsDashboardData,
+): AnalyticsMetricsLayer {
+  const kpis = computeAnalyticsKpis(data);
+
+  return {
+    kpis,
+    finance: {
+      budgetActuals: buildFinanceBudgetActualsMetric(
+        data.financialPlanning?.activeBudget,
+      ),
+    },
+  };
+}
 
 /**
  * Compute fallback KPIs from raw provider data when `data.kpis` is not

--- a/src/lib/analytics/monthly-pnl-history.ts
+++ b/src/lib/analytics/monthly-pnl-history.ts
@@ -63,34 +63,73 @@ interface MonthlySnapshot {
   mercury: MercuryData | null;
 }
 
+export const MONTHLY_HISTORY_START_DATE = new Date(Date.UTC(2025, 0, 1));
+export const MONTHLY_HISTORY_CONTEXT_KEY = "financial-planning";
+export const MONTHLY_HISTORY_RANGE_PRESET = "monthly";
+
+function monthKeyUtc(date: Date): string {
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function addMonthsUtc(date: Date, months: number): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + months, 1));
+}
+
+function buildMonthKeys(startDate: Date, endDate: Date): string[] {
+  const keys: string[] = [];
+  for (
+    let cursor = new Date(Date.UTC(startDate.getUTCFullYear(), startDate.getUTCMonth(), 1));
+    cursor <= endDate;
+    cursor = addMonthsUtc(cursor, 1)
+  ) {
+    keys.push(monthKeyUtc(cursor));
+  }
+  return keys;
+}
+
+function defaultHistoryEndDate(): Date {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+}
+
 async function loadMonthlySnapshots(
   userId: string,
-  monthsBack: number,
+  startDate: Date,
+  endDate: Date,
 ): Promise<MonthlySnapshot[]> {
-  const now = new Date();
-  const cutoff = new Date(now.getFullYear(), now.getMonth() - monthsBack, 1);
-
-  // Fetch all successful snapshots for stripe and mercury since cutoff
+  // Fetch all successful monthly source snapshots inside the reporting window.
   const snapshots = await prisma.analyticsSnapshot.findMany({
     where: {
       userId,
       providerKey: { in: ["stripe", "mercury"] },
+      contextKey: MONTHLY_HISTORY_CONTEXT_KEY,
+      rangePreset: MONTHLY_HISTORY_RANGE_PRESET,
       status: AnalyticsSnapshotStatus.SUCCESS,
-      capturedAt: { gte: cutoff },
+      fromDate: { gte: startDate },
     },
-    orderBy: { capturedAt: "desc" },
+    orderBy: [{ fromDate: "desc" }, { capturedAt: "desc" }],
     select: {
       providerKey: true,
       payload: true,
+      fromDate: true,
       capturedAt: true,
     },
   });
 
   // Group by month, taking the latest snapshot per provider per month
   const monthMap = new Map<string, { stripe: StripeData | null; mercury: MercuryData | null }>();
+  let latestSnapshotMonth: Date | null = null;
 
   for (const snap of snapshots) {
-    const month = `${snap.capturedAt.getFullYear()}-${String(snap.capturedAt.getMonth() + 1).padStart(2, "0")}`;
+    if (snap.fromDate.getTime() > endDate.getTime()) continue;
+
+    if (
+      latestSnapshotMonth == null ||
+      snap.fromDate.getTime() > latestSnapshotMonth.getTime()
+    ) {
+      latestSnapshotMonth = snap.fromDate;
+    }
+    const month = monthKeyUtc(snap.fromDate);
     if (!monthMap.has(month)) {
       monthMap.set(month, { stripe: null, mercury: null });
     }
@@ -104,13 +143,14 @@ async function loadMonthlySnapshots(
     }
   }
 
-  // Sort months chronologically
-  const sortedMonths = [...monthMap.entries()].sort(([a], [b]) => a.localeCompare(b));
+  if (!latestSnapshotMonth) return [];
 
-  return sortedMonths.map(([month, data]) => ({
+  const rangeEnd = latestSnapshotMonth.getTime() < endDate.getTime() ? latestSnapshotMonth : endDate;
+
+  return buildMonthKeys(startDate, rangeEnd).map((month) => ({
     month,
-    stripe: data.stripe,
-    mercury: data.mercury,
+    stripe: monthMap.get(month)?.stripe ?? null,
+    mercury: monthMap.get(month)?.mercury ?? null,
   }));
 }
 
@@ -176,10 +216,15 @@ function pctChange(current: number, previous: number): number {
 
 export async function buildMonthlyPnLHistory(
   sessionUserId: string,
-  monthsBack = 12,
+  options: {
+    startDate?: Date;
+    endDate?: Date;
+  } = {},
 ): Promise<MonthlyPnLHistory> {
   const userId = resolveIntegrationOwnerUserId(sessionUserId);
-  const snapshots = await loadMonthlySnapshots(userId, monthsBack);
+  const startDate = options.startDate ?? MONTHLY_HISTORY_START_DATE;
+  const endDate = options.endDate ?? defaultHistoryEndDate();
+  const snapshots = await loadMonthlySnapshots(userId, startDate, endDate);
 
   const months = snapshots.map((s) =>
     buildMonthEntry(s.month, s.stripe, s.mercury),

--- a/src/lib/analytics/refresh-runner.ts
+++ b/src/lib/analytics/refresh-runner.ts
@@ -1,4 +1,4 @@
-import { IntegrationProvider } from "@/generated/prisma/client";
+import { AnalyticsSnapshotStatus, IntegrationProvider } from "@/generated/prisma/client";
 import { getCredentials } from "@/lib/analytics/credentials";
 import {
   fetchHubSpotData,
@@ -14,7 +14,14 @@ import { fetchSemrushData } from "@/lib/analytics/fetchers-semrush";
 import { providerForSnapshotKey } from "@/lib/analytics/provider-health";
 import { snapshotExpiryFromNow, storeAnalyticsSnapshot, storeAnalyticsSnapshotFailure } from "@/lib/analytics/snapshots";
 import { parseAnalyticsTimeRange } from "@/lib/analytics/time-range";
+import {
+  MONTHLY_HISTORY_CONTEXT_KEY,
+  MONTHLY_HISTORY_RANGE_PRESET,
+  MONTHLY_HISTORY_START_DATE,
+} from "@/lib/analytics/monthly-pnl-history";
 import { prisma } from "@/lib/prisma";
+
+type RollingRangePreset = "7d" | "30d" | "90d";
 
 function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   return new Promise<T>((resolve, reject) => {
@@ -34,6 +41,69 @@ function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
 function timeoutMsForRefreshJob(providerKey: string): number {
   if (providerKey === "stripe") return 25_000;
   return 10_000;
+}
+
+function startOfUtcMonth(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+}
+
+function endOfUtcMonth(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 0, 23, 59, 59, 999));
+}
+
+function addUtcMonths(date: Date, months: number): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + months, 1));
+}
+
+function buildMonthlyHistoryPeriods(input: {
+  startDate?: Date;
+  asOf?: Date;
+} = {}): Array<{ fromDate: Date; toDate: Date }> {
+  const startDate = startOfUtcMonth(input.startDate ?? MONTHLY_HISTORY_START_DATE);
+  const endDate = startOfUtcMonth(input.asOf ?? new Date());
+  const periods: Array<{ fromDate: Date; toDate: Date }> = [];
+
+  for (let cursor = startDate; cursor <= endDate; cursor = addUtcMonths(cursor, 1)) {
+    periods.push({
+      fromDate: cursor,
+      toDate: endOfUtcMonth(cursor),
+    });
+  }
+
+  return periods;
+}
+
+function monthlySnapshotKey(input: { providerKey: string; fromDate: Date }): string {
+  return `${input.providerKey}:${input.fromDate.toISOString()}`;
+}
+
+async function loadExistingMonthlyFinancialSnapshotKeys(input: {
+  userId: string;
+  fromDate: Date;
+}): Promise<Set<string>> {
+  const snapshots = await prisma.analyticsSnapshot.findMany({
+    where: {
+      userId: input.userId,
+      providerKey: { in: ["stripe", "mercury"] },
+      contextKey: MONTHLY_HISTORY_CONTEXT_KEY,
+      rangePreset: MONTHLY_HISTORY_RANGE_PRESET,
+      status: AnalyticsSnapshotStatus.SUCCESS,
+      fromDate: { gte: input.fromDate },
+    },
+    select: {
+      providerKey: true,
+      fromDate: true,
+    },
+  });
+
+  return new Set(
+    snapshots.map((snapshot) =>
+      monthlySnapshotKey({
+        providerKey: snapshot.providerKey,
+        fromDate: snapshot.fromDate,
+      }),
+    ),
+  );
 }
 
 async function computeProductSnapshot(userId: string, fromDate: Date, toDate: Date) {
@@ -107,7 +177,7 @@ function recordProviderOutcome(
 
 async function refreshForUserAndRange(input: {
   userId: string;
-  rangePreset: "7d" | "30d" | "90d";
+  rangePreset: RollingRangePreset;
 }): Promise<{ refreshed: number; failures: number; providerOutcomes: Map<IntegrationProvider, ProviderRefreshOutcome> }> {
   const params = new URLSearchParams();
   params.set("range", input.rangePreset);
@@ -328,17 +398,95 @@ async function refreshForUserAndRange(input: {
   return { refreshed, failures, providerOutcomes };
 }
 
+async function refreshMonthlyFinancialHistoryForUser(input: {
+  userId: string;
+}): Promise<{ refreshed: number; failures: number; providerOutcomes: Map<IntegrationProvider, ProviderRefreshOutcome> }> {
+  const creds = await getCredentials(input.userId);
+  const expiresAt = snapshotExpiryFromNow(24);
+  const periods = buildMonthlyHistoryPeriods();
+  const currentMonthStart = startOfUtcMonth(new Date());
+  const existingSnapshotKeys =
+    periods.length > 0
+      ? await loadExistingMonthlyFinancialSnapshotKeys({
+          userId: input.userId,
+          fromDate: periods[0].fromDate,
+        })
+      : new Set<string>();
+  let refreshed = 0;
+  let failures = 0;
+  const providerOutcomes = new Map<IntegrationProvider, ProviderRefreshOutcome>();
+
+  for (const period of periods) {
+    const jobs: Array<{ providerKey: "stripe" | "mercury"; run: () => Promise<unknown> }> = [];
+    if (creds.stripeKey) {
+      const providerKey = "stripe";
+      const isCurrentMonth = period.fromDate.getTime() === currentMonthStart.getTime();
+      if (isCurrentMonth || !existingSnapshotKeys.has(monthlySnapshotKey({ providerKey, fromDate: period.fromDate }))) {
+        jobs.push({
+          providerKey,
+          run: () => fetchStripeData(creds.stripeKey!, period),
+        });
+      }
+    }
+    if (creds.mercuryKey) {
+      const providerKey = "mercury";
+      const isCurrentMonth = period.fromDate.getTime() === currentMonthStart.getTime();
+      if (isCurrentMonth || !existingSnapshotKeys.has(monthlySnapshotKey({ providerKey, fromDate: period.fromDate }))) {
+        jobs.push({
+          providerKey,
+          run: () => fetchMercuryData(creds.mercuryKey!, period),
+        });
+      }
+    }
+
+    for (const job of jobs) {
+      const provider = providerForSnapshotKey(job.providerKey);
+      try {
+        const payload = await timeout(job.run(), timeoutMsForRefreshJob(job.providerKey));
+        await storeAnalyticsSnapshot({
+          userId: input.userId,
+          providerKey: job.providerKey,
+          contextKey: MONTHLY_HISTORY_CONTEXT_KEY,
+          rangePreset: MONTHLY_HISTORY_RANGE_PRESET,
+          fromDate: period.fromDate,
+          toDate: period.toDate,
+          payload,
+          expiresAt,
+        });
+        refreshed += 1;
+        recordProviderOutcome(providerOutcomes, provider, { success: true });
+      } catch (error) {
+        failures += 1;
+        const message = error instanceof Error ? error.message : "monthly refresh failed";
+        await storeAnalyticsSnapshotFailure({
+          userId: input.userId,
+          providerKey: job.providerKey,
+          contextKey: MONTHLY_HISTORY_CONTEXT_KEY,
+          rangePreset: MONTHLY_HISTORY_RANGE_PRESET,
+          fromDate: period.fromDate,
+          toDate: period.toDate,
+          error: message,
+          expiresAt,
+        });
+        recordProviderOutcome(providerOutcomes, provider, { success: false, error: message });
+      }
+    }
+  }
+
+  return { refreshed, failures, providerOutcomes };
+}
+
 export async function runAnalyticsRefresh(input: {
   userIds?: string[];
-  rangePresets?: Array<"7d" | "30d" | "90d">;
+  rangePresets?: RollingRangePreset[];
+  includeMonthlyFinancialHistory?: boolean;
 } = {}): Promise<{
   usersProcessed: number;
   refreshCount: number;
   failureCount: number;
   completedAt: string;
 }> {
-  const rangePresets: Array<"7d" | "30d" | "90d"> =
-    input.rangePresets && input.rangePresets.length > 0 ? input.rangePresets : ["30d"];
+  const rangePresets: RollingRangePreset[] = input.rangePresets ?? ["30d"];
 
   const userIds =
     input.userIds && input.userIds.length > 0
@@ -358,6 +506,26 @@ export async function runAnalyticsRefresh(input: {
 
     for (const rangePreset of rangePresets) {
       const result = await refreshForUserAndRange({ userId, rangePreset });
+      refreshCount += result.refreshed;
+      failureCount += result.failures;
+
+      for (const [provider, outcome] of result.providerOutcomes.entries()) {
+        const existing = providerOutcomes.get(provider) ?? {
+          succeeded: false,
+          failed: false,
+          lastError: null,
+        };
+        existing.succeeded = existing.succeeded || outcome.succeeded;
+        existing.failed = existing.failed || outcome.failed;
+        if (outcome.lastError) {
+          existing.lastError = outcome.lastError;
+        }
+        providerOutcomes.set(provider, existing);
+      }
+    }
+
+    if (input.includeMonthlyFinancialHistory) {
+      const result = await refreshMonthlyFinancialHistoryForUser({ userId });
       refreshCount += result.refreshed;
       failureCount += result.failures;
 

--- a/src/lib/analytics/response-shape.ts
+++ b/src/lib/analytics/response-shape.ts
@@ -58,6 +58,7 @@ export function createEmptyAnalyticsDashboardData(input: {
     timeRange: input.timeRange,
     lastFullRefresh: input.lastFullRefresh ?? new Date().toISOString(),
     financialPlanning: null,
+    metrics: null,
     errors: [],
   };
 }

--- a/src/lib/analytics/snapshots.ts
+++ b/src/lib/analytics/snapshots.ts
@@ -1,4 +1,8 @@
 import { Prisma, AnalyticsSnapshotStatus } from "@/generated/prisma/client";
+import {
+  MONTHLY_HISTORY_CONTEXT_KEY,
+  MONTHLY_HISTORY_RANGE_PRESET,
+} from "@/lib/analytics/monthly-pnl-history";
 import { prisma } from "@/lib/prisma";
 
 export interface SnapshotQueryInput {
@@ -220,6 +224,10 @@ export async function pruneAnalyticsSnapshots(input: { olderThanDays: number }):
   const result = await prisma.analyticsSnapshot.deleteMany({
     where: {
       capturedAt: { lt: cutoffDate },
+      NOT: {
+        contextKey: MONTHLY_HISTORY_CONTEXT_KEY,
+        rangePreset: MONTHLY_HISTORY_RANGE_PRESET,
+      },
     },
   });
   return { deleted: result.count, cutoff: cutoffDate.toISOString() };

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -399,9 +399,22 @@ export interface CashFlowMetrics {
   burnRate: number;
 }
 
+export interface MercuryTransactionData {
+  id: string;
+  postedAt: string | null;
+  amount: number;
+  kind: string | null;
+  mercuryCategory: string | null;
+  description: string | null;
+  counterpartyName: string | null;
+  bankDescription?: string | null;
+  note?: string | null;
+}
+
 export interface MercuryData {
   accounts: AccountBalance[];
   cashFlow: CashFlowMetrics;
+  transactions?: MercuryTransactionData[];
   _meta: AnalyticsTimestamp;
 }
 
@@ -1709,6 +1722,46 @@ export interface UnitEconomics {
   grossMarginPct: number;
 }
 
+export interface FinanceBudgetActualMetric {
+  category: string;
+  budgeted: number;
+  actual: number;
+  variance: number;
+  variancePct: number;
+  status: "under" | "on_track" | "over";
+}
+
+export interface FinanceBudgetActualsMetric {
+  budgetId: string;
+  budgetName: string;
+  totalBudget: number;
+  totalActual: number;
+  totalVariance: number;
+  totalVariancePct: number;
+  overspendCategories: string[];
+  items: FinanceBudgetActualMetric[];
+}
+
+export interface AnalyticsKpis {
+  traffic: {
+    bounceRatePct: number;
+    pagesPerSession: number;
+    engagementScore: number;
+    pageDepthScore: number;
+  };
+  finance: {
+    mrr: number;
+    paymentSuccessPct: number;
+  };
+}
+
+export interface AnalyticsMetricsLayer {
+  kpis: AnalyticsKpis;
+  finance: {
+    budgetActuals: FinanceBudgetActualsMetric | null;
+  };
+}
+
 export interface FinancialPlanningData {
   budgets: BudgetData[];
   activeBudget: BudgetData | null;
@@ -1809,18 +1862,8 @@ export interface AnalyticsDashboardData {
   };
   lastFullRefresh: string;
   financialPlanning: FinancialPlanningData | null;
-  kpis?: {
-    traffic: {
-      bounceRatePct: number;
-      pagesPerSession: number;
-      engagementScore: number;
-      pageDepthScore: number;
-    };
-    finance: {
-      mrr: number;
-      paymentSuccessPct: number;
-    };
-  };
+  metrics?: AnalyticsMetricsLayer | null;
+  kpis?: AnalyticsKpis;
   deltas?: AnalyticsKpiDeltas;
   errors: { source: string; message: string }[];
 }


### PR DESCRIPTION
## Summary
- publish a canonical analytics metrics layer on /api/analytics with reusable KPIs and finance budget actuals
- compute budget actuals from normalized Mercury transaction detail, while keeping treasury/internal transfers out of operating cashflow
- materialize monthly Stripe/Mercury finance snapshots from January 2025 and preserve them from rolling snapshot pruning
- update finance UI/dashboard surfaces and tests to consume canonical metrics

## Verification
- npm test
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build
- precommit lint-staged quality gate