### PR TITLE
fix(analytics): run product refresh in tenant context

### DIFF
--- a/src/lib/__tests__/analytics-refresh-runner-monthly-history.test.ts
+++ b/src/lib/__tests__/analytics-refresh-runner-monthly-history.test.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runAnalyticsRefresh } from "@/lib/analytics/refresh-runner";
 import { fetchMercuryData, fetchStripeData } from "@/lib/analytics/fetchers";
 import { getCredentials } from "@/lib/analytics/credentials";
+import { fetchIntegrationTelemetryData } from "@/lib/analytics/fetchers-integrations";
 import { storeAnalyticsSnapshot } from "@/lib/analytics/snapshots";
 import { prisma } from "@/lib/prisma";
+import { getRequestContext } from "@/lib/request-context";
 
 vi.mock("@/lib/analytics/credentials", () => ({
   getCredentials: vi.fn(),
@@ -57,6 +59,9 @@ vi.mock("@/lib/prisma", () => ({
     analyticsSnapshot: {
       findMany: vi.fn(),
     },
+    user: {
+      findUnique: vi.fn(),
+    },
     task: {
       count: vi.fn(),
     },
@@ -76,7 +81,9 @@ describe("analytics monthly financial history refresh", () => {
     } as never);
     vi.mocked(fetchStripeData).mockResolvedValue({ provider: "stripe" } as never);
     vi.mocked(fetchMercuryData).mockResolvedValue({ provider: "mercury" } as never);
+    vi.mocked(fetchIntegrationTelemetryData).mockResolvedValue({ provider: "telemetry" } as never);
     vi.mocked(prisma.analyticsSnapshot.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ organizationId: "org-1" } as never);
     vi.mocked(prisma.task.count).mockResolvedValue(0);
     vi.mocked(prisma.statusHistory.findMany).mockResolvedValue([]);
     vi.mocked(storeAnalyticsSnapshot).mockResolvedValue(undefined);
@@ -193,6 +200,36 @@ describe("analytics monthly financial history refresh", () => {
         providerKey: "product",
         contextKey: "default",
         rangePreset: "30d",
+      }),
+    );
+  });
+
+  it("runs rolling product snapshots inside the user's organization context", async () => {
+    vi.mocked(getCredentials).mockResolvedValue({} as never);
+    vi.mocked(prisma.task.count).mockImplementation(async () => {
+      if (getRequestContext()?.organizationId !== "org-1") {
+        throw new Error("Missing tenant context");
+      }
+      return 0 as never;
+    });
+
+    const result = await runAnalyticsRefresh({
+      userIds: ["user-1"],
+      rangePresets: ["7d"],
+      includeMonthlyFinancialHistory: false,
+    });
+
+    expect(result.failureCount).toBe(0);
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      select: { organizationId: true },
+    });
+    expect(storeAnalyticsSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        providerKey: "product",
+        contextKey: "default",
+        rangePreset: "7d",
       }),
     );
   });

--- a/src/lib/analytics/refresh-runner.ts
+++ b/src/lib/analytics/refresh-runner.ts
@@ -14,6 +14,7 @@ import { fetchSemrushData } from "@/lib/analytics/fetchers-semrush";
 import { providerForSnapshotKey } from "@/lib/analytics/provider-health";
 import { snapshotExpiryFromNow, storeAnalyticsSnapshot, storeAnalyticsSnapshotFailure } from "@/lib/analytics/snapshots";
 import { parseAnalyticsTimeRange } from "@/lib/analytics/time-range";
+import { runWithContextAsync } from "@/lib/request-context";
 import {
   MONTHLY_HISTORY_CONTEXT_KEY,
   MONTHLY_HISTORY_RANGE_PRESET,
@@ -106,44 +107,71 @@ async function loadExistingMonthlyFinancialSnapshotKeys(input: {
   );
 }
 
-async function computeProductSnapshot(userId: string, fromDate: Date, toDate: Date) {
-  const [createdTasksInRange, completedTasksInRange, overdueOpenTasks, contributors] = await Promise.all([
-    prisma.task.count({ where: { createdAt: { gte: fromDate, lte: toDate } } }),
-    prisma.task.count({ where: { completedOn: { gte: fromDate, lte: toDate } } }),
-    prisma.task.count({
-      where: {
-        status: { not: "DONE" },
-        dueDate: { lt: toDate },
-      },
-    }),
-    prisma.statusHistory.findMany({
-      where: {
-        changedAt: { gte: fromDate, lte: toDate },
-        changedBy: { not: null },
-      },
-      distinct: ["changedBy"],
-      select: { changedBy: true },
-    }),
-  ]);
+async function resolveUserOrganizationId(userId: string): Promise<string | null> {
+  return (
+    (
+      await prisma.user.findUnique({
+        where: { id: userId },
+        select: { organizationId: true },
+      })
+    )?.organizationId ?? null
+  );
+}
 
-  const activeContributors = contributors.filter((entry) => Boolean(entry.changedBy)).length;
-  const backlogGrowth = createdTasksInRange - completedTasksInRange;
-  const throughputRate =
-    createdTasksInRange > 0 ? Math.round((completedTasksInRange / createdTasksInRange) * 10000) / 100 : null;
+async function computeProductSnapshot(input: {
+  userId: string;
+  organizationId: string | null;
+  fromDate: Date;
+  toDate: Date;
+}) {
+  const run = async () => {
+    const [createdTasksInRange, completedTasksInRange, overdueOpenTasks, contributors] = await Promise.all([
+      prisma.task.count({ where: { createdAt: { gte: input.fromDate, lte: input.toDate } } }),
+      prisma.task.count({ where: { completedOn: { gte: input.fromDate, lte: input.toDate } } }),
+      prisma.task.count({
+        where: {
+          status: { not: "DONE" },
+          dueDate: { lt: input.toDate },
+        },
+      }),
+      prisma.statusHistory.findMany({
+        where: {
+          changedAt: { gte: input.fromDate, lte: input.toDate },
+          changedBy: { not: null },
+        },
+        distinct: ["changedBy"],
+        select: { changedBy: true },
+      }),
+    ]);
 
-  return {
-    activeContributors,
-    createdTasksInRange,
-    completedTasksInRange,
-    overdueOpenTasks,
-    backlogGrowth,
-    throughputRate,
-    _meta: {
-      fetchedAt: new Date().toISOString(),
-      nextRefresh: snapshotExpiryFromNow(1).toISOString(),
-      source: "live" as const,
-    },
+    const activeContributors = contributors.filter((entry) => Boolean(entry.changedBy)).length;
+    const backlogGrowth = createdTasksInRange - completedTasksInRange;
+    const throughputRate =
+      createdTasksInRange > 0 ? Math.round((completedTasksInRange / createdTasksInRange) * 10000) / 100 : null;
+
+    return {
+      activeContributors,
+      createdTasksInRange,
+      completedTasksInRange,
+      overdueOpenTasks,
+      backlogGrowth,
+      throughputRate,
+      _meta: {
+        fetchedAt: new Date().toISOString(),
+        nextRefresh: snapshotExpiryFromNow(1).toISOString(),
+        source: "live" as const,
+      },
+    };
   };
+
+  if (!input.organizationId) {
+    return run();
+  }
+
+  return runWithContextAsync(
+    { organizationId: input.organizationId, userId: input.userId },
+    run,
+  );
 }
 
 interface ProviderRefreshOutcome {
@@ -186,6 +214,7 @@ async function refreshForUserAndRange(input: {
   const toDate = new Date(`${range.to}T23:59:59.999Z`);
 
   const creds = await getCredentials(input.userId);
+  const organizationId = await resolveUserOrganizationId(input.userId);
   const expiresAt = snapshotExpiryFromNow(1);
 
   const jobs: Array<{ providerKey: string; run: () => Promise<unknown> }> = [];
@@ -304,7 +333,16 @@ async function refreshForUserAndRange(input: {
     });
   }
 
-  jobs.push({ providerKey: "product", run: () => computeProductSnapshot(input.userId, fromDate, toDate) });
+  jobs.push({
+    providerKey: "product",
+    run: () =>
+      computeProductSnapshot({
+        userId: input.userId,
+        organizationId,
+        fromDate,
+        toDate,
+      }),
+  });
 
   jobs.push({
     providerKey: "googleWorkspace",


### PR DESCRIPTION
## Summary
- resolve the refresh user's organization before rolling analytics refreshes
- run product snapshot task/status queries inside the tenant request context
- add a regression test that fails if product refresh lacks organization context

## Verification
- npx vitest run src/lib/__tests__/analytics-refresh-runner-monthly-history.test.ts src/lib/__tests__/analytics-fetchers-ads.test.ts
- npx eslint --max-warnings=0 src/lib/analytics/refresh-runner.ts src/lib/__tests__/analytics-refresh-runner-monthly-history.test.ts
- npm run typecheck:staged -- src/lib/analytics/refresh-runner.ts src/lib/__tests__/analytics-refresh-runner-monthly-history.test.ts