### PR TITLE
fix(analytics): soft-fail SEMrush quota exhaustion

### DIFF
--- a/src/lib/__tests__/analytics-refresh-runner-monthly-history.test.ts
+++ b/src/lib/__tests__/analytics-refresh-runner-monthly-history.test.ts
@@ -2,8 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runAnalyticsRefresh } from "@/lib/analytics/refresh-runner";
 import { fetchMercuryData, fetchStripeData } from "@/lib/analytics/fetchers";
 import { getCredentials } from "@/lib/analytics/credentials";
+import { fetchSemrushData } from "@/lib/analytics/fetchers-semrush";
 import { fetchIntegrationTelemetryData } from "@/lib/analytics/fetchers-integrations";
-import { storeAnalyticsSnapshot } from "@/lib/analytics/snapshots";
+import { storeAnalyticsSnapshot, storeAnalyticsSnapshotFailure } from "@/lib/analytics/snapshots";
 import { prisma } from "@/lib/prisma";
 import { getRequestContext } from "@/lib/request-context";
 
@@ -230,6 +231,33 @@ describe("analytics monthly financial history refresh", () => {
         providerKey: "product",
         contextKey: "default",
         rangePreset: "7d",
+      }),
+    );
+  });
+
+  it("stores SEMrush exhausted API unit errors without counting cron failure", async () => {
+    vi.mocked(getCredentials).mockResolvedValue({
+      semrushApiToken: "semrush-token",
+      semrushDomain: "example.com",
+    } as never);
+    vi.mocked(fetchSemrushData).mockRejectedValue(
+      new Error("SEMrush API error (403): ERROR 403 :: ERROR 132 :: API UNITS BALANCE IS ZERO\n")
+    );
+
+    const result = await runAnalyticsRefresh({
+      userIds: ["user-1"],
+      rangePresets: ["7d"],
+      includeMonthlyFinancialHistory: false,
+    });
+
+    expect(result.failureCount).toBe(0);
+    expect(storeAnalyticsSnapshotFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        providerKey: "semrush",
+        contextKey: "default",
+        rangePreset: "7d",
+        error: "SEMrush API error (403): ERROR 403 :: ERROR 132 :: API UNITS BALANCE IS ZERO\n",
       }),
     );
   });

--- a/src/lib/analytics/refresh-runner.ts
+++ b/src/lib/analytics/refresh-runner.ts
@@ -203,6 +203,25 @@ function recordProviderOutcome(
   outcomes.set(provider, current);
 }
 
+function isSemrushApiUnitsExhausted(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("semrush api error") &&
+    normalized.includes("api units balance is zero")
+  );
+}
+
+function shouldCountRefreshFailure(input: {
+  providerKey: string;
+  errorMessage: string;
+}): boolean {
+  if (input.providerKey === "semrush" && isSemrushApiUnitsExhausted(input.errorMessage)) {
+    return false;
+  }
+
+  return true;
+}
+
 async function refreshForUserAndRange(input: {
   userId: string;
   rangePreset: RollingRangePreset;
@@ -417,8 +436,10 @@ async function refreshForUserAndRange(input: {
       refreshed += 1;
       recordProviderOutcome(providerOutcomes, provider, { success: true });
     } catch (error) {
-      failures += 1;
       const message = error instanceof Error ? error.message : "refresh failed";
+      if (shouldCountRefreshFailure({ providerKey: job.providerKey, errorMessage: message })) {
+        failures += 1;
+      }
       await storeAnalyticsSnapshotFailure({
         userId: input.userId,
         providerKey: job.providerKey,


### PR DESCRIPTION
## Summary
- keep storing SEMrush ERROR snapshots when the account has zero API units
- stop counting that exact SEMrush quota exhaustion state as a cron refresh failure
- add a regression test for the exhausted-units response

## Verification
- npx vitest run src/lib/__tests__/analytics-refresh-runner-monthly-history.test.ts src/lib/__tests__/analytics-fetchers-semrush.test.ts
- npx eslint --max-warnings=0 src/lib/analytics/refresh-runner.ts src/lib/__tests__/analytics-refresh-runner-monthly-history.test.ts
- npm run typecheck:staged -- src/lib/analytics/refresh-runner.ts src/lib/__tests__/analytics-refresh-runner-monthly-history.test.ts