### PR TITLE
fix(analytics): use meeting demos for journey paths

### DIFF
--- a/src/lib/__tests__/analytics-demo-analytics.test.ts
+++ b/src/lib/__tests__/analytics-demo-analytics.test.ts
@@ -303,7 +303,21 @@ describe("buildDemoAnalyticsData", () => {
         makeDeal({ dealId: "o1", dealName: "Org Prospect", stageId: "p", stageLabel: "Prospect", amount: 0, source: "Organic", ownerId: null, updatedAt: "2026-02-01T00:00:00.000Z", createdAt: "2026-01-01T00:00:00.000Z" }),
         makeDeal({ dealId: "o2", dealName: "Org Demo", stageId: "d", stageLabel: "Demo Scheduled", amount: 3000, source: "Organic", ownerId: null, updatedAt: "2026-02-02T00:00:00.000Z", createdAt: "2026-01-05T00:00:00.000Z" }),
         makeDeal({ dealId: "o3", dealName: "Org Won", stageId: "w", stageLabel: "Closed Won", amount: 5000, source: "Organic", ownerId: null, updatedAt: "2026-02-05T00:00:00.000Z", createdAt: "2026-01-10T00:00:00.000Z" }),
-        makeDeal({ dealId: "o4", dealName: "Org Churn", stageId: "ch", stageLabel: "Churn", amount: 2000, source: "Organic", ownerId: null, updatedAt: "2026-02-10T00:00:00.000Z", createdAt: "2026-01-15T00:00:00.000Z" }),
+        makeDeal({
+          dealId: "o4",
+          dealName: "Org Churn",
+          stageId: "ch",
+          stageLabel: "Churn",
+          amount: 2000,
+          source: "Organic",
+          ownerId: null,
+          updatedAt: "2026-02-10T00:00:00.000Z",
+          createdAt: "2026-01-15T00:00:00.000Z",
+          stageHistory: [
+            { occurredAt: "2026-02-01T00:00:00.000Z", stageId: "w", stageLabel: "Closed Won" },
+            { occurredAt: "2026-02-10T00:00:00.000Z", stageId: "ch", stageLabel: "Churn" },
+          ],
+        }),
         // Paid channel: no-show, demo follow-up → lost
         makeDeal({ dealId: "p1", dealName: "Paid NoShow", stageId: "ns", stageLabel: "No-Show/Reschedule", amount: 1000, source: "Paid", ownerId: null, updatedAt: "2026-02-03T00:00:00.000Z", createdAt: "2026-01-20T00:00:00.000Z" }),
         makeDeal({ dealId: "p2", dealName: "Paid Follow", stageId: "fu", stageLabel: "Demo Follow-Up", amount: 4000, source: "Paid", ownerId: null, updatedAt: "2026-02-04T00:00:00.000Z", createdAt: "2026-01-22T00:00:00.000Z" }),
@@ -324,7 +338,7 @@ describe("buildDemoAnalyticsData", () => {
     expect(organic.demoCompleted).toBe(1); // Closed Won is in POST_DEMO_STAGES
     expect(organic.demoNoShow).toBe(0);
     expect(organic.closedWon).toBe(1);
-    expect(organic.onboarding).toBe(1); // Closed Won = onboarded (Subscription/Closed Won)
+    expect(organic.onboarding).toBe(2); // Closed Won plus the later-churned activated customer
     expect(organic.avgContractValue).toBe(5000);
     expect(organic.churned).toBe(1); // HubSpot "Churn" stage
     expect(organic.churnedPct).toBeGreaterThan(0);
@@ -340,6 +354,109 @@ describe("buildDemoAnalyticsData", () => {
     expect(paid.onboarding).toBe(0); // No Subscription/Closed Won deals
     expect(paid.churned).toBe(0); // Closed Lost is a sales loss, not customer churn
     expect(paid.notActivated).toBe(0);
+  });
+
+  it("uses meeting-backed demo counts for journey paths and excludes unactivated churn", () => {
+    const data = baseData();
+    data.hubspot = {
+      funnel: {
+        totalDeals: 4,
+        closedWon: 1,
+        closedLost: 0,
+        unlikely: 0,
+        churn: 2,
+        activeSubscriptions: 1,
+        noShows: 0,
+        demoScheduled: 0,
+        demoFollowUp: 0,
+        avgDealSize: 5000,
+        winRate: 100,
+        effectiveWinRate: 100,
+        noShowRate: 0,
+        stages: [],
+        dealsBySource: [],
+      },
+      contacts: { totalContacts: 4, recentContacts: 1, bySource: [] },
+      deals: [
+        makeDeal({
+          dealId: "social-lead",
+          dealName: "Social Lead",
+          stageId: "lead",
+          stageLabel: "Prospect",
+          amount: 0,
+          source: "SOCIAL_MEDIA",
+          ownerId: null,
+        }),
+        makeDeal({
+          dealId: "social-won",
+          dealName: "Social Won",
+          stageId: "won",
+          stageLabel: "Closed Won",
+          amount: 5000,
+          source: "SOCIAL_MEDIA",
+          ownerId: null,
+        }),
+        makeDeal({
+          dealId: "social-real-churn",
+          dealName: "Social Real Churn",
+          stageId: "churn",
+          stageLabel: "Churn",
+          amount: 5000,
+          source: "SOCIAL_MEDIA",
+          ownerId: null,
+          updatedAt: "2026-02-20T00:00:00.000Z",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          stageHistory: [
+            { occurredAt: "2026-01-10T00:00:00.000Z", stageId: "won", stageLabel: "Closed Won" },
+            { occurredAt: "2026-02-20T00:00:00.000Z", stageId: "churn", stageLabel: "Churn" },
+          ],
+        }),
+        makeDeal({
+          dealId: "social-false-churn",
+          dealName: "Social False Churn",
+          stageId: "churn",
+          stageLabel: "Churn",
+          amount: 0,
+          source: "SOCIAL_MEDIA",
+          ownerId: null,
+          updatedAt: "2026-02-21T00:00:00.000Z",
+          createdAt: "2026-01-02T00:00:00.000Z",
+        }),
+      ],
+      _meta: META,
+    };
+
+    const demo = buildDemoAnalyticsData(data, {
+      meetings: [
+        makeMeeting({
+          id: "social-demo-1",
+          title: "Social Lead Demo",
+          status: "COMPLETED",
+          startAt: "2026-02-01T18:00:00.000Z",
+          endAt: "2026-02-01T18:45:00.000Z",
+          hubspotDealId: "social-lead",
+          dealName: "Social Lead",
+        }),
+        makeMeeting({
+          id: "social-demo-2",
+          title: "Social Won Demo",
+          status: "NO_SHOW",
+          startAt: "2026-02-02T18:00:00.000Z",
+          endAt: "2026-02-02T18:45:00.000Z",
+          hubspotDealId: "social-won",
+          dealName: "Social Won",
+        }),
+      ],
+    });
+
+    const social = demo.journeyPaths.find((p) => p.source === "SOCIAL_MEDIA")!;
+    expect(social.demosBooked).toBe(2);
+    expect(social.demoCompleted).toBe(1);
+    expect(social.demoNoShow).toBe(1);
+    expect(social.onboarding).toBe(2);
+    expect(social.churned).toBe(1);
+    expect(social.churned).toBeLessThanOrEqual(social.onboarding);
+    expect(social.churned).toBeLessThanOrEqual(social.demosBooked);
   });
 
   it("includes Stripe churn events in churned count", () => {

--- a/src/lib/analytics/demo-analytics.ts
+++ b/src/lib/analytics/demo-analytics.ts
@@ -556,10 +556,35 @@ function pct(num: number, denom: number): number {
   return denom > 0 ? Math.round((num / denom) * 1000) / 10 : 0;
 }
 
-function buildJourneyPathAnalysis(data: AnalyticsDashboardData): JourneyPathRow[] {
+function hasActivatedEvidence(deal: HubSpotDeal): boolean {
+  if (ONBOARDED_STAGES.has(deal.stageLabel)) return true;
+  if (deal.stageHistory?.some((stage) => ONBOARDED_STAGES.has(stage.stageLabel))) return true;
+  return Boolean(deal.stripeCustomerId?.trim());
+}
+
+function buildDemoStatsBySource(demos: DemoRecord[]): Map<string, { booked: number; completed: number; noShow: number }> {
+  const stats = new Map<string, { booked: number; completed: number; noShow: number }>();
+  for (const demo of demos) {
+    const source = demo.source || "Unknown";
+    const entry = stats.get(source) ?? { booked: 0, completed: 0, noShow: 0 };
+    entry.booked += 1;
+    if (demo.outcome === "completed") entry.completed += 1;
+    if (demo.outcome === "no-show") entry.noShow += 1;
+    stats.set(source, entry);
+  }
+  return stats;
+}
+
+function buildJourneyPathAnalysis(
+  data: AnalyticsDashboardData,
+  input?: { demoCohort?: DemoRecord[] },
+): JourneyPathRow[] {
   const deals = data.hubspot?.deals ?? [];
   const stripeChurnEvents = data.stripe?.subscriptions?.recentChurnEvents ?? [];
   const stripeChurnLookup = buildStripeChurnLookup(stripeChurnEvents);
+  const demoStatsBySource = input?.demoCohort?.length
+    ? buildDemoStatsBySource(input.demoCohort)
+    : null;
 
   const bySource = new Map<string, typeof deals>();
   for (const deal of deals) {
@@ -568,14 +593,24 @@ function buildJourneyPathAnalysis(data: AnalyticsDashboardData): JourneyPathRow[
     group.push(deal);
     bySource.set(source, group);
   }
+  for (const source of demoStatsBySource?.keys() ?? []) {
+    if (!bySource.has(source)) bySource.set(source, []);
+  }
 
   const rows: JourneyPathRow[] = [];
 
   for (const [source, sourceDeals] of bySource) {
     const totalLeads = sourceDeals.length;
-    const demosBooked = sourceDeals.filter((d) => DEMO_ENTRY_STAGES.has(d.stageLabel)).length;
-    const demoCompleted = sourceDeals.filter((d) => POST_DEMO_STAGES.includes(d.stageLabel)).length;
-    const demoNoShow = sourceDeals.filter((d) => d.stageLabel === "No-Show/Reschedule").length;
+    const demoStats = demoStatsBySource?.get(source) ?? null;
+    const demosBooked = demoStats
+      ? demoStats.booked
+      : sourceDeals.filter((d) => DEMO_ENTRY_STAGES.has(d.stageLabel)).length;
+    const demoCompleted = demoStats
+      ? demoStats.completed
+      : sourceDeals.filter((d) => POST_DEMO_STAGES.includes(d.stageLabel)).length;
+    const demoNoShow = demoStats
+      ? demoStats.noShow
+      : sourceDeals.filter((d) => d.stageLabel === "No-Show/Reschedule").length;
 
     const terminalDeals = sourceDeals.filter((d) => TERMINAL_STAGES.has(d.stageLabel) && d.updatedAt);
     let avgDaysToDecision: number | null = null;
@@ -590,7 +625,8 @@ function buildJourneyPathAnalysis(data: AnalyticsDashboardData): JourneyPathRow[
     const wonDeals = sourceDeals.filter((d) => d.stageLabel === "Closed Won");
     const closedWon = wonDeals.length;
     const closedLost = sourceDeals.filter((d) => d.stageLabel === "Closed Lost").length;
-    const onboarding = sourceDeals.filter((d) => ONBOARDED_STAGES.has(d.stageLabel)).length;
+    const activatedDeals = sourceDeals.filter(hasActivatedEvidence);
+    const onboarding = activatedDeals.length;
     const wonWithValue = wonDeals.filter((d) => d.amount > 0);
     const avgContractValue = wonWithValue.length > 0
       ? Math.round(wonWithValue.reduce((sum, deal) => sum + deal.amount, 0) / wonWithValue.length)
@@ -598,8 +634,9 @@ function buildJourneyPathAnalysis(data: AnalyticsDashboardData): JourneyPathRow[
 
     const churnedDeals = sourceDeals.flatMap((deal) => {
       const stripeEvent = resolveStripeChurnEvent(deal, stripeChurnLookup);
-      const hubspotChurned = HUBSPOT_CHURN_STAGES.has(deal.stageLabel);
-      const stripeChurned = Boolean(stripeEvent && ONBOARDED_STAGES.has(deal.stageLabel));
+      const activated = hasActivatedEvidence(deal);
+      const hubspotChurned = HUBSPOT_CHURN_STAGES.has(deal.stageLabel) && activated;
+      const stripeChurned = Boolean(stripeEvent && activated);
       if (!hubspotChurned && !stripeChurned) return [];
       return [{
         deal,
@@ -631,7 +668,7 @@ function buildJourneyPathAnalysis(data: AnalyticsDashboardData): JourneyPathRow[
       onboardingPct: pct(onboarding, closedWon),
       avgContractValue,
       churned: churnedDeals.length,
-      churnedPct: pct(churnedDeals.length, closedWon),
+      churnedPct: pct(churnedDeals.length, onboarding),
       notActivated: notActivatedDeals.length,
       notActivatedPct: pct(notActivatedDeals.length, closedWon),
     });
@@ -880,6 +917,6 @@ export function buildDemoAnalyticsData(
     byOutcome: buildOutcomeBreakdown(cohort),
     conversionFunnel: buildConversionFunnel(cohort),
     weeklyTrend: buildWeeklyTrend(cohort),
-    journeyPaths: buildJourneyPathAnalysis(data),
+    journeyPaths: buildJourneyPathAnalysis(data, { demoCohort: cohort }),
   };
 }

--- a/src/lib/analytics/fetchers.ts
+++ b/src/lib/analytics/fetchers.ts
@@ -374,6 +374,26 @@ function extractHubSpotStageEvents(deal: HubSpotDealObject): HubSpotStageEvent[]
   return events;
 }
 
+function buildHubSpotStageHistory(
+  deal: HubSpotDealObject,
+  stageLabelById: Map<string, string>,
+): Array<{ occurredAt: string; stageId: string; stageLabel: string }> {
+  const history = (deal.propertiesWithHistory?.dealstage ?? []) as HubSpotStageHistoryEntry[];
+  return history
+    .map((entry) => {
+      const stageId = entry.value ? String(entry.value).trim() : "";
+      const timestamp = parseHubSpotTimestamp(entry.timestamp);
+      if (!stageId || !timestamp) return null;
+      return {
+        occurredAt: new Date(timestamp).toISOString(),
+        stageId,
+        stageLabel: resolveHubSpotStageLabel(stageId, stageLabelById),
+      };
+    })
+    .filter((entry): entry is { occurredAt: string; stageId: string; stageLabel: string } => entry !== null)
+    .sort((a, b) => new Date(a.occurredAt).getTime() - new Date(b.occurredAt).getTime());
+}
+
 type HubSpotOwnerRecord = { id: string; name: string; email: string | null };
 
 async function fetchHubSpotOwners(input: {
@@ -592,6 +612,7 @@ export async function fetchHubSpotData(
       contactIds: [] as string[],
       primaryContactId: null as string | null,
       primaryContactEmail: null as string | null,
+      stageHistory: buildHubSpotStageHistory(deal, mainStageLabelById),
     };
   });
 
@@ -616,6 +637,7 @@ export async function fetchHubSpotData(
       contactIds: [] as string[],
       primaryContactId: null as string | null,
       primaryContactEmail: null as string | null,
+      stageHistory: buildHubSpotStageHistory(deal, stageLabelById),
     };
   });
 


### PR DESCRIPTION
## Summary
- use the same meeting-backed demo cohort for Customer Journey Path Analysis demo counts
- require activation evidence before counting HubSpot churn-stage deals as churned customers
- preserve HubSpot deal stage history in normalized analytics deals so churn-after-won can be detected

## Validation
- npx vitest run src/lib/__tests__/analytics-demo-analytics.test.ts src/lib/__tests__/analytics-fetchers-hubspot.test.ts
- npx eslint --max-warnings=0 src/lib/analytics/demo-analytics.ts src/lib/analytics/fetchers.ts src/lib/__tests__/analytics-demo-analytics.test.ts
- npm run typecheck:staged -- src/lib/analytics/demo-analytics.ts src/lib/analytics/fetchers.ts src/lib/__tests__/analytics-demo-analytics.test.ts