### PR TITLE
fix(analytics): use canonical finance dashboard metrics

### DIFF
--- a/src/components/analytics/integration-child-dashboards.test.tsx
+++ b/src/components/analytics/integration-child-dashboards.test.tsx
@@ -3,6 +3,7 @@ import type { ComponentType } from "react";
 import { describe, expect, it } from "vitest";
 import { INTEGRATION_CHILD_DASHBOARD_REGISTRY, type IntegrationChildDashboardProps } from "@/components/analytics/integration-child-dashboards";
 import { createEmptyAnalyticsDashboardData } from "@/lib/analytics/response-shape";
+import { buildAnalyticsMetricsLayer } from "@/lib/analytics/kpis";
 
 describe("integration child dashboards", () => {
   const baseData = createEmptyAnalyticsDashboardData({ freshness: {}, timeRange: undefined });
@@ -120,5 +121,78 @@ describe("integration child dashboards", () => {
     render(<Dashboard data={data} />);
     expect(screen.getByText("Engaged Leads Missing from Funnel")).toBeTruthy();
     expect(screen.getByRole("link", { name: "Search in HubSpot" })).toBeTruthy();
+  });
+
+  it("uses canonical Mercury metrics in the finance Mercury child dashboard", () => {
+    const Dashboard = INTEGRATION_CHILD_DASHBOARD_REGISTRY["finance-mercury"] as ComponentType<IntegrationChildDashboardProps>;
+    const data = {
+      ...baseData,
+      mercury: {
+        accounts: [],
+        cashFlow: {
+          totalBalance: 500000,
+          inflows30d: 18000,
+          outflows30d: 45000,
+          netCashFlow: -27000,
+          runway: 18.5,
+          burnRate: 27000,
+        },
+        _meta: {
+          fetchedAt: "2026-02-18T00:00:00.000Z",
+          nextRefresh: "2026-02-18T01:00:00.000Z",
+          source: "live" as const,
+        },
+      },
+    };
+    data.metrics = buildAnalyticsMetricsLayer(data);
+    data.metrics.finance.mercury!.totalBalance = 1234;
+
+    render(<Dashboard data={data} />);
+
+    expect(screen.getByText("$1.2K")).toBeTruthy();
+  });
+
+  it("uses canonical Stripe metrics in the sales Stripe child dashboard", () => {
+    const Dashboard = INTEGRATION_CHILD_DASHBOARD_REGISTRY["sales-stripe"] as ComponentType<IntegrationChildDashboardProps>;
+    const data = {
+      ...baseData,
+      stripe: {
+        revenue: {
+          mrr: 12000,
+          mrrChange: 500,
+          totalRevenue30d: 15000,
+          totalRevenuePrev30d: 14000,
+          revenueGrowth: 7.1,
+          avgRevenuePerCustomer: 300,
+        },
+        subscriptions: {
+          active: 40,
+          pastDue: 2,
+          canceled: 1,
+          trialing: 3,
+          churnRate: 0.04,
+          recentChurnEvents: [],
+        },
+        payments: {
+          succeeded: 79,
+          failed: 1,
+          successRate: 0.987,
+        },
+        revenueTrend: [],
+        _meta: {
+          fetchedAt: "2026-02-18T00:00:00.000Z",
+          nextRefresh: "2026-02-18T01:00:00.000Z",
+          source: "live" as const,
+        },
+      },
+    };
+    data.metrics = buildAnalyticsMetricsLayer(data);
+    data.metrics.finance.stripe!.activeSubscriptions = 88;
+    data.metrics.finance.stripe!.paymentSuccessPct = 91.2;
+
+    render(<Dashboard data={data} />);
+
+    expect(screen.getByText("88")).toBeTruthy();
+    expect(screen.getByText("91.2%")).toBeTruthy();
   });
 });

--- a/src/components/analytics/integration-child-dashboards.tsx
+++ b/src/components/analytics/integration-child-dashboards.tsx
@@ -726,14 +726,18 @@ export function AdsCodaKanbanDashboard({ data }: IntegrationChildDashboardProps)
 
 export function FinanceMercuryDashboard({ data }: IntegrationChildDashboardProps) {
   const mercury = data?.mercury;
+  const mercuryMetrics = data?.metrics?.finance.mercury ?? null;
   const reasons = providerErrors(data, ["mercury"]);
   if (!mercury) {
     return <EmptyProviderState title="Mercury data is unavailable" description="Connect Mercury to inspect cash position and runway." reasons={reasons} />;
   }
-  const bankCash = mercury.cashFlow.bankCash ?? mercury.accounts
+  if (!mercuryMetrics) {
+    return <EmptyProviderState title="Mercury metrics are unavailable" description="The canonical finance metrics layer was not included in this analytics payload." reasons={reasons} />;
+  }
+  const bankCash = mercuryMetrics.bankCash ?? mercury.accounts
     .filter((account) => account.type.toLowerCase() !== "treasury")
     .reduce((sum, account) => sum + account.balance, 0);
-  const treasuryCash = mercury.cashFlow.treasuryCash ?? mercury.accounts
+  const treasuryCash = mercuryMetrics.treasuryCash ?? mercury.accounts
     .filter((account) => account.type.toLowerCase() === "treasury")
     .reduce((sum, account) => sum + account.balance, 0);
 
@@ -741,14 +745,14 @@ export function FinanceMercuryDashboard({ data }: IntegrationChildDashboardProps
     <DashboardShell title="Mercury" subtitle="Cash position, burn profile, and account-level liquidity.">
       <MetricGrid
         metrics={[
-          { label: "Total Balance", value: fmtCurrency(mercury.cashFlow.totalBalance) },
+          { label: "Total Balance", value: fmtCurrency(mercuryMetrics.totalBalance) },
           { label: "Bank Cash", value: fmtCurrency(bankCash) },
           { label: "Treasury Cash", value: fmtCurrency(treasuryCash) },
-          { label: "Inflows (30d)", value: fmtCurrency(mercury.cashFlow.inflows30d) },
-          { label: "Outflows (30d)", value: fmtCurrency(mercury.cashFlow.outflows30d) },
-          { label: "Net Cash Flow", value: fmtCurrency(mercury.cashFlow.netCashFlow) },
-          { label: "Runway", value: `${mercury.cashFlow.runway.toFixed(1)} mo` },
-          { label: "Burn Rate", value: fmtCurrency(mercury.cashFlow.burnRate) },
+          { label: "Inflows (30d)", value: fmtCurrency(mercuryMetrics.inflows30d) },
+          { label: "Outflows (30d)", value: fmtCurrency(mercuryMetrics.outflows30d) },
+          { label: "Net Cash Flow", value: fmtCurrency(mercuryMetrics.netCashFlow30d) },
+          { label: "Runway", value: `${mercuryMetrics.runwayMonths.toFixed(1)} mo` },
+          { label: "Burn Rate", value: fmtCurrency(mercuryMetrics.burnRate) },
         ]}
       />
 
@@ -816,23 +820,27 @@ export function SalesHubSpotDashboard({ data }: IntegrationChildDashboardProps) 
 
 export function SalesStripeDashboard({ data }: IntegrationChildDashboardProps) {
   const stripe = data?.stripe;
+  const stripeMetrics = data?.metrics?.finance.stripe ?? null;
   const reasons = providerErrors(data, ["stripe"]);
   if (!stripe) {
     return <EmptyProviderState title="Stripe sales data is unavailable" description="Connect Stripe to monitor subscription-led sales outcomes." reasons={reasons} />;
+  }
+  if (!stripeMetrics) {
+    return <EmptyProviderState title="Stripe sales metrics are unavailable" description="The canonical finance metrics layer was not included in this analytics payload." reasons={reasons} />;
   }
 
   return (
     <DashboardShell title="Stripe Sales Lens" subtitle="Commercial outcomes from subscription motion and payment behavior.">
       <MetricGrid
         metrics={[
-          { label: "MRR", value: fmtCurrency(stripe.revenue.mrr), subtitle: `${stripe.revenue.mrrChange.toFixed(1)}% MoM` },
-          { label: "Active Subs", value: fmtInt(stripe.subscriptions.active) },
-          { label: "Trialing", value: fmtInt(stripe.subscriptions.trialing) },
-          { label: "Past Due", value: fmtInt(stripe.subscriptions.pastDue) },
-          { label: "Churn Rate", value: fmtRatio(stripe.subscriptions.churnRate) },
-          { label: "Canceled", value: fmtInt(stripe.subscriptions.canceled) },
-          { label: "Payment Success", value: fmtRatio(stripe.payments.successRate) },
-          { label: "Failed Payments", value: fmtInt(stripe.payments.failed) },
+          { label: "MRR", value: fmtCurrency(stripeMetrics.mrr), subtitle: `${stripeMetrics.mrrChange.toFixed(1)}% MoM` },
+          { label: "Active Subs", value: fmtInt(stripeMetrics.activeSubscriptions) },
+          { label: "Trialing", value: fmtInt(stripeMetrics.trialingSubscriptions) },
+          { label: "Past Due", value: fmtInt(stripeMetrics.pastDueSubscriptions) },
+          { label: "Churn Rate", value: fmtPct(stripeMetrics.churnRatePct) },
+          { label: "Canceled", value: fmtInt(stripeMetrics.canceledSubscriptions) },
+          { label: "Payment Success", value: fmtPct(stripeMetrics.paymentSuccessPct) },
+          { label: "Failed Payments", value: fmtInt(stripeMetrics.failedPayments) },
         ]}
       />
 

--- a/src/components/analytics/sub-dashboards/stripe-dashboard.test.tsx
+++ b/src/components/analytics/sub-dashboards/stripe-dashboard.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { StripeDashboard } from "@/components/analytics/sub-dashboards/stripe-dashboard";
+import { createEmptyAnalyticsDashboardData } from "@/lib/analytics/response-shape";
+import { buildAnalyticsMetricsLayer } from "@/lib/analytics/kpis";
+
+describe("StripeDashboard", () => {
+  it("uses canonical Stripe finance metrics for KPI cards", () => {
+    const data = createEmptyAnalyticsDashboardData({
+      freshness: {},
+      timeRange: undefined,
+    });
+    data.stripe = {
+      revenue: {
+        mrr: 12000,
+        mrrChange: 500,
+        totalRevenue30d: 15000,
+        totalRevenuePrev30d: 14000,
+        revenueGrowth: 7.1,
+        avgRevenuePerCustomer: 300,
+      },
+      subscriptions: {
+        active: 40,
+        pastDue: 2,
+        canceled: 1,
+        trialing: 3,
+        churnRate: 0.04,
+        recentChurnEvents: [],
+      },
+      payments: {
+        succeeded: 79,
+        failed: 1,
+        successRate: 0.987,
+      },
+      revenueTrend: [],
+      _meta: {
+        fetchedAt: "2026-02-18T00:00:00.000Z",
+        nextRefresh: "2026-02-18T01:00:00.000Z",
+        source: "live",
+      },
+    };
+    data.metrics = buildAnalyticsMetricsLayer(data);
+    data.metrics.finance.stripe!.mrr = 99000;
+    data.metrics.finance.stripe!.activeSubscriptions = 88;
+    data.metrics.finance.stripe!.paymentSuccessPct = 91.2;
+
+    render(<StripeDashboard data={data} />);
+
+    expect(screen.getByText("$99.0K")).toBeTruthy();
+    expect(screen.getAllByText("88").length).toBeGreaterThan(0);
+    expect(screen.getByText("91.2%")).toBeTruthy();
+  });
+});

--- a/src/components/analytics/sub-dashboards/stripe-dashboard.tsx
+++ b/src/components/analytics/sub-dashboards/stripe-dashboard.tsx
@@ -40,9 +40,9 @@ export function StripeDashboard({ data }: StripeDashboardProps) {
     );
   }
 
-  const { revenue, subscriptions, payments, revenueTrend } = stripe;
-  const kpis = data.metrics?.kpis ?? data.kpis;
-  if (!kpis) {
+  const { subscriptions, revenueTrend } = stripe;
+  const stripeMetrics = data.metrics?.finance.stripe ?? null;
+  if (!stripeMetrics) {
     return (
       <div className="flex items-center justify-center py-16">
         <p className="text-muted-foreground">No Stripe metrics available</p>
@@ -50,18 +50,19 @@ export function StripeDashboard({ data }: StripeDashboardProps) {
     );
   }
 
-  const mrr = kpis.finance.mrr ?? revenue.mrr;
-  const paymentSuccessPct = kpis.finance.paymentSuccessPct ?? payments.successRate;
-
   /* ── Subscription health donut ─── */
   const subSegments = [
-    { name: "Active", value: subscriptions.active, color: CHART_PALETTE[2] },
-    { name: "Past Due", value: subscriptions.pastDue, color: CHART_PALETTE[4] },
-    { name: "Trialing", value: subscriptions.trialing, color: CHART_PALETTE[3] },
-    { name: "Canceled", value: subscriptions.canceled, color: CHART_PALETTE[5] },
+    { name: "Active", value: stripeMetrics.activeSubscriptions, color: CHART_PALETTE[2] },
+    { name: "Past Due", value: stripeMetrics.pastDueSubscriptions, color: CHART_PALETTE[4] },
+    { name: "Trialing", value: stripeMetrics.trialingSubscriptions, color: CHART_PALETTE[3] },
+    { name: "Canceled", value: stripeMetrics.canceledSubscriptions, color: CHART_PALETTE[5] },
   ].filter((s) => s.value > 0);
 
-  const totalSubs = subscriptions.active + subscriptions.pastDue + subscriptions.trialing + subscriptions.canceled;
+  const totalSubs =
+    stripeMetrics.activeSubscriptions +
+    stripeMetrics.pastDueSubscriptions +
+    stripeMetrics.trialingSubscriptions +
+    stripeMetrics.canceledSubscriptions;
 
   return (
     <SubDashboardTemplate
@@ -71,28 +72,28 @@ export function StripeDashboard({ data }: StripeDashboardProps) {
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
           <StatCard
             label="MRR"
-            value={fmt$(mrr)}
-            change={revenue.mrrChange !== 0 ? fmt$(revenue.mrrChange) : undefined}
-            changeType={revenue.mrrChange > 0 ? "positive" : revenue.mrrChange < 0 ? "negative" : "neutral"}
+            value={fmt$(stripeMetrics.mrr)}
+            change={stripeMetrics.mrrChange !== 0 ? fmt$(stripeMetrics.mrrChange) : undefined}
+            changeType={stripeMetrics.mrrChange > 0 ? "positive" : stripeMetrics.mrrChange < 0 ? "negative" : "neutral"}
             trend={{
               data: revenueTrend.map((t) => t.revenue),
             }}
           />
           <StatCard
             label="Active Subscriptions"
-            value={subscriptions.active.toLocaleString()}
-            subtitle={subscriptions.pastDue > 0 ? `${subscriptions.pastDue} past due` : undefined}
+            value={stripeMetrics.activeSubscriptions.toLocaleString()}
+            subtitle={stripeMetrics.pastDueSubscriptions > 0 ? `${stripeMetrics.pastDueSubscriptions} past due` : undefined}
           />
           <StatCard
             label="Payment Success"
-            value={fmtPct(paymentSuccessPct)}
-            changeType={paymentSuccessPct >= 95 ? "positive" : "negative"}
-            subtitle={`${payments.succeeded.toLocaleString()} succeeded / ${payments.failed.toLocaleString()} failed`}
+            value={fmtPct(stripeMetrics.paymentSuccessPct)}
+            changeType={stripeMetrics.paymentSuccessPct >= 95 ? "positive" : "negative"}
+            subtitle={`${stripeMetrics.succeededPayments.toLocaleString()} succeeded / ${stripeMetrics.failedPayments.toLocaleString()} failed`}
           />
           <StatCard
             label="Revenue Growth"
-            value={fmtPct(revenue.revenueGrowth)}
-            changeType={revenue.revenueGrowth > 0 ? "positive" : revenue.revenueGrowth < 0 ? "negative" : "neutral"}
+            value={fmtPct(stripeMetrics.revenueGrowth)}
+            changeType={stripeMetrics.revenueGrowth > 0 ? "positive" : stripeMetrics.revenueGrowth < 0 ? "negative" : "neutral"}
           />
         </div>
       }


### PR DESCRIPTION
## Summary
- route Mercury and Stripe child dashboards through canonical finance provider metrics
- route the Stripe sub-dashboard KPI cards and subscription chart through canonical Stripe metrics
- add regression coverage for canonical dashboard values overriding raw provider payloads

## Validation
- npx vitest run src/components/analytics/integration-child-dashboards.test.tsx src/components/analytics/sub-dashboards/stripe-dashboard.test.tsx src/lib/__tests__/metric-history.test.ts src/app/api/analytics/route.test.ts
- npx eslint --max-warnings=0 src/components/analytics/integration-child-dashboards.tsx src/components/analytics/integration-child-dashboards.test.tsx src/components/analytics/sub-dashboards/stripe-dashboard.tsx src/components/analytics/sub-dashboards/stripe-dashboard.test.tsx
- npm run typecheck:staged -- src/components/analytics/integration-child-dashboards.tsx src/components/analytics/integration-child-dashboards.test.tsx src/components/analytics/sub-dashboards/stripe-dashboard.tsx src/components/analytics/sub-dashboards/stripe-dashboard.test.tsx