### PR TITLE
Fix retired route redirects

### DIFF
--- a/src/__tests__/security-headers.test.ts
+++ b/src/__tests__/security-headers.test.ts
@@ -171,6 +171,28 @@ describe("Middleware", () => {
     });
   });
 
+  it("redirects retired task product routes to metrics", async () => {
+    const { middleware } = await import("../middleware");
+
+    const response = middleware(
+      new NextRequest("http://localhost:3000/tasks?view=mine")
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("http://localhost:3000/metrics");
+  });
+
+  it("redirects retired local deals routes to sources", async () => {
+    const { middleware } = await import("../middleware");
+
+    const response = middleware(
+      new NextRequest("http://localhost:3000/deals/new?source=local")
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("http://localhost:3000/sources");
+  });
+
   it("returns 410 for versioned legacy product APIs when disabled", async () => {
     process.env.ENABLE_LEGACY_PRODUCT_APIS = "false";
     const { middleware } = await import("../middleware");

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -19,6 +19,25 @@ const LEGACY_PRODUCT_API_PREFIXES = [
   "/api/v1/tasks",
 ] as const;
 
+const RETIRED_ROUTE_REDIRECTS = [
+  { prefixes: ["/deals"], destination: "/sources" },
+  {
+    prefixes: [
+      "/dashboard",
+      "/tasks",
+      "/board",
+      "/my-tasks",
+      "/projects",
+      "/standup",
+      "/today",
+      "/whip",
+      "/table",
+      "/logbook",
+    ],
+    destination: "/metrics",
+  },
+] as const;
+
 /**
  * Next.js Middleware
  *
@@ -33,6 +52,9 @@ export function middleware(request: NextRequest) {
 
   const canonicalRedirect = maybeRedirectToCanonicalHost(request, pathname);
   if (canonicalRedirect) return canonicalRedirect;
+
+  const retiredRouteRedirect = maybeRedirectRetiredRoute(request, pathname);
+  if (retiredRouteRedirect) return retiredRouteRedirect;
 
   // For non-API routes, just add security headers
   if (!pathname.startsWith("/api/")) {
@@ -91,6 +113,29 @@ export function middleware(request: NextRequest) {
   response.headers.set("API-Version", CURRENT_API_VERSION);
   addSecurityHeaders(response);
   return response;
+}
+
+function maybeRedirectRetiredRoute(
+  request: NextRequest,
+  pathname: string
+): NextResponse | null {
+  for (const redirect of RETIRED_ROUTE_REDIRECTS) {
+    const matched = redirect.prefixes.some(
+      (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+    );
+    if (!matched) continue;
+
+    const redirectUrl = new URL(request.url);
+    redirectUrl.pathname = redirect.destination;
+    redirectUrl.search = "";
+    redirectUrl.hash = "";
+
+    const response = NextResponse.redirect(redirectUrl, 307);
+    addSecurityHeaders(response);
+    return response;
+  }
+
+  return null;
 }
 
 function maybeRejectLegacyProductApi(pathname: string): NextResponse | null {


### PR DESCRIPTION
## Summary
- Restore middleware redirects for retired task/product routes to /metrics
- Restore retired local /deals redirects to /sources
- Add middleware regression tests for both destinations

## Verification
- npm run db:generate
- npx vitest run src/__tests__/security-headers.test.ts
- npx tsc --noEmit --pretty false
- npx eslint src/middleware.ts src/__tests__/security-headers.test.ts
- npm run build