### PR TITLE
Fix env-managed health checks poisoning their own credential resolution

### DIFF
--- a/src/lib/__tests__/analytics-credentials-env-fallback.test.ts
+++ b/src/lib/__tests__/analytics-credentials-env-fallback.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Regression tests for env-credential fallback vs. placeholder connection rows.
+ *
+ * Env-managed health checks persist connection rows that hold no real secret
+ * (accessToken NULL, or the legacy "env-managed" literal). Those rows must
+ * never disable the env fallback in getCredentials — otherwise the first
+ * persisted health status starves every later check of the credential it was
+ * monitoring (self-perpetuating ERROR: "Missing Meta Page credential").
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  IntegrationConnectionStatus,
+  IntegrationProvider,
+} from "@/generated/prisma/client";
+
+const {
+  mockIntegrationConnectionFindMany,
+  mockIntegrationConnectionUpsert,
+  mockIntegrationConnectionUpdateMany,
+  mockIntegrationConnectionUpdate,
+} = vi.hoisted(() => ({
+  mockIntegrationConnectionFindMany: vi.fn(),
+  mockIntegrationConnectionUpsert: vi.fn(),
+  mockIntegrationConnectionUpdateMany: vi.fn(),
+  mockIntegrationConnectionUpdate: vi.fn(),
+}));
+
+const {
+  mockDiscoverMetaAdAccountId,
+  mockDiscoverMetaPageAndInstagram,
+  mockExchangeMetaForLongLivedToken,
+} = vi.hoisted(() => ({
+  mockDiscoverMetaAdAccountId: vi.fn(),
+  mockDiscoverMetaPageAndInstagram: vi.fn(),
+  mockExchangeMetaForLongLivedToken: vi.fn(),
+}));
+
+const { mockGetValidIntegrationAccessToken } = vi.hoisted(() => ({
+  mockGetValidIntegrationAccessToken: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    integrationConnection: {
+      findMany: mockIntegrationConnectionFindMany,
+      upsert: mockIntegrationConnectionUpsert,
+      updateMany: mockIntegrationConnectionUpdateMany,
+      update: mockIntegrationConnectionUpdate,
+    },
+  },
+}));
+
+vi.mock("@/lib/integrations/meta-auth", () => ({
+  discoverMetaAdAccountId: mockDiscoverMetaAdAccountId,
+  discoverMetaPageAndInstagram: mockDiscoverMetaPageAndInstagram,
+  exchangeMetaForLongLivedToken: mockExchangeMetaForLongLivedToken,
+}));
+
+vi.mock("@/lib/integrations/token-refresh", () => ({
+  getValidIntegrationAccessToken: mockGetValidIntegrationAccessToken,
+}));
+
+const ENV_KEYS = [
+  "INTEGRATION_OWNER_USER_ID",
+  "META_ACCESS_TOKEN",
+  "META_AD_ACCOUNT_ID",
+  "META_PAGE_ID",
+  "META_INSTAGRAM_ACCOUNT_ID",
+  "META_APP_ID",
+  "META_APP_SECRET",
+  "META_CLIENT_ID",
+  "META_CLIENT_SECRET",
+  "STRIPE_SECRET_KEY",
+  "REDDIT_REFRESH_TOKEN",
+] as const;
+
+function connectionRow(overrides: {
+  provider: IntegrationProvider;
+  status: IntegrationConnectionStatus;
+  accessToken?: string | null;
+  refreshToken?: string | null;
+  metadata?: Record<string, unknown> | null;
+  lastError?: string | null;
+}) {
+  return {
+    userId: "user_1",
+    provider: overrides.provider,
+    status: overrides.status,
+    accessToken: overrides.accessToken ?? null,
+    refreshToken: overrides.refreshToken ?? null,
+    tokenType: "Bearer",
+    expiresAt: null,
+    scopes: [],
+    metadata: overrides.metadata ?? null,
+    connectedAt: new Date("2026-06-01T00:00:00.000Z"),
+    lastSyncedAt: null,
+    lastError: overrides.lastError ?? null,
+  };
+}
+
+describe("analytics credentials env fallback vs placeholder rows", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of ENV_KEYS) {
+      delete process.env[key];
+    }
+    mockGetValidIntegrationAccessToken.mockResolvedValue("oauth-token-from-refresh");
+  });
+
+  it("keeps the Meta env fallback engaged when only placeholder rows exist", async () => {
+    // Exact shape persisted by buggy health-check runs: META_ADS flipped to
+    // ERROR with no token at all, META_PAGE created with the literal
+    // "env-managed" placeholder.
+    process.env.META_ACCESS_TOKEN = "meta-env-token";
+    process.env.META_AD_ACCOUNT_ID = "act_env";
+    process.env.META_PAGE_ID = "417375498119621";
+    process.env.META_INSTAGRAM_ACCOUNT_ID = "ig_env";
+    // Real OAuth app credentials present, as on a configured deployment.
+    process.env.META_APP_ID = "app_id";
+    process.env.META_APP_SECRET = "app_secret";
+
+    mockIntegrationConnectionFindMany.mockResolvedValueOnce([
+      connectionRow({
+        provider: IntegrationProvider.META_ADS,
+        status: IntegrationConnectionStatus.ERROR,
+        accessToken: null,
+        lastError: "Missing Meta access token",
+      }),
+      connectionRow({
+        provider: IntegrationProvider.META_PAGE,
+        status: IntegrationConnectionStatus.ERROR,
+        accessToken: "env-managed",
+        lastError: "Missing Meta Page credential",
+      }),
+    ]);
+
+    const { getCredentials } = await import("@/lib/analytics/credentials");
+    const creds = await getCredentials("user_1");
+
+    expect(creds.metaAdsAccessToken).toBe("meta-env-token");
+    expect(creds.metaPageAccessToken).toBe("meta-env-token");
+    expect(creds.metaAccessToken).toBe("meta-env-token");
+    expect(creds.metaAdAccountId).toBe("act_env");
+    expect(creds.metaPageId).toBe("417375498119621");
+
+    // Placeholder rows hold no real token, so no OAuth lookup should happen.
+    expect(mockGetValidIntegrationAccessToken).not.toHaveBeenCalled();
+    // And no bogus "Missing Meta access token" refresh failure may be
+    // persisted back onto the row (that is what kept re-poisoning it).
+    expect(mockIntegrationConnectionUpdateMany).not.toHaveBeenCalled();
+    expect(mockExchangeMetaForLongLivedToken).not.toHaveBeenCalled();
+
+    expect(creds.freshness[IntegrationProvider.META_PAGE].source).toBe("env");
+    expect(creds.freshness[IntegrationProvider.META_ADS].source).toBe("env");
+  });
+
+  it("still prefers a real connected Meta row over env credentials", async () => {
+    process.env.META_ACCESS_TOKEN = "meta-env-token";
+    process.env.META_AD_ACCOUNT_ID = "act_env";
+    process.env.META_PAGE_ID = "page_env";
+    process.env.META_INSTAGRAM_ACCOUNT_ID = "ig_env";
+
+    mockIntegrationConnectionFindMany.mockResolvedValueOnce([
+      connectionRow({
+        provider: IntegrationProvider.META_PAGE,
+        status: IntegrationConnectionStatus.CONNECTED,
+        accessToken: "plainv1.real-page-token",
+        metadata: { pageId: "page_real", instagramAccountId: "ig_real" },
+      }),
+    ]);
+    mockGetValidIntegrationAccessToken.mockResolvedValue("real-page-oauth-token");
+
+    const { getCredentials } = await import("@/lib/analytics/credentials");
+    const creds = await getCredentials("user_1");
+
+    expect(creds.metaPageAccessToken).toBe("real-page-oauth-token");
+    expect(creds.metaPageId).toBe("page_real");
+    expect(mockGetValidIntegrationAccessToken).toHaveBeenCalledWith({
+      userId: "user_1",
+      provider: IntegrationProvider.META_PAGE,
+    });
+  });
+
+  it("keeps the Stripe env fallback engaged when only a placeholder row exists", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_env";
+
+    mockIntegrationConnectionFindMany.mockResolvedValueOnce([
+      connectionRow({
+        provider: IntegrationProvider.STRIPE,
+        status: IntegrationConnectionStatus.CONNECTED,
+        accessToken: "env-managed",
+      }),
+    ]);
+
+    const { getCredentials } = await import("@/lib/analytics/credentials");
+    const creds = await getCredentials("user_1");
+
+    expect(creds.stripeKey).toBe("sk_env");
+    expect(mockGetValidIntegrationAccessToken).not.toHaveBeenCalled();
+    expect(creds.freshness[IntegrationProvider.STRIPE].source).toBe("env");
+  });
+
+  it("keeps the Reddit env fallback engaged when only a placeholder row exists", async () => {
+    process.env.REDDIT_REFRESH_TOKEN = "reddit-env-refresh";
+
+    mockIntegrationConnectionFindMany.mockResolvedValueOnce([
+      connectionRow({
+        provider: IntegrationProvider.REDDIT,
+        status: IntegrationConnectionStatus.CONNECTED,
+        accessToken: "env-managed",
+        refreshToken: null,
+      }),
+    ]);
+
+    const { getCredentials } = await import("@/lib/analytics/credentials");
+    const creds = await getCredentials("user_1");
+
+    expect(creds.redditRefreshToken).toBe("reddit-env-refresh");
+    expect(creds.freshness[IntegrationProvider.REDDIT].source).toBe("env");
+  });
+});

--- a/src/lib/__tests__/integrations-health-checks-env-fallback.test.ts
+++ b/src/lib/__tests__/integrations-health-checks-env-fallback.test.ts
@@ -1,0 +1,418 @@
+/**
+ * End-to-end regression for env-managed Meta health checks.
+ *
+ * Uses the REAL getCredentials and the REAL runIntegrationHealthChecks with
+ * only Prisma (stateful in-memory store) and global.fetch mocked. The fetch
+ * mock rejects any bearer token other than the env credential, mirroring the
+ * Graph API.
+ *
+ * Bug being guarded against: the first health-check run persisted placeholder
+ * connection rows (accessToken "env-managed" / NULL) with a non-DISCONNECTED
+ * status. getCredentials treated any non-DISCONNECTED row as an authoritative
+ * connection, disabling the META env fallback, so the second run (and even
+ * later checks within the same run) failed with "Missing Meta Page credential"
+ * and re-persisted ERROR — a self-perpetuating failure.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  IntegrationConnectionStatus,
+  IntegrationProvider,
+} from "@/generated/prisma/client";
+
+type StoredRow = {
+  userId: string;
+  provider: IntegrationProvider;
+  status: IntegrationConnectionStatus;
+  accessToken: string | null;
+  refreshToken: string | null;
+  tokenType: string | null;
+  expiresAt: Date | null;
+  scopes: string[];
+  metadata: unknown;
+  connectedAt: Date;
+  lastSyncedAt: Date | null;
+  lastError: string | null;
+};
+
+const { connectionStore } = vi.hoisted(() => ({
+  connectionStore: new Map<string, StoredRow>(),
+}));
+
+function rowKey(userId: string, provider: string): string {
+  return `${userId}:${provider}`;
+}
+
+vi.mock("@/lib/prisma", () => {
+  const matchesStatus = (row: StoredRow, statusClause: unknown): boolean => {
+    if (statusClause === undefined) return true;
+    if (typeof statusClause === "string") return row.status === statusClause;
+    const inClause = (statusClause as { in?: string[] })?.in;
+    if (Array.isArray(inClause)) return inClause.includes(row.status);
+    return true;
+  };
+
+  return {
+    prisma: {
+      integrationConnection: {
+        findMany: vi.fn(
+          async (args?: {
+            where?: { userId?: string; status?: unknown };
+          }) =>
+            Array.from(connectionStore.values()).filter(
+              (row) =>
+                (!args?.where?.userId || row.userId === args.where.userId) &&
+                matchesStatus(row, args?.where?.status),
+            ),
+        ),
+        findUnique: vi.fn(
+          async (args: {
+            where: { userId_provider: { userId: string; provider: string } };
+          }) =>
+            connectionStore.get(
+              rowKey(
+                args.where.userId_provider.userId,
+                args.where.userId_provider.provider,
+              ),
+            ) ?? null,
+        ),
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(
+          async (args: {
+            where: { userId_provider: { userId: string; provider: string } };
+            data: Partial<StoredRow>;
+          }) => {
+            const key = rowKey(
+              args.where.userId_provider.userId,
+              args.where.userId_provider.provider,
+            );
+            const existing = connectionStore.get(key);
+            if (!existing) {
+              const error = new Error("Record to update not found");
+              (error as Error & { code?: string }).code = "P2025";
+              throw error;
+            }
+            const next = { ...existing, ...args.data };
+            connectionStore.set(key, next);
+            return next;
+          },
+        ),
+        updateMany: vi.fn(
+          async (args: {
+            where: { userId: string; provider: string };
+            data: Partial<StoredRow>;
+          }) => {
+            const key = rowKey(args.where.userId, args.where.provider);
+            const existing = connectionStore.get(key);
+            if (!existing) {
+              return { count: 0 };
+            }
+            connectionStore.set(key, { ...existing, ...args.data });
+            return { count: 1 };
+          },
+        ),
+        upsert: vi.fn(
+          async (args: {
+            where: { userId_provider: { userId: string; provider: string } };
+            create: Partial<StoredRow>;
+            update: Partial<StoredRow>;
+          }) => {
+            const { userId, provider } = args.where.userId_provider;
+            const key = rowKey(userId, provider);
+            const existing = connectionStore.get(key);
+            if (existing) {
+              const next = { ...existing, ...args.update };
+              connectionStore.set(key, next);
+              return next;
+            }
+            const created: StoredRow = {
+              userId,
+              provider: provider as IntegrationProvider,
+              status:
+                (args.create.status as IntegrationConnectionStatus) ??
+                IntegrationConnectionStatus.DISCONNECTED,
+              accessToken: args.create.accessToken ?? null,
+              refreshToken: args.create.refreshToken ?? null,
+              tokenType: args.create.tokenType ?? null,
+              expiresAt: args.create.expiresAt ?? null,
+              scopes: args.create.scopes ?? [],
+              metadata: args.create.metadata ?? null,
+              connectedAt: new Date("2026-06-01T00:00:00.000Z"),
+              lastSyncedAt: args.create.lastSyncedAt ?? null,
+              lastError: args.create.lastError ?? null,
+            };
+            connectionStore.set(key, created);
+            return created;
+          },
+        ),
+      },
+    },
+  };
+});
+
+const ENV_TOKEN = "meta-env-token";
+const PAGE_SCOPED_TOKEN = "page-scoped-token";
+const PAGE_ID = "417375498119621";
+const USER_ID = "localdev_5z5ueqq0";
+
+// Every env var that can make hasIntegrationCredential() true for some
+// provider. Cleared so the run is hermetic: only the Meta env credentials
+// set by each test are visible to the real getCredentials().
+const PROVIDER_ENV_KEYS = [
+  "INTEGRATION_OWNER_USER_ID",
+  "HUBSPOT_ACCESS_TOKEN",
+  "CODA_API_TOKEN",
+  "CODA_DOC_ID",
+  "REDDIT_CLIENT_ID",
+  "REDDIT_CLIENT_SECRET",
+  "REDDIT_REFRESH_TOKEN",
+  "REDDIT_AD_ACCOUNT_ID",
+  "REDDIT_USER_AGENT",
+  "STRIPE_SECRET_KEY",
+  "MERCURY_API_TOKEN",
+  "WEBFLOW_API_TOKEN",
+  "WEBFLOW_SITE_ID",
+  "SEMRUSH_API_TOKEN",
+  "SEMRUSH_API_KEY",
+  "SEMRUSH_DOMAIN",
+  "PYLON_API_KEY",
+  "PYLON_API_BASE_URL",
+  "META_ACCESS_TOKEN",
+  "META_AD_ACCOUNT_ID",
+  "META_PAGE_ID",
+  "META_INSTAGRAM_ACCOUNT_ID",
+  "META_APP_ID",
+  "META_APP_SECRET",
+  "META_CLIENT_ID",
+  "META_CLIENT_SECRET",
+  "POSTHOG_API_KEY",
+  "POSTHOG_PERSONAL_API_KEY",
+  "POSTHOG_PROJECT_ID",
+  "POSTHOG_HOST",
+  "POSTHOG_API_HOST",
+  "LINEAR_API_KEY",
+  "LINEAR_TOKEN",
+  "GITHUB_TOKEN",
+  "GITHUB_ACCESS_TOKEN",
+  "GITHUB_REPO_OWNER",
+  "GITHUB_OWNER",
+  "GITHUB_REPO_NAME",
+  "GITHUB_REPO",
+  "UNIFY_DATA_API_KEY",
+  "UNIFY_API_KEY",
+  "UNIFY_FUNNEL_OBJECT_NAME",
+  "GA_PROPERTY_ID",
+  "GA_CLIENT_EMAIL",
+  "GA_PRIVATE_KEY",
+  "GA_REFRESH_TOKEN",
+  "GOOGLE_CLIENT_ID",
+  "GOOGLE_CLIENT_SECRET",
+  "GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN",
+  "GSC_ACCESS_TOKEN",
+  "GOOGLE_SEARCH_CONSOLE_SITE_URL",
+  "GSC_SITE_URL",
+  "GOOGLE_ADS_DEVELOPER_TOKEN",
+  "GOOGLE_ADS_CUSTOMER_ID",
+  "GOOGLE_ADS_REFRESH_TOKEN",
+  "GOOGLE_ADS_CLIENT_ID",
+  "GOOGLE_ADS_CLIENT_SECRET",
+  "GOOGLE_ADS_LOGIN_CUSTOMER_ID",
+] as const;
+
+function graphJson(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Graph API stand-in. Crucially it AUTHENTICATES: any bearer other than the
+ * env token (or the page-scoped token it hands out) is rejected, so a check
+ * that resolves the wrong credential fails the same way it would in
+ * production.
+ */
+function buildGraphFetchMock(): typeof global.fetch {
+  return vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const headers = new Headers(init?.headers);
+    const authorization = headers.get("Authorization") ?? "";
+    const bearerOk =
+      authorization === `Bearer ${ENV_TOKEN}` ||
+      authorization === `Bearer ${PAGE_SCOPED_TOKEN}`;
+    const tokenParamOk = url.searchParams.get("access_token") === ENV_TOKEN;
+    if (!bearerOk && !tokenParamOk) {
+      return graphJson(
+        { error: { message: "Invalid OAuth access token.", code: 190 } },
+        401,
+      );
+    }
+
+    if (url.pathname.endsWith("/me/accounts")) {
+      return graphJson({
+        data: [{ id: PAGE_ID, access_token: PAGE_SCOPED_TOKEN }],
+      });
+    }
+    if (url.pathname.includes("act_") && url.pathname.endsWith("/insights")) {
+      return graphJson({
+        data: [{ spend: "0", impressions: "0", clicks: "0" }],
+      });
+    }
+    if (
+      url.pathname.endsWith(`/${PAGE_ID}`) &&
+      !url.pathname.endsWith(`/${PAGE_ID}/posts`)
+    ) {
+      return graphJson({ fan_count: 10, followers_count: 12 });
+    }
+    return graphJson({ data: [] });
+  }) as typeof global.fetch;
+}
+
+describe("env-managed Meta health checks with real credential resolution", () => {
+  const originalFetch = global.fetch;
+  const savedEnv = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    connectionStore.clear();
+    for (const key of PROVIDER_ENV_KEYS) {
+      savedEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+    process.env.META_ACCESS_TOKEN = ENV_TOKEN;
+    process.env.META_AD_ACCOUNT_ID = "act_12345";
+    process.env.META_PAGE_ID = PAGE_ID;
+    process.env.META_INSTAGRAM_ACCOUNT_ID = "ig_12345";
+    global.fetch = buildGraphFetchMock();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    for (const [key, value] of savedEnv) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    savedEnv.clear();
+  });
+
+  it("passes META checks on two consecutive runs (rows from run 1 must not poison run 2)", async () => {
+    const { runIntegrationHealthChecks } = await import(
+      "@/lib/integrations/health-checks"
+    );
+
+    const firstRun = await runIntegrationHealthChecks({ userId: USER_ID });
+    expect(firstRun.results).toEqual(
+      expect.arrayContaining([
+        { provider: IntegrationProvider.META_ADS, ok: true, message: null },
+        { provider: IntegrationProvider.META_PAGE, ok: true, message: null },
+      ]),
+    );
+    expect(firstRun.checked).toBe(2);
+    expect(firstRun.failed).toBe(0);
+
+    // Run 1 persisted health rows for both providers — without real tokens.
+    const adsRow = connectionStore.get(rowKey(USER_ID, "META_ADS"));
+    const pageRow = connectionStore.get(rowKey(USER_ID, "META_PAGE"));
+    expect(adsRow?.status).toBe(IntegrationConnectionStatus.CONNECTED);
+    expect(pageRow?.status).toBe(IntegrationConnectionStatus.CONNECTED);
+    expect(adsRow?.accessToken).toBeNull();
+    expect(pageRow?.accessToken).toBeNull();
+
+    const secondRun = await runIntegrationHealthChecks({ userId: USER_ID });
+    expect(secondRun.results).toEqual(
+      expect.arrayContaining([
+        { provider: IntegrationProvider.META_ADS, ok: true, message: null },
+        { provider: IntegrationProvider.META_PAGE, ok: true, message: null },
+      ]),
+    );
+    expect(secondRun.checked).toBe(2);
+    expect(secondRun.failed).toBe(0);
+
+    expect(
+      connectionStore.get(rowKey(USER_ID, "META_ADS"))?.lastError,
+    ).toBeNull();
+    expect(
+      connectionStore.get(rowKey(USER_ID, "META_PAGE"))?.lastError,
+    ).toBeNull();
+  });
+
+  it("heals rows poisoned by earlier runs (NULL and 'env-managed' placeholder tokens)", async () => {
+    // Exact state observed in the dev database after the buggy loop ran.
+    connectionStore.set(rowKey(USER_ID, "META_ADS"), {
+      userId: USER_ID,
+      provider: IntegrationProvider.META_ADS,
+      status: IntegrationConnectionStatus.ERROR,
+      accessToken: null,
+      refreshToken: null,
+      tokenType: null,
+      expiresAt: null,
+      scopes: [],
+      metadata: null,
+      connectedAt: new Date("2026-06-01T00:00:00.000Z"),
+      lastSyncedAt: null,
+      lastError: "Missing Meta access token",
+    });
+    connectionStore.set(rowKey(USER_ID, "META_PAGE"), {
+      userId: USER_ID,
+      provider: IntegrationProvider.META_PAGE,
+      status: IntegrationConnectionStatus.ERROR,
+      accessToken: "env-managed",
+      refreshToken: null,
+      tokenType: null,
+      expiresAt: null,
+      scopes: [],
+      metadata: null,
+      connectedAt: new Date("2026-06-01T00:00:00.000Z"),
+      lastSyncedAt: null,
+      lastError: "Missing Meta Page credential",
+    });
+
+    const { runIntegrationHealthChecks } = await import(
+      "@/lib/integrations/health-checks"
+    );
+    const result = await runIntegrationHealthChecks({ userId: USER_ID });
+
+    expect(result.checked).toBe(2);
+    expect(result.failed).toBe(0);
+    expect(result.results).toEqual(
+      expect.arrayContaining([
+        { provider: IntegrationProvider.META_ADS, ok: true, message: null },
+        { provider: IntegrationProvider.META_PAGE, ok: true, message: null },
+      ]),
+    );
+
+    const adsRow = connectionStore.get(rowKey(USER_ID, "META_ADS"));
+    const pageRow = connectionStore.get(rowKey(USER_ID, "META_PAGE"));
+    expect(adsRow?.status).toBe(IntegrationConnectionStatus.CONNECTED);
+    expect(adsRow?.lastError).toBeNull();
+    expect(pageRow?.status).toBe(IntegrationConnectionStatus.CONNECTED);
+    expect(pageRow?.lastError).toBeNull();
+  });
+
+  it("resolves Meta env credentials via the real getCredentials even when placeholder rows exist", async () => {
+    connectionStore.set(rowKey(USER_ID, "META_PAGE"), {
+      userId: USER_ID,
+      provider: IntegrationProvider.META_PAGE,
+      status: IntegrationConnectionStatus.ERROR,
+      accessToken: "env-managed",
+      refreshToken: null,
+      tokenType: null,
+      expiresAt: null,
+      scopes: [],
+      metadata: null,
+      connectedAt: new Date("2026-06-01T00:00:00.000Z"),
+      lastSyncedAt: null,
+      lastError: "Missing Meta Page credential",
+    });
+
+    const { getCredentials } = await import("@/lib/analytics/credentials");
+    const creds = await getCredentials(USER_ID);
+
+    expect(creds.metaPageAccessToken).toBe(ENV_TOKEN);
+    expect(creds.metaAdsAccessToken).toBe(ENV_TOKEN);
+    expect(creds.metaPageId).toBe(PAGE_ID);
+    expect(creds.metaAdAccountId).toBe("act_12345");
+  });
+});

--- a/src/lib/__tests__/integrations-health-checks.test.ts
+++ b/src/lib/__tests__/integrations-health-checks.test.ts
@@ -8,7 +8,7 @@
 
 import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
 
-const mockConnections = new Map<string, { provider: string; accessToken: string; status: string }>();
+const mockConnections = new Map<string, { provider: string; accessToken: string | null; status: string }>();
 const mockUpdatedConnections = new Map<string, { status: string; lastError: string | null }>();
 const mockUpsertedConnections = new Map<string, { status: string; lastError: string | null; accessToken: string | null }>();
 const mockGetCredentials = vi.fn();
@@ -45,10 +45,15 @@ vi.mock("@/lib/prisma", () => ({
         if (mockUpdateFailureProviders.has(args.where.userId_provider.provider)) {
           throw new Error("health status write failed");
         }
-        mockUpdatedConnections.set(args.where.userId_provider.provider, {
+        const provider = args.where.userId_provider.provider;
+        mockUpdatedConnections.set(provider, {
           status: args.data.status,
           lastError: args.data.lastError,
         });
+        const existing = mockConnections.get(provider);
+        if (existing) {
+          mockConnections.set(provider, { ...existing, status: args.data.status });
+        }
         return {};
       }),
       upsert: vi.fn(async (args: {
@@ -62,6 +67,19 @@ vi.mock("@/lib/prisma", () => ({
           lastError: args.update.lastError,
           accessToken: args.create.accessToken ?? null,
         });
+        // Emulate real upsert semantics so consecutive runs observe rows
+        // persisted by earlier runs: update only mutates status on existing
+        // rows; create stores the persisted accessToken.
+        const existing = mockConnections.get(provider);
+        if (existing) {
+          mockConnections.set(provider, { ...existing, status: args.update.status });
+        } else {
+          mockConnections.set(provider, {
+            provider,
+            accessToken: args.create.accessToken ?? null,
+            status: args.create.status,
+          });
+        }
         return {};
       }),
     },
@@ -69,6 +87,10 @@ vi.mock("@/lib/prisma", () => ({
 }));
 
 vi.mock("@/lib/integrations/token-crypto", () => ({
+  ENV_MANAGED_TOKEN_PLACEHOLDER: "env-managed",
+  isEnvManagedTokenPlaceholder: vi.fn(
+    (token: string | null | undefined) => token === "env-managed",
+  ),
   unprotectIntegrationSecret: vi.fn((token: string | null) => {
     if (!token) return null;
     return token.startsWith("enc") ? "decrypted_token" : token;
@@ -405,7 +427,7 @@ describe("runIntegrationHealthChecks (extended)", () => {
     expect(mockUpsertedConnections.get("SEMRUSH")).toEqual({
       status: "CONNECTED",
       lastError: null,
-      accessToken: "env-managed",
+      accessToken: null,
     });
   });
 
@@ -430,7 +452,7 @@ describe("runIntegrationHealthChecks (extended)", () => {
     expect(mockUpsertedConnections.get("PYLON")).toEqual({
       status: "CONNECTED",
       lastError: null,
-      accessToken: "env-managed",
+      accessToken: null,
     });
   });
 
@@ -456,7 +478,7 @@ describe("runIntegrationHealthChecks (extended)", () => {
     expect(mockUpsertedConnections.get("CODA")).toEqual({
       status: "CONNECTED",
       lastError: null,
-      accessToken: "env-managed",
+      accessToken: null,
     });
   });
 
@@ -493,7 +515,7 @@ describe("runIntegrationHealthChecks (extended)", () => {
     expect(mockUpsertedConnections.get("STRIPE")).toEqual({
       status: "CONNECTED",
       lastError: null,
-      accessToken: "env-managed",
+      accessToken: null,
     });
   });
 
@@ -530,7 +552,7 @@ describe("runIntegrationHealthChecks (extended)", () => {
     expect(mockUpsertedConnections.get("HUBSPOT")).toEqual({
       status: "CONNECTED",
       lastError: null,
-      accessToken: "env-managed",
+      accessToken: null,
     });
   });
 
@@ -585,12 +607,12 @@ describe("runIntegrationHealthChecks (extended)", () => {
     expect(mockUpsertedConnections.get("GOOGLE_WORKSPACE")).toEqual({
       status: "CONNECTED",
       lastError: null,
-      accessToken: "env-managed",
+      accessToken: null,
     });
     expect(mockUpsertedConnections.get("SLACK")).toEqual({
       status: "CONNECTED",
       lastError: null,
-      accessToken: "env-managed",
+      accessToken: null,
     });
   });
 
@@ -627,7 +649,7 @@ describe("runIntegrationHealthChecks (extended)", () => {
     expect(mockUpsertedConnections.get("MERCURY")).toEqual({
       status: "CONNECTED",
       lastError: null,
-      accessToken: "env-managed",
+      accessToken: null,
     });
   });
 
@@ -686,7 +708,7 @@ describe("runIntegrationHealthChecks (extended)", () => {
     expect(mockUpsertedConnections.get("GOOGLE_ADS")).toEqual({
       status: "CONNECTED",
       lastError: null,
-      accessToken: "env-managed",
+      accessToken: null,
     });
   });
 
@@ -722,7 +744,7 @@ describe("runIntegrationHealthChecks (extended)", () => {
     expect(mockUpsertedConnections.get("GOOGLE_SEARCH_CONSOLE")).toEqual({
       status: "CONNECTED",
       lastError: null,
-      accessToken: "env-managed",
+      accessToken: null,
     });
   });
 
@@ -774,7 +796,7 @@ describe("runIntegrationHealthChecks (extended)", () => {
     expect(mockUpsertedConnections.get("GOOGLE_ANALYTICS")).toEqual({
       status: "CONNECTED",
       lastError: null,
-      accessToken: "env-managed",
+      accessToken: null,
     });
   });
 
@@ -821,7 +843,7 @@ describe("runIntegrationHealthChecks (extended)", () => {
     expect(mockUpsertedConnections.get("META_ADS")).toEqual({
       status: "CONNECTED",
       lastError: null,
-      accessToken: "env-managed",
+      accessToken: null,
     });
   });
 
@@ -874,8 +896,125 @@ describe("runIntegrationHealthChecks (extended)", () => {
     expect(mockUpsertedConnections.get("META_PAGE")).toEqual({
       status: "CONNECTED",
       lastError: null,
-      accessToken: "env-managed",
+      accessToken: null,
     });
+  });
+
+  it("keeps env-managed Meta Page checks passing on consecutive runs", async () => {
+    // Regression: the first run persists a META_PAGE connection row for the
+    // env-managed credential. The second run sees that row and must treat it
+    // as env-managed again — not fail with "Missing access token" because
+    // the persisted row holds no real token.
+    mockGetCredentials.mockResolvedValue({
+      metaPageAccessToken: "meta-page-env-token",
+      metaPageId: "page_123",
+    });
+    global.fetch = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith("/me/accounts")) {
+        return new Response(
+          JSON.stringify({ data: [{ id: "page_123", access_token: "page-scoped-token" }] }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.pathname.endsWith("/page_123") && !url.pathname.endsWith("/page_123/posts")) {
+        return new Response(JSON.stringify({ fan_count: 10, followers_count: 12 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof global.fetch;
+
+    const { runIntegrationHealthChecks } = await import("@/lib/integrations/health-checks");
+
+    const firstRun = await runIntegrationHealthChecks({ userId: "user_1" });
+    expect(firstRun.failed).toBe(0);
+    // The first run persisted a row without a real token.
+    expect(mockConnections.get("META_PAGE")).toEqual({
+      provider: "META_PAGE",
+      accessToken: null,
+      status: "CONNECTED",
+    });
+
+    const secondRun = await runIntegrationHealthChecks({ userId: "user_1" });
+    expect(secondRun.checked).toBe(1);
+    expect(secondRun.failed).toBe(0);
+    expect(secondRun.results).toEqual([
+      {
+        provider: "META_PAGE",
+        ok: true,
+        message: null,
+      },
+    ]);
+    expect(mockConnections.get("META_PAGE")).toEqual({
+      provider: "META_PAGE",
+      accessToken: null,
+      status: "CONNECTED",
+    });
+  });
+
+  it("recovers env-managed Meta rows previously poisoned by placeholder persistence", async () => {
+    // Regression: rows persisted by earlier (buggy) runs — META_PAGE with the
+    // literal "env-managed" accessToken and META_ADS with a NULL accessToken
+    // (a discovery stub flipped by health persistence) — must be re-checked
+    // through env credentials and healed, not fail the missing-token gate.
+    mockConnections.set("META_ADS", {
+      provider: "META_ADS",
+      accessToken: null,
+      status: "ERROR",
+    });
+    mockConnections.set("META_PAGE", {
+      provider: "META_PAGE",
+      accessToken: "env-managed",
+      status: "ERROR",
+    });
+    mockGetCredentials.mockResolvedValue({
+      metaAdsAccessToken: "meta-env-token",
+      metaAdAccountId: "act_12345",
+      metaPageAccessToken: "meta-env-token",
+      metaPageId: "page_123",
+    });
+    global.fetch = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith("/act_12345/insights")) {
+        return new Response(
+          JSON.stringify({ data: [{ spend: "0", impressions: "0", clicks: "0" }] }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.pathname.endsWith("/me/accounts")) {
+        return new Response(
+          JSON.stringify({ data: [{ id: "page_123", access_token: "page-scoped-token" }] }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.pathname.endsWith("/page_123") && !url.pathname.endsWith("/page_123/posts")) {
+        return new Response(JSON.stringify({ fan_count: 10, followers_count: 12 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof global.fetch;
+
+    const { runIntegrationHealthChecks } = await import("@/lib/integrations/health-checks");
+    const result = await runIntegrationHealthChecks({ userId: "user_1" });
+
+    expect(result.checked).toBe(2);
+    expect(result.failed).toBe(0);
+    expect(result.results.map((entry) => entry.provider).sort()).toEqual([
+      "META_ADS",
+      "META_PAGE",
+    ]);
+    expect(mockConnections.get("META_ADS")?.status).toBe("CONNECTED");
+    expect(mockConnections.get("META_PAGE")?.status).toBe("CONNECTED");
   });
 
   it("checks env-managed Meta Instagram credentials without requiring a Page ID", async () => {
@@ -933,7 +1072,7 @@ describe("runIntegrationHealthChecks (extended)", () => {
     expect(mockUpsertedConnections.get("META_PAGE")).toEqual({
       status: "CONNECTED",
       lastError: null,
-      accessToken: "env-managed",
+      accessToken: null,
     });
   });
 
@@ -971,7 +1110,7 @@ describe("runIntegrationHealthChecks (extended)", () => {
     expect(mockUpsertedConnections.get("WEBFLOW")).toEqual({
       status: "CONNECTED",
       lastError: null,
-      accessToken: "env-managed",
+      accessToken: null,
     });
   });
 
@@ -1032,7 +1171,7 @@ describe("runIntegrationHealthChecks (extended)", () => {
     expect(mockUpsertedConnections.get("REDDIT")).toEqual({
       status: "CONNECTED",
       lastError: null,
-      accessToken: "env-managed",
+      accessToken: null,
     });
   });
 

--- a/src/lib/analytics/credentials.ts
+++ b/src/lib/analytics/credentials.ts
@@ -22,6 +22,7 @@ import { listProviderRegistryEntries } from "@/lib/integrations/provider-registr
 import { validateIntegrationScopes } from "@/lib/integrations/scope-validation";
 import { prisma } from "@/lib/prisma";
 import {
+  isEnvManagedTokenPlaceholder,
   protectIntegrationSecret,
   unprotectIntegrationSecret,
 } from "@/lib/integrations/token-crypto";
@@ -244,6 +245,38 @@ function metadataString(metadata: unknown, key: string): string | null {
 
 function hasValue(value: string | null): boolean {
   return Boolean(value && value.trim().length > 0);
+}
+
+/**
+ * Returns the stored secret only when it is a real credential. Health checks
+ * persist placeholder rows for env-managed credentials (accessToken
+ * "env-managed", or no token at all); those hold nothing usable.
+ */
+function realConnectionSecret(value: string | null): string | null {
+  const secret = unprotectIntegrationSecret(value);
+  if (!secret || isEnvManagedTokenPlaceholder(secret)) {
+    return null;
+  }
+  return secret;
+}
+
+/**
+ * A connection row should take precedence over an env credential only when a
+ * user actually connected the integration, i.e. the row is not DISCONNECTED
+ * and holds a real secret. Placeholder rows persisted by env-managed health
+ * checks (status CONNECTED/ERROR but no real token) must NOT disable the env
+ * fallback — otherwise the first persisted health status starves every later
+ * check of the credential it was monitoring, a self-perpetuating ERROR.
+ */
+function connectionBlocksEnvFallback(
+  connection: ConnectionRecord | null,
+  secretField: "accessToken" | "refreshToken" = "accessToken"
+): connection is ConnectionRecord {
+  return Boolean(
+    connection &&
+      connection.status !== IntegrationConnectionStatus.DISCONNECTED &&
+      realConnectionSecret(connection[secretField])
+  );
 }
 
 function looksInvalidMetaInstagramAccountId(value: string | null): boolean {
@@ -741,7 +774,14 @@ export async function getCredentials(userId?: string): Promise<AnalyticsCredenti
           return;
         }
 
-        const hasAccessToken = Boolean(unprotectIntegrationSecret(connection.accessToken));
+        const hasAccessToken = Boolean(realConnectionSecret(connection.accessToken));
+        const hasRefreshSecret = Boolean(realConnectionSecret(connection.refreshToken));
+        if (!hasAccessToken && !hasRefreshSecret) {
+          // Placeholder rows persisted by env-managed health checks hold no
+          // secret to refresh; attempting would just persist a bogus
+          // "Missing ... token" ERROR on every credentials lookup.
+          return;
+        }
         const expiresAtMs = connection.expiresAt?.getTime() ?? null;
         const refreshMarginMs =
           provider === IntegrationProvider.META_ADS ? META_REFRESH_MARGIN_MS : REFRESH_MARGIN_MS;
@@ -824,32 +864,26 @@ export async function getCredentials(userId?: string): Promise<AnalyticsCredenti
     getIntegrationEnvValue("GOOGLE_SEARCH_CONSOLE_SITE_URL")
   );
 
-  const hubspotToken =
-    hubspotConnection && hubspotConnection.status !== IntegrationConnectionStatus.DISCONNECTED
-      ? await getValidIntegrationAccessToken({
-          userId: hubspotConnection.userId,
-          provider: IntegrationProvider.HUBSPOT,
-        }).catch(() => null)
-      : envHubspot;
-  const usingHubspotEnvFallback =
-    Boolean(envHubspot) &&
-    (!hubspotConnection || hubspotConnection.status === IntegrationConnectionStatus.DISCONNECTED);
+  const hubspotBlocksEnv = connectionBlocksEnvFallback(hubspotConnection);
+  const hubspotToken = hubspotBlocksEnv
+    ? await getValidIntegrationAccessToken({
+        userId: hubspotConnection.userId,
+        provider: IntegrationProvider.HUBSPOT,
+      }).catch(() => null)
+    : envHubspot;
+  const usingHubspotEnvFallback = Boolean(envHubspot) && !hubspotBlocksEnv;
 
-  const codaApiToken =
-    codaConnection && codaConnection.status !== IntegrationConnectionStatus.DISCONNECTED
-      ? unprotectIntegrationSecret(codaConnection.accessToken)
-      : envCoda;
-  const usingCodaEnvFallback =
-    Boolean(envCoda) &&
-    (!codaConnection || codaConnection.status === IntegrationConnectionStatus.DISCONNECTED);
+  const codaBlocksEnv = connectionBlocksEnvFallback(codaConnection);
+  const codaApiToken = codaBlocksEnv
+    ? unprotectIntegrationSecret(codaConnection.accessToken)
+    : envCoda;
+  const usingCodaEnvFallback = Boolean(envCoda) && !codaBlocksEnv;
 
-  const redditRefreshToken =
-    redditConnection && redditConnection.status !== IntegrationConnectionStatus.DISCONNECTED
-      ? unprotectIntegrationSecret(redditConnection.refreshToken)
-      : envRedditRefresh;
-  const usingRedditEnvFallback =
-    Boolean(envRedditRefresh) &&
-    (!redditConnection || redditConnection.status === IntegrationConnectionStatus.DISCONNECTED);
+  const redditBlocksEnv = connectionBlocksEnvFallback(redditConnection, "refreshToken");
+  const redditRefreshToken = redditBlocksEnv
+    ? unprotectIntegrationSecret(redditConnection.refreshToken)
+    : envRedditRefresh;
+  const usingRedditEnvFallback = Boolean(envRedditRefresh) && !redditBlocksEnv;
 
   const googleWorkspaceAccessToken =
     googleWorkspaceConnection?.status === IntegrationConnectionStatus.CONNECTED
@@ -864,43 +898,37 @@ export async function getCredentials(userId?: string): Promise<AnalyticsCredenti
       ? unprotectIntegrationSecret(slackConnection.accessToken)
       : null;
 
-  const stripeKey =
-    stripeConnection && stripeConnection.status !== IntegrationConnectionStatus.DISCONNECTED
-      ? await getValidIntegrationAccessToken({
-          userId: stripeConnection.userId,
-          provider: IntegrationProvider.STRIPE,
-        }).catch(() => null)
-      : envStripe;
-  const usingStripeEnvFallback =
-    Boolean(envStripe) &&
-    (!stripeConnection || stripeConnection.status === IntegrationConnectionStatus.DISCONNECTED);
+  const stripeBlocksEnv = connectionBlocksEnvFallback(stripeConnection);
+  const stripeKey = stripeBlocksEnv
+    ? await getValidIntegrationAccessToken({
+        userId: stripeConnection.userId,
+        provider: IntegrationProvider.STRIPE,
+      }).catch(() => null)
+    : envStripe;
+  const usingStripeEnvFallback = Boolean(envStripe) && !stripeBlocksEnv;
 
-  const mercuryKey =
-    mercuryConnection && mercuryConnection.status !== IntegrationConnectionStatus.DISCONNECTED
-      ? await getValidIntegrationAccessToken({
-          userId: mercuryConnection.userId,
-          provider: IntegrationProvider.MERCURY,
-        }).catch(() => null)
-      : envMercury;
-  const usingMercuryEnvFallback =
-    Boolean(envMercury) &&
-    (!mercuryConnection || mercuryConnection.status === IntegrationConnectionStatus.DISCONNECTED);
+  const mercuryBlocksEnv = connectionBlocksEnvFallback(mercuryConnection);
+  const mercuryKey = mercuryBlocksEnv
+    ? await getValidIntegrationAccessToken({
+        userId: mercuryConnection.userId,
+        provider: IntegrationProvider.MERCURY,
+      }).catch(() => null)
+    : envMercury;
+  const usingMercuryEnvFallback = Boolean(envMercury) && !mercuryBlocksEnv;
 
-  const webflowApiToken =
-    webflowConnection && webflowConnection.status !== IntegrationConnectionStatus.DISCONNECTED
-      ? await getValidIntegrationAccessToken({
-          userId: webflowConnection.userId,
-          provider: IntegrationProvider.WEBFLOW,
-        }).catch(() => null)
-      : envWebflowToken;
-  const usingWebflowEnvFallback =
-    Boolean(envWebflowToken) &&
-    (!webflowConnection || webflowConnection.status === IntegrationConnectionStatus.DISCONNECTED);
+  const webflowBlocksEnv = connectionBlocksEnvFallback(webflowConnection);
+  const webflowApiToken = webflowBlocksEnv
+    ? await getValidIntegrationAccessToken({
+        userId: webflowConnection.userId,
+        provider: IntegrationProvider.WEBFLOW,
+      }).catch(() => null)
+    : envWebflowToken;
+  const usingWebflowEnvFallback = Boolean(envWebflowToken) && !webflowBlocksEnv;
 
   const webflowSiteId =
-    (webflowConnection && webflowConnection.status !== IntegrationConnectionStatus.DISCONNECTED
-      ? metadataString(webflowConnection?.metadata, "siteId") ??
-        metadataString(webflowConnection?.metadata, "defaultSiteId")
+    (webflowBlocksEnv
+      ? metadataString(webflowConnection.metadata, "siteId") ??
+        metadataString(webflowConnection.metadata, "defaultSiteId")
       : null) ?? envWebflowSiteId;
 
   const googleAdsConnectionRefreshToken =
@@ -913,24 +941,22 @@ export async function getCredentials(userId?: string): Promise<AnalyticsCredenti
   const usingGoogleAdsEnvFallback =
     !googleAdsConnectionRefreshToken && envGoogleAdsReady();
 
-  const metaAccessTokenFromAds =
-    metaAdsConnection && metaAdsConnection.status !== IntegrationConnectionStatus.DISCONNECTED
-      ? await getValidIntegrationAccessToken({
-          userId: metaAdsConnection.userId,
-          provider: IntegrationProvider.META_ADS,
-        }).catch(() => null)
-      : null;
-  const metaAccessTokenFromPage =
-    metaPageConnection && metaPageConnection.status !== IntegrationConnectionStatus.DISCONNECTED
-      ? await getValidIntegrationAccessToken({
-          userId: metaPageConnection.userId,
-          provider: IntegrationProvider.META_PAGE,
-        }).catch(() => null)
-      : null;
+  const metaAdsBlocksEnv = connectionBlocksEnvFallback(metaAdsConnection);
+  const metaPageBlocksEnv = connectionBlocksEnvFallback(metaPageConnection);
+  const metaAccessTokenFromAds = metaAdsBlocksEnv
+    ? await getValidIntegrationAccessToken({
+        userId: metaAdsConnection.userId,
+        provider: IntegrationProvider.META_ADS,
+      }).catch(() => null)
+    : null;
+  const metaAccessTokenFromPage = metaPageBlocksEnv
+    ? await getValidIntegrationAccessToken({
+        userId: metaPageConnection.userId,
+        provider: IntegrationProvider.META_PAGE,
+      }).catch(() => null)
+    : null;
   const usingMetaEnvFallback =
-    Boolean(envMetaAccessToken) &&
-    (!metaAdsConnection || metaAdsConnection.status === IntegrationConnectionStatus.DISCONNECTED) &&
-    (!metaPageConnection || metaPageConnection.status === IntegrationConnectionStatus.DISCONNECTED);
+    Boolean(envMetaAccessToken) && !metaAdsBlocksEnv && !metaPageBlocksEnv;
   const metaEnvAccessToken = usingMetaEnvFallback ? envMetaAccessToken : null;
   const metaAdsAccessToken = metaAccessTokenFromAds ?? metaEnvAccessToken;
   const metaPageAccessToken =
@@ -1058,75 +1084,67 @@ export async function getCredentials(userId?: string): Promise<AnalyticsCredenti
   }
 
 
-  const pylonApiKey =
-    pylonConnection && pylonConnection.status !== IntegrationConnectionStatus.DISCONNECTED
-      ? unprotectIntegrationSecret(pylonConnection.accessToken)
-      : envPylonApiKey;
-  const usingPylonEnvFallback =
-    hasValue(envPylonApiKey) &&
-    (!pylonConnection || pylonConnection.status === IntegrationConnectionStatus.DISCONNECTED);
+  const pylonBlocksEnv = connectionBlocksEnvFallback(pylonConnection);
+  const pylonApiKey = pylonBlocksEnv
+    ? unprotectIntegrationSecret(pylonConnection.accessToken)
+    : envPylonApiKey;
+  const usingPylonEnvFallback = hasValue(envPylonApiKey) && !pylonBlocksEnv;
 
   const pylonBaseUrl =
     metadataString(pylonConnection?.metadata, "baseUrl") ?? envPylonBaseUrl;
 
-  const semrushApiToken =
-    semrushConnection && semrushConnection.status !== IntegrationConnectionStatus.DISCONNECTED
-      ? unprotectIntegrationSecret(semrushConnection.accessToken)
-      : envSemrushApiToken;
+  const semrushBlocksEnv = connectionBlocksEnvFallback(semrushConnection);
+  const semrushApiToken = semrushBlocksEnv
+    ? unprotectIntegrationSecret(semrushConnection.accessToken)
+    : envSemrushApiToken;
   const semrushDomain =
     metadataString(semrushConnection?.metadata, "domain") ?? envSemrushDomain;
   const usingSemrushEnvFallback =
-    hasValue(envSemrushApiToken) &&
-    hasValue(envSemrushDomain) &&
-    (!semrushConnection || semrushConnection.status === IntegrationConnectionStatus.DISCONNECTED);
+    hasValue(envSemrushApiToken) && hasValue(envSemrushDomain) && !semrushBlocksEnv;
 
-  const posthogApiKey =
-    posthogConnection && posthogConnection.status !== IntegrationConnectionStatus.DISCONNECTED
-      ? unprotectIntegrationSecret(posthogConnection.accessToken)
-      : envPosthogApiKey;
+  const posthogBlocksEnv = connectionBlocksEnvFallback(posthogConnection);
+  const posthogApiKey = posthogBlocksEnv
+    ? unprotectIntegrationSecret(posthogConnection.accessToken)
+    : envPosthogApiKey;
   const posthogProjectId =
-    (posthogConnection && posthogConnection.status !== IntegrationConnectionStatus.DISCONNECTED
+    (posthogBlocksEnv
       ? metadataString(posthogConnection.metadata, "projectId") ??
         metadataString(posthogConnection.metadata, "defaultProjectId")
       : null) ?? envPosthogProjectId;
   const posthogHost =
-    (posthogConnection && posthogConnection.status !== IntegrationConnectionStatus.DISCONNECTED
+    (posthogBlocksEnv
       ? metadataString(posthogConnection.metadata, "host") ??
         metadataString(posthogConnection.metadata, "apiHost")
       : null) ?? envPosthogHost;
   const usingPosthogEnvFallback =
-    Boolean(envPosthogApiKey && envPosthogProjectId) &&
-    (!posthogConnection || posthogConnection.status === IntegrationConnectionStatus.DISCONNECTED);
+    Boolean(envPosthogApiKey && envPosthogProjectId) && !posthogBlocksEnv;
 
-  const linearApiKey =
-    linearConnection && linearConnection.status !== IntegrationConnectionStatus.DISCONNECTED
-      ? unprotectIntegrationSecret(linearConnection.accessToken)
-      : envLinearApiKey;
-  const usingLinearEnvFallback =
-    Boolean(envLinearApiKey) &&
-    (!linearConnection || linearConnection.status === IntegrationConnectionStatus.DISCONNECTED);
+  const linearBlocksEnv = connectionBlocksEnvFallback(linearConnection);
+  const linearApiKey = linearBlocksEnv
+    ? unprotectIntegrationSecret(linearConnection.accessToken)
+    : envLinearApiKey;
+  const usingLinearEnvFallback = Boolean(envLinearApiKey) && !linearBlocksEnv;
 
-  const githubToken =
-    githubConnection && githubConnection.status !== IntegrationConnectionStatus.DISCONNECTED
-      ? unprotectIntegrationSecret(githubConnection.accessToken)
-      : envGithubToken;
+  const githubBlocksEnv = connectionBlocksEnvFallback(githubConnection);
+  const githubToken = githubBlocksEnv
+    ? unprotectIntegrationSecret(githubConnection.accessToken)
+    : envGithubToken;
   const githubOwner =
-    (githubConnection && githubConnection.status !== IntegrationConnectionStatus.DISCONNECTED
+    (githubBlocksEnv
       ? metadataString(githubConnection.metadata, "owner") ??
         metadataString(githubConnection.metadata, "repoOwner")
       : null) ?? envGithubOwner;
   const githubRepo =
-    (githubConnection && githubConnection.status !== IntegrationConnectionStatus.DISCONNECTED
+    (githubBlocksEnv
       ? metadataString(githubConnection.metadata, "repo") ??
         metadataString(githubConnection.metadata, "repoName")
       : null) ?? envGithubRepo;
   const usingGithubEnvFallback =
-    Boolean(envGithubToken && envGithubOwner && envGithubRepo) &&
-    (!githubConnection || githubConnection.status === IntegrationConnectionStatus.DISCONNECTED);
+    Boolean(envGithubToken && envGithubOwner && envGithubRepo) && !githubBlocksEnv;
 
   const usingUnifyEnvFallback =
     Boolean(envUnifyApiKey && envOrNull(process.env.UNIFY_FUNNEL_OBJECT_NAME)) &&
-    (!unifyConnection || unifyConnection.status === IntegrationConnectionStatus.DISCONNECTED);
+    !connectionBlocksEnvFallback(unifyConnection);
 
   const freshness: Record<IntegrationProvider, ProviderFreshnessSnapshot> = {
     [IntegrationProvider.GOOGLE_WORKSPACE]: buildFreshness(

--- a/src/lib/integrations/health-checks.ts
+++ b/src/lib/integrations/health-checks.ts
@@ -1,6 +1,10 @@
 import { IntegrationConnectionStatus, IntegrationProvider } from "@/generated/prisma/client";
 import { prisma } from "@/lib/prisma";
-import { unprotectIntegrationSecret } from "@/lib/integrations/token-crypto";
+import {
+  ENV_MANAGED_TOKEN_PLACEHOLDER,
+  isEnvManagedTokenPlaceholder,
+  unprotectIntegrationSecret,
+} from "@/lib/integrations/token-crypto";
 import { verifyCodaApiToken, verifyPylonApiToken } from "@/lib/integrations/oauth";
 import { getValidIntegrationAccessToken } from "@/lib/integrations/token-refresh";
 import {
@@ -582,7 +586,12 @@ async function persistConnectionHealth(input: {
     userId: input.userId,
     provider: input.provider,
     status: input.status,
-    accessToken: input.accessToken ?? null,
+    // Never persist the in-memory env-managed placeholder: a stored
+    // non-null accessToken reads as a real credential and would shadow the
+    // env fallback in credential resolution.
+    accessToken: isEnvManagedTokenPlaceholder(input.accessToken)
+      ? null
+      : input.accessToken ?? null,
     lastError: input.lastError,
     lastSyncedAt: input.lastSyncedAt,
   };
@@ -644,13 +653,41 @@ function isMissingConnectionUpdateError(error: unknown): boolean {
   );
 }
 
+const ENV_MANAGED_HEALTH_PROVIDER_SET = new Set<IntegrationProvider>(
+  ENV_MANAGED_HEALTH_PROVIDERS,
+);
+
+function holdsRealAccessToken(accessToken: string | null): boolean {
+  const token = unprotectIntegrationSecret(accessToken);
+  return Boolean(token) && !isEnvManagedTokenPlaceholder(token);
+}
+
 function addEnvManagedHealthConnections(input: {
   userId: string;
   connections: HealthConnection[];
   credentials: AnalyticsCredentials;
 }): HealthConnection[] {
-  const providers = new Set(input.connections.map((connection) => connection.provider));
-  const connections = [...input.connections];
+  // Existing rows that hold no real secret (placeholder rows persisted by a
+  // previous env-managed run, or stubs created by metadata discovery) are
+  // health-checked through env credentials, exactly like providers with no
+  // row at all. Without this, the row persisted by the first run would fail
+  // the "Missing access token" gate on every later run.
+  const connections: HealthConnection[] = input.connections.map((connection) => {
+    if (
+      !holdsRealAccessToken(connection.accessToken) &&
+      ENV_MANAGED_HEALTH_PROVIDER_SET.has(connection.provider) &&
+      hasIntegrationCredential(connection.provider, input.credentials)
+    ) {
+      return {
+        ...connection,
+        accessToken: ENV_MANAGED_TOKEN_PLACEHOLDER,
+        envManaged: true,
+      };
+    }
+    return connection;
+  });
+
+  const providers = new Set(connections.map((connection) => connection.provider));
 
   for (const provider of ENV_MANAGED_HEALTH_PROVIDERS) {
     if (providers.has(provider)) {
@@ -662,7 +699,7 @@ function addEnvManagedHealthConnections(input: {
     connections.push({
       userId: input.userId,
       provider,
-      accessToken: "env-managed",
+      accessToken: ENV_MANAGED_TOKEN_PLACEHOLDER,
       envManaged: true,
     });
     providers.add(provider);

--- a/src/lib/integrations/token-crypto.ts
+++ b/src/lib/integrations/token-crypto.ts
@@ -3,6 +3,23 @@ import { createCipheriv, createDecipheriv, createHash, randomBytes } from "crypt
 const ENCRYPTED_PREFIX = "encv1";
 const PLAINTEXT_PREFIX = "plainv1";
 
+/**
+ * Placeholder stored in IntegrationConnection.accessToken for rows that only
+ * track the health of env-managed credentials. It is never a real secret:
+ * credential resolution must treat it as "no token stored", otherwise the
+ * placeholder row shadows the env credential it was created to monitor.
+ *
+ * New health-check rows persist NULL instead, but rows written before that
+ * change still hold this literal, so readers must keep recognizing it.
+ */
+export const ENV_MANAGED_TOKEN_PLACEHOLDER = "env-managed";
+
+export function isEnvManagedTokenPlaceholder(
+  value: string | null | undefined
+): boolean {
+  return value === ENV_MANAGED_TOKEN_PLACEHOLDER;
+}
+
 function getSecret(): string {
   return (
     process.env.INTEGRATION_TOKEN_SECRET ||

--- a/src/lib/integrations/token-refresh.ts
+++ b/src/lib/integrations/token-refresh.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/integrations/catalog";
 import { IntegrationAuthError, IntegrationConfigError } from "@/lib/integrations/errors";
 import {
+  isEnvManagedTokenPlaceholder,
   protectIntegrationSecret,
   unprotectIntegrationSecret,
 } from "@/lib/integrations/token-crypto";
@@ -234,7 +235,10 @@ export async function getValidIntegrationAccessToken(input: {
     }
 
     const token = unprotectIntegrationSecret(connection.accessToken);
-    if (!token) {
+    if (!token || isEnvManagedTokenPlaceholder(token)) {
+      // Env-managed health rows store a placeholder, never a real token —
+      // surfacing it as a usable credential would send "env-managed" as a
+      // bearer token to provider APIs.
       throw new IntegrationAuthError(providerLabel(input.provider), "Access token is missing");
     }
 


### PR DESCRIPTION
## Problem

Once an integration health-check run persisted a row for an env-managed credential, every subsequent META_PAGE (and intermittently META_ADS) check failed with `Missing Meta Page credential` / `Missing Meta Ads credential` — even with a valid `META_ACCESS_TOKEN` in env. Three mutually reinforcing paths:

1. **health-checks.ts** appended "env-managed" connections and persisted the literal `"env-managed"` as `accessToken` (or flipped an existing discovery stub's status, leaving `accessToken=NULL`).
2. **credentials.ts** — `usingMetaEnvFallback` (and every other `using*EnvFallback` guard) only engaged when connection rows were absent or `DISCONNECTED`. A persisted placeholder row with status `CONNECTED`/`ERROR` disabled the fallback, so the credential resolved to `null` and the next check persisted `ERROR` again. Self-perpetuating, and order-dependent within a single run (each check calls `getCredentials()` fresh while earlier checks mutate row state).
3. **credentials.ts refresh loop** re-persisted `ERROR: "Missing Meta access token"` on every `getCredentials()` call for token-less META_ADS rows.

Same pattern affected all env-fallback providers (HubSpot, Coda, Reddit, Stripe, Mercury, Webflow, Pylon, SEMrush, PostHog, Linear, GitHub, Unify). Bonus hazard: a `CONNECTED` placeholder row with no expiry made `getValidIntegrationAccessToken` return the literal string `"env-managed"` as a bearer token.

## Fix

- **credentials.ts**: new `connectionBlocksEnvFallback()` — a row only overrides env credentials when it is non-`DISCONNECTED` **and** holds a real secret (not `NULL`, not the placeholder). Applied to all env-fallback providers (Reddit keys on `refreshToken`). The refresh loop skips rows with no refreshable secret.
- **health-checks.ts**: never persists the `"env-managed"` literal (stores `NULL`); existing secret-less rows are re-marked as env-managed candidates, so previously poisoned rows **self-heal to CONNECTED on the next run** — no manual DB cleanup.
- **token-refresh.ts**: legacy placeholder tokens are treated as missing, never returned as bearer tokens.
- **token-crypto.ts**: shared `ENV_MANAGED_TOKEN_PLACEHOLDER` sentinel (lowest-level module; no import cycles).

## Tests

- `integrations-health-checks-env-fallback.test.ts` (new, end-to-end): real `getCredentials` + real `runIntegrationHealthChecks`, only Prisma (stateful) and `fetch` mocked; the Graph API mock rejects any bearer that isn't the env token. Covers two consecutive runs and healing of the exact poisoned row shapes observed in the dev DB.
- `analytics-credentials-env-fallback.test.ts` (new): placeholder rows keep Meta/Stripe/Reddit env fallbacks engaged; real connected rows still take precedence; no bogus refresh-failure writes.
- `integrations-health-checks.test.ts`: stateful prisma mock; consecutive-run and poisoned-row recovery cases; persistence assertions updated to expect `NULL`.

**Verification:** 6 of the 7 new tests fail against the previous code (revert-checked). Full suite: 257 files / 3062 tests pass. tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)