### PR TITLE
DB growth controls: lineage TTL + per-source cap, metric value thinning, outbox retention

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,3 +108,20 @@ SEMRUSH_API_TOKEN=
 
 # Worker toggles
 WORKER_SYNC_AUTOMATIONS=true
+
+# Database growth controls (see docs/db-growth-controls.md). All optional —
+# defaults shown. Enforced continuously during the sync cycle, mirroring
+# ANALYTICS_SNAPSHOT_RETENTION_DAYS (default 30) for analytics snapshots.
+# Lineage detail of superseded Imladris metric values is deleted after this
+# many days; the latest reader-visible value per metric always keeps its
+# lineage regardless of age.
+IMLADRIS_LINEAGE_RETENTION_DAYS=14
+# Per-source cap on lineage rows persisted per metric value.
+IMLADRIS_LINEAGE_MAX_ROWS_PER_SOURCE=1000
+# Soft time budget per sync cycle for lineage pruning (resumes next cycle).
+IMLADRIS_LINEAGE_PRUNE_BUDGET_MS=60000
+# Terminal outbox events: DISPATCHED deleted after N days; DEAD_LETTER kept
+# longer so they stay inspectable/replayable. PENDING/FAILED are never pruned.
+OUTBOX_DISPATCHED_RETENTION_DAYS=14
+OUTBOX_DEAD_LETTER_RETENTION_DAYS=30
+OUTBOX_PRUNE_BUDGET_MS=15000

--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,11 @@ IMLADRIS_LINEAGE_RETENTION_DAYS=14
 IMLADRIS_LINEAGE_MAX_ROWS_PER_SOURCE=1000
 # Soft time budget per sync cycle for lineage pruning (resumes next cycle).
 IMLADRIS_LINEAGE_PRUNE_BUDGET_MS=60000
+# Metric values older than this keep one end-of-day row per metric per day
+# (full intraday detail is kept inside the window; lineage-carrying rows are
+# never thinned).
+IMLADRIS_METRIC_VALUE_INTRADAY_RETENTION_DAYS=14
+IMLADRIS_METRIC_VALUE_PRUNE_BUDGET_MS=15000
 # Terminal outbox events: DISPATCHED deleted after N days; DEAD_LETTER kept
 # longer so they stay inspectable/replayable. PENDING/FAILED are never pruned.
 OUTBOX_DISPATCHED_RETENTION_DAYS=14

--- a/docs/db-growth-controls.md
+++ b/docs/db-growth-controls.md
@@ -14,9 +14,10 @@ All controls run continuously inside the shared sync cycle
 (`runAnalyticsSync` in `src/lib/sync/analytics.ts`), which both the worker
 orchestrator (`worker/sync-runner.ts` → `src/lib/sync/orchestrator.ts`) and
 the legacy cron route (`/api/cron/sync`) call. Results appear in the sync
-output as `lineagePruning` / `outboxPruning` (the name `retention` was already
-taken by customer-retention materialization), and pruning errors surface as
-partial failures so a silently regrowing table stays visible.
+output as `lineagePruning` / `metricValuePruning` / `outboxPruning` (the name
+`retention` was already taken by customer-retention materialization), and
+pruning errors surface as partial failures so a silently regrowing table
+stays visible.
 
 ### 1. Lineage retention — `src/lib/imladris/lineage-retention.ts`
 
@@ -63,6 +64,27 @@ the primary control.
 
 Status counts in `/api/events` metrics reflect the retained window.
 
+### 4. Metric value thinning — `src/lib/imladris/metric-value-retention.ts`
+
+`ImladrisCanonicalMetricValue` itself gains one row per metric per user every
+~10-minute cycle (`periodEnd = now` mints a new row each run) — slow but
+unbounded. Rows older than `IMLADRIS_METRIC_VALUE_INTRADAY_RETENTION_DAYS`
+(default 14) are thinned to **one row per (organizationId, userId, metricKey,
+UTC day)** — the day's last `(periodEnd, computedAt)`, i.e. the end-of-day
+value. Safe because `imladris/history.ts` buckets monthly (one best row per
+metric per month) and backdated exports pick the latest row `<= toDate`, which
+after thinning is that day's end-of-day value. Sub-daily resolution is only
+lost for dates older than the intraday window.
+
+Two extra guards: future-period rows (`periodEnd > now`) are never touched,
+and only rows with **no lineage** are deleted (`NOT EXISTS` on
+`ImladrisMetricLineage.metricValueId`). The lineage guard is load-bearing
+twice over: the FK cascade from metric values to lineage can never fire (every
+DELETE stays exactly LIMIT-bounded), and the thinner is strictly sequenced
+behind the lineage pruner — the overall-latest value per group and anything
+inside the lineage window still carry lineage and are untouchable. If lineage
+pruning breaks, thinning fail-safes to a no-op for those rows.
+
 ## Why no schema migration
 
 Deliberate: on a ~9GB table, the safest migration is none. Both pruners use
@@ -83,8 +105,8 @@ sync cycles, and the outbox backlog in a few cycles. Watch the sync output's
 `lineagePruning.deletedRows` / `completed` fields (worker logs or
 `/api/cron/sync?wait=1` response).
 
-During the drain the analytics module runs up to ~75s longer per cycle
-(`IMLADRIS_LINEAGE_PRUNE_BUDGET_MS` + `OUTBOX_PRUNE_BUDGET_MS`). The worker's
+During the drain the analytics module runs up to ~90s longer per cycle (the
+sum of the three `*_PRUNE_BUDGET_MS` budgets). The worker's
 whole-cycle timeout is `WORKER_SYNC_TIMEOUT` (default 300s); if cycles already
 run near that ceiling, either raise it temporarily or lower the prune budgets
 — an interrupted pass is harmless and resumes next cycle.
@@ -112,6 +134,8 @@ writes reuse freed pages — but does not shrink files on disk. After
 | `IMLADRIS_LINEAGE_RETENTION_DAYS` | 14 | Lower = smaller steady-state table; keep ≥ a few days above the board-pack generation lag. |
 | `IMLADRIS_LINEAGE_MAX_ROWS_PER_SOURCE` | 1000 | Per-source lineage detail cap per metric value. |
 | `IMLADRIS_LINEAGE_PRUNE_BUDGET_MS` | 60000 | Per-cycle pruning time budget. |
+| `IMLADRIS_METRIC_VALUE_INTRADAY_RETENTION_DAYS` | 14 | Full intraday metric value detail kept this long; older days thin to one end-of-day row. Keep ≥ the lineage retention window (rows with lineage are skipped regardless). |
+| `IMLADRIS_METRIC_VALUE_PRUNE_BUDGET_MS` | 15000 | Per-cycle thinning time budget. |
 | `OUTBOX_DISPATCHED_RETENTION_DAYS` | 14 | Window for terminal-success events. |
 | `OUTBOX_DEAD_LETTER_RETENTION_DAYS` | 30 | Window for inspectable/replayable dead letters. |
 | `OUTBOX_PRUNE_BUDGET_MS` | 15000 | Per-cycle pruning time budget. |

--- a/docs/db-growth-controls.md
+++ b/docs/db-growth-controls.md
@@ -1,0 +1,117 @@
+# Database growth controls
+
+Context: on 2026-06-10 the Railway Postgres volume (20GB) hit ENOSPC and the
+database crash-looped for ~17h. Two tables grew without bound:
+
+| Table                   | Size at outage | Rows        | Cause |
+| ----------------------- | -------------- | ----------- | ----- |
+| `ImladrisMetricLineage` | 8,164MB (91% of DB) | 21,983,741 | Every 10-minute sync materializes canonical metric values with `periodEnd = now`, minting NEW `ImladrisCanonicalMetricValue` rows each cycle; `replaceLineage` writes one lineage row per contributing raw record per value, and lineage of superseded values was never aged out (~273 retained generations per raw record). |
+| `OutboxEvent`           | 664MB          | 906,352     | No cleanup anywhere; events accumulated since 2026-02-16. |
+
+## Controls
+
+All controls run continuously inside the shared sync cycle
+(`runAnalyticsSync` in `src/lib/sync/analytics.ts`), which both the worker
+orchestrator (`worker/sync-runner.ts` → `src/lib/sync/orchestrator.ts`) and
+the legacy cron route (`/api/cron/sync`) call. Results appear in the sync
+output as `lineagePruning` / `outboxPruning` (the name `retention` was already
+taken by customer-retention materialization), and pruning errors surface as
+partial failures so a silently regrowing table stays visible.
+
+### 1. Lineage retention — `src/lib/imladris/lineage-retention.ts`
+
+Deletes lineage rows belonging to metric values that are **(a)** older than
+`IMLADRIS_LINEAGE_RETENTION_DAYS` (default 14), **(b)** not the latest
+reader-visible value of their `(organizationId, userId, metricKey)` group, and
+**(c)** reader-visible at all (`periodEnd <= now`). The canonical metric value
+rows are kept — they power history trends and are small; only their per-record
+lineage detail is dropped.
+
+Why this is safe for the lineage feature (source provenance for trusted
+metrics): every read path — `imladris/service.ts`, `company-tracker.ts`,
+`investor-dashboard-export.ts`, `investor/board-pack.ts`, `ceo/service.ts` —
+loads lineage only via `include: { lineage }` on the **latest** metric value
+per metricKey; `imladris/history.ts` never includes lineage; there are no
+reverse lookups by `rawRecordId`. CEO/board reports copy lineage into
+`CeoMetricSourceLineage` at generation time, so existing reports are
+unaffected. The 14-day window also covers the monthly board-pack cron, which
+reads month-end metric values days after the month closes. Regenerating an
+export backdated further than the window yields metric values without lineage
+detail (readers fall back to the metric definition's source keys).
+
+### 2. Lineage write cap — `capLineageRecordsPerSource` in `src/lib/imladris/materialization.ts`
+
+Bounds rows persisted per metric value at
+`IMLADRIS_LINEAGE_MAX_ROWS_PER_SOURCE` (default 1,000) **per sourceKey**, not
+globally, so every contributing source stays represented in provenance even
+when truncated. Keeps each source's most recently captured records with a
+deterministic id tie-break. This is defense-in-depth against pathological
+per-cycle volume (e.g. a PostHog event backfill); the retention job above is
+the primary control.
+
+### 3. Outbox retention — `src/lib/events/outbox-retention.ts`
+
+- `DISPATCHED` (terminal success): deleted after
+  `OUTBOX_DISPATCHED_RETENTION_DAYS` (default 14), measured by `dispatchedAt`
+  (fallback `createdAt`).
+- `DEAD_LETTER` (terminal failure): deleted after
+  `OUTBOX_DEAD_LETTER_RETENTION_DAYS` (default 30) so they stay inspectable
+  (`/api/events/dead-letter`) and replayable (`/api/events` replay) for a
+  month.
+- `PENDING` / `FAILED` are the live retry queue (`pollPendingEvents`) and are
+  **never** deleted, regardless of age.
+
+Status counts in `/api/events` metrics reflect the retained window.
+
+## Why no schema migration
+
+Deliberate: on a ~9GB table, the safest migration is none. Both pruners use
+LIMIT-bounded, autocommitted `DELETE` statements driven by existing indexes
+(`ImladrisMetricLineage.metricValueId`; `ImladrisCanonicalMetricValue` and the
+post-cleanup `OutboxEvent` table are small), so no statement's locks or WAL
+grow with the backlog and no long transactions are held. Each pass is also
+time-budgeted (`IMLADRIS_LINEAGE_PRUNE_BUDGET_MS` default 60s,
+`OUTBOX_PRUNE_BUDGET_MS` default 15s); an interrupted pass reports
+`completed: false` and resumes on the next sync cycle. Raw SQL is used because
+Prisma's `deleteMany` cannot bound rows per statement.
+
+## Draining the existing backlog
+
+No manual action is required: with a 60s/cycle budget at ~10K rows per
+statement, the ~22M-row lineage backlog drains in roughly a day of normal
+sync cycles, and the outbox backlog in a few cycles. Watch the sync output's
+`lineagePruning.deletedRows` / `completed` fields (worker logs or
+`/api/cron/sync?wait=1` response).
+
+During the drain the analytics module runs up to ~75s longer per cycle
+(`IMLADRIS_LINEAGE_PRUNE_BUDGET_MS` + `OUTBOX_PRUNE_BUDGET_MS`). The worker's
+whole-cycle timeout is `WORKER_SYNC_TIMEOUT` (default 300s); if cycles already
+run near that ceiling, either raise it temporarily or lower the prune budgets
+— an interrupted pass is harmless and resumes next cycle.
+
+## Reclaiming disk after the drain
+
+`DELETE` makes space reusable (autovacuum) — the tables stop growing and new
+writes reuse freed pages — but does not shrink files on disk. After
+`lineagePruning.completed: true` appears consistently:
+
+1. `VACUUM (VERBOSE, ANALYZE) "ImladrisMetricLineage";` — confirms dead tuples
+   are reclaimed and refreshes planner stats.
+2. To return the ~7-8GB to the OS, run `pg_repack` (no long exclusive lock) or
+   `VACUUM FULL "ImladrisMetricLineage";` (takes an exclusive lock — only
+   during a maintenance window with the worker/cron paused). With retention
+   active, the steady-state table is a few hundred MB, so this is a one-time
+   cleanup.
+3. Check Railway volume metrics afterwards; alert headroom should be set well
+   below 20GB.
+
+## Tuning
+
+| Env var | Default | Effect |
+| --- | --- | --- |
+| `IMLADRIS_LINEAGE_RETENTION_DAYS` | 14 | Lower = smaller steady-state table; keep ≥ a few days above the board-pack generation lag. |
+| `IMLADRIS_LINEAGE_MAX_ROWS_PER_SOURCE` | 1000 | Per-source lineage detail cap per metric value. |
+| `IMLADRIS_LINEAGE_PRUNE_BUDGET_MS` | 60000 | Per-cycle pruning time budget. |
+| `OUTBOX_DISPATCHED_RETENTION_DAYS` | 14 | Window for terminal-success events. |
+| `OUTBOX_DEAD_LETTER_RETENTION_DAYS` | 30 | Window for inspectable/replayable dead letters. |
+| `OUTBOX_PRUNE_BUDGET_MS` | 15000 | Per-cycle pruning time budget. |

--- a/src/app/api/cron/sync/route.ts
+++ b/src/app/api/cron/sync/route.ts
@@ -153,6 +153,7 @@ function collectAnalyticsPartialFailures(value: unknown): string[] {
   // filled the database volume on 2026-06-10.
   for (const [field, label] of [
     ["lineagePruning", "lineage_pruning"],
+    ["metricValuePruning", "metric_value_pruning"],
     ["outboxPruning", "outbox_pruning"],
   ] as const) {
     const outcome = asRecord(record[field]);
@@ -401,6 +402,7 @@ async function executeCronSync(input: {
       pruning: null as unknown,
       retention: null as unknown,
       lineagePruning: null as unknown,
+      metricValuePruning: null as unknown,
       outboxPruning: null as unknown,
     };
 
@@ -413,6 +415,7 @@ async function executeCronSync(input: {
       settled.analytics = analyticsSyncResult.value.refresh;
       settled.pruning = analyticsSyncResult.value.pruning;
       settled.lineagePruning = analyticsSyncResult.value.lineagePruning;
+      settled.metricValuePruning = analyticsSyncResult.value.metricValuePruning;
       settled.outboxPruning = analyticsSyncResult.value.outboxPruning;
       failures.push(...collectAnalyticsPartialFailures(analyticsSyncResult.value));
     } else {

--- a/src/app/api/cron/sync/route.ts
+++ b/src/app/api/cron/sync/route.ts
@@ -148,6 +148,19 @@ function collectAnalyticsPartialFailures(value: unknown): string[] {
     );
   }
 
+  // Growth-control pruning failures (see src/lib/sync/analytics.ts). These
+  // must stay loud: an unnoticed retention failure is how ImladrisMetricLineage
+  // filled the database volume on 2026-06-10.
+  for (const [field, label] of [
+    ["lineagePruning", "lineage_pruning"],
+    ["outboxPruning", "outbox_pruning"],
+  ] as const) {
+    const outcome = asRecord(record[field]);
+    if (typeof outcome?.error === "string" && outcome.error.trim().length > 0) {
+      failures.push(`${label}: ${outcome.error}`);
+    }
+  }
+
   return failures;
 }
 
@@ -387,13 +400,20 @@ async function executeCronSync(input: {
       health: null as unknown,
       pruning: null as unknown,
       retention: null as unknown,
+      lineagePruning: null as unknown,
+      outboxPruning: null as unknown,
     };
 
     if (analyticsSyncResult.status === "fulfilled") {
       // Split bundled result back into `analytics` (refresh) and `pruning`
       // top-level fields — external monitors read these separately.
+      // `lineagePruning`/`outboxPruning` are the growth controls for the
+      // tables behind the 2026-06-10 disk-full outage (`retention` was
+      // already taken by customer-retention materialization).
       settled.analytics = analyticsSyncResult.value.refresh;
       settled.pruning = analyticsSyncResult.value.pruning;
+      settled.lineagePruning = analyticsSyncResult.value.lineagePruning;
+      settled.outboxPruning = analyticsSyncResult.value.outboxPruning;
       failures.push(...collectAnalyticsPartialFailures(analyticsSyncResult.value));
     } else {
       const msg = analyticsSyncResult.reason instanceof Error ? analyticsSyncResult.reason.message : String(analyticsSyncResult.reason);

--- a/src/lib/events/outbox-retention.test.ts
+++ b/src/lib/events/outbox-retention.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { pruneOutboxEvents } from "@/lib/events/outbox-retention";
+
+const NOW = new Date("2026-06-10T12:00:00.000Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * prisma.$executeRaw`...` invokes the mock as a tagged template:
+ * (strings, ...boundValues).
+ */
+type SqlCall = [TemplateStringsArray, ...unknown[]];
+
+function sqlTextOf(call: SqlCall): string {
+  return call[0].join(" ¶ ");
+}
+
+function boundValuesOf(call: SqlCall): unknown[] {
+  return call.slice(1);
+}
+
+function createPrismaMock(input: { dispatchedCounts: number[]; deadLetterCounts: number[] }) {
+  const dispatched = [...input.dispatchedCounts];
+  const deadLetter = [...input.deadLetterCounts];
+  const $executeRaw = vi.fn(async (strings: TemplateStringsArray) => {
+    const sql = strings.join(" ");
+    if (sql.includes("DEAD_LETTER")) return deadLetter.shift() ?? 0;
+    return dispatched.shift() ?? 0;
+  });
+  return { $executeRaw };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("pruneOutboxEvents", () => {
+  it("deletes terminal events with status-specific cutoffs and never touches the retry queue", async () => {
+    const prisma = createPrismaMock({ dispatchedCounts: [3], deadLetterCounts: [1] });
+
+    const result = await pruneOutboxEvents({ prisma: prisma as never, now: NOW });
+
+    expect(result).toEqual({
+      deletedDispatched: 3,
+      deletedDeadLetter: 1,
+      batches: 2,
+      dispatchedCutoff: new Date(NOW.getTime() - 14 * DAY_MS).toISOString(),
+      deadLetterCutoff: new Date(NOW.getTime() - 30 * DAY_MS).toISOString(),
+      completed: true,
+      durationMs: expect.any(Number),
+    });
+
+    const [dispatchedCall, deadLetterCall] = prisma.$executeRaw.mock.calls as SqlCall[];
+
+    const dispatchedSql = sqlTextOf(dispatchedCall);
+    expect(dispatchedSql).toContain('DELETE FROM "OutboxEvent"');
+    expect(dispatchedSql).toContain(`"status" = 'DISPATCHED'`);
+    // dispatchedAt is authoritative for terminal success; createdAt is only a
+    // fallback for rows that never recorded it.
+    expect(dispatchedSql).toContain('COALESCE("dispatchedAt", "createdAt")');
+    expect(dispatchedSql).toContain("LIMIT");
+    expect(boundValuesOf(dispatchedCall)).toEqual([
+      new Date(NOW.getTime() - 14 * DAY_MS),
+      10_000,
+    ]);
+
+    const deadLetterSql = sqlTextOf(deadLetterCall);
+    expect(deadLetterSql).toContain(`"status" = 'DEAD_LETTER'`);
+    expect(deadLetterSql).toContain('"createdAt" <');
+    expect(boundValuesOf(deadLetterCall)).toEqual([
+      new Date(NOW.getTime() - 30 * DAY_MS),
+      10_000,
+    ]);
+
+    // PENDING and FAILED are the live retry queue (pollPendingEvents) — they
+    // must never appear in a retention DELETE.
+    for (const sql of [dispatchedSql, deadLetterSql]) {
+      expect(sql).not.toContain("PENDING");
+      expect(sql).not.toContain("'FAILED'");
+    }
+  });
+
+  it("loops in bounded batches until each backlog drains", async () => {
+    const prisma = createPrismaMock({
+      dispatchedCounts: [2, 2, 1],
+      deadLetterCounts: [2, 0],
+    });
+
+    const result = await pruneOutboxEvents({
+      prisma: prisma as never,
+      now: NOW,
+      batchSize: 2,
+    });
+
+    expect(result.deletedDispatched).toBe(5);
+    expect(result.deletedDeadLetter).toBe(2);
+    expect(result.batches).toBe(5);
+    expect(result.completed).toBe(true);
+  });
+
+  it("stops at the time budget and leaves the dead-letter phase for the next cycle", async () => {
+    const ticks = [0, 10, 200, 250];
+    const clock = vi.fn(() => (ticks.length > 1 ? (ticks.shift() as number) : ticks[0]));
+    const prisma = createPrismaMock({
+      // A full batch means the dispatched backlog is not yet drained when the
+      // budget expires.
+      dispatchedCounts: [2],
+      deadLetterCounts: [99],
+    });
+
+    const result = await pruneOutboxEvents({
+      prisma: prisma as never,
+      now: NOW,
+      batchSize: 2,
+      budgetMs: 100,
+      clock,
+    });
+
+    expect(result.completed).toBe(false);
+    expect(result.deletedDispatched).toBe(2);
+    expect(result.deletedDeadLetter).toBe(0);
+    expect(result.batches).toBe(1);
+    expect(result.durationMs).toBe(250);
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads retention windows from env when no overrides are provided", async () => {
+    vi.stubEnv("OUTBOX_DISPATCHED_RETENTION_DAYS", "2");
+    vi.stubEnv("OUTBOX_DEAD_LETTER_RETENTION_DAYS", "4");
+    const prisma = createPrismaMock({ dispatchedCounts: [0], deadLetterCounts: [0] });
+
+    const result = await pruneOutboxEvents({ prisma: prisma as never, now: NOW });
+
+    expect(result.dispatchedCutoff).toBe(new Date(NOW.getTime() - 2 * DAY_MS).toISOString());
+    expect(result.deadLetterCutoff).toBe(new Date(NOW.getTime() - 4 * DAY_MS).toISOString());
+  });
+
+  it("honors explicit retention overrides over env", async () => {
+    vi.stubEnv("OUTBOX_DISPATCHED_RETENTION_DAYS", "2");
+    const prisma = createPrismaMock({ dispatchedCounts: [0], deadLetterCounts: [0] });
+
+    const result = await pruneOutboxEvents({
+      prisma: prisma as never,
+      now: NOW,
+      dispatchedRetentionDays: 7,
+      deadLetterRetentionDays: 9,
+    });
+
+    expect(result.dispatchedCutoff).toBe(new Date(NOW.getTime() - 7 * DAY_MS).toISOString());
+    expect(result.deadLetterCutoff).toBe(new Date(NOW.getTime() - 9 * DAY_MS).toISOString());
+  });
+});

--- a/src/lib/events/outbox-retention.ts
+++ b/src/lib/events/outbox-retention.ts
@@ -1,0 +1,177 @@
+/**
+ * OutboxEvent retention.
+ *
+ * OutboxEvent previously had no cleanup anywhere: every domain event written
+ * by src/lib/event-bus.ts, src/lib/events/outbox-writer.ts,
+ * src/lib/automations/runtime.ts and src/lib/integrations/slack-notifications.ts
+ * stayed forever (906K rows / 664MB at the 2026-06-10 disk-full outage, with
+ * events dating back to 2026-02-16).
+ *
+ * Lifecycle (src/lib/events/outbox-worker.ts):
+ *   - PENDING / FAILED are live — pollPendingEvents retries them — so they are
+ *     NEVER deleted here, regardless of age.
+ *   - DISPATCHED is terminal success; pruned after a short window.
+ *   - DEAD_LETTER is terminal failure but stays inspectable
+ *     (/api/events/dead-letter) and replayable (/api/events replay), so it
+ *     gets a longer window.
+ *
+ * Mirrors the AnalyticsSnapshot retention pattern (env-configured days,
+ * enforced during the sync cycle — see pruneAnalyticsSnapshots in
+ * src/lib/analytics/snapshots.ts), with two differences required by the
+ * backlog: deletes are bounded per statement (id-subquery LIMIT, which
+ * Prisma's deleteMany cannot express) and the pass is time-budgeted so it can
+ * never stall a sync cycle. Status counts in /api/events metrics
+ * (collectOutboxMetrics) reflect the retained window after pruning.
+ */
+
+import type { PrismaClientType } from "@/lib/prisma";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_DISPATCHED_RETENTION_DAYS = 14;
+const DEFAULT_DEAD_LETTER_RETENTION_DAYS = 30;
+const DEFAULT_BUDGET_MS = 15_000;
+const DEFAULT_BATCH_SIZE = 10_000;
+
+export interface PruneOutboxEventsInput {
+  prisma: PrismaClientType;
+  /**
+   * DISPATCHED events older than this many days (by dispatchedAt, falling
+   * back to createdAt) are deleted. Defaults to
+   * OUTBOX_DISPATCHED_RETENTION_DAYS (env) or 14.
+   */
+  dispatchedRetentionDays?: number;
+  /**
+   * DEAD_LETTER events created more than this many days ago are deleted.
+   * Defaults to OUTBOX_DEAD_LETTER_RETENTION_DAYS (env) or 30. Dead letters
+   * dead-letter within minutes of creation (5 retries, 5-minute max backoff),
+   * so createdAt is a faithful age signal.
+   */
+  deadLetterRetentionDays?: number;
+  /**
+   * Soft time budget for one pruning pass. Defaults to
+   * OUTBOX_PRUNE_BUDGET_MS (env) or 15s.
+   */
+  budgetMs?: number;
+  /** Max events deleted per DELETE statement. */
+  batchSize?: number;
+  /** Test seam: reference time for cutoffs. Defaults to now. */
+  now?: Date;
+  /** Test seam: monotonic clock for the time budget. Defaults to Date.now. */
+  clock?: () => number;
+}
+
+export interface PruneOutboxEventsResult {
+  deletedDispatched: number;
+  deletedDeadLetter: number;
+  /** DELETE statements issued. */
+  batches: number;
+  dispatchedCutoff: string;
+  deadLetterCutoff: string;
+  /**
+   * False when the time budget expired before both backlogs fully drained.
+   * The next sync cycle picks up where this one stopped.
+   */
+  completed: boolean;
+  durationMs: number;
+}
+
+function positiveIntFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  const parsed = raw ? Number(raw) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
+  return fallback;
+}
+
+export async function pruneOutboxEvents(
+  input: PruneOutboxEventsInput,
+): Promise<PruneOutboxEventsResult> {
+  const dispatchedRetentionDays = Math.max(
+    1,
+    Math.floor(
+      input.dispatchedRetentionDays ??
+        positiveIntFromEnv(
+          "OUTBOX_DISPATCHED_RETENTION_DAYS",
+          DEFAULT_DISPATCHED_RETENTION_DAYS,
+        ),
+    ),
+  );
+  const deadLetterRetentionDays = Math.max(
+    1,
+    Math.floor(
+      input.deadLetterRetentionDays ??
+        positiveIntFromEnv(
+          "OUTBOX_DEAD_LETTER_RETENTION_DAYS",
+          DEFAULT_DEAD_LETTER_RETENTION_DAYS,
+        ),
+    ),
+  );
+  const budgetMs = Math.max(
+    1,
+    Math.floor(input.budgetMs ?? positiveIntFromEnv("OUTBOX_PRUNE_BUDGET_MS", DEFAULT_BUDGET_MS)),
+  );
+  const batchSize = Math.max(1, Math.floor(input.batchSize ?? DEFAULT_BATCH_SIZE));
+  const now = input.now ?? new Date();
+  const clock = input.clock ?? (() => Date.now());
+  const dispatchedCutoff = new Date(now.getTime() - dispatchedRetentionDays * DAY_MS);
+  const deadLetterCutoff = new Date(now.getTime() - deadLetterRetentionDays * DAY_MS);
+
+  const startedAt = clock();
+  const deadline = startedAt + budgetMs;
+
+  let deletedDispatched = 0;
+  let deletedDeadLetter = 0;
+  let batches = 0;
+  let dispatchedDrained = false;
+  let deadLetterDrained = false;
+
+  // Terminal-success events first: they dominate the backlog. Statuses are
+  // inlined as SQL literals (not bind params) so Postgres coerces them to the
+  // "OutboxEventStatus" enum; PENDING/FAILED are intentionally absent.
+  while (clock() < deadline) {
+    const deleted = await input.prisma.$executeRaw`
+      DELETE FROM "OutboxEvent"
+      WHERE "id" IN (
+        SELECT "id"
+        FROM "OutboxEvent"
+        WHERE "status" = 'DISPATCHED'
+          AND COALESCE("dispatchedAt", "createdAt") < ${dispatchedCutoff}
+        LIMIT ${batchSize}
+      )
+    `;
+    batches += 1;
+    deletedDispatched += deleted;
+    if (deleted < batchSize) {
+      dispatchedDrained = true;
+      break;
+    }
+  }
+
+  while (dispatchedDrained && clock() < deadline) {
+    const deleted = await input.prisma.$executeRaw`
+      DELETE FROM "OutboxEvent"
+      WHERE "id" IN (
+        SELECT "id"
+        FROM "OutboxEvent"
+        WHERE "status" = 'DEAD_LETTER'
+          AND "createdAt" < ${deadLetterCutoff}
+        LIMIT ${batchSize}
+      )
+    `;
+    batches += 1;
+    deletedDeadLetter += deleted;
+    if (deleted < batchSize) {
+      deadLetterDrained = true;
+      break;
+    }
+  }
+
+  return {
+    deletedDispatched,
+    deletedDeadLetter,
+    batches,
+    dispatchedCutoff: dispatchedCutoff.toISOString(),
+    deadLetterCutoff: deadLetterCutoff.toISOString(),
+    completed: dispatchedDrained && deadLetterDrained,
+    durationMs: clock() - startedAt,
+  };
+}

--- a/src/lib/imladris/lineage-retention.test.ts
+++ b/src/lib/imladris/lineage-retention.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { pruneImladrisMetricLineage } from "@/lib/imladris/lineage-retention";
+
+const NOW = new Date("2026-06-10T12:00:00.000Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * prisma.$queryRaw`...` / prisma.$executeRaw`...` invoke the mock as a tagged
+ * template: (strings, ...boundValues).
+ */
+type SqlCall = [TemplateStringsArray, ...unknown[]];
+
+function sqlTextOf(call: SqlCall): string {
+  return call[0].join(" ¶ ");
+}
+
+function boundValuesOf(call: SqlCall): unknown[] {
+  return call.slice(1);
+}
+
+function createPrismaMock(input: {
+  candidateBatches: Array<Array<{ id: string }>>;
+  deleteCounts: number[];
+}) {
+  const candidateBatches = [...input.candidateBatches];
+  const deleteCounts = [...input.deleteCounts];
+  return {
+    $queryRaw: vi.fn(async () => candidateBatches.shift() ?? []),
+    $executeRaw: vi.fn(async () => deleteCounts.shift() ?? 0),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("pruneImladrisMetricLineage", () => {
+  it("completes immediately when no superseded lineage remains", async () => {
+    const prisma = createPrismaMock({ candidateBatches: [[]], deleteCounts: [] });
+
+    const result = await pruneImladrisMetricLineage({
+      prisma: prisma as never,
+      now: NOW,
+    });
+
+    expect(result).toEqual({
+      deletedRows: 0,
+      prunedMetricValues: 0,
+      batches: 0,
+      cutoff: new Date(NOW.getTime() - 14 * DAY_MS).toISOString(),
+      completed: true,
+      durationMs: expect.any(Number),
+    });
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(prisma.$executeRaw).not.toHaveBeenCalled();
+  });
+
+  it("only targets superseded, reader-invisible-by-now metric values that still carry lineage", async () => {
+    const prisma = createPrismaMock({ candidateBatches: [[]], deleteCounts: [] });
+
+    await pruneImladrisMetricLineage({ prisma: prisma as never, now: NOW });
+
+    const call = prisma.$queryRaw.mock.calls[0] as unknown as SqlCall;
+    const sql = sqlTextOf(call);
+    // The latest reader-visible value per scope group keeps its lineage…
+    expect(sql).toContain('DISTINCT ON ("organizationId", "userId", "metricKey")');
+    expect(sql).toContain('ORDER BY "organizationId", "userId", "metricKey", "periodEnd" DESC, "computedAt" DESC');
+    expect(sql).toContain('NOT IN (SELECT "id" FROM latest)');
+    // …and already-pruned values drop out of future scans.
+    expect(sql).toContain('EXISTS');
+    expect(sql).toContain('LIMIT');
+    // Bound values, in order: latest-CTE visibility guards (periodEnd <= now,
+    // computedAt <= now), retention cutoff, candidate visibility guard
+    // (periodEnd <= now), id batch size.
+    expect(boundValuesOf(call)).toEqual([
+      NOW,
+      NOW,
+      new Date(NOW.getTime() - 14 * DAY_MS),
+      NOW,
+      200,
+    ]);
+  });
+
+  it("drains each id batch with bounded DELETE statements and keeps scanning until empty", async () => {
+    const prisma = createPrismaMock({
+      // First scan finds two superseded values; the rescan finds nothing left.
+      candidateBatches: [[{ id: "mv_old_1" }, { id: "mv_old_2" }], []],
+      // Two full delete batches, then a short batch signals the ids are drained.
+      deleteCounts: [2, 2, 1],
+    });
+
+    const result = await pruneImladrisMetricLineage({
+      prisma: prisma as never,
+      now: NOW,
+      rowBatchSize: 2,
+    });
+
+    expect(result.deletedRows).toBe(5);
+    expect(result.prunedMetricValues).toBe(2);
+    expect(result.batches).toBe(3);
+    expect(result.completed).toBe(true);
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(2);
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(3);
+    for (const rawCall of prisma.$executeRaw.mock.calls) {
+      const call = rawCall as unknown as SqlCall;
+      const sql = sqlTextOf(call);
+      expect(sql).toContain('DELETE FROM "ImladrisMetricLineage"');
+      // Every statement is LIMIT-bounded via the id subquery — the safety
+      // property that keeps locks/WAL flat on the multi-GB backlog.
+      expect(sql).toContain('LIMIT');
+      expect(sql).toContain('"metricValueId" = ANY');
+      expect(boundValuesOf(call)).toEqual([["mv_old_1", "mv_old_2"], 2]);
+    }
+  });
+
+  it("stops at the time budget mid-backlog and reports an incomplete pass", async () => {
+    const ticks = [0, 10, 200, 250];
+    const clock = vi.fn(() => (ticks.length > 1 ? (ticks.shift() as number) : ticks[0]));
+    const prisma = createPrismaMock({
+      candidateBatches: [[{ id: "mv_old_1" }]],
+      // A full batch means more rows remain for this id when the budget hits.
+      deleteCounts: [2],
+    });
+
+    const result = await pruneImladrisMetricLineage({
+      prisma: prisma as never,
+      now: NOW,
+      rowBatchSize: 2,
+      budgetMs: 100,
+      clock,
+    });
+
+    expect(result.completed).toBe(false);
+    expect(result.deletedRows).toBe(2);
+    expect(result.batches).toBe(1);
+    expect(result.durationMs).toBe(250);
+    // No further scans once the budget is spent — the next sync cycle resumes.
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("does no work at all when the budget is already exhausted", async () => {
+    const ticks = [0, 100];
+    const clock = vi.fn(() => (ticks.length > 1 ? (ticks.shift() as number) : ticks[0]));
+    const prisma = createPrismaMock({
+      candidateBatches: [[{ id: "mv_old_1" }]],
+      deleteCounts: [1],
+    });
+
+    const result = await pruneImladrisMetricLineage({
+      prisma: prisma as never,
+      now: NOW,
+      budgetMs: 50,
+      clock,
+    });
+
+    expect(result.completed).toBe(false);
+    expect(result.deletedRows).toBe(0);
+    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+    expect(prisma.$executeRaw).not.toHaveBeenCalled();
+  });
+
+  it("honors an explicit retentionDays override", async () => {
+    const prisma = createPrismaMock({ candidateBatches: [[]], deleteCounts: [] });
+
+    const result = await pruneImladrisMetricLineage({
+      prisma: prisma as never,
+      now: NOW,
+      retentionDays: 3,
+    });
+
+    expect(result.cutoff).toBe(new Date(NOW.getTime() - 3 * DAY_MS).toISOString());
+  });
+
+  it("reads IMLADRIS_LINEAGE_RETENTION_DAYS when no override is provided", async () => {
+    vi.stubEnv("IMLADRIS_LINEAGE_RETENTION_DAYS", "5");
+    const prisma = createPrismaMock({ candidateBatches: [[]], deleteCounts: [] });
+
+    const result = await pruneImladrisMetricLineage({
+      prisma: prisma as never,
+      now: NOW,
+    });
+
+    expect(result.cutoff).toBe(new Date(NOW.getTime() - 5 * DAY_MS).toISOString());
+    const call = prisma.$queryRaw.mock.calls[0] as unknown as SqlCall;
+    expect(boundValuesOf(call)).toContainEqual(new Date(NOW.getTime() - 5 * DAY_MS));
+  });
+
+  it("falls back to the default retention when the env value is invalid", async () => {
+    vi.stubEnv("IMLADRIS_LINEAGE_RETENTION_DAYS", "not-a-number");
+    const prisma = createPrismaMock({ candidateBatches: [[]], deleteCounts: [] });
+
+    const result = await pruneImladrisMetricLineage({
+      prisma: prisma as never,
+      now: NOW,
+    });
+
+    expect(result.cutoff).toBe(new Date(NOW.getTime() - 14 * DAY_MS).toISOString());
+  });
+});

--- a/src/lib/imladris/lineage-retention.ts
+++ b/src/lib/imladris/lineage-retention.ts
@@ -1,0 +1,201 @@
+/**
+ * Imladris metric lineage retention.
+ *
+ * Why this exists: every sync cycle materializes canonical metric values with
+ * `periodEnd = now`, so each cycle mints NEW ImladrisCanonicalMetricValue rows
+ * and `replaceLineage` (src/lib/imladris/materialization.ts) writes a full
+ * per-raw-record lineage set for each of them. Lineage attached to superseded
+ * metric values was never aged out, which let ImladrisMetricLineage grow to
+ * ~22M rows / ~8GB (91% of the database) and exhaust the 20GB Postgres volume
+ * on 2026-06-10.
+ *
+ * Read-path audit (imladris/service.ts, imladris/company-tracker.ts,
+ * imladris/investor-dashboard-export.ts, investor/board-pack.ts,
+ * ceo/service.ts): lineage is ONLY read via `include: { lineage }` on the
+ * latest reader-visible metric value per (organizationId, userId, metricKey).
+ * There are no reverse lookups by rawRecordId and history trends
+ * (imladris/history.ts) never include lineage. CEO/board reports copy lineage
+ * into CeoMetricSourceLineage at generation time, so pruning does not affect
+ * already-generated reports.
+ *
+ * Policy — delete lineage rows whose metric value is:
+ *   1. older than the retention cutoff (computedAt < now - retentionDays), AND
+ *   2. not the latest reader-visible value of its
+ *      (organizationId, userId, metricKey) group, AND
+ *   3. reader-visible at all (periodEnd <= now); future-period rows are kept.
+ *
+ * The canonical metric value rows themselves are kept — they power history
+ * trends and are small. Only their per-record lineage detail is dropped.
+ *
+ * Operational safety on a multi-GB table (the reason this is raw SQL —
+ * Prisma's deleteMany cannot bound row counts per statement):
+ *   - every DELETE is bounded by an id-subquery LIMIT, so no statement (or
+ *     its row locks) grows with the backlog and there are no long
+ *     transactions or exclusive locks;
+ *   - the pass is time-budgeted per sync cycle and resumes next cycle, so the
+ *     initial multi-million-row backlog drains incrementally;
+ *   - all access rides existing indexes (ImladrisMetricLineage.metricValueId);
+ *     no schema migration is needed.
+ *
+ * Deleted space is made reusable by autovacuum (the table stops growing);
+ * returning disk to the OS needs VACUUM FULL / pg_repack — see
+ * docs/db-growth-controls.md.
+ */
+
+import type { PrismaClientType } from "@/lib/prisma";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_RETENTION_DAYS = 14;
+const DEFAULT_BUDGET_MS = 60_000;
+const DEFAULT_ID_BATCH_SIZE = 200;
+const DEFAULT_ROW_BATCH_SIZE = 10_000;
+
+export interface PruneImladrisMetricLineageInput {
+  prisma: PrismaClientType;
+  /**
+   * Lineage for superseded metric values computed more than this many days
+   * ago is deleted. Defaults to IMLADRIS_LINEAGE_RETENTION_DAYS (env) or 14.
+   * 14 days comfortably covers the monthly board-pack cron, which reads
+   * month-end metric values (and snapshots their lineage) days after the
+   * month closes.
+   */
+  retentionDays?: number;
+  /**
+   * Soft time budget for one pruning pass. Defaults to
+   * IMLADRIS_LINEAGE_PRUNE_BUDGET_MS (env) or 60s. The pass stops at the
+   * budget and resumes on the next sync cycle.
+   */
+  budgetMs?: number;
+  /** Max superseded metric value ids fetched per candidate scan. */
+  idBatchSize?: number;
+  /** Max lineage rows deleted per DELETE statement. */
+  rowBatchSize?: number;
+  /** Test seam: reference time for cutoffs. Defaults to now. */
+  now?: Date;
+  /** Test seam: monotonic clock for the time budget. Defaults to Date.now. */
+  clock?: () => number;
+}
+
+export interface PruneImladrisMetricLineageResult {
+  deletedRows: number;
+  /**
+   * Superseded metric values targeted this pass. Approximate when the budget
+   * interrupts a batch: partially drained values are re-counted next cycle.
+   */
+  prunedMetricValues: number;
+  /** DELETE statements issued. */
+  batches: number;
+  cutoff: string;
+  /**
+   * False when the time budget expired before the backlog fully drained.
+   * The next sync cycle picks up where this one stopped.
+   */
+  completed: boolean;
+  durationMs: number;
+}
+
+function positiveIntFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  const parsed = raw ? Number(raw) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
+  return fallback;
+}
+
+interface MetricValueIdRow {
+  id: string;
+}
+
+export async function pruneImladrisMetricLineage(
+  input: PruneImladrisMetricLineageInput,
+): Promise<PruneImladrisMetricLineageResult> {
+  const retentionDays = Math.max(
+    1,
+    Math.floor(
+      input.retentionDays ??
+        positiveIntFromEnv("IMLADRIS_LINEAGE_RETENTION_DAYS", DEFAULT_RETENTION_DAYS),
+    ),
+  );
+  const budgetMs = Math.max(
+    1,
+    Math.floor(
+      input.budgetMs ?? positiveIntFromEnv("IMLADRIS_LINEAGE_PRUNE_BUDGET_MS", DEFAULT_BUDGET_MS),
+    ),
+  );
+  const idBatchSize = Math.max(1, Math.floor(input.idBatchSize ?? DEFAULT_ID_BATCH_SIZE));
+  const rowBatchSize = Math.max(1, Math.floor(input.rowBatchSize ?? DEFAULT_ROW_BATCH_SIZE));
+  const now = input.now ?? new Date();
+  const clock = input.clock ?? (() => Date.now());
+  const cutoff = new Date(now.getTime() - retentionDays * DAY_MS);
+
+  const startedAt = clock();
+  const deadline = startedAt + budgetMs;
+
+  let deletedRows = 0;
+  let prunedMetricValues = 0;
+  let batches = 0;
+  let completed = false;
+
+  outer: while (clock() < deadline) {
+    // Find superseded, out-of-retention metric values that still carry
+    // lineage. `latest` mirrors reader selection (periodEnd DESC, computedAt
+    // DESC over reader-visible rows), so the value currently displayed for
+    // every (organizationId, userId, metricKey) group always keeps its
+    // lineage — including groups whose materialization stopped long ago.
+    // DISTINCT ON groups NULL organizationId/userId together, matching scope
+    // semantics. The EXISTS probe (ImladrisMetricLineage.metricValueId index)
+    // keeps already-pruned values out of later scans, so the steady state is
+    // a single cheap query per cycle.
+    const candidates = await input.prisma.$queryRaw<MetricValueIdRow[]>`
+      WITH latest AS (
+        SELECT DISTINCT ON ("organizationId", "userId", "metricKey") "id"
+        FROM "ImladrisCanonicalMetricValue"
+        WHERE "periodEnd" <= ${now} AND "computedAt" <= ${now}
+        ORDER BY "organizationId", "userId", "metricKey", "periodEnd" DESC, "computedAt" DESC
+      )
+      SELECT mv."id"
+      FROM "ImladrisCanonicalMetricValue" mv
+      WHERE mv."computedAt" < ${cutoff}
+        AND mv."periodEnd" <= ${now}
+        AND mv."id" NOT IN (SELECT "id" FROM latest)
+        AND EXISTS (
+          SELECT 1 FROM "ImladrisMetricLineage" l WHERE l."metricValueId" = mv."id"
+        )
+      LIMIT ${idBatchSize}
+    `;
+
+    if (candidates.length === 0) {
+      completed = true;
+      break;
+    }
+    prunedMetricValues += candidates.length;
+    const ids = candidates.map((row) => row.id);
+
+    // Drain lineage for this id batch in bounded DELETE statements (each
+    // autocommits) so locks and WAL per statement stay flat regardless of
+    // backlog size.
+    for (;;) {
+      const deleted = await input.prisma.$executeRaw`
+        DELETE FROM "ImladrisMetricLineage"
+        WHERE "id" IN (
+          SELECT "id"
+          FROM "ImladrisMetricLineage"
+          WHERE "metricValueId" = ANY(${ids})
+          LIMIT ${rowBatchSize}
+        )
+      `;
+      batches += 1;
+      deletedRows += deleted;
+      if (deleted < rowBatchSize) break; // this id batch is drained
+      if (clock() >= deadline) break outer;
+    }
+  }
+
+  return {
+    deletedRows,
+    prunedMetricValues,
+    batches,
+    cutoff: cutoff.toISOString(),
+    completed,
+    durationMs: clock() - startedAt,
+  };
+}

--- a/src/lib/imladris/materialization.test.ts
+++ b/src/lib/imladris/materialization.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { IntegrationProvider } from "@/generated/prisma/client";
 import {
+  capLineageRecordsPerSource,
   materializeImladrisCustomerSuccessMetrics,
   materializeImladrisDevelopmentMetrics,
   materializeImladrisFinanceMetrics,
@@ -24531,5 +24532,179 @@ describe("Imladris canonical materialization", () => {
       atRiskAccounts: 1,
       accountsWithBillingRisk: 1,
     });
+  });
+});
+
+describe("lineage growth controls", () => {
+  const AS_OF = new Date("2026-05-29T12:00:00.000Z");
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function lineageRecord(input: {
+    id: string;
+    provider: IntegrationProvider;
+    occurredAt: string | null;
+  }): RawSourceRecordFixture {
+    return {
+      id: input.id,
+      provider: input.provider,
+      objectType: "issue",
+      externalId: input.id,
+      occurredAt: input.occurredAt ? new Date(input.occurredAt) : null,
+      sourceCreatedAt: null,
+      sourceUpdatedAt: null,
+      payload: {},
+    };
+  }
+
+  function cap(records: RawSourceRecordFixture[], maxPerSource: number) {
+    return capLineageRecordsPerSource(
+      records as unknown as Parameters<typeof capLineageRecordsPerSource>[0],
+      AS_OF,
+      maxPerSource,
+    ) as unknown as RawSourceRecordFixture[];
+  }
+
+  describe("capLineageRecordsPerSource", () => {
+    it("returns the original records when every source is within the cap", () => {
+      const records = [
+        lineageRecord({ id: "linear_a", provider: IntegrationProvider.LINEAR, occurredAt: "2026-05-10T00:00:00.000Z" }),
+        lineageRecord({ id: "linear_b", provider: IntegrationProvider.LINEAR, occurredAt: "2026-05-11T00:00:00.000Z" }),
+        lineageRecord({ id: "github_a", provider: IntegrationProvider.GITHUB, occurredAt: "2026-05-12T00:00:00.000Z" }),
+      ];
+
+      // Per-source groups are all within the cap even though the total exceeds it.
+      expect(cap(records, 2)).toBe(records);
+      // Fast path: total under the cap.
+      expect(cap(records, 5)).toBe(records);
+    });
+
+    it("caps each overflowing source to its most recently captured records, preserving order", () => {
+      const records = [
+        lineageRecord({ id: "linear_old", provider: IntegrationProvider.LINEAR, occurredAt: "2026-05-01T00:00:00.000Z" }),
+        lineageRecord({ id: "linear_new", provider: IntegrationProvider.LINEAR, occurredAt: "2026-05-20T00:00:00.000Z" }),
+        lineageRecord({ id: "linear_mid", provider: IntegrationProvider.LINEAR, occurredAt: "2026-05-10T00:00:00.000Z" }),
+        lineageRecord({ id: "github_a", provider: IntegrationProvider.GITHUB, occurredAt: "2026-05-05T00:00:00.000Z" }),
+      ];
+
+      const result = cap(records, 2);
+
+      expect(result.map((record) => record.id)).toEqual([
+        "linear_new",
+        "linear_mid",
+        "github_a",
+      ]);
+    });
+
+    it("keeps every source represented under an aggressive cap — provenance coverage is never lost", () => {
+      const records = [
+        lineageRecord({ id: "linear_1", provider: IntegrationProvider.LINEAR, occurredAt: "2026-05-01T00:00:00.000Z" }),
+        lineageRecord({ id: "linear_2", provider: IntegrationProvider.LINEAR, occurredAt: "2026-05-02T00:00:00.000Z" }),
+        lineageRecord({ id: "linear_3", provider: IntegrationProvider.LINEAR, occurredAt: "2026-05-03T00:00:00.000Z" }),
+        lineageRecord({ id: "github_1", provider: IntegrationProvider.GITHUB, occurredAt: "2026-05-04T00:00:00.000Z" }),
+        lineageRecord({ id: "github_2", provider: IntegrationProvider.GITHUB, occurredAt: "2026-05-05T00:00:00.000Z" }),
+        lineageRecord({ id: "posthog_1", provider: IntegrationProvider.POSTHOG, occurredAt: "2026-05-06T00:00:00.000Z" }),
+      ];
+
+      const result = cap(records, 1);
+
+      expect(result.map((record) => record.id)).toEqual([
+        "linear_3",
+        "github_2",
+        "posthog_1",
+      ]);
+      expect(new Set(result.map((record) => record.provider)).size).toBe(3);
+    });
+
+    it("drops undated and future-dated records before dated ones and tie-breaks by id", () => {
+      const records = [
+        lineageRecord({ id: "linear_undated", provider: IntegrationProvider.LINEAR, occurredAt: null }),
+        lineageRecord({ id: "linear_future", provider: IntegrationProvider.LINEAR, occurredAt: "2026-07-01T00:00:00.000Z" }),
+        lineageRecord({ id: "linear_tie_b", provider: IntegrationProvider.LINEAR, occurredAt: "2026-05-15T00:00:00.000Z" }),
+        lineageRecord({ id: "linear_tie_a", provider: IntegrationProvider.LINEAR, occurredAt: "2026-05-15T00:00:00.000Z" }),
+      ];
+
+      const result = cap(records, 2);
+
+      // Both tied records beat the undated and future-dated ones (future
+      // occurredAt is not observable as of AS_OF); original order preserved.
+      expect(result.map((record) => record.id)).toEqual(["linear_tie_b", "linear_tie_a"]);
+
+      // Deterministic id tie-break when only one slot remains.
+      expect(cap(records, 1).map((record) => record.id)).toEqual(["linear_tie_a"]);
+    });
+  });
+
+  it("applies IMLADRIS_LINEAGE_MAX_ROWS_PER_SOURCE when persisting lineage", async () => {
+    vi.stubEnv("IMLADRIS_LINEAGE_MAX_ROWS_PER_SOURCE", "1");
+    const prisma = createPrismaMock();
+    prisma.imladrisRawSourceRecord.findMany.mockResolvedValueOnce([
+      {
+        id: "raw_linear_1",
+        provider: IntegrationProvider.LINEAR,
+        objectType: "issue",
+        externalId: "LIN-1",
+        occurredAt: new Date("2026-05-15T10:00:00.000Z"),
+        sourceCreatedAt: new Date("2026-05-10T10:00:00.000Z"),
+        sourceUpdatedAt: new Date("2026-05-15T10:00:00.000Z"),
+        payload: {
+          id: "LIN-1",
+          state: { type: "completed" },
+          createdAt: "2026-05-10T10:00:00.000Z",
+          completedAt: "2026-05-15T10:00:00.000Z",
+        },
+      },
+      {
+        id: "raw_linear_2",
+        provider: IntegrationProvider.LINEAR,
+        objectType: "issue",
+        externalId: "LIN-2",
+        occurredAt: new Date("2026-05-20T10:00:00.000Z"),
+        sourceCreatedAt: new Date("2026-05-16T10:00:00.000Z"),
+        sourceUpdatedAt: new Date("2026-05-20T10:00:00.000Z"),
+        payload: {
+          id: "LIN-2",
+          state: { type: "completed" },
+          createdAt: "2026-05-16T10:00:00.000Z",
+          completedAt: "2026-05-20T10:00:00.000Z",
+        },
+      },
+      {
+        id: "raw_github_1",
+        provider: IntegrationProvider.GITHUB,
+        objectType: "pull_request",
+        externalId: "repo/pull/7",
+        occurredAt: new Date("2026-05-18T10:00:00.000Z"),
+        sourceCreatedAt: new Date("2026-05-16T10:00:00.000Z"),
+        sourceUpdatedAt: new Date("2026-05-18T10:00:00.000Z"),
+        payload: {
+          number: 7,
+          merged: true,
+          created_at: "2026-05-16T10:00:00.000Z",
+          merged_at: "2026-05-18T10:00:00.000Z",
+        },
+      },
+    ]);
+
+    await materializeImladrisDevelopmentMetrics({
+      prisma: prisma as never,
+      context: CONTEXT,
+      periodStart: new Date("2026-05-01T00:00:00.000Z"),
+      periodEnd: new Date("2026-05-29T00:00:00.000Z"),
+      now: new Date("2026-05-29T12:00:00.000Z"),
+    });
+
+    expect(prisma.imladrisMetricLineage.createMany).toHaveBeenCalledTimes(1);
+    const createManyArgs = prisma.imladrisMetricLineage.createMany.mock.calls[0][0] as {
+      data: Array<{ rawRecordId: string }>;
+    };
+    const rawRecordIds = createManyArgs.data.map((row) => row.rawRecordId);
+    // Linear is capped to its single most recent record; GitHub stays — the
+    // cap is per source, so no contributing source disappears from provenance.
+    expect(rawRecordIds).toContain("raw_linear_2");
+    expect(rawRecordIds).toContain("raw_github_1");
+    expect(rawRecordIds).not.toContain("raw_linear_1");
   });
 });

--- a/src/lib/imladris/materialization.ts
+++ b/src/lib/imladris/materialization.ts
@@ -1308,19 +1308,101 @@ function dedupeRawSourceRecords(
   );
 }
 
+const DEFAULT_LINEAGE_MAX_ROWS_PER_SOURCE = 1_000;
+
+function lineageMaxRowsPerSourceFromEnv(): number {
+  const raw = process.env.IMLADRIS_LINEAGE_MAX_ROWS_PER_SOURCE?.trim();
+  const parsed = raw ? Number(raw) : NaN;
+  if (Number.isFinite(parsed) && parsed >= 1) return Math.floor(parsed);
+  return DEFAULT_LINEAGE_MAX_ROWS_PER_SOURCE;
+}
+
+function lineageRecencyTimestamp(record: RawSourceRecordRow, asOf: Date): number {
+  return (
+    firstDateAtOrBefore(
+      asOf,
+      record.occurredAt,
+      record.sourceUpdatedAt,
+      record.sourceCreatedAt,
+    )?.getTime() ?? Number.NEGATIVE_INFINITY
+  );
+}
+
+/**
+ * Bound per-metric-value lineage detail WITHOUT losing source coverage.
+ *
+ * Growth control from the 2026-06-10 disk-full outage: lineage volume is one
+ * row per contributing raw record per metric value, so a single provider
+ * backfill (e.g. a PostHog event flood) can mint enormous lineage sets on
+ * every 10-minute materialization. The cap applies PER sourceKey rather than
+ * globally so every contributing source stays represented in provenance —
+ * the feature's purpose — keeping each source's most recently captured
+ * records (deterministic record-id tie-break). Original record ordering is
+ * preserved so persisted lineage display order is unchanged.
+ *
+ * Bulk aging-out of superseded metric values' lineage lives in
+ * src/lib/imladris/lineage-retention.ts; this cap only bounds pathological
+ * per-cycle volume.
+ */
+export function capLineageRecordsPerSource(
+  records: RawSourceRecordRow[],
+  asOf: Date,
+  maxPerSource: number,
+): RawSourceRecordRow[] {
+  if (!Number.isFinite(maxPerSource) || maxPerSource < 1 || records.length <= maxPerSource) {
+    return records;
+  }
+  const bySource = new Map<string, RawSourceRecordRow[]>();
+  for (const record of records) {
+    const key = sourceKeyForProvider(record.provider);
+    const group = bySource.get(key);
+    if (group) {
+      group.push(record);
+    } else {
+      bySource.set(key, [record]);
+    }
+  }
+  let truncated = false;
+  const keptIds = new Set<string>();
+  for (const group of bySource.values()) {
+    if (group.length <= maxPerSource) {
+      for (const record of group) keptIds.add(record.id);
+      continue;
+    }
+    truncated = true;
+    const ranked = [...group].sort(
+      (left, right) =>
+        lineageRecencyTimestamp(right, asOf) - lineageRecencyTimestamp(left, asOf) ||
+        left.id.localeCompare(right.id),
+    );
+    for (const record of ranked.slice(0, maxPerSource)) keptIds.add(record.id);
+  }
+  if (!truncated) return records;
+  return records.filter((record) => keptIds.has(record.id));
+}
+
 async function replaceLineage(input: {
   metricLineage: MetricLineageDelegate;
   metricValueId: string;
   records: RawSourceRecordRow[];
   calculationVersion: string;
   asOf: Date;
+  maxRowsPerSource?: number;
 }) {
+  // Growth control: bound per-source lineage detail before persisting (see
+  // capLineageRecordsPerSource). IMLADRIS_LINEAGE_MAX_ROWS_PER_SOURCE
+  // overrides the default cap of 1,000 rows per source per metric value.
+  const records = capLineageRecordsPerSource(
+    input.records,
+    input.asOf,
+    input.maxRowsPerSource ?? lineageMaxRowsPerSourceFromEnv(),
+  );
   await input.metricLineage.deleteMany({
     where: { metricValueId: input.metricValueId },
   });
-  if (input.records.length === 0) return;
+  if (records.length === 0) return;
   await input.metricLineage.createMany({
-    data: input.records.map((record) => ({
+    data: records.map((record) => ({
       metricValueId: input.metricValueId,
       rawRecordId: record.id,
       sourceKey: sourceKeyForProvider(record.provider),

--- a/src/lib/imladris/metric-value-retention.test.ts
+++ b/src/lib/imladris/metric-value-retention.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { pruneImladrisMetricValues } from "@/lib/imladris/metric-value-retention";
+
+const NOW = new Date("2026-06-10T12:00:00.000Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * prisma.$executeRaw`...` invokes the mock as a tagged template:
+ * (strings, ...boundValues).
+ */
+type SqlCall = [TemplateStringsArray, ...unknown[]];
+
+function sqlTextOf(call: SqlCall): string {
+  return call[0].join(" ¶ ");
+}
+
+function boundValuesOf(call: SqlCall): unknown[] {
+  return call.slice(1);
+}
+
+function createPrismaMock(deleteCounts: number[]) {
+  const counts = [...deleteCounts];
+  return {
+    $executeRaw: vi.fn(async () => counts.shift() ?? 0),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("pruneImladrisMetricValues", () => {
+  it("completes immediately when nothing is left to thin", async () => {
+    const prisma = createPrismaMock([0]);
+
+    const result = await pruneImladrisMetricValues({
+      prisma: prisma as never,
+      now: NOW,
+    });
+
+    expect(result).toEqual({
+      deletedRows: 0,
+      batches: 1,
+      cutoff: new Date(NOW.getTime() - 14 * DAY_MS).toISOString(),
+      completed: true,
+      durationMs: expect.any(Number),
+    });
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("only thins old, reader-visible, non-keeper, lineage-free rows", async () => {
+    const prisma = createPrismaMock([0]);
+
+    await pruneImladrisMetricValues({ prisma: prisma as never, now: NOW });
+
+    const call = prisma.$executeRaw.mock.calls[0] as unknown as SqlCall;
+    const sql = sqlTextOf(call);
+    expect(sql).toContain('DELETE FROM "ImladrisCanonicalMetricValue"');
+    // One keeper per scope group per UTC day survives (the day's last value).
+    expect(sql).toContain(
+      `"organizationId", "userId", "metricKey", date_trunc('day', "periodEnd")`,
+    );
+    expect(sql).toContain('"periodEnd" DESC, "computedAt" DESC');
+    // Rows still carrying lineage are untouchable: keeps the overall-latest
+    // value safe, defers to the lineage pruner, and guarantees the cascade
+    // from ImladrisCanonicalMetricValue → ImladrisMetricLineage never fires.
+    expect(sql).toContain("NOT EXISTS");
+    expect(sql).toContain(
+      'FROM "ImladrisMetricLineage" l WHERE l."metricValueId" = mv."id"',
+    );
+    expect(sql).toContain("LIMIT");
+    // Bound values, in order: intraday cutoff, candidate visibility guard
+    // (periodEnd <= now), keeper visibility guards (periodEnd/computedAt <=
+    // now), batch size.
+    expect(boundValuesOf(call)).toEqual([
+      new Date(NOW.getTime() - 14 * DAY_MS),
+      NOW,
+      NOW,
+      NOW,
+      10_000,
+    ]);
+  });
+
+  it("loops in bounded batches until the backlog drains", async () => {
+    const prisma = createPrismaMock([2, 2, 1]);
+
+    const result = await pruneImladrisMetricValues({
+      prisma: prisma as never,
+      now: NOW,
+      batchSize: 2,
+    });
+
+    expect(result.deletedRows).toBe(5);
+    expect(result.batches).toBe(3);
+    expect(result.completed).toBe(true);
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops at the time budget and reports an incomplete pass", async () => {
+    const ticks = [0, 10, 200, 250];
+    const clock = vi.fn(() => (ticks.length > 1 ? (ticks.shift() as number) : ticks[0]));
+    // A full batch means more rows remain when the budget expires.
+    const prisma = createPrismaMock([2]);
+
+    const result = await pruneImladrisMetricValues({
+      prisma: prisma as never,
+      now: NOW,
+      batchSize: 2,
+      budgetMs: 100,
+      clock,
+    });
+
+    expect(result.completed).toBe(false);
+    expect(result.deletedRows).toBe(2);
+    expect(result.batches).toBe(1);
+    expect(result.durationMs).toBe(250);
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors an explicit retentionDays override", async () => {
+    const prisma = createPrismaMock([0]);
+
+    const result = await pruneImladrisMetricValues({
+      prisma: prisma as never,
+      now: NOW,
+      retentionDays: 30,
+    });
+
+    expect(result.cutoff).toBe(new Date(NOW.getTime() - 30 * DAY_MS).toISOString());
+  });
+
+  it("reads IMLADRIS_METRIC_VALUE_INTRADAY_RETENTION_DAYS when no override is provided", async () => {
+    vi.stubEnv("IMLADRIS_METRIC_VALUE_INTRADAY_RETENTION_DAYS", "7");
+    const prisma = createPrismaMock([0]);
+
+    const result = await pruneImladrisMetricValues({
+      prisma: prisma as never,
+      now: NOW,
+    });
+
+    expect(result.cutoff).toBe(new Date(NOW.getTime() - 7 * DAY_MS).toISOString());
+    const call = prisma.$executeRaw.mock.calls[0] as unknown as SqlCall;
+    expect(boundValuesOf(call)).toContainEqual(new Date(NOW.getTime() - 7 * DAY_MS));
+  });
+});

--- a/src/lib/imladris/metric-value-retention.ts
+++ b/src/lib/imladris/metric-value-retention.ts
@@ -1,0 +1,165 @@
+/**
+ * Imladris canonical metric value thinning.
+ *
+ * Companion to src/lib/imladris/lineage-retention.ts (see
+ * docs/db-growth-controls.md). The sync cycle materializes metric values with
+ * `periodEnd = now`, so ImladrisCanonicalMetricValue gains one row per metric
+ * per user every ~10 minutes (~144/day/metric) forever. Rows are narrow —
+ * this is far slower growth than the lineage table behind the 2026-06-10
+ * outage — but it is still unbounded and makes history scans heavier.
+ *
+ * Read-path facts that make daily thinning safe:
+ *   - imladris/history.ts buckets MONTHLY (one best row per metricKey per
+ *     month), so daily keepers exceed history's granularity needs.
+ *   - Dashboards/exports read the latest reader-visible row per
+ *     (organizationId, userId, metricKey); backdated exports pick the latest
+ *     row with periodEnd <= toDate, which after thinning is that day's
+ *     end-of-day value.
+ *
+ * Policy — delete rows that are ALL of:
+ *   1. older than the intraday window (computedAt < now - retentionDays);
+ *   2. reader-visible (periodEnd <= now) — future-period rows are kept;
+ *   3. not their (organizationId, userId, metricKey, UTC day of periodEnd)
+ *      group's keeper — the keeper is the day's last (periodEnd, computedAt),
+ *      i.e. the end-of-day value. NULL org/user group together, so every
+ *      scope variant keeps its own daily row;
+ *   4. carrying NO lineage rows (NOT EXISTS).
+ *
+ * Guard 4 is load-bearing twice over:
+ *   - ImladrisMetricLineage has `onDelete: Cascade` from metric values, so
+ *     deleting only lineage-free rows means DELETE statements never cascade
+ *     and stay exactly LIMIT-bounded (no lock/WAL amplification);
+ *   - it sequences this pruner strictly AFTER the lineage pruner: the overall
+ *     latest value per group and everything inside the lineage retention
+ *     window still carry lineage and are untouchable here. If lineage pruning
+ *     is broken or backlogged, thinning fail-safes to a no-op for those rows
+ *     instead of deleting rows whose provenance is still live.
+ */
+
+import type { PrismaClientType } from "@/lib/prisma";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_INTRADAY_RETENTION_DAYS = 14;
+const DEFAULT_BUDGET_MS = 15_000;
+const DEFAULT_BATCH_SIZE = 10_000;
+
+export interface PruneImladrisMetricValuesInput {
+  prisma: PrismaClientType;
+  /**
+   * Full intraday detail is kept for this many days; older values are thinned
+   * to one row per metric per UTC day. Defaults to
+   * IMLADRIS_METRIC_VALUE_INTRADAY_RETENTION_DAYS (env) or 14 — matching the
+   * lineage retention window, since rows inside that window still carry
+   * lineage and are skipped here anyway.
+   */
+  retentionDays?: number;
+  /**
+   * Soft time budget for one thinning pass. Defaults to
+   * IMLADRIS_METRIC_VALUE_PRUNE_BUDGET_MS (env) or 15s.
+   */
+  budgetMs?: number;
+  /** Max metric value rows deleted per DELETE statement. */
+  batchSize?: number;
+  /** Test seam: reference time for cutoffs. Defaults to now. */
+  now?: Date;
+  /** Test seam: monotonic clock for the time budget. Defaults to Date.now. */
+  clock?: () => number;
+}
+
+export interface PruneImladrisMetricValuesResult {
+  deletedRows: number;
+  /** DELETE statements issued. */
+  batches: number;
+  cutoff: string;
+  /**
+   * False when the time budget expired before the backlog fully drained.
+   * The next sync cycle picks up where this one stopped.
+   */
+  completed: boolean;
+  durationMs: number;
+}
+
+function positiveIntFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  const parsed = raw ? Number(raw) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
+  return fallback;
+}
+
+export async function pruneImladrisMetricValues(
+  input: PruneImladrisMetricValuesInput,
+): Promise<PruneImladrisMetricValuesResult> {
+  const retentionDays = Math.max(
+    1,
+    Math.floor(
+      input.retentionDays ??
+        positiveIntFromEnv(
+          "IMLADRIS_METRIC_VALUE_INTRADAY_RETENTION_DAYS",
+          DEFAULT_INTRADAY_RETENTION_DAYS,
+        ),
+    ),
+  );
+  const budgetMs = Math.max(
+    1,
+    Math.floor(
+      input.budgetMs ??
+        positiveIntFromEnv("IMLADRIS_METRIC_VALUE_PRUNE_BUDGET_MS", DEFAULT_BUDGET_MS),
+    ),
+  );
+  const batchSize = Math.max(1, Math.floor(input.batchSize ?? DEFAULT_BATCH_SIZE));
+  const now = input.now ?? new Date();
+  const clock = input.clock ?? (() => Date.now());
+  const cutoff = new Date(now.getTime() - retentionDays * DAY_MS);
+
+  const startedAt = clock();
+  const deadline = startedAt + budgetMs;
+
+  let deletedRows = 0;
+  let batches = 0;
+  let completed = false;
+
+  // The keeper subquery mirrors reader ordering (periodEnd DESC, computedAt
+  // DESC over reader-visible rows) per UTC day; DISTINCT ON groups NULL
+  // organizationId/userId together. Each DELETE is a single bounded
+  // autocommitted statement; the NOT EXISTS probe rides the
+  // ImladrisMetricLineage.metricValueId index.
+  while (clock() < deadline) {
+    const deleted = await input.prisma.$executeRaw`
+      DELETE FROM "ImladrisCanonicalMetricValue"
+      WHERE "id" IN (
+        SELECT mv."id"
+        FROM "ImladrisCanonicalMetricValue" mv
+        WHERE mv."computedAt" < ${cutoff}
+          AND mv."periodEnd" <= ${now}
+          AND mv."id" NOT IN (
+            SELECT DISTINCT ON (
+              "organizationId", "userId", "metricKey", date_trunc('day', "periodEnd")
+            ) "id"
+            FROM "ImladrisCanonicalMetricValue"
+            WHERE "periodEnd" <= ${now} AND "computedAt" <= ${now}
+            ORDER BY
+              "organizationId", "userId", "metricKey", date_trunc('day', "periodEnd"),
+              "periodEnd" DESC, "computedAt" DESC
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM "ImladrisMetricLineage" l WHERE l."metricValueId" = mv."id"
+          )
+        LIMIT ${batchSize}
+      )
+    `;
+    batches += 1;
+    deletedRows += deleted;
+    if (deleted < batchSize) {
+      completed = true;
+      break;
+    }
+  }
+
+  return {
+    deletedRows,
+    batches,
+    cutoff: cutoff.toISOString(),
+    completed,
+    durationMs: clock() - startedAt,
+  };
+}

--- a/src/lib/sync/__tests__/orchestrator.test.ts
+++ b/src/lib/sync/__tests__/orchestrator.test.ts
@@ -554,6 +554,42 @@ describe('sync orchestrator', () => {
     expect(results[0].error).toContain('imladris: 1 canonical materialization failure');
   });
 
+  it('marks analytics module failed when growth-control pruning fails', async () => {
+    vi.mocked(runAnalyticsSync).mockResolvedValueOnce({
+      refresh: {
+        usersProcessed: 1,
+        refreshCount: 4,
+        failureCount: 0,
+        completedAt: '2026-06-10T12:00:00.000Z',
+      },
+      pruning: { deleted: 0 },
+      imladris: [],
+      lineagePruning: { error: 'lineage prune exploded' },
+      outboxPruning: { error: 'outbox prune exploded' },
+    } as never);
+
+    const results = await runSync(mockPrisma, {
+      hubspot: false,
+      slack: false,
+      coda: false,
+      google: false,
+      providerRules: false,
+      visitorFunnelEnrichment: false,
+      analytics: true,
+      automations: false,
+      healthChecks: false,
+    });
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        module: 'analytics',
+        success: false,
+        error:
+          'lineage_pruning: lineage prune exploded; outbox_pruning: outbox prune exploded',
+      }),
+    ]);
+  });
+
   it('marks provider-rules module failed when user-level rule runs fail', async () => {
     vi.mocked(runRules).mockResolvedValueOnce({
       executedRules: 2,

--- a/src/lib/sync/__tests__/orchestrator.test.ts
+++ b/src/lib/sync/__tests__/orchestrator.test.ts
@@ -565,6 +565,7 @@ describe('sync orchestrator', () => {
       pruning: { deleted: 0 },
       imladris: [],
       lineagePruning: { error: 'lineage prune exploded' },
+      metricValuePruning: { error: 'metric value prune exploded' },
       outboxPruning: { error: 'outbox prune exploded' },
     } as never);
 
@@ -585,7 +586,7 @@ describe('sync orchestrator', () => {
         module: 'analytics',
         success: false,
         error:
-          'lineage_pruning: lineage prune exploded; outbox_pruning: outbox prune exploded',
+          'lineage_pruning: lineage prune exploded; metric_value_pruning: metric value prune exploded; outbox_pruning: outbox prune exploded',
       }),
     ]);
   });

--- a/src/lib/sync/analytics.test.ts
+++ b/src/lib/sync/analytics.test.ts
@@ -3,6 +3,7 @@ import { runAnalyticsRefresh } from "@/lib/analytics/refresh-runner";
 import { pruneAnalyticsSnapshots } from "@/lib/analytics/snapshots";
 import { pruneOutboxEvents } from "@/lib/events/outbox-retention";
 import { pruneImladrisMetricLineage } from "@/lib/imladris/lineage-retention";
+import { pruneImladrisMetricValues } from "@/lib/imladris/metric-value-retention";
 import { materializeImladrisCanonicalMetrics } from "@/lib/imladris/materialization";
 import { runAnalyticsSync } from "@/lib/sync/analytics";
 import { discoverConnectedUserIds } from "@/lib/sync/users";
@@ -21,6 +22,10 @@ vi.mock("@/lib/events/outbox-retention", () => ({
 
 vi.mock("@/lib/imladris/lineage-retention", () => ({
   pruneImladrisMetricLineage: vi.fn(),
+}));
+
+vi.mock("@/lib/imladris/metric-value-retention", () => ({
+  pruneImladrisMetricValues: vi.fn(),
 }));
 
 vi.mock("@/lib/imladris/materialization", () => ({
@@ -55,6 +60,13 @@ describe("runAnalyticsSync", () => {
     vi.mocked(pruneImladrisMetricLineage).mockResolvedValue({
       deletedRows: 0,
       prunedMetricValues: 0,
+      batches: 0,
+      cutoff: "2026-05-18T12:00:00.000Z",
+      completed: true,
+      durationMs: 1,
+    } as never);
+    vi.mocked(pruneImladrisMetricValues).mockResolvedValue({
+      deletedRows: 0,
       batches: 0,
       cutoff: "2026-05-18T12:00:00.000Z",
       completed: true,
@@ -370,6 +382,13 @@ describe("runAnalyticsSync", () => {
       completed: true,
       durationMs: 5,
     };
+    const metricValueResult = {
+      deletedRows: 30,
+      batches: 1,
+      cutoff: "2026-05-18T12:00:00.000Z",
+      completed: true,
+      durationMs: 2,
+    };
     const outboxResult = {
       deletedDispatched: 7,
       deletedDeadLetter: 1,
@@ -380,6 +399,7 @@ describe("runAnalyticsSync", () => {
       durationMs: 3,
     };
     vi.mocked(pruneImladrisMetricLineage).mockResolvedValueOnce(lineageResult as never);
+    vi.mocked(pruneImladrisMetricValues).mockResolvedValueOnce(metricValueResult as never);
     vi.mocked(pruneOutboxEvents).mockResolvedValueOnce(outboxResult as never);
 
     const result = await runAnalyticsSync({
@@ -387,8 +407,13 @@ describe("runAnalyticsSync", () => {
     });
 
     expect(result.lineagePruning).toEqual(lineageResult);
+    expect(result.metricValuePruning).toEqual(metricValueResult);
     expect(result.outboxPruning).toEqual(outboxResult);
     expect(pruneImladrisMetricLineage).toHaveBeenCalledWith({
+      prisma,
+      now: new Date("2026-06-01T12:00:00.000Z"),
+    });
+    expect(pruneImladrisMetricValues).toHaveBeenCalledWith({
       prisma,
       now: new Date("2026-06-01T12:00:00.000Z"),
     });
@@ -398,13 +423,16 @@ describe("runAnalyticsSync", () => {
     });
 
     // Pruning must run after materialization so it never contends with the
-    // cycle's own lineage writes.
+    // cycle's own lineage writes, and metric value thinning must run after
+    // lineage pruning (it only deletes lineage-free rows).
     const lastMaterializeOrder = vi
       .mocked(materializeImladrisCanonicalMetrics)
       .mock.invocationCallOrder.at(-1);
     const lineageOrder = vi.mocked(pruneImladrisMetricLineage).mock.invocationCallOrder[0];
+    const metricValueOrder = vi.mocked(pruneImladrisMetricValues).mock.invocationCallOrder[0];
     expect(lastMaterializeOrder).toBeDefined();
     expect(lineageOrder).toBeGreaterThan(lastMaterializeOrder as number);
+    expect(metricValueOrder).toBeGreaterThan(lineageOrder);
   });
 
   it("captures growth-control pruning failures without failing the sync", async () => {
@@ -413,6 +441,9 @@ describe("runAnalyticsSync", () => {
     vi.mocked(pruneImladrisMetricLineage).mockRejectedValueOnce(
       new Error("lineage prune exploded"),
     );
+    vi.mocked(pruneImladrisMetricValues).mockRejectedValueOnce(
+      new Error("metric value prune exploded"),
+    );
     vi.mocked(pruneOutboxEvents).mockRejectedValueOnce(new Error("outbox prune exploded"));
 
     const result = await runAnalyticsSync({
@@ -420,12 +451,16 @@ describe("runAnalyticsSync", () => {
     });
 
     expect(result.lineagePruning).toEqual({ error: "lineage prune exploded" });
+    expect(result.metricValuePruning).toEqual({ error: "metric value prune exploded" });
     expect(result.outboxPruning).toEqual({ error: "outbox prune exploded" });
     // The sync itself still succeeds end-to-end.
     expect(result.refresh).toEqual({ refreshed: true });
     expect(result.imladris).toHaveLength(2);
     expect(consoleError).toHaveBeenCalledWith("analytics_sync.lineage_pruning_failed", {
       error: "lineage prune exploded",
+    });
+    expect(consoleError).toHaveBeenCalledWith("analytics_sync.metric_value_pruning_failed", {
+      error: "metric value prune exploded",
     });
     expect(consoleError).toHaveBeenCalledWith("analytics_sync.outbox_pruning_failed", {
       error: "outbox prune exploded",

--- a/src/lib/sync/analytics.test.ts
+++ b/src/lib/sync/analytics.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runAnalyticsRefresh } from "@/lib/analytics/refresh-runner";
 import { pruneAnalyticsSnapshots } from "@/lib/analytics/snapshots";
+import { pruneOutboxEvents } from "@/lib/events/outbox-retention";
+import { pruneImladrisMetricLineage } from "@/lib/imladris/lineage-retention";
 import { materializeImladrisCanonicalMetrics } from "@/lib/imladris/materialization";
 import { runAnalyticsSync } from "@/lib/sync/analytics";
 import { discoverConnectedUserIds } from "@/lib/sync/users";
@@ -11,6 +13,14 @@ vi.mock("@/lib/analytics/refresh-runner", () => ({
 
 vi.mock("@/lib/analytics/snapshots", () => ({
   pruneAnalyticsSnapshots: vi.fn(),
+}));
+
+vi.mock("@/lib/events/outbox-retention", () => ({
+  pruneOutboxEvents: vi.fn(),
+}));
+
+vi.mock("@/lib/imladris/lineage-retention", () => ({
+  pruneImladrisMetricLineage: vi.fn(),
 }));
 
 vi.mock("@/lib/imladris/materialization", () => ({
@@ -42,6 +52,23 @@ describe("runAnalyticsSync", () => {
     vi.clearAllMocks();
     vi.mocked(runAnalyticsRefresh).mockResolvedValue({ refreshed: true } as never);
     vi.mocked(pruneAnalyticsSnapshots).mockResolvedValue({ deleted: 0 } as never);
+    vi.mocked(pruneImladrisMetricLineage).mockResolvedValue({
+      deletedRows: 0,
+      prunedMetricValues: 0,
+      batches: 0,
+      cutoff: "2026-05-18T12:00:00.000Z",
+      completed: true,
+      durationMs: 1,
+    } as never);
+    vi.mocked(pruneOutboxEvents).mockResolvedValue({
+      deletedDispatched: 0,
+      deletedDeadLetter: 0,
+      batches: 0,
+      dispatchedCutoff: "2026-05-18T12:00:00.000Z",
+      deadLetterCutoff: "2026-05-02T12:00:00.000Z",
+      completed: true,
+      durationMs: 1,
+    } as never);
     vi.mocked(materializeImladrisCanonicalMetrics).mockResolvedValue([
       {
         metricKey: "development.delivery_health",
@@ -330,6 +357,79 @@ describe("runAnalyticsSync", () => {
         error: "canonical write failed",
       }),
     );
+    consoleError.mockRestore();
+  });
+
+  it("runs growth-control pruning after materialization and surfaces the results", async () => {
+    const prisma = createPrismaMock();
+    const lineageResult = {
+      deletedRows: 12,
+      prunedMetricValues: 3,
+      batches: 2,
+      cutoff: "2026-05-18T12:00:00.000Z",
+      completed: true,
+      durationMs: 5,
+    };
+    const outboxResult = {
+      deletedDispatched: 7,
+      deletedDeadLetter: 1,
+      batches: 2,
+      dispatchedCutoff: "2026-05-18T12:00:00.000Z",
+      deadLetterCutoff: "2026-05-02T12:00:00.000Z",
+      completed: false,
+      durationMs: 3,
+    };
+    vi.mocked(pruneImladrisMetricLineage).mockResolvedValueOnce(lineageResult as never);
+    vi.mocked(pruneOutboxEvents).mockResolvedValueOnce(outboxResult as never);
+
+    const result = await runAnalyticsSync({
+      prisma: prisma as never,
+    });
+
+    expect(result.lineagePruning).toEqual(lineageResult);
+    expect(result.outboxPruning).toEqual(outboxResult);
+    expect(pruneImladrisMetricLineage).toHaveBeenCalledWith({
+      prisma,
+      now: new Date("2026-06-01T12:00:00.000Z"),
+    });
+    expect(pruneOutboxEvents).toHaveBeenCalledWith({
+      prisma,
+      now: new Date("2026-06-01T12:00:00.000Z"),
+    });
+
+    // Pruning must run after materialization so it never contends with the
+    // cycle's own lineage writes.
+    const lastMaterializeOrder = vi
+      .mocked(materializeImladrisCanonicalMetrics)
+      .mock.invocationCallOrder.at(-1);
+    const lineageOrder = vi.mocked(pruneImladrisMetricLineage).mock.invocationCallOrder[0];
+    expect(lastMaterializeOrder).toBeDefined();
+    expect(lineageOrder).toBeGreaterThan(lastMaterializeOrder as number);
+  });
+
+  it("captures growth-control pruning failures without failing the sync", async () => {
+    const prisma = createPrismaMock();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(pruneImladrisMetricLineage).mockRejectedValueOnce(
+      new Error("lineage prune exploded"),
+    );
+    vi.mocked(pruneOutboxEvents).mockRejectedValueOnce(new Error("outbox prune exploded"));
+
+    const result = await runAnalyticsSync({
+      prisma: prisma as never,
+    });
+
+    expect(result.lineagePruning).toEqual({ error: "lineage prune exploded" });
+    expect(result.outboxPruning).toEqual({ error: "outbox prune exploded" });
+    // The sync itself still succeeds end-to-end.
+    expect(result.refresh).toEqual({ refreshed: true });
+    expect(result.imladris).toHaveLength(2);
+    expect(consoleError).toHaveBeenCalledWith("analytics_sync.lineage_pruning_failed", {
+      error: "lineage prune exploded",
+    });
+    expect(consoleError).toHaveBeenCalledWith("analytics_sync.outbox_pruning_failed", {
+      error: "outbox prune exploded",
+    });
     consoleError.mockRestore();
   });
 });

--- a/src/lib/sync/analytics.ts
+++ b/src/lib/sync/analytics.ts
@@ -25,6 +25,14 @@ import type { PrismaClientType } from '@/lib/prisma';
 import { runAnalyticsRefresh } from '@/lib/analytics/refresh-runner';
 import { pruneAnalyticsSnapshots } from '@/lib/analytics/snapshots';
 import {
+  pruneOutboxEvents,
+  type PruneOutboxEventsResult,
+} from '@/lib/events/outbox-retention';
+import {
+  pruneImladrisMetricLineage,
+  type PruneImladrisMetricLineageResult,
+} from '@/lib/imladris/lineage-retention';
+import {
   materializeImladrisCanonicalMetrics,
   type MaterializedImladrisMetricResult,
 } from '@/lib/imladris/materialization';
@@ -46,10 +54,26 @@ export interface AnalyticsSyncInput {
   now?: Date;
 }
 
+/**
+ * Outcome of a growth-control pruning pass. A failed pass is captured as
+ * `{ error }` instead of throwing so retention hiccups cannot abort the
+ * analytics sync — but callers (orchestrator + cron route) surface the error
+ * as a partial failure so a silently regrowing table stays visible.
+ */
+export type GrowthPruneOutcome<T> = T | { error: string };
+
 export interface AnalyticsSyncResult {
   refresh: Awaited<ReturnType<typeof runAnalyticsRefresh>>;
   pruning: Awaited<ReturnType<typeof pruneAnalyticsSnapshots>>;
   imladris: ImladrisMaterializationSyncResult[];
+  /**
+   * Growth controls for the two unbounded tables behind the 2026-06-10
+   * disk-full outage. Named *Pruning (not *Retention) because the cron sync
+   * response already has a `retention` field for the customer-retention
+   * domain.
+   */
+  lineagePruning: GrowthPruneOutcome<PruneImladrisMetricLineageResult>;
+  outboxPruning: GrowthPruneOutcome<PruneOutboxEventsResult>;
 }
 
 const DEFAULT_RANGE_PRESETS: RollingRangePreset[] = ['7d', '30d'];
@@ -239,5 +263,27 @@ export async function runAnalyticsSync(
     }),
   ]);
 
-  return { refresh, pruning, imladris };
+  // Growth-control retention for the two unbounded tables (lineage detail of
+  // superseded metric values; terminal outbox events). Runs after
+  // materialization so pruning never contends with this cycle's lineage
+  // writes. Both passes are time-budgeted and resume next cycle, so the
+  // initial multi-million-row backlog drains incrementally.
+  const lineagePruning = await pruneImladrisMetricLineage({
+    prisma: input.prisma,
+    now,
+  }).catch((error: unknown): GrowthPruneOutcome<PruneImladrisMetricLineageResult> => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('analytics_sync.lineage_pruning_failed', { error: message });
+    return { error: message };
+  });
+  const outboxPruning = await pruneOutboxEvents({
+    prisma: input.prisma,
+    now,
+  }).catch((error: unknown): GrowthPruneOutcome<PruneOutboxEventsResult> => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('analytics_sync.outbox_pruning_failed', { error: message });
+    return { error: message };
+  });
+
+  return { refresh, pruning, imladris, lineagePruning, outboxPruning };
 }

--- a/src/lib/sync/analytics.ts
+++ b/src/lib/sync/analytics.ts
@@ -33,6 +33,10 @@ import {
   type PruneImladrisMetricLineageResult,
 } from '@/lib/imladris/lineage-retention';
 import {
+  pruneImladrisMetricValues,
+  type PruneImladrisMetricValuesResult,
+} from '@/lib/imladris/metric-value-retention';
+import {
   materializeImladrisCanonicalMetrics,
   type MaterializedImladrisMetricResult,
 } from '@/lib/imladris/materialization';
@@ -73,6 +77,7 @@ export interface AnalyticsSyncResult {
    * domain.
    */
   lineagePruning: GrowthPruneOutcome<PruneImladrisMetricLineageResult>;
+  metricValuePruning: GrowthPruneOutcome<PruneImladrisMetricValuesResult>;
   outboxPruning: GrowthPruneOutcome<PruneOutboxEventsResult>;
 }
 
@@ -276,6 +281,16 @@ export async function runAnalyticsSync(
     console.error('analytics_sync.lineage_pruning_failed', { error: message });
     return { error: message };
   });
+  // Runs after lineage pruning by design: it only deletes lineage-free rows,
+  // so the lineage pass clears the way and this pass can never cascade.
+  const metricValuePruning = await pruneImladrisMetricValues({
+    prisma: input.prisma,
+    now,
+  }).catch((error: unknown): GrowthPruneOutcome<PruneImladrisMetricValuesResult> => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('analytics_sync.metric_value_pruning_failed', { error: message });
+    return { error: message };
+  });
   const outboxPruning = await pruneOutboxEvents({
     prisma: input.prisma,
     now,
@@ -285,5 +300,5 @@ export async function runAnalyticsSync(
     return { error: message };
   });
 
-  return { refresh, pruning, imladris, lineagePruning, outboxPruning };
+  return { refresh, pruning, imladris, lineagePruning, metricValuePruning, outboxPruning };
 }

--- a/src/lib/sync/orchestrator.ts
+++ b/src/lib/sync/orchestrator.ts
@@ -104,6 +104,19 @@ function collectAnalyticsPartialFailures(value: unknown): string[] {
     );
   }
 
+  // Growth-control pruning failures (see src/lib/sync/analytics.ts). These
+  // must stay loud: an unnoticed retention failure is how ImladrisMetricLineage
+  // filled the database volume on 2026-06-10.
+  for (const [field, label] of [
+    ['lineagePruning', 'lineage_pruning'],
+    ['outboxPruning', 'outbox_pruning'],
+  ] as const) {
+    const outcome = asRecord(record[field]);
+    if (typeof outcome?.error === 'string' && outcome.error.trim().length > 0) {
+      failures.push(`${label}: ${outcome.error}`);
+    }
+  }
+
   return failures;
 }
 

--- a/src/lib/sync/orchestrator.ts
+++ b/src/lib/sync/orchestrator.ts
@@ -109,6 +109,7 @@ function collectAnalyticsPartialFailures(value: unknown): string[] {
   // filled the database volume on 2026-06-10.
   for (const [field, label] of [
     ['lineagePruning', 'lineage_pruning'],
+    ['metricValuePruning', 'metric_value_pruning'],
     ['outboxPruning', 'outbox_pruning'],
   ] as const) {
     const outcome = asRecord(record[field]);


### PR DESCRIPTION
## Summary

Remediates the 2026-06-10 ENOSPC outage (Railway Postgres 20GB volume full; DB crash-looped ~17h). At recovery, `ImladrisMetricLineage` was 8,164MB / 21.9M rows (91% of the database) and `OutboxEvent` 664MB / 906K rows with no cleanup. Root cause: every 10-minute sync materializes canonical metric values with `periodEnd = now`, minting new rows each cycle; `replaceLineage` writes one lineage row per contributing raw record per value and superseded generations were never aged out.

Three continuous growth controls, all enforced inside the shared sync cycle (`runAnalyticsSync` → worker orchestrator **and** legacy cron route), surfaced as `lineagePruning` / `metricValuePruning` / `outboxPruning` with errors raised as partial failures:

1. **Lineage retention** (`src/lib/imladris/lineage-retention.ts`) — TTLs lineage of superseded metric values after `IMLADRIS_LINEAGE_RETENTION_DAYS` (14). Read-path audit showed every consumer loads lineage only via `include: {lineage}` on the latest reader-visible value per `(org, user, metricKey)`; CEO/board reports snapshot lineage at generation time. The latest value always keeps full per-record provenance, so the feature's purpose (source provenance for trusted metrics) is preserved. Aggregating to per-source rows was rejected: the external finance-dashboard API exposes `sourceLineage[].rawRecordId`/`sourceId`.
2. **Per-source lineage write cap** (`capLineageRecordsPerSource` in `materialization.ts`) — bounds rows per `sourceKey` per metric value (`IMLADRIS_LINEAGE_MAX_ROWS_PER_SOURCE`, 1000) so a provider backfill can't flood a cycle, while every contributing source stays represented.
3. **Metric value thinning** (`src/lib/imladris/metric-value-retention.ts`) — after `IMLADRIS_METRIC_VALUE_INTRADAY_RETENTION_DAYS` (14), keeps one end-of-day row per `(org, user, metricKey, UTC day)`. Safe by reader audit (history buckets monthly; backdated exports pick the latest row ≤ toDate). Only lineage-free rows are deleted, so the FK cascade never fires and the thinner is fail-safe sequenced behind the lineage pruner.
4. **Outbox retention** (`src/lib/events/outbox-retention.ts`) — `DISPATCHED` >14d, `DEAD_LETTER` >30d (stays inspectable/replayable); `PENDING`/`FAILED` (live retry queue) never touched. Idempotency keys are run/alert/bucket-scoped, so pruning cannot cause duplicate side effects.

## Migration safety

**No schema migrations.** All deletes are LIMIT-bounded autocommitted statements riding existing indexes, time-budgeted per cycle (60s/15s/15s, env-tunable) with `completed: false` → resume next cycle. The ~22M-row backlog drains in roughly a day of normal cycles. Ops runbook in `docs/db-growth-controls.md` covers drain monitoring, `WORKER_SYNC_TIMEOUT` headroom, and the one-time `VACUUM`/pg_repack to return ~8GB to the OS.

## Tests

- 26 new tests: pruner loop/budget/latest-guard semantics for all three pruners, per-source cap behavior (incl. env-driven path through a real materializer), sync wiring + ordering, failure capture, and partial-failure surfacing in orchestrator + cron route
- Full suite: 262 files / 3,108 tests passing; `tsc --noEmit` and eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)