### PR TITLE
fix(ceo): treat reddit ads as optional social source

### DIFF
--- a/src/lib/ceo/metric-trust.test.ts
+++ b/src/lib/ceo/metric-trust.test.ts
@@ -50,9 +50,53 @@ describe("CEO metric trust layer", () => {
     expect(trust.warnings.join(" ")).toContain("stripe");
   });
 
+  it("keeps metric trust fresh when an optional source errors but required sources are fresh", () => {
+    const trust = evaluateMetricTrust({
+      asOf: AS_OF,
+      freshnessSlaHours: 24,
+      requiredSourceKeys: ["googleAds", "metaAds"],
+      optionalSourceKeys: ["redditAds"],
+      sources: [
+        {
+          sourceKey: "googleAds",
+          sourceId: "google-ads-snapshot",
+          status: "SUCCESS",
+          capturedAt: "2026-05-01T10:00:00.000Z",
+          expiresAt: "2026-05-01T13:00:00.000Z",
+        },
+        {
+          sourceKey: "metaAds",
+          sourceId: "meta-ads-snapshot",
+          status: "SUCCESS",
+          capturedAt: "2026-05-01T10:00:00.000Z",
+          expiresAt: "2026-05-01T13:00:00.000Z",
+        },
+        {
+          sourceKey: "redditAds",
+          sourceId: "reddit-ads-snapshot",
+          status: "ERROR",
+          capturedAt: "2026-05-01T10:00:00.000Z",
+          expiresAt: "2026-05-01T13:00:00.000Z",
+          lastError: "Request timed out after 10000ms",
+        },
+      ],
+    });
+
+    expect(trust.status).toBe("fresh");
+    expect(trust.confidence).toBe(1);
+    expect(trust.sourceStates.map((state) => state.sourceKey)).toEqual([
+      "googleAds",
+      "metaAds",
+      "redditAds",
+    ]);
+    expect(trust.warnings.join(" ")).toContain("Optional source redditAds errored");
+  });
+
   it("registers default metric definitions across every existing analytics domain", () => {
     const definitions = getDefaultCeoMetricDefinitions();
     const domains = new Set(definitions.map((definition) => definition.domain));
+    const socialPaidSpend = definitions.find((definition) => definition.key === "social.paid_spend");
+    const socialDomainHealth = definitions.find((definition) => definition.key === "domain.social-media.health");
 
     expect(domains).toContain("finance");
     expect(domains).toContain("sales-pipeline");
@@ -62,6 +106,10 @@ describe("CEO metric trust layer", () => {
     expect(domains).toContain("social-media");
     expect(domains).toContain("ceo");
     expect(definitions.every((definition) => definition.sourceDependencies.length > 0)).toBe(true);
+    expect(socialPaidSpend?.sourceDependencies).toEqual(["googleAds", "metaAds"]);
+    expect(socialPaidSpend?.optionalSourceDependencies).toEqual(["redditAds"]);
+    expect(socialDomainHealth?.sourceDependencies).toEqual(["googleAds", "metaAds"]);
+    expect(socialDomainHealth?.optionalSourceDependencies).toEqual(["redditAds"]);
   });
 
   it("builds deterministic markdown, csv, and slide-ready JSON for a report pack", () => {

--- a/src/lib/ceo/metric-trust.ts
+++ b/src/lib/ceo/metric-trust.ts
@@ -31,6 +31,7 @@ export interface CeoMetricDefinition {
   unit: CeoMetricUnit;
   calculationVersion: string;
   sourceDependencies: string[];
+  optionalSourceDependencies?: string[];
   freshnessSlaHours: number;
   boardEligible: boolean;
   weeklyEligible: boolean;
@@ -285,7 +286,8 @@ const CORE_METRICS: CeoMetricDefinition[] = [
     ownerAudience: "CEO",
     unit: "currency",
     calculationVersion: CALCULATION_VERSION,
-    sourceDependencies: ["googleAds", "metaAds", "redditAds"],
+    sourceDependencies: ["googleAds", "metaAds"],
+    optionalSourceDependencies: ["redditAds"],
     freshnessSlaHours: 24,
     boardEligible: true,
     weeklyEligible: true,
@@ -309,7 +311,7 @@ function hoursBetween(fromIso: string | null, to: Date): number | null {
 function sourceKeyForPrimary(primaryId: AnalyticsPrimarySectionId): string[] {
   const boardGradeSources: Partial<Record<AnalyticsPrimarySectionId, string[]>> = {
     "website-traffic": ["googleAnalytics", "webflow"],
-    "social-media": ["googleAds", "metaAds", "redditAds"],
+    "social-media": ["googleAds", "metaAds"],
     finance: ["mercury", "stripe", "hubspot"],
     "sales-pipeline": ["hubspot"],
     retention: ["retention"],
@@ -328,20 +330,29 @@ function sourceKeyForPrimary(primaryId: AnalyticsPrimarySectionId): string[] {
   return Array.from(new Set(keys.length > 0 ? keys : [primaryId]));
 }
 
+function optionalSourceKeyForPrimary(primaryId: AnalyticsPrimarySectionId): string[] {
+  if (primaryId === "social-media") return ["redditAds"];
+  return [];
+}
+
 export function getDefaultCeoMetricDefinitions(): CeoMetricDefinition[] {
-  const domainDefinitions = ANALYTICS_PRIMARY_SECTIONS.map((section) => ({
-    key: `domain.${section.id}.health`,
-    label: `${section.label} Health`,
-    domain: section.id,
-    ownerAudience: "CEO" as const,
-    unit: "score" as const,
-    calculationVersion: CALCULATION_VERSION,
-    sourceDependencies: sourceKeyForPrimary(section.id),
-    freshnessSlaHours: section.id === "process-analytics" ? 1 : 24,
-    boardEligible: true,
-    weeklyEligible: true,
-    description: `Trust-weighted health metric for ${section.description.toLowerCase()}`,
-  }));
+  const domainDefinitions = ANALYTICS_PRIMARY_SECTIONS.map((section) => {
+    const optionalSourceDependencies = optionalSourceKeyForPrimary(section.id);
+    return {
+      key: `domain.${section.id}.health`,
+      label: `${section.label} Health`,
+      domain: section.id,
+      ownerAudience: "CEO" as const,
+      unit: "score" as const,
+      calculationVersion: CALCULATION_VERSION,
+      sourceDependencies: sourceKeyForPrimary(section.id),
+      ...(optionalSourceDependencies.length > 0 ? { optionalSourceDependencies } : {}),
+      freshnessSlaHours: section.id === "process-analytics" ? 1 : 24,
+      boardEligible: true,
+      weeklyEligible: true,
+      description: `Trust-weighted health metric for ${section.description.toLowerCase()}`,
+    };
+  });
 
   const subSectionDefinitions = ANALYTICS_SUB_SECTIONS.map((section) => ({
     key: `source.${section.id}.health`,
@@ -376,13 +387,17 @@ export function evaluateMetricTrust(input: {
   asOf: Date;
   freshnessSlaHours: number;
   requiredSourceKeys: string[];
+  optionalSourceKeys?: string[];
   sources: CeoSourceSample[];
 }): CeoMetricTrust {
   const required = Array.from(new Set(input.requiredSourceKeys));
+  const optional = Array.from(new Set(input.optionalSourceKeys ?? [])).filter(
+    (key) => !required.includes(key)
+  );
   const warnings: string[] = [];
   const sourceStates: CeoMetricSourceState[] = [];
 
-  for (const key of required) {
+  for (const key of [...required, ...optional]) {
     const candidates = input.sources
       .filter((source) => source.sourceKey === key)
       .sort((a, b) => {
@@ -412,11 +427,17 @@ export function evaluateMetricTrust(input: {
     });
   }
 
-  const missing = sourceStates.filter((state) => state.status === "MISSING");
-  const errored = sourceStates.filter((state) => state.status === "ERROR");
-  const partial = sourceStates.filter((state) => state.status === "PARTIAL");
-  const successful = sourceStates.filter((state) => state.status === "SUCCESS");
+  const requiredStates = sourceStates.filter((state) => required.includes(state.sourceKey));
+  const optionalStates = sourceStates.filter((state) => optional.includes(state.sourceKey));
+  const missing = requiredStates.filter((state) => state.status === "MISSING");
+  const errored = requiredStates.filter((state) => state.status === "ERROR");
+  const partial = requiredStates.filter((state) => state.status === "PARTIAL");
+  const successful = requiredStates.filter((state) => state.status === "SUCCESS");
   const stale = successful.filter((state) => !state.fresh);
+  const optionalMissing = optionalStates.filter((state) => state.status === "MISSING");
+  const optionalErrored = optionalStates.filter((state) => state.status === "ERROR");
+  const optionalPartial = optionalStates.filter((state) => state.status === "PARTIAL");
+  const optionalStale = optionalStates.filter((state) => state.status === "SUCCESS" && !state.fresh);
 
   for (const state of missing) {
     warnings.push(`Required source ${state.sourceKey} is missing.`);
@@ -431,6 +452,20 @@ export function evaluateMetricTrust(input: {
   }
   for (const state of stale) {
     warnings.push(`Required source ${state.sourceKey} is stale.`);
+  }
+  for (const state of optionalMissing) {
+    warnings.push(`Optional source ${state.sourceKey} is missing.`);
+  }
+  for (const state of optionalErrored) {
+    warnings.push(
+      `Optional source ${state.sourceKey} errored${state.lastError ? `: ${state.lastError}` : "."}`
+    );
+  }
+  for (const state of optionalPartial) {
+    warnings.push(`Optional source ${state.sourceKey} is partial.`);
+  }
+  for (const state of optionalStale) {
+    warnings.push(`Optional source ${state.sourceKey} is stale.`);
   }
 
   let status: CeoMetricTrustStatus = "fresh";

--- a/src/lib/ceo/service.test.ts
+++ b/src/lib/ceo/service.test.ts
@@ -41,6 +41,18 @@ function snapshot(providerKey: string, payload: unknown) {
   };
 }
 
+function errorSnapshot(providerKey: string, lastError = "Request timed out after 10000ms") {
+  return {
+    id: `${providerKey}-snapshot`,
+    providerKey,
+    status: AnalyticsSnapshotStatus.ERROR,
+    capturedAt: new Date("2026-05-01T11:30:00.000Z"),
+    expiresAt: new Date("2026-05-02T11:30:00.000Z"),
+    lastError,
+    payload: null,
+  };
+}
+
 describe("loadCeoMetricSnapshot", () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -159,5 +171,74 @@ describe("loadCeoMetricSnapshot", () => {
       "investor-update",
       "custom-metric-snapshot",
     ]);
+  });
+
+  it("keeps social metrics board-ready when optional Reddit Ads is errored", async () => {
+    vi.mocked(prisma.analyticsSnapshot.findMany).mockResolvedValue([
+      snapshot("mercury", {
+        cashFlow: {
+          bankCash: 23456,
+          treasuryCash: 100000,
+          totalCash: 123456,
+          totalBalance: 123456,
+        },
+      }),
+      snapshot("stripe", {
+        revenue: { mrr: 20000, mrrChange: 1500 },
+        subscriptions: {
+          active: 1,
+          activeCustomerRefs: [{ customerId: "cus_linked", email: "finance@example.com", emailDomain: "example.com" }],
+        },
+      }),
+      snapshot("hubspot", {
+        repScoreboard: [{ totalPipeline: 90000 }, { totalPipeline: 10000 }],
+        subscriptionDeals: [
+          {
+            dealId: "hs-only",
+            dealName: "HubSpot Only",
+            stageLabel: "Subscriptions",
+            amount: 5000,
+            stripeCustomerId: null,
+            primaryContactEmail: "ops@example-subscription.com",
+          },
+        ],
+      }),
+      snapshot("pylon", { openIssues: 7 }),
+      snapshot("googleAnalytics", { sessions30d: 5432 }),
+      snapshot("webflow", { site: "connected" }),
+      snapshot("googleAds", { totalSpend30d: 400 }),
+      snapshot("metaAds", { totalSpend30d: 700 }),
+      errorSnapshot("redditAds"),
+      snapshot("googleWorkspace", { enabledRules: 4 }),
+      snapshot("slack", { enabledRules: 4 }),
+    ] as never);
+
+    const payload = await loadCeoMetricSnapshot({
+      userId: "user-1",
+      organizationId: "org-1",
+      persist: false,
+    });
+
+    const metricByKey = new Map(payload.metrics.map((metric) => [metric.definition.key, metric]));
+    const paidSpend = metricByKey.get("social.paid_spend");
+    const socialHealth = metricByKey.get("domain.social-media.health");
+    const firstFindManyCall = vi.mocked(prisma.analyticsSnapshot.findMany).mock.calls[0]?.[0] as
+      | { where?: { providerKey?: { in?: string[] } } }
+      | undefined;
+    const requestedSources = firstFindManyCall?.where?.providerKey?.in;
+
+    expect(requestedSources).toContain("redditAds");
+    expect(paidSpend?.value).toBe(1100);
+    expect(paidSpend?.trust.status).toBe("fresh");
+    expect(paidSpend?.trust.warnings.join(" ")).toContain("Optional source redditAds errored");
+    expect(paidSpend?.lineage.map((lineage) => lineage.sourceKey)).toEqual([
+      "googleAds",
+      "metaAds",
+      "redditAds",
+    ]);
+    expect(socialHealth?.value).toBe(100);
+    expect(socialHealth?.trust.status).toBe("fresh");
+    expect(socialHealth?.trust.warnings.join(" ")).toContain("Optional source redditAds errored");
+    expect(payload.readiness.status).toBe("board_ready");
   });
 });

--- a/src/lib/ceo/service.ts
+++ b/src/lib/ceo/service.ts
@@ -114,6 +114,15 @@ function latestSnapshotByProvider(snapshots: AnalyticsSnapshotSample[]): Map<str
   return latest;
 }
 
+function sourceKeysForDefinition(definition: CeoMetricDefinition): string[] {
+  return Array.from(
+    new Set([
+      ...definition.sourceDependencies,
+      ...(definition.optionalSourceDependencies ?? []),
+    ])
+  );
+}
+
 function decisionDashboardSourceSample(
   dashboard: Awaited<ReturnType<typeof computeDecisionDashboard>>
 ): CeoSourceSample {
@@ -384,6 +393,7 @@ function healthScoreForDefinition(input: MetricCalculatorInput): MetricCalculati
     asOf: input.asOf,
     freshnessSlaHours: input.definition.freshnessSlaHours,
     requiredSourceKeys: input.definition.sourceDependencies,
+    optionalSourceKeys: input.definition.optionalSourceDependencies,
     sources: input.sourceSamples,
   });
   const scoreByStatus: Record<CeoMetricTrustStatus, number> = {
@@ -570,7 +580,7 @@ export async function loadCeoMetricSnapshot(input: {
   persist?: boolean;
 }): Promise<CeoMetricSnapshotPayload> {
   const definitions = getDefaultCeoMetricDefinitions();
-  const sourceKeys = definitions.flatMap((definition) => definition.sourceDependencies);
+  const sourceKeys = definitions.flatMap(sourceKeysForDefinition);
   const [decisionDashboard, snapshots] = await Promise.all([
     computeDecisionDashboard(),
     loadLatestAnalyticsSnapshots({ userId: input.userId, sourceKeys }),
@@ -621,6 +631,7 @@ export async function loadCeoMetricSnapshot(input: {
       asOf,
       freshnessSlaHours: definition.freshnessSlaHours,
       requiredSourceKeys: definition.sourceDependencies,
+      optionalSourceKeys: definition.optionalSourceDependencies,
       sources: sourceSamples,
     });
     const value = valueForDefinition({


### PR DESCRIPTION
## Summary
- Make Reddit Ads an optional CEO social metric dependency while Google Ads and Meta Ads remain required
- Keep optional Reddit Ads visible in source states, warnings, lineage, and spend calculations when available
- Add tests covering optional source errors and board-ready social metrics

## Verification
- npm test -- src/lib/ceo/metric-trust.test.ts src/lib/ceo/service.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build
- npm test