### PR TITLE
Fix Linear sync GraphQL validation: DateTime → DateTimeOrDuration

### DIFF
--- a/src/lib/analytics/fetchers-development.ts
+++ b/src/lib/analytics/fetchers-development.ts
@@ -285,8 +285,8 @@ export async function fetchLinearData(input: {
       body: JSON.stringify({
         query: `
           query ImladrisLinear(
-            $updatedAfter: DateTime!
-            $updatedBefore: DateTime!
+            $updatedAfter: DateTimeOrDuration!
+            $updatedBefore: DateTimeOrDuration!
             $after: String
             $projectAfter: String
             $includeIssues: Boolean!


### PR DESCRIPTION
## Problem

Prod Linear data sync fails GraphQL validation on every run:

```
Variable "$updatedAfter" of type "DateTime!" used in position expecting type "DateTimeOrDuration".
```

Linear evolved their date filter comparators to the `DateTimeOrDuration` scalar. The `ImladrisLinear` query in `src/lib/analytics/fetchers-development.ts` still declared `$updatedAfter`/`$updatedBefore` as `DateTime!`.

This was invisible until #581: env-managed credential resolution previously failed before the query ever ran (Linear row showed a 401 from the placeholder token). Once #581 deployed and Linear authenticated, the sync hit this validation error immediately — observed live on the prod `IntegrationConnection` row at 2026-06-10 20:21 UTC.

## Fix

Two-line change: declare both variables as `DateTimeOrDuration!`. ISO-8601 string values remain valid for the new scalar, so no call-site changes.

## Verification

- Reproduced the failure against the live Linear API with `DateTime!` (exact error above), then confirmed the corrected query returns real data (`issues.nodes` populated).
- `npx vitest run src/lib/__tests__/analytics-fetchers-development.test.ts src/lib/integrations/provider-metrics-sync.test.ts` — 51/51 pass.

After merge + auto-deploy, Linear's data sync should heal on the next 20-minute cron sweep (connection health is already CONNECTED post-#581).

🤖 Generated with [Claude Code](https://claude.com/claude-code)