### PR TITLE
Fix Meta Page single-day ranges rejected by Graph API (since==until)

### DIFF
--- a/src/lib/__tests__/analytics-fetchers-ads.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-ads.test.ts
@@ -18,6 +18,30 @@ function textResponse(body: string, status = 200): Response {
   return new Response(body, { status, headers: { "Content-Type": "text/plain" } });
 }
 
+function metaPageRoutingFetchMock() {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = new URL(String(input));
+
+    if (url.pathname.endsWith("/me/accounts")) {
+      return jsonResponse({ data: [{ id: "page-1", access_token: "page-token" }] });
+    }
+
+    if (url.pathname.endsWith("/page-1")) {
+      return jsonResponse({ fan_count: 10, followers_count: 15 });
+    }
+
+    if (url.pathname.endsWith("/page-1/insights")) {
+      return jsonResponse({ data: [] });
+    }
+
+    if (url.pathname.endsWith("/page-1/posts")) {
+      return jsonResponse({ data: [] });
+    }
+
+    throw new Error(`Unexpected Meta Page request: ${url.pathname}`);
+  });
+}
+
 describe("analytics ads fetchers", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -675,6 +699,111 @@ describe("analytics ads fetchers", () => {
 
     expect(accountRequests).toHaveLength(2);
     expect(accountRequests[1]?.searchParams.get("after")).toBe("accounts_cursor_2");
+  });
+
+  it("extends a single-day Meta Page range so Graph API since stays before until", async () => {
+    const fetchMock = metaPageRoutingFetchMock();
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    // Mirrors checkMetaPageHealth: both bounds land on the same UTC day.
+    // Serialized naively this becomes since === until, which the Graph API
+    // rejects with "(#100) since should be less than until".
+    await fetchMetaPageData("user-token", "page-1", {
+      fromDate: new Date("2026-06-11T00:00:00.000Z"),
+      toDate: new Date("2026-06-11T23:59:59.999Z"),
+    });
+
+    const rangedRequests = fetchMock.mock.calls
+      .map(([url]) => new URL(String(url)))
+      .filter((url) => url.searchParams.has("since"));
+
+    expect(rangedRequests.some((url) => url.pathname.endsWith("/page-1/insights"))).toBe(true);
+    expect(rangedRequests.some((url) => url.pathname.endsWith("/page-1/posts"))).toBe(true);
+    for (const url of rangedRequests) {
+      expect(url.searchParams.get("since")).toBe("2026-06-11");
+      // Date-string `until` is an exclusive bound, so the next day covers
+      // exactly the requested single day.
+      expect(url.searchParams.get("until")).toBe("2026-06-12");
+    }
+  });
+
+  it("extends a single-day Meta Page range across year boundaries", async () => {
+    const fetchMock = metaPageRoutingFetchMock();
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    await fetchMetaPageData("user-token", "page-1", {
+      fromDate: new Date("2026-12-31T00:00:00.000Z"),
+      toDate: new Date("2026-12-31T23:59:59.999Z"),
+    });
+
+    const rangedRequests = fetchMock.mock.calls
+      .map(([url]) => new URL(String(url)))
+      .filter((url) => url.searchParams.has("since"));
+
+    expect(rangedRequests.length).toBeGreaterThan(0);
+    for (const url of rangedRequests) {
+      expect(url.searchParams.get("since")).toBe("2026-12-31");
+      expect(url.searchParams.get("until")).toBe("2027-01-01");
+    }
+  });
+
+  it("keeps multi-day Meta Page ranges unchanged", async () => {
+    const fetchMock = metaPageRoutingFetchMock();
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    await fetchMetaPageData("user-token", "page-1", {
+      fromDate: new Date("2026-02-01T00:00:00.000Z"),
+      toDate: new Date("2026-02-10T23:59:59.999Z"),
+    });
+
+    const rangedRequests = fetchMock.mock.calls
+      .map(([url]) => new URL(String(url)))
+      .filter((url) => url.searchParams.has("since"));
+
+    expect(rangedRequests.length).toBeGreaterThan(0);
+    for (const url of rangedRequests) {
+      expect(url.searchParams.get("since")).toBe("2026-02-01");
+      expect(url.searchParams.get("until")).toBe("2026-02-10");
+    }
+  });
+
+  it("keeps single-day Meta Ads time_range bounds equal", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+
+      if (url.pathname.endsWith("/act_12345/insights")) {
+        return jsonResponse({ data: [] });
+      }
+
+      if (url.pathname.endsWith("/act_12345/campaigns")) {
+        return jsonResponse({ data: [] });
+      }
+
+      throw new Error(`Unexpected Meta request: ${url.pathname}`);
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    await fetchMetaAdsData("meta-token", "12345", {
+      fromDate: new Date("2026-06-11T00:00:00.000Z"),
+      toDate: new Date("2026-06-11T23:59:59.999Z"),
+    });
+
+    const rangedRequests = fetchMock.mock.calls
+      .map(([url]) => new URL(String(url)))
+      .filter((url) => url.searchParams.has("time_range"));
+
+    // The Marketing API time_range param is inclusive on both ends;
+    // since === until is the documented single-day query and must not be
+    // extended, or single-day requests would include an extra day of spend.
+    expect(rangedRequests).toHaveLength(2);
+    for (const url of rangedRequests) {
+      const timeRange = JSON.parse(url.searchParams.get("time_range") ?? "{}") as {
+        since?: string;
+        until?: string;
+      };
+      expect(timeRange.since).toBe("2026-06-11");
+      expect(timeRange.until).toBe("2026-06-11");
+    }
   });
 
   it("follows Meta Page post pagination before computing top posts", async () => {

--- a/src/lib/analytics/fetchers-ads.ts
+++ b/src/lib/analytics/fetchers-ads.ts
@@ -1356,6 +1356,10 @@ export async function fetchMetaAdsData(
     !Number.isNaN(rangeTo?.getTime() ?? NaN) &&
     Boolean(rangeFrom && rangeTo && rangeFrom <= rangeTo);
 
+  // The Marketing API `time_range` JSON param is inclusive on both ends, and
+  // since === until is the documented way to query a single day. Do NOT extend
+  // it the way toMetaSinceUntilDateStrings does for query-string `since`/`until`
+  // params, or single-day requests would silently include an extra day of spend.
   const since = useRange ? rangeFrom!.toISOString().slice(0, 10) : null;
   const until = useRange ? rangeTo!.toISOString().slice(0, 10) : null;
 
@@ -1596,6 +1600,36 @@ async function resolveMetaPageAccessToken(input: {
   }
 }
 
+/**
+ * Serialize a date range to Graph API query-string `since`/`until` values
+ * (YYYY-MM-DD).
+ *
+ * The Graph API parses bare date strings as midnight UTC and requires
+ * since < until, so a single-day range serialized naively (since === until)
+ * is rejected with "(#100) since should be less than until". When both
+ * bounds land on the same UTC day, extend `until` to the next day — `until`
+ * is an exclusive bound for date strings, so the request covers exactly
+ * that one day.
+ *
+ * This applies to query-string `since`/`until` params (Page posts, Page
+ * insights). The Marketing API `time_range` JSON param is inclusive on both
+ * ends and accepts since === until for a single day, so it must NOT be
+ * extended this way.
+ */
+function toMetaSinceUntilDateStrings(
+  fromDate: Date,
+  toDate: Date
+): { since: string; until: string } {
+  const since = fromDate.toISOString().slice(0, 10);
+  let until = toDate.toISOString().slice(0, 10);
+  if (since === until) {
+    const nextDay = new Date(`${until}T00:00:00.000Z`);
+    nextDay.setUTCDate(nextDay.getUTCDate() + 1);
+    until = nextDay.toISOString().slice(0, 10);
+  }
+  return { since, until };
+}
+
 export async function fetchMetaPageData(
   accessToken: string,
   pageId: string,
@@ -1623,8 +1657,9 @@ export async function fetchMetaPageData(
     !Number.isNaN(rangeTo?.getTime() ?? NaN) &&
     Boolean(rangeFrom && rangeTo && rangeFrom <= rangeTo);
 
-  const since = useRange ? rangeFrom!.toISOString().slice(0, 10) : null;
-  const until = useRange ? rangeTo!.toISOString().slice(0, 10) : null;
+  const range = useRange ? toMetaSinceUntilDateStrings(rangeFrom!, rangeTo!) : null;
+  const since = range?.since ?? null;
+  const until = range?.until ?? null;
 
   const pageUrl = new URL(
     `https://graph.facebook.com/${META_GRAPH_VERSION}/${normalizedPageId}`


### PR DESCRIPTION
## Problem

`checkMetaPageHealth` builds a single-day window (today 00:00:00 → 23:59:59 UTC) and calls `fetchMetaPageData`, which serializes both bounds with `.toISOString().slice(0, 10)`. That produces `since=2026-06-11&until=2026-06-11`, and the Graph API query-string params reject it:

> Meta Page posts error (400): (#100) since should be less than until

Reproduced live 2x on 2026-06-10 against the real Arda page. This path only became reachable after #581 fixed Meta credential resolution for env-managed setups — previously resolution failed before any request was made.

## Fix

Fetcher-level guard in `fetchMetaPageData` (`toMetaSinceUntilDateStrings`): when both bounds serialize to the same `YYYY-MM-DD`, extend `until` to the next day. The Graph API parses date strings as midnight UTC with `until` as an exclusive bound, so `since=2026-06-11&until=2026-06-12` covers exactly the requested day. Handles month/year rollover via `setUTCDate`. Fixing at the fetcher protects **all** single-day callers on **both** affected requests (page insights + posts), not just the health check.

## Deliberately unchanged

- `fetchMetaAdsData`'s `time_range` JSON: the Marketing API param is inclusive on both ends, and `since === until` is the documented single-day query. Extending it would silently add a day of spend data. Documented with a comment and pinned with a test (the live repro only erroring on the posts edge confirms the asymmetry).
- Google Ads GAQL `BETWEEN` (inclusive) and Instagram unix-second timestamps (00:00:00 ≠ 23:59:59) — audited, not affected.

## Behavior note

Single-day page-insights requests previously sent a zero-width window (tolerated by Meta, returning no day buckets). They now return the full day's bucket — intended, but visible anywhere fed by single-day windows.

## Tests

- 4 new tests: single-day extension on both insights and posts URLs (exact health-check shape), year-boundary rollover, multi-day ranges untouched, ads `time_range` stays `since === until`
- `analytics-fetchers-ads.test.ts` 33/33, `integrations-health-checks*.test.ts` 32/32
- Full suite: 259 files / 3085 tests passing; `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)