### PR TITLE
Fix Meta Page posts fetch rejecting single-day ranges

### DIFF
--- a/src/lib/__tests__/analytics-fetchers-ads.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-ads.test.ts
@@ -677,6 +677,81 @@ describe("analytics ads fetchers", () => {
     expect(accountRequests[1]?.searchParams.get("after")).toBe("accounts_cursor_2");
   });
 
+  it("extends the posts until bound when callers pass a single-day range", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+
+      if (url.pathname.endsWith("/me/accounts")) {
+        return jsonResponse({ data: [{ id: "page-1", access_token: "page-token" }] });
+      }
+
+      if (url.pathname.endsWith("/page-1")) {
+        return jsonResponse({ fan_count: 10, followers_count: 15 });
+      }
+
+      if (url.pathname.endsWith("/page-1/insights")) {
+        return jsonResponse({ data: [] });
+      }
+
+      if (url.pathname.endsWith("/page-1/posts")) {
+        // Graph rejects equal date-string bounds on this edge:
+        // "(#100) since should be less than until"
+        expect(url.searchParams.get("since")).not.toBe(url.searchParams.get("until"));
+        return jsonResponse({ data: [] });
+      }
+
+      throw new Error(`Unexpected Meta Page request: ${url.pathname}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    await fetchMetaPageData("user-token", "page-1", {
+      fromDate: new Date("2026-06-11T00:00:00.000Z"),
+      toDate: new Date("2026-06-11T23:59:59.999Z"),
+    });
+
+    const urls = fetchMock.mock.calls.map(([url]) => new URL(String(url)));
+    const postsRequest = urls.find((url) => url.pathname.endsWith("/page-1/posts"));
+    expect(postsRequest?.searchParams.get("since")).toBe("2026-06-11");
+    expect(postsRequest?.searchParams.get("until")).toBe("2026-06-12");
+  });
+
+  it("keeps the caller's posts until bound for multi-day ranges", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+
+      if (url.pathname.endsWith("/me/accounts")) {
+        return jsonResponse({ data: [{ id: "page-1", access_token: "page-token" }] });
+      }
+
+      if (url.pathname.endsWith("/page-1")) {
+        return jsonResponse({ fan_count: 10, followers_count: 15 });
+      }
+
+      if (url.pathname.endsWith("/page-1/insights")) {
+        return jsonResponse({ data: [] });
+      }
+
+      if (url.pathname.endsWith("/page-1/posts")) {
+        return jsonResponse({ data: [] });
+      }
+
+      throw new Error(`Unexpected Meta Page request: ${url.pathname}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    await fetchMetaPageData("user-token", "page-1", {
+      fromDate: new Date("2026-06-01T00:00:00.000Z"),
+      toDate: new Date("2026-06-11T23:59:59.999Z"),
+    });
+
+    const urls = fetchMock.mock.calls.map(([url]) => new URL(String(url)));
+    const postsRequest = urls.find((url) => url.pathname.endsWith("/page-1/posts"));
+    expect(postsRequest?.searchParams.get("since")).toBe("2026-06-01");
+    expect(postsRequest?.searchParams.get("until")).toBe("2026-06-11");
+  });
+
   it("follows Meta Page post pagination before computing top posts", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = new URL(String(input));

--- a/src/lib/analytics/fetchers-ads.ts
+++ b/src/lib/analytics/fetchers-ads.ts
@@ -1678,8 +1678,20 @@ export async function fetchMetaPageData(
   );
   postsUrl.searchParams.set("limit", "100");
   if (useRange) {
+    // The posts edge rejects equal date-string bounds with
+    // "(#100) since should be less than until", which happens whenever a
+    // caller passes a single-day range (e.g. integration health checks).
+    // Graph treats a date-string `until` as an exclusive bound, so extend it
+    // by one day to keep the window covering the intended single day. The
+    // insights edge accepts equal bounds, so only the posts request needs it.
+    const postsUntil =
+      since === until
+        ? new Date(rangeTo!.getTime() + 24 * 60 * 60 * 1000)
+            .toISOString()
+            .slice(0, 10)
+        : until!;
     postsUrl.searchParams.set("since", since!);
-    postsUrl.searchParams.set("until", until!);
+    postsUrl.searchParams.set("until", postsUntil);
   }
 
   const postPageResult = await fetchMetaGraphPages<{


### PR DESCRIPTION
## Problem

`fetchMetaPageData` serializes range bounds to date strings (`.toISOString().slice(0, 10)`). For a single-day range — which is exactly what integration health checks pass — `since` and `until` collapse to the same date, and the Graph posts edge rejects it:

```
Meta Page posts error (400): (#100) since should be less than until
```

Unreachable until #581 fixed env-managed Meta credential resolution; once the credential resolved, the META_PAGE health check failed here on every run (reproduced live 2026-06-10).

## Fix

When the serialized bounds are equal, extend the exclusive `until` by one day on the **posts request only** — the window still covers the intended day. The page profile and insights edges accept equal bounds (verified live) and are untouched.

## Verification

- Live against the real page: `since=2026-06-11&until=2026-06-11` → exact `(#100)` error; `since=2026-06-11&until=2026-06-12` → 200 with data.
- Two new regression tests (single-day extends until; multi-day bounds untouched); `npx vitest run src/lib/__tests__/analytics-fetchers-ads.test.ts` — 31/31 pass.

Related: #586 (the other latent bug #581 unmasked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)