### PR TITLE
fix(analytics): use canonical finance metrics in consumers

### DIFF
--- a/src/app/api/analytics/route.test.ts
+++ b/src/app/api/analytics/route.test.ts
@@ -570,6 +570,42 @@ describe("GET /api/analytics", () => {
     });
   });
 
+  it("uses canonical finance metrics for financial goal progress", async () => {
+    const { prisma } = await import("@/lib/prisma");
+    vi.mocked(prisma.financialGoal.findMany).mockResolvedValueOnce([
+      {
+        id: "goal-mrr",
+        metric: "mrr",
+        targetValue: 20000,
+        deadline: new Date("2027-01-01T00:00:00.000Z"),
+      },
+      {
+        id: "goal-customers",
+        metric: "customer_count",
+        targetValue: 10,
+        deadline: new Date("2027-01-01T00:00:00.000Z"),
+      },
+    ] as never);
+
+    const { GET } = await import("@/app/api/analytics/route");
+    const response = await GET(new Request("http://localhost/api/analytics?section=finance-planning"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.financialPlanning.goals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "goal-mrr",
+          currentValue: 15598,
+        }),
+        expect.objectContaining({
+          id: "goal-customers",
+          currentValue: 2,
+        }),
+      ]),
+    );
+  });
+
   it("returns process analytics domain data", async () => {
     const { GET } = await import("@/app/api/analytics/route");
     const response = await GET(new Request("http://localhost/api/analytics?section=process-analytics"));

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -637,7 +637,19 @@ async function buildFinancialPlanningData(
   const mercury = data.mercury as MercuryData | null;
   const hubspot = data.hubspot as HubSpotData | null;
   const subscriptionOverview = buildSubscriptionOverview(data);
-  const totalMrr = subscriptionOverview?.totalMrr ?? stripe?.revenue.mrr ?? 0;
+  const planningMetrics = buildAnalyticsMetricsLayer({
+    ...data,
+    financialPlanning: {
+      budgets: [],
+      activeBudget: null,
+      forecasts: [],
+      goals: [],
+      pnl: null,
+      unitEconomics: null,
+      subscriptionOverview,
+    },
+  });
+  const financeSummary = planningMetrics.finance.summary;
 
   const [dbBudgets, dbGoals, dbForecasts] = await Promise.all([
     prisma.budget.findMany({
@@ -708,13 +720,13 @@ async function buildFinancialPlanningData(
 
   // --- Goals with current progress ---
   const currentMetrics: Record<string, number> = {
-    mrr: totalMrr,
-    arr: totalMrr * 12,
-    runway: mercury?.cashFlow.runway ?? 0,
-    burn_rate: mercury?.cashFlow.burnRate ?? 0,
-    net_cash_flow: mercury?.cashFlow.netCashFlow ?? 0,
-    revenue: stripe?.revenue.totalRevenue30d ?? 0,
-    customer_count: subscriptionOverview?.mergedActiveSubscriptions ?? 0,
+    mrr: financeSummary.mrr,
+    arr: financeSummary.mrr * 12,
+    runway: financeSummary.runwayMonths,
+    burn_rate: financeSummary.burnRate,
+    net_cash_flow: financeSummary.netCashFlow30d,
+    revenue: financeSummary.totalRevenue30d,
+    customer_count: financeSummary.activeSubscriptions,
   };
 
   const goals: FinancialGoalData[] = dbGoals.map((g: { id: string; metric: GoalMetric | string; targetValue: number; deadline: Date; }) => {

--- a/src/lib/__tests__/metric-history.test.ts
+++ b/src/lib/__tests__/metric-history.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { getMetricsBySection } from "@/lib/analytics/metric-history";
+import { buildAnalyticsMetricsLayer } from "@/lib/analytics/kpis";
+import type { AnalyticsDashboardData } from "@/lib/analytics/types";
+
+function financeExtractors() {
+  return Object.fromEntries(
+    getMetricsBySection("finance").map((metric) => [metric.key, metric.extract]),
+  );
+}
+
+describe("metric history finance extraction", () => {
+  it("uses canonical finance summary metrics when they are present", () => {
+    const data = {
+      metrics: buildAnalyticsMetricsLayer({} as AnalyticsDashboardData),
+    } as AnalyticsDashboardData;
+    data.metrics!.finance.summary.mrr = 42000;
+    data.metrics!.finance.summary.churnRatePct = 3.5;
+    data.metrics!.finance.summary.activeSubscriptions = 12;
+    data.metrics!.finance.summary.runwayMonths = 9.25;
+
+    const extract = financeExtractors();
+
+    expect(extract["stripe.mrr"]?.(data)).toBe(42000);
+    expect(extract["stripe.churnRate"]?.(data)).toBe(3.5);
+    expect(extract["stripe.activeSubscriptions"]?.(data)).toBe(12);
+    expect(extract["mercury.runway"]?.(data)).toBe(9.25);
+  });
+
+  it("builds canonical finance metrics before extracting raw snapshot payloads", () => {
+    const data = {
+      stripe: {
+        revenue: {
+          mrr: 10000,
+          mrrChange: 500,
+          totalRevenue30d: 12000,
+          totalRevenuePrev30d: 11000,
+          revenueGrowth: 9.1,
+          avgRevenuePerCustomer: 250,
+        },
+        subscriptions: {
+          active: 40,
+          pastDue: 2,
+          canceled: 1,
+          trialing: 3,
+          churnRate: 0.04,
+          recentChurnEvents: [],
+        },
+        payments: { succeeded: 79, failed: 1, successRate: 0.987 },
+        revenueTrend: [],
+      },
+      mercury: {
+        accounts: [],
+        cashFlow: {
+          totalBalance: 500000,
+          inflows30d: 18000,
+          outflows30d: 45000,
+          netCashFlow: -27000,
+          runway: 18.5,
+          burnRate: 27000,
+        },
+      },
+    } as unknown as AnalyticsDashboardData;
+
+    const extract = financeExtractors();
+
+    expect(extract["stripe.churnRate"]?.(data)).toBe(4);
+    expect(extract["stripe.activeSubscriptions"]?.(data)).toBe(40);
+    expect(extract["mercury.totalBalance"]?.(data)).toBe(500000);
+    expect(extract["mercury.netCashFlow"]?.(data)).toBe(-27000);
+  });
+});

--- a/src/lib/analytics/metric-history.ts
+++ b/src/lib/analytics/metric-history.ts
@@ -1,5 +1,10 @@
 import { prisma } from "@/lib/prisma";
-import type { AnalyticsDashboardData, AnalyticsSectionId } from "@/lib/analytics/types";
+import type {
+  AnalyticsDashboardData,
+  AnalyticsMetricsLayer,
+  AnalyticsSectionId,
+} from "@/lib/analytics/types";
+import { buildAnalyticsMetricsLayer } from "@/lib/analytics/kpis";
 
 // ── Metric Definition Registry ──
 
@@ -8,6 +13,17 @@ interface MetricDefinition {
   section: AnalyticsSectionId;
   label: string;
   extract: (data: AnalyticsDashboardData) => number | null;
+}
+
+const computedMetricsCache = new WeakMap<AnalyticsDashboardData, AnalyticsMetricsLayer>();
+
+function getCanonicalMetrics(data: AnalyticsDashboardData): AnalyticsMetricsLayer {
+  if (data.metrics) return data.metrics;
+  const cached = computedMetricsCache.get(data);
+  if (cached) return cached;
+  const metrics = buildAnalyticsMetricsLayer(data);
+  computedMetricsCache.set(data, metrics);
+  return metrics;
 }
 
 const METRIC_REGISTRY: MetricDefinition[] = [
@@ -25,15 +41,15 @@ const METRIC_REGISTRY: MetricDefinition[] = [
   { key: "metaAds.clicks", section: "social-media", label: "Meta Ads Clicks", extract: (d) => d.metaAds?.totalClicks ?? null },
 
   // Finance
-  { key: "stripe.mrr", section: "finance", label: "MRR", extract: (d) => d.stripe?.revenue?.mrr ?? null },
-  { key: "stripe.revenue30d", section: "finance", label: "Revenue (30d)", extract: (d) => d.stripe?.revenue?.totalRevenue30d ?? null },
-  { key: "stripe.revenueGrowth", section: "finance", label: "Revenue Growth %", extract: (d) => d.stripe?.revenue?.revenueGrowth ?? null },
-  { key: "stripe.churnRate", section: "finance", label: "Churn Rate", extract: (d) => d.stripe?.subscriptions?.churnRate ?? null },
-  { key: "stripe.activeSubscriptions", section: "finance", label: "Active Subscriptions", extract: (d) => d.stripe?.subscriptions?.active ?? null },
-  { key: "mercury.runway", section: "finance", label: "Runway (months)", extract: (d) => d.mercury?.cashFlow?.runway ?? null },
-  { key: "mercury.burnRate", section: "finance", label: "Burn Rate", extract: (d) => d.mercury?.cashFlow?.burnRate ?? null },
-  { key: "mercury.totalBalance", section: "finance", label: "Total Balance", extract: (d) => d.mercury?.cashFlow?.totalBalance ?? null },
-  { key: "mercury.netCashFlow", section: "finance", label: "Net Cash Flow", extract: (d) => d.mercury?.cashFlow?.netCashFlow ?? null },
+  { key: "stripe.mrr", section: "finance", label: "MRR", extract: (d) => getCanonicalMetrics(d).finance.summary.mrr },
+  { key: "stripe.revenue30d", section: "finance", label: "Revenue (30d)", extract: (d) => getCanonicalMetrics(d).finance.summary.totalRevenue30d },
+  { key: "stripe.revenueGrowth", section: "finance", label: "Revenue Growth %", extract: (d) => getCanonicalMetrics(d).finance.summary.revenueGrowth },
+  { key: "stripe.churnRate", section: "finance", label: "Churn Rate", extract: (d) => getCanonicalMetrics(d).finance.summary.churnRatePct },
+  { key: "stripe.activeSubscriptions", section: "finance", label: "Active Subscriptions", extract: (d) => getCanonicalMetrics(d).finance.summary.activeSubscriptions },
+  { key: "mercury.runway", section: "finance", label: "Runway (months)", extract: (d) => getCanonicalMetrics(d).finance.summary.runwayMonths },
+  { key: "mercury.burnRate", section: "finance", label: "Burn Rate", extract: (d) => getCanonicalMetrics(d).finance.summary.burnRate },
+  { key: "mercury.totalBalance", section: "finance", label: "Total Balance", extract: (d) => getCanonicalMetrics(d).finance.summary.cashBalance },
+  { key: "mercury.netCashFlow", section: "finance", label: "Net Cash Flow", extract: (d) => getCanonicalMetrics(d).finance.summary.netCashFlow30d },
 
   // Sales & Pipeline
   { key: "hubspot.totalDeals", section: "sales-pipeline", label: "Total Deals", extract: (d) => d.hubspot?.funnel?.totalDeals ?? null },


### PR DESCRIPTION
## Summary
- route finance metric history extraction through the canonical finance summary layer
- compute canonical metrics for raw analytics snapshots when `data.metrics` is absent
- use canonical finance summary values for financial goal progress
- add regression coverage for precomputed metrics, raw payload extraction, and finance goal current values

## Validation
- npm test -- src/lib/__tests__/metric-history.test.ts
- npm test -- src/app/api/analytics/route.test.ts
- npm test -- src/lib/__tests__/metric-history.test.ts src/app/api/analytics/route.test.ts
- npm run typecheck:staged -- src/lib/analytics/metric-history.ts src/lib/__tests__/metric-history.test.ts
- npm run typecheck:staged -- src/app/api/analytics/route.ts src/app/api/analytics/route.test.ts
- npx eslint --max-warnings=0 src/lib/analytics/metric-history.ts src/lib/__tests__/metric-history.test.ts
- npx eslint --max-warnings=0 src/app/api/analytics/route.ts src/app/api/analytics/route.test.ts