### PR TITLE
Raise Railway restart retry cap so OOM cycles don't strand prod down

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
   },
   "deploy": {
     "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 10,
+    "restartPolicyMaxRetries": 250,
     "healthcheckPath": "/api/health/live",
     "healthcheckTimeout": 120
   }


### PR DESCRIPTION
## Problem

WIPGuard-app OOM-crashes every ~20-25 min (continuous heap leak, ~3.4 MB/s, hits V8's 4 GB cap — observed fatals at 22:37/22:57/23:18/23:38/00:03 UTC overnight 2026-06-11→12). Each crash consumes one `ON_FAILURE` retry. With `restartPolicyMaxRetries: 10`, the 19:48 deployment exhausted its budget in ~4h and Railway left the service **CRASHED** — hard-down until manual redeploy, which is how production was found at 00:10 UTC.

## Change

`restartPolicyMaxRetries: 10 → 250` (~2-4 days of self-revival at current crash cadence). Downtime per cycle is seconds (boot is <100ms + healthcheck); the alternative is indefinite hard-down at night.

## Explicitly a stopgap

This masks the symptom so production survives until the root-cause fix (the `/api/analytics` heap leak — capture procedure in HEAP_CAPTURE_RUNBOOK.md) lands. Revert to a sane retry cap once heap is flat.

Merging this auto-deploys and also brings the currently-crashed service back up with the new policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)