### PR TITLE
Fix SEMrush saved credentials

### DIFF
--- a/src/app/api/integrations/semrush/token/route.test.ts
+++ b/src/app/api/integrations/semrush/token/route.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+import { IntegrationProvider } from "@/generated/prisma/client";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  enforcePermission: vi.fn(),
+}));
+
+vi.mock("@/lib/integrations/ownership", () => ({
+  ensureIntegrationOwnerOrganizationId: vi.fn(),
+  resolveIntegrationOwnerUserId: vi.fn((userId: string) => userId),
+}));
+
+vi.mock("@/lib/integrations/oauth", () => ({
+  compactErrorMessage: (error: unknown) =>
+    error instanceof Error ? error.message : "Integration request failed",
+}));
+
+vi.mock("@/lib/integrations/token-crypto", () => ({
+  protectIntegrationSecret: (value: string) => `enc:${value}`,
+  unprotectIntegrationSecret: (value: string | null) =>
+    value?.startsWith("plainv1.") ? value.slice("plainv1.".length) : value,
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    integrationConnection: {
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+describe("POST /api/integrations/semrush/token", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    delete process.env.SEMRUSH_API_TOKEN;
+    delete process.env.SEMRUSH_DOMAIN;
+  });
+
+  afterEach(() => {
+    delete process.env.SEMRUSH_API_TOKEN;
+    delete process.env.SEMRUSH_DOMAIN;
+  });
+
+  it("persists a new SEMrush token and target domain", async () => {
+    const { auth } = await import("@/lib/auth");
+    const { ensureIntegrationOwnerOrganizationId } = await import("@/lib/integrations/ownership");
+    const { enforcePermission } = await import("@/lib/permissions");
+    const { prisma } = await import("@/lib/prisma");
+
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "user-1", organizationId: "org-1" },
+    } as never);
+    vi.mocked(ensureIntegrationOwnerOrganizationId).mockResolvedValue("org-1");
+    vi.mocked(enforcePermission).mockResolvedValue({ deniedResponse: null } as never);
+    vi.mocked(prisma.integrationConnection.findUnique).mockResolvedValue(null as never);
+    vi.mocked(prisma.integrationConnection.upsert).mockResolvedValue({} as never);
+
+    const { POST } = await import("@/app/api/integrations/semrush/token/route");
+    const request = new Request("http://localhost/api/integrations/semrush/token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        token: "semrush-token",
+        domain: "example.com",
+      }),
+    }) as unknown as NextRequest;
+
+    const response = await POST(request);
+    const body = (await response.json()) as { ok: boolean; domain: string };
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ ok: true, domain: "example.com" });
+    expect(prisma.integrationConnection.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId_provider: {
+            userId: "user-1",
+            provider: IntegrationProvider.SEMRUSH,
+          },
+        },
+        create: expect.objectContaining({
+          organizationId: "org-1",
+          accessToken: "enc:semrush-token",
+          accountLabel: "example.com",
+          metadata: expect.objectContaining({
+            authType: "api_token",
+            connectedByUserId: "user-1",
+            domain: "example.com",
+          }),
+        }),
+        update: expect.objectContaining({
+          organizationId: "org-1",
+          accessToken: "enc:semrush-token",
+          accountLabel: "example.com",
+          metadata: expect.objectContaining({
+            domain: "example.com",
+          }),
+        }),
+      })
+    );
+  });
+
+  it("allows domain-only updates when a saved token already exists", async () => {
+    const { auth } = await import("@/lib/auth");
+    const { ensureIntegrationOwnerOrganizationId } = await import("@/lib/integrations/ownership");
+    const { enforcePermission } = await import("@/lib/permissions");
+    const { prisma } = await import("@/lib/prisma");
+
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "user-2", organizationId: "org-2" },
+    } as never);
+    vi.mocked(ensureIntegrationOwnerOrganizationId).mockResolvedValue("org-2");
+    vi.mocked(enforcePermission).mockResolvedValue({ deniedResponse: null } as never);
+    vi.mocked(prisma.integrationConnection.findUnique).mockResolvedValue({
+      accessToken: "plainv1.saved-semrush-token",
+      metadata: {
+        authType: "api_token",
+        domain: "old.example.com",
+        custom: "preserved",
+      },
+    } as never);
+    vi.mocked(prisma.integrationConnection.upsert).mockResolvedValue({} as never);
+
+    const { POST } = await import("@/app/api/integrations/semrush/token/route");
+    const request = new Request("http://localhost/api/integrations/semrush/token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        domain: "example.com",
+      }),
+    }) as unknown as NextRequest;
+
+    const response = await POST(request);
+    const body = (await response.json()) as { ok: boolean; domain: string };
+
+    expect(response.status).toBe(200);
+    expect(body.domain).toBe("example.com");
+    expect(prisma.integrationConnection.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          accessToken: "enc:saved-semrush-token",
+          metadata: expect.objectContaining({
+            custom: "preserved",
+            domain: "example.com",
+          }),
+        }),
+      })
+    );
+  });
+
+  it("still requires token and domain when neither is saved nor provided", async () => {
+    const { auth } = await import("@/lib/auth");
+    const { ensureIntegrationOwnerOrganizationId } = await import("@/lib/integrations/ownership");
+    const { enforcePermission } = await import("@/lib/permissions");
+    const { prisma } = await import("@/lib/prisma");
+
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "user-3", organizationId: "org-3" },
+    } as never);
+    vi.mocked(ensureIntegrationOwnerOrganizationId).mockResolvedValue("org-3");
+    vi.mocked(enforcePermission).mockResolvedValue({ deniedResponse: null } as never);
+    vi.mocked(prisma.integrationConnection.findUnique).mockResolvedValue(null as never);
+
+    const { POST } = await import("@/app/api/integrations/semrush/token/route");
+    const missingToken = new Request("http://localhost/api/integrations/semrush/token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        domain: "example.com",
+      }),
+    }) as unknown as NextRequest;
+
+    const tokenResponse = await POST(missingToken);
+    const tokenBody = (await tokenResponse.json()) as { error?: string };
+
+    expect(tokenResponse.status).toBe(400);
+    expect(tokenBody.error).toContain("SEMrush API Token is required");
+    expect(prisma.integrationConnection.upsert).not.toHaveBeenCalled();
+
+    process.env.SEMRUSH_API_TOKEN = "env-token";
+    const missingDomain = new Request("http://localhost/api/integrations/semrush/token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    }) as unknown as NextRequest;
+
+    const domainResponse = await POST(missingDomain);
+    const domainBody = (await domainResponse.json()) as { error?: string };
+
+    expect(domainResponse.status).toBe(400);
+    expect(domainBody.error).toContain("SEMrush Target Domain is required");
+    expect(prisma.integrationConnection.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/integrations/semrush/token/route.ts
+++ b/src/app/api/integrations/semrush/token/route.ts
@@ -13,7 +13,7 @@ import {
   resolveIntegrationOwnerUserId,
 } from "@/lib/integrations/ownership";
 import { compactErrorMessage } from "@/lib/integrations/oauth";
-import { protectIntegrationSecret } from "@/lib/integrations/token-crypto";
+import { protectIntegrationSecret, unprotectIntegrationSecret } from "@/lib/integrations/token-crypto";
 import { enforcePermission } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import { getAuthenticatedUser } from "@/lib/session-user";
@@ -21,6 +21,23 @@ import { getAuthenticatedUser } from "@/lib/session-user";
 interface ConnectSemrushBody {
   token?: string;
   domain?: string;
+}
+
+function asMetadataObject(metadata: unknown): Prisma.InputJsonObject {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return {};
+  }
+  return metadata as Prisma.InputJsonObject;
+}
+
+function readPersistedDomain(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return null;
+  }
+  const candidate = (metadata as Record<string, unknown>).domain;
+  return typeof candidate === "string" && candidate.trim().length > 0
+    ? candidate.trim()
+    : null;
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -50,8 +67,29 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const organizationId = sessionUser.organizationId ?? null;
     await ensureIntegrationOwnerOrganizationId(ownerUserId, organizationId);
     const body = (await request.json().catch(() => ({}))) as ConnectSemrushBody;
-    const token = body.token?.trim() || getIntegrationEnvValue("SEMRUSH_API_TOKEN");
-    const domain = body.domain?.trim() || process.env.SEMRUSH_DOMAIN?.trim();
+    const existing = await prisma.integrationConnection.findUnique({
+      where: {
+        userId_provider: {
+          userId: ownerUserId,
+          provider: IntegrationProvider.SEMRUSH,
+        },
+      },
+      select: {
+        accessToken: true,
+        metadata: true,
+      },
+    });
+    const existingToken = existing?.accessToken
+      ? unprotectIntegrationSecret(existing.accessToken)
+      : null;
+    const token =
+      body.token?.trim() ||
+      existingToken?.trim() ||
+      getIntegrationEnvValue("SEMRUSH_API_TOKEN");
+    const domain =
+      body.domain?.trim() ||
+      readPersistedDomain(existing?.metadata ?? null) ||
+      process.env.SEMRUSH_DOMAIN?.trim();
 
     if (!token) {
       return NextResponse.json(
@@ -71,6 +109,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     const metadata: Prisma.InputJsonObject = {
+      ...asMetadataObject(existing?.metadata ?? null),
       authType: "api_token",
       connectedByUserId: session.user.id,
       domain,

--- a/src/components/settings/integrations-tab.test.tsx
+++ b/src/components/settings/integrations-tab.test.tsx
@@ -231,4 +231,59 @@ describe("IntegrationsTab", () => {
     expect(screen.queryByText("Disconnect")).toBeNull();
     expect(screen.getByText("Managed by server environment")).toBeTruthy();
   });
+
+  it("renders SEMrush saved-settings inputs and posts token plus domain", async () => {
+    mockIntegrationsFetch({
+      items: [
+        {
+          slug: "semrush",
+          provider: "SEMRUSH",
+          name: "SEMrush",
+          description: "SEMrush integration",
+          capabilities: ["Organic Search"],
+          authType: "token",
+          configured: true,
+          missingEnv: [],
+          connected: false,
+          status: "DISCONNECTED",
+          accountLabel: null,
+          connectedAt: null,
+          lastSyncedAt: null,
+          lastError: null,
+          credentialSource: "none",
+          syncHealth: "missing",
+          syncHealthReason: "No integration credentials found.",
+          lastSnapshotAt: null,
+          lastSnapshotStatus: null,
+        },
+      ],
+    });
+
+    render(<IntegrationsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Toggle SEMrush").getAttribute("aria-expanded")).toBe("true");
+    });
+
+    fireEvent.change(screen.getByLabelText("SEMrush Target Domain"), {
+      target: { value: "example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("SEMrush API Token (optional if already saved)"), {
+      target: { value: "semrush-token" },
+    });
+    fireEvent.click(screen.getByText("Connect SEMrush"));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/integrations/semrush/token",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            token: "semrush-token",
+            domain: "example.com",
+          }),
+        })
+      );
+    });
+  });
 });

--- a/src/components/settings/integrations/provider-card.tsx
+++ b/src/components/settings/integrations/provider-card.tsx
@@ -113,6 +113,11 @@ export function ProviderCard({
   onCodaTokenChange,
   onCodaDocChange,
   onConnectCoda,
+  semrushToken,
+  semrushDomain,
+  onSemrushTokenChange,
+  onSemrushDomainChange,
+  onConnectSemrush,
   pylonToken,
   pylonBaseUrl,
   onPylonTokenChange,
@@ -405,6 +410,63 @@ export function ProviderCard({
                 ) : null}
               </div>
               <p className="mt-1 text-xs text-muted-foreground">Current doc: {item.docId || "Not configured"}</p>
+            </div>
+          ) : null}
+
+          {item.slug === "semrush" ? (
+            <div className="rounded-lg border border-border p-3">
+              <p className="text-sm font-medium text-foreground">SEMrush Connection</p>
+              <div className="mt-2 grid gap-2 md:grid-cols-2">
+                <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                  SEMrush Target Domain
+                  <input
+                    type="text"
+                    value={semrushDomain ?? ""}
+                    onChange={(event) => onSemrushDomainChange?.(event.target.value)}
+                    placeholder="example.com"
+                    className="rounded-md border border-border bg-background px-2 py-1.5 text-sm text-foreground"
+                  />
+                </label>
+                <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                  SEMrush API Token (optional if already saved)
+                  <input
+                    type="password"
+                    value={semrushToken ?? ""}
+                    onChange={(event) => onSemrushTokenChange?.(event.target.value)}
+                    placeholder="SEMrush API token"
+                    className="rounded-md border border-border bg-background px-2 py-1.5 text-sm text-foreground"
+                  />
+                </label>
+              </div>
+              <div className="mt-2 flex gap-2">
+                <button
+                  type="button"
+                  onClick={onConnectSemrush}
+                  disabled={!onConnectSemrush || loadingProviderAction === "semrush"}
+                  className="btn-primary-theme rounded-md px-3 py-1.5 text-xs disabled:opacity-60"
+                >
+                  {loadingProviderAction === "semrush" ? (
+                    <span className="inline-flex items-center gap-1">
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      Saving...
+                    </span>
+                  ) : item.connected ? (
+                    "Save SEMrush Settings"
+                  ) : (
+                    "Connect SEMrush"
+                  )}
+                </button>
+                {canDisconnectStoredConnection ? (
+                  <button
+                    type="button"
+                    onClick={() => onDisconnect(item.slug)}
+                    disabled={loadingProviderAction === item.slug}
+                    className="rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground disabled:opacity-60"
+                  >
+                    Disconnect
+                  </button>
+                ) : null}
+              </div>
             </div>
           ) : null}
 

--- a/src/lib/__tests__/analytics-credentials-owner-fallback.test.ts
+++ b/src/lib/__tests__/analytics-credentials-owner-fallback.test.ts
@@ -43,6 +43,8 @@ describe("analytics credentials owner fallback", () => {
 
   afterEach(() => {
     delete process.env.INTEGRATION_OWNER_USER_ID;
+    delete process.env.SEMRUSH_API_TOKEN;
+    delete process.env.SEMRUSH_DOMAIN;
   });
 
   it("fills a missing Stripe provider from another connected user when the owner has other rows", async () => {
@@ -168,6 +170,77 @@ describe("analytics credentials owner fallback", () => {
         source: "connection",
         status: IntegrationConnectionStatus.CONNECTED,
         lastError: null,
+      })
+    );
+  });
+
+  it("uses a saved SEMrush token and domain from the integration connection", async () => {
+    mockIntegrationConnectionFindMany
+      .mockResolvedValueOnce([
+        {
+          userId: "owner_1",
+          provider: IntegrationProvider.SEMRUSH,
+          status: IntegrationConnectionStatus.CONNECTED,
+          accessToken: "plainv1.semrush-token",
+          refreshToken: null,
+          tokenType: "Bearer",
+          expiresAt: null,
+          scopes: [],
+          metadata: { domain: "example.com" },
+          connectedAt: new Date("2026-03-03T00:00:00.000Z"),
+          lastSyncedAt: new Date("2026-03-03T01:00:00.000Z"),
+          lastError: null,
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const { getCredentials, hasIntegrationCredential } = await import("@/lib/analytics/credentials");
+    const creds = await getCredentials("owner_1");
+
+    expect(creds.semrushApiToken).toBe("semrush-token");
+    expect(creds.semrushDomain).toBe("example.com");
+    expect(hasIntegrationCredential(IntegrationProvider.SEMRUSH, creds)).toBe(true);
+    expect(creds.freshness[IntegrationProvider.SEMRUSH]).toEqual(
+      expect.objectContaining({
+        provider: IntegrationProvider.SEMRUSH,
+        source: "connection",
+        status: IntegrationConnectionStatus.CONNECTED,
+      })
+    );
+  });
+
+  it("requires both SEMrush token and domain for env fallback credentials", async () => {
+    mockIntegrationConnectionFindMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    process.env.SEMRUSH_API_TOKEN = "env-semrush-token";
+
+    const { getCredentials, hasIntegrationCredential } = await import("@/lib/analytics/credentials");
+    const withoutDomain = await getCredentials("owner_1");
+
+    expect(withoutDomain.semrushApiToken).toBe("env-semrush-token");
+    expect(withoutDomain.semrushDomain).toBeNull();
+    expect(hasIntegrationCredential(IntegrationProvider.SEMRUSH, withoutDomain)).toBe(false);
+    expect(withoutDomain.freshness[IntegrationProvider.SEMRUSH]).toEqual(
+      expect.objectContaining({
+        provider: IntegrationProvider.SEMRUSH,
+        source: "none",
+      })
+    );
+
+    mockIntegrationConnectionFindMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    process.env.SEMRUSH_DOMAIN = "example.com";
+
+    const withDomain = await getCredentials("owner_1");
+    expect(withDomain.semrushApiToken).toBe("env-semrush-token");
+    expect(withDomain.semrushDomain).toBe("example.com");
+    expect(hasIntegrationCredential(IntegrationProvider.SEMRUSH, withDomain)).toBe(true);
+    expect(withDomain.freshness[IntegrationProvider.SEMRUSH]).toEqual(
+      expect.objectContaining({
+        provider: IntegrationProvider.SEMRUSH,
+        source: "env",
       })
     );
   });

--- a/src/lib/analytics/credentials.ts
+++ b/src/lib/analytics/credentials.ts
@@ -784,6 +784,7 @@ export async function getCredentials(userId?: string): Promise<AnalyticsCredenti
   const googleAdsConnection = byProvider.get(IntegrationProvider.GOOGLE_ADS) ?? null;
   const metaAdsConnection = byProvider.get(IntegrationProvider.META_ADS) ?? null;
   const metaPageConnection = byProvider.get(IntegrationProvider.META_PAGE) ?? null;
+  const semrushConnection = byProvider.get(IntegrationProvider.SEMRUSH) ?? null;
   const pylonConnection = byProvider.get(IntegrationProvider.PYLON) ?? null;
   const posthogConnection = byProvider.get(IntegrationProvider.POSTHOG) ?? null;
   const linearConnection = byProvider.get(IntegrationProvider.LINEAR) ?? null;
@@ -797,6 +798,8 @@ export async function getCredentials(userId?: string): Promise<AnalyticsCredenti
   const envMercury = envOrNull(process.env.MERCURY_API_TOKEN);
   const envWebflowToken = envOrNull(process.env.WEBFLOW_API_TOKEN);
   const envWebflowSiteId = envOrNull(process.env.WEBFLOW_SITE_ID);
+  const envSemrushApiToken = envOrNull(getIntegrationEnvValue("SEMRUSH_API_TOKEN"));
+  const envSemrushDomain = envOrNull(process.env.SEMRUSH_DOMAIN);
   const envPylonApiKey = envOrNull(process.env.PYLON_API_KEY);
   const envPylonBaseUrl = envOrNull(process.env.PYLON_API_BASE_URL);
   const envMetaAccessToken = envOrNull(process.env.META_ACCESS_TOKEN);
@@ -1066,6 +1069,17 @@ export async function getCredentials(userId?: string): Promise<AnalyticsCredenti
   const pylonBaseUrl =
     metadataString(pylonConnection?.metadata, "baseUrl") ?? envPylonBaseUrl;
 
+  const semrushApiToken =
+    semrushConnection && semrushConnection.status !== IntegrationConnectionStatus.DISCONNECTED
+      ? unprotectIntegrationSecret(semrushConnection.accessToken)
+      : envSemrushApiToken;
+  const semrushDomain =
+    metadataString(semrushConnection?.metadata, "domain") ?? envSemrushDomain;
+  const usingSemrushEnvFallback =
+    hasValue(envSemrushApiToken) &&
+    hasValue(envSemrushDomain) &&
+    (!semrushConnection || semrushConnection.status === IntegrationConnectionStatus.DISCONNECTED);
+
   const posthogApiKey =
     posthogConnection && posthogConnection.status !== IntegrationConnectionStatus.DISCONNECTED
       ? unprotectIntegrationSecret(posthogConnection.accessToken)
@@ -1173,8 +1187,8 @@ export async function getCredentials(userId?: string): Promise<AnalyticsCredenti
     ),
     [IntegrationProvider.SEMRUSH]: buildFreshness(
       IntegrationProvider.SEMRUSH,
-      null,
-      Boolean(getIntegrationEnvValue("SEMRUSH_API_TOKEN"))
+      semrushConnection,
+      usingSemrushEnvFallback
     ),
     [IntegrationProvider.GOOGLE_SEARCH_CONSOLE]: buildFreshness(
       IntegrationProvider.GOOGLE_SEARCH_CONSOLE,
@@ -1250,8 +1264,8 @@ export async function getCredentials(userId?: string): Promise<AnalyticsCredenti
     redditAdAccountId: envOrNull(process.env.REDDIT_AD_ACCOUNT_ID),
     redditUserAgent: envOrNull(process.env.REDDIT_USER_AGENT),
 
-    semrushApiToken: envOrNull(getIntegrationEnvValue("SEMRUSH_API_TOKEN")),
-    semrushDomain: envOrNull(process.env.SEMRUSH_DOMAIN),
+    semrushApiToken,
+    semrushDomain,
 
     webflowApiToken,
     webflowSiteId,


### PR DESCRIPTION
## Summary
- Render SEMrush token/domain controls in Settings so saved credentials can be managed from the UI
- Reuse saved SEMrush tokens/domains in the token route for domain-only updates
- Resolve SEMrush analytics credentials from stored integration connections before env fallback

## Test Plan
- npx vitest run src/lib/__tests__/analytics-fetchers-semrush.test.ts src/lib/__tests__/analytics-credentials-owner-fallback.test.ts src/app/api/integrations/semrush/token/route.test.ts src/components/settings/integrations-tab.test.tsx
- npm run typecheck:staged -- src/lib/analytics/credentials.ts src/app/api/integrations/semrush/token/route.ts src/components/settings/integrations/provider-card.tsx src/components/settings/integrations-tab.test.tsx src/app/api/integrations/semrush/token/route.test.ts src/lib/__tests__/analytics-credentials-owner-fallback.test.ts
- npx eslint src/lib/analytics/credentials.ts src/app/api/integrations/semrush/token/route.ts src/components/settings/integrations/provider-card.tsx src/components/settings/integrations-tab.test.tsx src/app/api/integrations/semrush/token/route.test.ts src/lib/__tests__/analytics-credentials-owner-fallback.test.ts