### PR TITLE
Security: stop NextAuth debug logs leaking the Google OAuth secret in production

### DIFF
--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -57,15 +57,33 @@ vi.mock("@/lib/security-audit", () => ({
   recordSecurityAuditEvent: mockRecordSecurityAuditEvent,
 }));
 
-async function loadAuthOptions() {
+async function loadAuthOptions(env: Record<string, string | undefined> = {}) {
   vi.resetModules();
   const mutableEnv = process.env as Record<string, string | undefined>;
-  mutableEnv.NODE_ENV = "test";
-  mutableEnv.E2E_MODE = "false";
-  delete mutableEnv.GOOGLE_CLIENT_ID;
-  delete mutableEnv.GOOGLE_CLIENT_SECRET;
-  const { authOptions } = await import("@/lib/auth");
-  return authOptions;
+  const overrides: Record<string, string | undefined> = {
+    NODE_ENV: "test",
+    E2E_MODE: "false",
+    GOOGLE_CLIENT_ID: undefined,
+    GOOGLE_CLIENT_SECRET: undefined,
+    NEXTAUTH_DEBUG: undefined,
+    ...env,
+  };
+  const previous: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(overrides)) {
+    previous[key] = mutableEnv[key];
+    if (value === undefined) delete mutableEnv[key];
+    else mutableEnv[key] = value;
+  }
+  try {
+    const { authOptions } = await import("@/lib/auth");
+    return authOptions;
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete mutableEnv[key];
+      else mutableEnv[key] = value;
+    }
+    mutableEnv.NODE_ENV = "test";
+  }
 }
 
 describe("auth options", () => {
@@ -128,6 +146,87 @@ describe("auth options", () => {
   it("keeps next-auth debug logging opt-in so provider secrets stay out of logs", async () => {
     const authOptions = await loadAuthOptions();
     expect(authOptions.debug).toBe(false);
+  });
+
+  it("allows opting into debug logging outside production", async () => {
+    const authOptions = await loadAuthOptions({ NEXTAUTH_DEBUG: "true" });
+    expect(authOptions.debug).toBe(true);
+  });
+
+  it("never enables debug logging in production, even with NEXTAUTH_DEBUG=true", async () => {
+    // Regression guard: NEXTAUTH_DEBUG=true on the production host previously
+    // dumped the full provider config — Google client secret included — plus
+    // state/PKCE cookies into Railway logs.
+    const authOptions = await loadAuthOptions({
+      NODE_ENV: "production",
+      NEXTAUTH_DEBUG: "true",
+    });
+    expect(authOptions.debug).toBe(false);
+  });
+
+  it("redacts provider secrets and cookie values from debug log metadata", async () => {
+    const authOptions = await loadAuthOptions();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    try {
+      // Shape mirrors next-auth's GET_AUTHORIZATION_URL debug event.
+      authOptions.logger?.debug?.("GET_AUTHORIZATION_URL", {
+        url: "https://accounts.google.com/o/oauth2/v2/auth?client_id=abc",
+        cookies: [
+          { name: "next-auth.pkce.code_verifier", value: "pkce-verifier-value" },
+          { name: "next-auth.state", value: "state-cookie-value" },
+        ],
+        provider: {
+          id: "google",
+          clientId: "public-client-id",
+          clientSecret: "GOCSPX-super-secret",
+          callbackUrl: "https://app.example.com/api/auth/callback/google",
+        },
+      });
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const [prefix, code, metadata] = logSpy.mock.calls[0];
+      expect(prefix).toBe("[next-auth][debug]");
+      expect(code).toBe("GET_AUTHORIZATION_URL");
+
+      const serialized = JSON.stringify(metadata);
+      expect(serialized).not.toContain("GOCSPX-super-secret");
+      expect(serialized).not.toContain("pkce-verifier-value");
+      expect(serialized).not.toContain("state-cookie-value");
+
+      // Non-sensitive context survives so debug output stays useful.
+      const sanitized = metadata as {
+        url: string;
+        cookies: string;
+        provider: Record<string, string>;
+      };
+      expect(sanitized.url).toContain("accounts.google.com");
+      expect(sanitized.cookies).toBe("[REDACTED]");
+      expect(sanitized.provider.id).toBe("google");
+      expect(sanitized.provider.clientSecret).toBe("[REDACTED]");
+      expect(sanitized.provider.callbackUrl).toContain("/api/auth/callback/google");
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("redacts secret-bearing fields from error log metadata while keeping the error", async () => {
+    const authOptions = await loadAuthOptions();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    try {
+      authOptions.logger?.error?.("OAUTH_CALLBACK_ERROR", {
+        error: new Error("callback failed"),
+        provider: { id: "google", clientSecret: "GOCSPX-super-secret" },
+      } as never);
+
+      const [, , metadata] = errorSpy.mock.calls[0];
+      const serialized = JSON.stringify(metadata);
+      expect(serialized).not.toContain("GOCSPX-super-secret");
+      expect(serialized).toContain("callback failed");
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it("bootstraps a development organization for credential logins without one", async () => {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -169,22 +169,63 @@ if (
   );
 }
 
+// Keys whose values must never reach logs, matched case-insensitively as
+// substrings: clientSecret / client_secret, cookies, csrfToken, code_verifier,
+// state / nonce values, passwords, Authorization headers, etc. next-auth debug
+// events such as GET_AUTHORIZATION_URL include the full provider config
+// (OAuth client secret) and the state/PKCE cookie payloads in `metadata`.
+const SENSITIVE_LOG_KEY_PATTERN =
+  /secret|token|cookie|password|credential|authorization|signature|code_verifier|codeverifier|pkce|state|nonce|session/i;
+
+const REDACTED = "[REDACTED]";
+const MAX_SANITIZE_DEPTH = 8;
+
+function sanitizeLogMetadata(
+  value: unknown,
+  depth = 0,
+  seen = new WeakSet<object>(),
+): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (value instanceof Error) {
+    return { name: value.name, message: value.message, stack: value.stack };
+  }
+  if (depth >= MAX_SANITIZE_DEPTH) return "[Truncated]";
+  if (seen.has(value)) return "[Circular]";
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeLogMetadata(entry, depth + 1, seen));
+  }
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    sanitized[key] = SENSITIVE_LOG_KEY_PATTERN.test(key)
+      ? REDACTED
+      : sanitizeLogMetadata(entry, depth + 1, seen);
+  }
+  return sanitized;
+}
+
 export const authOptions: NextAuthOptions = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   adapter: createResilientAdapter() as any,
   providers,
-  // Opt-in only: next-auth's debug output dumps the full provider config —
-  // including the OAuth client secret — into server logs.
-  debug: process.env.NEXTAUTH_DEBUG === "true",
+  // Hard-disabled in production builds, opt-in elsewhere: next-auth's debug
+  // output dumps the full provider config — including the OAuth client
+  // secret — plus state/PKCE cookies into server logs. A stray
+  // NEXTAUTH_DEBUG=true on the production host must never re-enable it.
+  debug: process.env.NODE_ENV !== "production" && process.env.NEXTAUTH_DEBUG === "true",
   logger: {
     error(code, metadata) {
-      console.error("[next-auth][error]", code, metadata);
+      console.error("[next-auth][error]", code, sanitizeLogMetadata(metadata));
     },
     warn(code) {
       console.warn("[next-auth][warn]", code);
     },
     debug(code, metadata) {
-      console.log("[next-auth][debug]", code, metadata);
+      // Defense in depth: even with debug enabled, never print secret-bearing
+      // metadata (provider config, cookie values) verbatim.
+      console.log("[next-auth][debug]", code, sanitizeLogMetadata(metadata));
     },
   },
   session: {


### PR DESCRIPTION
## 🚨 OPERATOR ACTION REQUIRED — secret already exposed, rotate it

**The Google OAuth client secret has been written to Railway production logs in plaintext** (observed live 2026-06-11 in WIPGuard-app logs, `[next-auth][debug] GET_AUTHORIZATION_URL` entries). This PR stops future leakage but **cannot un-leak the secret**. Before/alongside merging:

1. **Rotate the client secret** in [Google Cloud Console → APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials) for OAuth client ID `560005703075-272ut7d7ausu1tbci45drbvvdl62qsea.apps.googleusercontent.com` (the leaked value starts with `GOCSPX-`).
2. **Update `GOOGLE_CLIENT_SECRET`** in the Railway WIPGuard-app service env vars with the new value and redeploy.
3. **Unset `NEXTAUTH_DEBUG=true`** in Railway — this is what turned debug on in production. (After this PR it's inert in production, but remove it anyway.)
4. **Purge/expire the affected Railway logs** if retention allows; anyone with log access could read the secret. State/PKCE cookie values were also logged — these are short-lived per-flow values, so rotation isn't needed for them, but it's another reason to clear the logs.

None of the above is automated by this PR — deliberately left to the operator.

## What was wrong

`src/lib/auth.ts` gates NextAuth debug behind `NEXTAUTH_DEBUG === "true"`, and that flag was set on the production service. NextAuth's `GET_AUTHORIZATION_URL` debug event passes the **full resolved provider config** (including `clientSecret`) and the state/PKCE **cookie payloads** as `metadata`, which the custom `logger.debug` handler `console.log`-ed verbatim.

## Fix (two independent layers)

1. **Hard production gate**: `debug` is now `NODE_ENV !== "production" && NEXTAUTH_DEBUG === "true"`. A stray `NEXTAUTH_DEBUG=true` on the production host can never re-enable debug output. Opt-in still works in dev/test.
2. **Metadata redaction, even when debug is on**: `logger.debug` and `logger.error` now pass metadata through `sanitizeLogMetadata()`, which recursively replaces values under secret-bearing keys (`secret`, `token`, `cookie`, `password`, `credential`, `authorization`, `code_verifier`, `pkce`, `state`, `nonce`, `session`, …) with `[REDACTED]`, normalizes `Error`s to `{name, message, stack}`, and guards against cycles/deep nesting. Non-sensitive context (provider id, callback URL, authorization URL) is preserved so debug output stays useful.

## Tests

Extended `src/lib/__tests__/auth.test.ts` (now 14 tests, all green via `npx vitest run`):
- debug stays off by default (existing, kept)
- `NEXTAUTH_DEBUG=true` enables debug **outside** production
- `NEXTAUTH_DEBUG=true` + `NODE_ENV=production` → debug **forced off** (regression guard for this incident)
- `logger.debug` redacts `clientSecret` + cookie values from a realistic `GET_AUTHORIZATION_URL` payload while keeping provider id / URLs
- `logger.error` redacts secrets but preserves the error message

Also verified: `auth-google-linking` + `socket-auth` suites green, eslint clean, staged typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)