### PR TITLE
fix(analytics): tolerate invalid Meta Page insight metrics

### DIFF
--- a/src/lib/__tests__/analytics-fetchers-ads.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-ads.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   fetchGoogleAdsData,
   fetchMetaAdsData,
+  fetchMetaPageData,
   fetchMetaInstagramData,
   fetchRedditAdsData,
 } from "@/lib/analytics/fetchers-ads";
@@ -189,6 +190,81 @@ describe("analytics ads fetchers", () => {
     await expect(fetchMetaAdsData("123|not-a-user-token", "12345")).rejects.toThrow(
       "looks like an app access token"
     );
+  });
+
+  it("skips invalid optional Meta Page insight metrics without failing the sync", async () => {
+    const fetchMock = vi.fn();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ fan_count: 10, followers_count: 15 }))
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            error: {
+              message: "(#100) The value must be a valid insights metric",
+            },
+          },
+          400
+        )
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            error: {
+              message: "(#100) The value must be a valid insights metric",
+            },
+          },
+          400
+        )
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: [
+            {
+              name: "page_engaged_users",
+              values: [{ value: 17 }],
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: [
+            {
+              message: "Launch update",
+              created_time: "2026-02-18T12:00:00.000Z",
+              insights: {
+                data: [
+                  { name: "post_impressions", values: [{ value: 30 }] },
+                  { name: "post_engaged_users", values: [{ value: 4 }] },
+                ],
+              },
+            },
+          ],
+        })
+      );
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const data = await fetchMetaPageData("meta-token", "page-1");
+
+    expect(data.pageLikes).toBe(10);
+    expect(data.pageFollowers).toBe(15);
+    expect(data.postReach30d).toBe(0);
+    expect(data.postEngagement30d).toBe(17);
+    expect(data.topPosts).toEqual([
+      {
+        message: "Launch update",
+        reach: 30,
+        engagement: 4,
+        createdAt: "2026-02-18T12:00:00.000Z",
+      },
+    ]);
+
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain(
+      "metric=page_impressions%2Cpage_engaged_users"
+    );
+    expect(String(fetchMock.mock.calls[2]?.[0])).toContain("metric=page_impressions");
+    expect(String(fetchMock.mock.calls[3]?.[0])).toContain("metric=page_engaged_users");
   });
 
   it("uses Reddit v3 report shape and joins campaign metadata", async () => {

--- a/src/lib/analytics/fetchers-ads.ts
+++ b/src/lib/analytics/fetchers-ads.ts
@@ -777,9 +777,22 @@ async function parseErrorBody(response: Response): Promise<string> {
   return trimmed.slice(0, 500);
 }
 
+function isInvalidMetaInsightsMetricError(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("valid insights metric") ||
+    normalized.includes("invalid metric")
+  );
+}
+
 function normalizeBearerToken(value: string): string {
   return value.replace(/^Bearer\s+/i, "").trim();
 }
+
+type MetaPageInsightMetric = {
+  name: string;
+  values?: Array<{ value: string | number }>;
+};
 
 function normalizeMetaAdAccountId(adAccountId: string): string {
   return adAccountId.trim().replace(/^act_/i, "");
@@ -1330,6 +1343,77 @@ export async function fetchMetaAdsData(
 /**
  * Fetch Meta Page Insights data.
  */
+function buildMetaPageInsightsUrl(input: {
+  normalizedPageId: string;
+  metrics: string[];
+  useRange: boolean;
+  since: string | null;
+  until: string | null;
+}): URL {
+  const insightsUrl = new URL(
+    `https://graph.facebook.com/${META_GRAPH_VERSION}/${input.normalizedPageId}/insights`
+  );
+  insightsUrl.searchParams.set("metric", input.metrics.join(","));
+  if (input.useRange) {
+    insightsUrl.searchParams.set("period", "day");
+    insightsUrl.searchParams.set("since", input.since!);
+    insightsUrl.searchParams.set("until", input.until!);
+  } else {
+    insightsUrl.searchParams.set("period", "days_28");
+  }
+  return insightsUrl;
+}
+
+async function fetchMetaPageInsightMetrics(input: {
+  normalizedPageId: string;
+  metrics: string[];
+  useRange: boolean;
+  since: string | null;
+  until: string | null;
+  headers: Record<string, string>;
+}): Promise<MetaPageInsightMetric[]> {
+  const insightsUrl = buildMetaPageInsightsUrl(input);
+  const insightsResponse = await fetch(insightsUrl, { headers: input.headers });
+  if (insightsResponse.ok) {
+    const insightsData = (await safeJson<{
+      data?: MetaPageInsightMetric[];
+    }>(insightsResponse, "Meta Page insights")) as {
+      data?: MetaPageInsightMetric[];
+    };
+    return insightsData.data ?? [];
+  }
+
+  const errorBody = await parseErrorBody(insightsResponse);
+  if (!isInvalidMetaInsightsMetricError(errorBody)) {
+    throw new Error(`Meta Page insights error (${insightsResponse.status}): ${errorBody}`);
+  }
+
+  const validMetrics: MetaPageInsightMetric[] = [];
+  for (const metric of input.metrics) {
+    const metricUrl = buildMetaPageInsightsUrl({
+      ...input,
+      metrics: [metric],
+    });
+    const metricResponse = await fetch(metricUrl, { headers: input.headers });
+    if (metricResponse.ok) {
+      const metricData = (await safeJson<{
+        data?: MetaPageInsightMetric[];
+      }>(metricResponse, `Meta Page insights ${metric}`)) as {
+        data?: MetaPageInsightMetric[];
+      };
+      validMetrics.push(...(metricData.data ?? []));
+      continue;
+    }
+
+    const metricError = await parseErrorBody(metricResponse);
+    if (!isInvalidMetaInsightsMetricError(metricError)) {
+      throw new Error(`Meta Page insights error (${metricResponse.status}): ${metricError}`);
+    }
+  }
+
+  return validMetrics;
+}
+
 export async function fetchMetaPageData(
   accessToken: string,
   pageId: string,
@@ -1378,39 +1462,18 @@ export async function fetchMetaPageData(
   const pageLikes = readNumber(pageData.fan_count);
   const pageFollowers = readNumber(pageData.followers_count);
 
-  const insightsUrl = new URL(
-    `https://graph.facebook.com/${META_GRAPH_VERSION}/${normalizedPageId}/insights`
-  );
-  insightsUrl.searchParams.set("metric", "page_impressions,page_engaged_users");
-  if (useRange) {
-    insightsUrl.searchParams.set("period", "day");
-    insightsUrl.searchParams.set("since", since!);
-    insightsUrl.searchParams.set("until", until!);
-  } else {
-    insightsUrl.searchParams.set("period", "days_28");
-  }
-
-  const insightsResponse = await fetch(insightsUrl, { headers: baseHeaders });
-  if (!insightsResponse.ok) {
-    throw new Error(
-      `Meta Page insights error (${insightsResponse.status}): ${await parseErrorBody(insightsResponse)}`
-    );
-  }
-  const insightsData = (await safeJson<{
-    data?: Array<{
-      name: string;
-      values?: Array<{ value: string | number }>;
-    }>;
-  }>(insightsResponse, "Meta Page insights")) as {
-    data?: Array<{
-      name: string;
-      values?: Array<{ value: string | number }>;
-    }>;
-  };
+  const insightsMetrics = await fetchMetaPageInsightMetrics({
+    normalizedPageId,
+    metrics: ["page_impressions", "page_engaged_users"],
+    useRange,
+    since,
+    until,
+    headers: baseHeaders,
+  });
 
   let postReach30d = 0;
   let postEngagement30d = 0;
-  for (const metric of insightsData.data ?? []) {
+  for (const metric of insightsMetrics) {
     const value = (metric.values ?? []).reduce((sum, item) => sum + readNumber(item.value), 0);
     if (metric.name === "page_impressions") {
       postReach30d = value;


### PR DESCRIPTION
## Summary
- retry Meta Page Insights metrics individually when Meta rejects the combined metric request as invalid
- skip only invalid optional page-level metrics instead of failing the whole Meta Page provider sync
- add regression coverage for deprecated/invalid Page Insights metrics while preserving profile and post data

## Validation
- npx vitest run src/lib/__tests__/analytics-fetchers-ads.test.ts
- npx eslint --max-warnings=0 src/lib/analytics/fetchers-ads.ts src/lib/__tests__/analytics-fetchers-ads.test.ts
- npm run typecheck:staged -- src/lib/analytics/fetchers-ads.ts src/lib/__tests__/analytics-fetchers-ads.test.ts