### PR TITLE
Fix Railway Docker entrypoint copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,8 @@ RUN mkdir -p /app/.next/cache && chown -R nextjs:nodejs /app/.next
 COPY --from=builder /app/migrate.cjs ./migrate.cjs
 # Copy ops scripts used by runbooks (e.g. OAuth scope backfills)
 COPY --from=builder /app/scripts/backfill-google-oauth-scope-aliases.cjs ./scripts/backfill-google-oauth-scope-aliases.cjs
-# Copy entrypoint script
-COPY docker-entrypoint.sh ./docker-entrypoint.sh
+# Copy entrypoint script from the already materialized build context.
+COPY --from=builder /app/docker-entrypoint.sh ./docker-entrypoint.sh
 # Verify migrate.cjs exists
 RUN ls -la /app/migrate.cjs /app/docker-entrypoint.sh
 


### PR DESCRIPTION
## Summary
- copy docker-entrypoint.sh from the builder stage during runtime image assembly
- avoids Railway final-stage context lookup failure during production deploy

## Verification
- git diff --check