### PR TITLE
Remove restart-retries stopgap now that the OOM leak is fixed

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
   },
   "deploy": {
     "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 1000,
+    "restartPolicyMaxRetries": 10,
     "healthcheckPath": "/api/health/live",
     "healthcheckTimeout": 120
   }


### PR DESCRIPTION
Follow-up to #578.

#578 fixed the real cause of the `WIPGuard-app` heap-OOM crash loop (two Imladris dashboard paths loaded the entire ever-growing `analyticsSnapshot` history with full payloads per request; now bounded with `DISTINCT ON (providerKey)`). The deploy held well past the old ~10-minute crash point.

That makes the `restartPolicyMaxRetries: 1000` stopgap unnecessary, so this restores it to the intended **10**. The `1000` was only there to keep the service self-healing while the leak was unfixed.

**Tradeoff to be aware of:** `10` is fail-loud — if a *future* crash loop ever appears, Railway gives up after 10 attempts and the service goes down (this is what turned the leak into a 3-day outage). If you'd rather bias toward resilience, set it to something like `20–50` instead of `10`. I went with the original `10` since the underlying cause is fixed; say the word and I'll bump it.

### Deliberately NOT changed
The two remaining `analyticsSnapshot`/canonical reads (`service.ts:1335`, `:1526`) select **no payload** (~100-byte rows) and rely on reductions (`bestSnapshotForProvider` user-precedence; `compareCanonicalMetricRows`) that a `DISTINCT ON` rewrite would subtly break. They're not memory drivers, so changing them trades real correctness risk for negligible benefit.

https://claude.ai/code/session_01GdvJ383ZfoT2aya9AfzTPB

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdvJ383ZfoT2aya9AfzTPB)_