### PR TITLE
fix(analytics): resolve Meta Page scoped token

### DIFF
--- a/src/lib/__tests__/analytics-fetchers-ads.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-ads.test.ts
@@ -195,6 +195,11 @@ describe("analytics ads fetchers", () => {
   it("skips invalid optional Meta Page insight metrics without failing the sync", async () => {
     const fetchMock = vi.fn();
     fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: [{ id: "page-1", access_token: "page-token" }],
+        })
+      )
       .mockResolvedValueOnce(jsonResponse({ fan_count: 10, followers_count: 15 }))
       .mockResolvedValueOnce(
         jsonResponse(
@@ -234,8 +239,8 @@ describe("analytics ads fetchers", () => {
               created_time: "2026-02-18T12:00:00.000Z",
               insights: {
                 data: [
-                  { name: "post_impressions", values: [{ value: 30 }] },
-                  { name: "post_engaged_users", values: [{ value: 4 }] },
+                  { name: "post_impressions_unique", values: [{ value: 30 }] },
+                  { name: "post_clicks", values: [{ value: 4 }] },
                 ],
               },
             },
@@ -261,10 +266,43 @@ describe("analytics ads fetchers", () => {
     ]);
 
     expect(String(fetchMock.mock.calls[1]?.[0])).toContain(
+      "/page-1"
+    );
+    expect((fetchMock.mock.calls[1]?.[1] as RequestInit).headers).toEqual({
+      Authorization: "Bearer page-token",
+    });
+    expect(String(fetchMock.mock.calls[2]?.[0])).toContain(
       "metric=page_impressions%2Cpage_engaged_users"
     );
-    expect(String(fetchMock.mock.calls[2]?.[0])).toContain("metric=page_impressions");
-    expect(String(fetchMock.mock.calls[3]?.[0])).toContain("metric=page_engaged_users");
+    expect(String(fetchMock.mock.calls[3]?.[0])).toContain("metric=page_impressions");
+    expect(String(fetchMock.mock.calls[4]?.[0])).toContain("metric=page_engaged_users");
+  });
+
+  it("resolves and uses the Meta Page access token for page-owned endpoints", async () => {
+    const fetchMock = vi.fn();
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: [{ id: "page-1", access_token: "page-token" }],
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ fan_count: 10, followers_count: 15 }))
+      .mockResolvedValueOnce(jsonResponse({ data: [] }))
+      .mockResolvedValueOnce(jsonResponse({ data: [] }));
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    await fetchMetaPageData("user-token", "page-1");
+
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/me/accounts");
+    expect((fetchMock.mock.calls[0]?.[1] as RequestInit).headers).toEqual({
+      Authorization: "Bearer user-token",
+    });
+    for (const call of fetchMock.mock.calls.slice(1)) {
+      expect((call[1] as RequestInit).headers).toEqual({
+        Authorization: "Bearer page-token",
+      });
+    }
   });
 
   it("uses Reddit v3 report shape and joins campaign metadata", async () => {

--- a/src/lib/analytics/fetchers-ads.ts
+++ b/src/lib/analytics/fetchers-ads.ts
@@ -1414,6 +1414,31 @@ async function fetchMetaPageInsightMetrics(input: {
   return validMetrics;
 }
 
+async function resolveMetaPageAccessToken(input: {
+  userAccessToken: string;
+  normalizedPageId: string;
+}): Promise<string> {
+  const accountsUrl = new URL(`https://graph.facebook.com/${META_GRAPH_VERSION}/me/accounts`);
+  accountsUrl.searchParams.set("fields", "id,access_token");
+  accountsUrl.searchParams.set("limit", "200");
+
+  const response = await fetch(accountsUrl, {
+    headers: { Authorization: `Bearer ${input.userAccessToken}` },
+  });
+  if (!response.ok) {
+    return input.userAccessToken;
+  }
+
+  const payload = (await safeJson<{
+    data?: Array<{ id?: string; access_token?: string }>;
+  }>(response, "Meta Page accounts")) as {
+    data?: Array<{ id?: string; access_token?: string }>;
+  };
+
+  const page = (payload.data ?? []).find((item) => item.id === input.normalizedPageId);
+  return page?.access_token?.trim() || input.userAccessToken;
+}
+
 export async function fetchMetaPageData(
   accessToken: string,
   pageId: string,
@@ -1426,8 +1451,12 @@ export async function fetchMetaPageData(
     );
   }
 
-  const baseHeaders = { Authorization: `Bearer ${token}` };
   const normalizedPageId = pageId.trim();
+  const pageAccessToken = await resolveMetaPageAccessToken({
+    userAccessToken: token,
+    normalizedPageId,
+  });
+  const baseHeaders = { Authorization: `Bearer ${pageAccessToken}` };
 
   const rangeFrom = options?.fromDate ?? null;
   const rangeTo = options?.toDate ?? null;
@@ -1488,7 +1517,7 @@ export async function fetchMetaPageData(
   );
   postsUrl.searchParams.set(
     "fields",
-    "message,insights{metric(post_impressions,post_engaged_users)},created_time"
+    "message,created_time,insights.metric(post_impressions_unique,post_clicks){name,values}"
   );
   postsUrl.searchParams.set("limit", "5");
   if (useRange) {
@@ -1533,10 +1562,10 @@ export async function fetchMetaPageData(
     let engagement = 0;
     for (const metric of post.insights?.data ?? []) {
       const metricValue = readNumber(metric.values?.[0]?.value);
-      if (metric.name === "post_impressions") {
+      if (metric.name === "post_impressions_unique") {
         reach = metricValue;
       }
-      if (metric.name === "post_engaged_users") {
+      if (metric.name === "post_clicks") {
         engagement = metricValue;
       }
     }


### PR DESCRIPTION
## Summary
- resolve the Page access token from /me/accounts before calling Page-owned endpoints
- keep Meta Page post insights on valid post metric names

## Verification
- npx vitest run src/lib/__tests__/analytics-fetchers-ads.test.ts
- npx eslint --max-warnings=0 src/lib/analytics/fetchers-ads.ts src/lib/__tests__/analytics-fetchers-ads.test.ts
- npm run typecheck:staged -- src/lib/analytics/fetchers-ads.ts src/lib/__tests__/analytics-fetchers-ads.test.ts