### PR TITLE
Fix Linear sync exceeding GraphQL complexity cap

### DIFF
--- a/src/lib/analytics/fetchers-development.ts
+++ b/src/lib/analytics/fetchers-development.ts
@@ -316,8 +316,14 @@ export async function fetchLinearData(input: {
                 endCursor
               }
             }
+            # Page sizes are complexity-bounded: Linear caps query complexity
+            # at 10,000 and the original projects(first: 50) x issues(first: 100)
+            # shape scored ~37,578 ("Query too complex"). projects(20) with
+            # nested issues(25) measures comfortably under the cap; deeper
+            # projects continue via $projectAfter and the ImladrisProjectIssues
+            # follow-up pagination, so nothing is truncated.
             projects(
-              first: 50
+              first: 20
               after: $projectAfter
               includeArchived: false
               orderBy: updatedAt
@@ -336,7 +342,7 @@ export async function fetchLinearData(input: {
                 completedAt
                 lead { id name email }
                 teams { nodes { id key name } }
-                issues(first: 100) {
+                issues(first: 25) {
                   nodes {
                     id
                     identifier


### PR DESCRIPTION
## Problem

Third and final link in the chain unmasked by #581 → #586: with credentials and scalar types fixed, the `ImladrisLinear` query finally reached Linear's executor — which rejected it:

```
Query too complex. Complexity: 37577.90000000001. Maximum allowed complexity: 10000.
```

`projects(first: 50)` × nested `issues(first: 100)` dominates the score (~5,000 worst-case nested nodes before field multipliers). This query has **never successfully executed in production** — every prior failure layer hid this one.

## Fix

Rebalance page sizes in the combined query: `projects(first: 20)`, nested `issues(first: 25)`. Top-level `issues(first: 100)` unchanged.

**Zero truncation**: projects beyond 20 continue via the existing `$projectAfter` outer pagination; projects with >25 issues already overflow into the `ImladrisProjectIssues` follow-up pagination query (first: 100 standalone, well under the cap).

## Verification

- Live probe of the new shape passes Linear's complexity check (the old shape reproduces the exact 37,578 error).
- Full `fetchLinearData` run against the real workspace completed for the first time: **522 issues, 34 projects** — outer project pagination exercised (34 > 20).
- `npx vitest run src/lib/__tests__/analytics-fetchers-development.test.ts src/lib/integrations/provider-metrics-sync.test.ts` passes.

Chain: #581 (credentials) → #586 (scalar) → this (complexity). After merge + deploy, the prod `linear` snapshot should record SUCCESS for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)