### PR TITLE
Fix next-auth debug logger leaking the OAuth client secret despite debug:false

### DIFF
--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -126,8 +126,24 @@ describe("auth options", () => {
   });
 
   it("keeps next-auth debug logging opt-in so provider secrets stay out of logs", async () => {
+    const mutableEnv = process.env as Record<string, string | undefined>;
+    delete mutableEnv.NEXTAUTH_DEBUG;
     const authOptions = await loadAuthOptions();
     expect(authOptions.debug).toBe(false);
+    // The flag alone is not enough: next-auth's setLogger() overrides the
+    // debug no-op with any custom logger.debug AFTER applying the flag, so a
+    // custom debug method must not exist at all unless explicitly opted in.
+    expect(authOptions.logger?.debug).toBeUndefined();
+  });
+
+  it("enables the debug logger only when NEXTAUTH_DEBUG=true", async () => {
+    const mutableEnv = process.env as Record<string, string | undefined>;
+    mutableEnv.NEXTAUTH_DEBUG = "true";
+    const authOptions = await loadAuthOptions();
+    delete mutableEnv.NEXTAUTH_DEBUG;
+
+    expect(authOptions.debug).toBe(true);
+    expect(typeof authOptions.logger?.debug).toBe("function");
   });
 
   it("bootstraps a development organization for credential logins without one", async () => {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -183,9 +183,18 @@ export const authOptions: NextAuthOptions = {
     warn(code) {
       console.warn("[next-auth][warn]", code);
     },
-    debug(code, metadata) {
-      console.log("[next-auth][debug]", code, metadata);
-    },
+    // The debug method must be OMITTED unless explicitly opted in: next-auth's
+    // setLogger() applies the `debug: false` no-op FIRST and then overrides it
+    // with any custom logger.debug, so a custom debug logger runs even when
+    // `debug` is false — leaking the provider config (client secret included)
+    // into production logs. Verified against prod logs on 2026-06-11.
+    ...(process.env.NEXTAUTH_DEBUG === "true"
+      ? {
+          debug(code: string, metadata?: unknown) {
+            console.log("[next-auth][debug]", code, metadata);
+          },
+        }
+      : {}),
   },
   session: {
     strategy: "jwt",


### PR DESCRIPTION
## What

PR #580 set `debug: process.env.NEXTAUTH_DEBUG === "true"` to keep provider secrets out of logs — but it left a custom `logger.debug` in `authOptions.logger`. next-auth's `setLogger()` applies the `debug:false` no-op **first**, then overrides it with any user-supplied `logger.debug`, so the custom debug method runs unconditionally.

**Confirmed in production logs (2026-06-11):** `[next-auth][debug]` output including the Google `clientSecret`, with `NEXTAUTH_DEBUG` unset on the service.

## Fix

Omit the `debug` method from the logger entirely unless `NEXTAUTH_DEBUG=true`. Regression tests now assert:
- `logger.debug` is `undefined` by default (the flag alone was the gap #580's test missed)
- `logger.debug` is a function only when `NEXTAUTH_DEBUG=true`

## Ops follow-up (not in this PR)

- **Rotate the Google OAuth client secret** — prior values sit in retained Railway logs.
- Context: today's sign-in outage was *not* this leak — it was Postgres temp-file disk exhaustion (bursts 05:06–05:42 UTC) wedging the connection pool → `jwt callback` timeouts. Volume headroom decision tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)