### PR TITLE
Stop next-auth debug events firing in production despite debug:false

### DIFF
--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -164,8 +164,46 @@ describe("auth options", () => {
     expect(authOptions.debug).toBe(false);
   });
 
-  it("redacts provider secrets and cookie values from debug log metadata", async () => {
+  it("silences the custom debug handler when NEXTAUTH_DEBUG is unset", async () => {
+    // Regression guard: next-auth v4 invokes a custom logger.debug even when
+    // the `debug` option is false — setLogger() installs the debug-flag no-op
+    // first, then unconditionally overwrites it with the user-supplied
+    // handler. An ungated handler is exactly how GET_AUTHORIZATION_URL
+    // entries (provider config, cookie payloads) kept reaching production
+    // Railway logs with NEXTAUTH_DEBUG unset.
     const authOptions = await loadAuthOptions();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    try {
+      authOptions.logger?.debug?.("GET_AUTHORIZATION_URL", {
+        provider: { id: "google", clientSecret: "GOCSPX-super-secret" },
+      });
+      expect(logSpy).not.toHaveBeenCalled();
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("silences the custom debug handler in production even with NEXTAUTH_DEBUG=true", async () => {
+    const authOptions = await loadAuthOptions({
+      NODE_ENV: "production",
+      NEXTAUTH_DEBUG: "true",
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    try {
+      authOptions.logger?.debug?.("GET_AUTHORIZATION_URL", {
+        provider: { id: "google", clientSecret: "GOCSPX-super-secret" },
+      });
+      expect(logSpy).not.toHaveBeenCalled();
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("redacts provider secrets and cookie values from debug log metadata", async () => {
+    // Debug output is opt-in; even once opted in, secrets must be redacted.
+    const authOptions = await loadAuthOptions({ NEXTAUTH_DEBUG: "true" });
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
 
     try {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -206,15 +206,18 @@ function sanitizeLogMetadata(
   return sanitized;
 }
 
+// Hard-disabled in production builds, opt-in elsewhere: next-auth's debug
+// output dumps the full provider config — including the OAuth client
+// secret — plus state/PKCE cookies into server logs. A stray
+// NEXTAUTH_DEBUG=true on the production host must never re-enable it.
+const nextAuthDebugEnabled =
+  process.env.NODE_ENV !== "production" && process.env.NEXTAUTH_DEBUG === "true";
+
 export const authOptions: NextAuthOptions = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   adapter: createResilientAdapter() as any,
   providers,
-  // Hard-disabled in production builds, opt-in elsewhere: next-auth's debug
-  // output dumps the full provider config — including the OAuth client
-  // secret — plus state/PKCE cookies into server logs. A stray
-  // NEXTAUTH_DEBUG=true on the production host must never re-enable it.
-  debug: process.env.NODE_ENV !== "production" && process.env.NEXTAUTH_DEBUG === "true",
+  debug: nextAuthDebugEnabled,
   logger: {
     error(code, metadata) {
       console.error("[next-auth][error]", code, sanitizeLogMetadata(metadata));
@@ -223,6 +226,13 @@ export const authOptions: NextAuthOptions = {
       console.warn("[next-auth][warn]", code);
     },
     debug(code, metadata) {
+      // next-auth v4 invokes a custom logger.debug even when `debug` is
+      // false: setLogger() (next-auth/utils/logger) installs the debug-flag
+      // no-op first, then unconditionally overwrites it with this handler.
+      // The handler must gate itself, or debug events (GET_AUTHORIZATION_URL
+      // with provider config and cookie payloads) reach production logs
+      // regardless of the `debug` option above.
+      if (!nextAuthDebugEnabled) return;
       // Defense in depth: even with debug enabled, never print secret-bearing
       // metadata (provider config, cookie values) verbatim.
       console.log("[next-auth][debug]", code, sanitizeLogMetadata(metadata));


### PR DESCRIPTION
## Symptom

Production Railway logs for `WIPGuard-app` on **2026-06-11 ~07:50 UTC** contain `[next-auth][debug] GET_AUTHORIZATION_URL` entries dumping provider config, even though:

- `NEXTAUTH_DEBUG` is **not** set on the service (verified via `railway variables --service WIPGuard-app --kv`), and
- the `debug` option resolves to `false` (hardened in 2e0513d1 and again in #590).

## Root cause — verified against installed `next-auth@4.24.13`

`node_modules/next-auth/utils/logger.js`:

```js
function setLogger(newLogger = {}, debug) {
  if (!debug) _logger.debug = function () {};   // debug:false installs a no-op…
  if (newLogger.error) _logger.error = newLogger.error;
  if (newLogger.warn)  _logger.warn  = newLogger.warn;
  if (newLogger.debug) _logger.debug = newLogger.debug;  // …then a custom debug handler UNCONDITIONALLY overwrites it
}
```

`core/index.js:58` calls `setLogger(authOptions.logger, authOptions.debug)` on every auth request. Because `src/lib/auth.ts` supplies a custom `logger.debug` (added for redaction in #590), the no-op installed by `debug: false` is immediately replaced — so debug events fire **regardless of the `debug` flag**. The flag-only fixes in 2e0513d1/#590 could never silence them.

## Fix

Compute the opt-in once and gate **both** the `debug` option and the custom handler on it:

- `nextAuthDebugEnabled = NODE_ENV !== "production" && NEXTAUTH_DEBUG === "true"`
- `logger.debug` early-returns unless enabled.
- The handler stays supplied (rather than omitted) so that an *enabled* debug path still goes through `sanitizeLogMetadata` redaction instead of next-auth's raw default logger.

Result: zero debug output unless `NEXTAUTH_DEBUG=true` outside production; even then, secrets are redacted.

## Severity of the leak — ⚠️ HIGH, client secret confirmed leaked pre-#590

`GET_AUTHORIZATION_URL` metadata is `{ url, cookies, provider }` (`core/lib/oauth/authorization-url.js:65`):

- **`provider` is the fully-resolved provider config and includes `clientSecret`** (`core/lib/oauth/client.js:26` reads `provider.clientSecret` from this same object). 
- `cookies` carries the freshly-minted **state / PKCE `code_verifier` / nonce cookie values**.
- `url` includes `client_id`, `state`, `code_challenge` query params.

Timeline:
- **Entries before #590 deployed (including the 2026-06-11 ~07:50 UTC batch): the Google OAuth client secret and state/PKCE cookie values were logged verbatim.** The handler at that time was `console.log("[next-auth][debug]", code, metadata)` with no redaction.
- Entries after #590 deployed: still emitted (this bug), but `clientSecret`/`cookies` render as `[REDACTED]` — residual exposure limited to the authorization URL params; protection relied entirely on the key-pattern sanitizer until this PR.

**Action items (not automated here):**
1. **Rotate the Google OAuth client secret** — still outstanding from #590; anyone with Railway log access could have read it.
2. Consider purging/expiring the affected Railway log range if retention policy allows.
3. State/PKCE cookie values are short-lived one-time artifacts — low residual risk, no action beyond rotation.

## Tests

`src/lib/__tests__/auth.test.ts` (16/16 passing, `tsc --noEmit` clean):

- **new** — custom debug handler emits nothing when `NEXTAUTH_DEBUG` is unset (the exact prod scenario: handler invoked despite `debug:false`).
- **new** — handler emits nothing in production even with `NEXTAUTH_DEBUG=true`.
- updated — the redaction test now opts in via `NEXTAUTH_DEBUG=true`, asserting enabled debug output still redacts `clientSecret`/cookie/PKCE values.
- existing #590 tests (production gate, dev opt-in, error-logger redaction) unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)