### PR TITLE
fix(db): enforce retention and stop ImladrisMetricLineage disk explosion

### DIFF
--- a/docs/runbooks/postgres-disk-incident-2026-06.md
+++ b/docs/runbooks/postgres-disk-incident-2026-06.md
@@ -1,0 +1,159 @@
+# Postgres disk incident — June 2026
+
+**Status:** volume at 18,598 MB / 20,000 MB (93%) as of 2026-06-11.
+**Impact when full:** writes fail, the app goes down.
+**Immediate mitigation:** grow the volume in the Railway dashboard (Postgres service → volume → grow). Do this first; everything below is the durable fix.
+
+## What happened
+
+Measured directly against production on 2026-06-12 (read-only):
+
+| Consumer | Size | Rows | Cause |
+| --- | --- | --- | --- |
+| `ImladrisMetricLineage` | **15.17 GB** (12.0 GB heap + 3.15 GB indexes) | ~41.5M | Bug below — essentially all inserted between 2026-06-01 and 2026-06-11 |
+| `OutboxEvent` | **664 MB** | 906K (904.8K `DEAD_LETTER`, 1.5K `PENDING`) | Dead letters accumulated Feb–May; nothing ever pruned the outbox |
+| `ImladrisRawSourceRecord` | 143 MB | ~104K | Normal |
+| Everything else | < 50 MB combined | — | The originally-suspected tables (AnalyticsSnapshot 16 MB, funnel tables < 1 MB, SecurityAuditEvent 112 KB) were immaterial |
+| WAL | 144 MB | — | Normal (no inactive replication slots, archive off) |
+| `wipguard_probe_*` databases | ~50 MB | — | Leftover probe DBs, safe to drop |
+
+### Root cause of the lineage explosion
+
+`runImladrisMaterializationSync` (and `runCompanyReadinessSetup`) passed
+`periodEnd = now` into canonical materialization. `periodEnd` is part of the
+canonical metric upsert key `(organizationId, userId, metricKey, periodEnd,
+calculationVersion)`, so **every sync run minted a brand-new
+`ImladrisCanonicalMetricValue` row instead of updating the existing one** —
+3,408 metric values accumulated for just six days (Jun 5–11).
+
+`replaceLineage` then "replaced" lineage for the *new* metric value id
+(deleting nothing) and inserted a full copy of every matching raw-record
+lineage row — ~12K rows per metric value on average, up to ~300K for
+`marketing.website_traffic`. With the cron schedule every 10 minutes, that
+compounded to ~4–6M rows/day.
+
+The same explosion crashed the app: `buildCompanyTrackerDashboard` loaded
+**all** canonical rows with `include: { lineage }` (no limit), pulling tens of
+millions of rows into the Node heap → `FATAL ERROR: Reached heap limit` at
+4 GB. The crashed app made `wipguard-cron-sync` fail too (it POSTs
+`/api/cron/sync` and got 502s), which also stopped the one retention job that
+did exist (AnalyticsSnapshot pruning — a 16 MB table).
+
+### Why retention didn't save us
+
+- The only scheduled pruning covered `AnalyticsSnapshot` (16 MB).
+- `ImladrisMetricLineage`, `ImladrisCanonicalMetricValue`, `OutboxEvent`,
+  `SecurityAuditEvent` and the funnel tables had **no retention at all**.
+- The pruning that existed ran via `wipguard-cron-sync` → `POST /api/cron/sync`,
+  which requires the app to be up. The app was OOM-crash-looping.
+
+## The fix (this PR)
+
+1. **Stop the growth** — `imladrisCanonicalPeriodEnd()` truncates `periodEnd`
+   to the start of the current UTC day, so repeated runs upsert the same row
+   (one metric value per metricKey per day). `replaceLineage` now inserts the
+   fresh evidence set first and prunes rows older than its own insert stamp,
+   so a crash or concurrent run can no longer duplicate or destroy lineage.
+2. **Retention sweep** — `src/lib/ops/data-retention.ts` runs from
+   `runAnalyticsSync()` (worker orchestrator **and** cron route), deleting in
+   bounded batches per cycle:
+   - lineage of superseded metric values older than `IMLADRIS_LINEAGE_RETENTION_DAYS` (default 7)
+   - canonical metric values older than `IMLADRIS_METRIC_RETENTION_DAYS` (default 365)
+   - `OutboxEvent` `DISPATCHED` > `OUTBOX_DISPATCHED_RETENTION_DAYS` (default 14)
+   - `OutboxEvent` `DEAD_LETTER` > `OUTBOX_DEAD_LETTER_RETENTION_DAYS` (default 90)
+   - `SecurityAuditEvent` > `SECURITY_AUDIT_RETENTION_DAYS` (default 365)
+   - `FunnelEvent` > `FUNNEL_EVENT_RETENTION_DAYS` (default 365)
+
+   Knobs: `DATA_RETENTION_ENABLED` (default true), `DATA_RETENTION_DRY_RUN`,
+   `DATA_RETENTION_BATCH_SIZE` (20K), `DATA_RETENTION_MAX_ROWS_PER_RUN` (200K).
+   Each run logs a `[data-retention]` JSON summary including
+   `databaseSizeBytes`.
+3. **Dashboard / export OOM fixes** —
+   - `buildCompanyTrackerDashboard` aggregates lineage facts (count, source
+     keys, latest capture) in SQL (`groupBy`), never loading rows.
+   - `buildImladrisMetrics` and `buildInvestorDashboardExport` (which emit
+     full per-row evidence and so can't aggregate) cap nested lineage loads
+     at `MAX_LINEAGE_EVIDENCE_ROWS` (500) per metric value.
+   All three previously did `include: { lineage }` with no bound and were the
+   OOM vector that crash-looped the app.
+4. **Monitoring** — `GET /api/health` now includes a `storage` check
+   (`pg_database_size` vs `DATABASE_VOLUME_CAPACITY_MB`, default 20,000 MB).
+   ≥75% → `warning` + `[health:storage]` error log; ≥90% → `critical`,
+   overall `degraded`, HTTP 503.
+
+## Operator actions
+
+### 1. Immediately (no deploy needed)
+
+- **Grow the volume** in Railway (Postgres → volume). Even 25–30 GB buys
+  weeks of headroom while the backlog drains.
+- Set up **Railway alerts**: project → Settings → Notifications / usage
+  alerts for volume usage, and a log-based alert matching `[health:storage]`
+  or `[data-retention]`.
+- Point an external uptime monitor (Better Stack / UptimeRobot / Checkly) at
+  `GET /api/health` — it returns 503 once disk usage is critical, so the
+  existing "is it up" alarm doubles as the disk alarm.
+
+### 2. After this PR deploys
+
+The retention sweep drains the backlog automatically at ≤200K rows per
+sync cycle (~hours to a couple of days for 41.5M rows). To drain it in one
+supervised pass instead, use the one-time script — **requires explicit
+operator approval, it deletes data**:
+
+```bash
+# Dry run first — prints exact counts, deletes nothing:
+railway run --service WIPGuard-app npm run ops:db-disk-cleanup
+
+# After reviewing the counts:
+railway run --service WIPGuard-app npm run ops:db-disk-cleanup -- --execute
+```
+
+Defaults: keep lineage for the latest metric value per key + anything newer
+than 7 days; delete `DEAD_LETTER` outbox rows older than 30 days and
+`DISPATCHED` older than 14. All deletes are batched (20K/statement).
+
+### 3. Reclaim the disk space (maintenance window)
+
+Deleting rows does **not** shrink the volume — Postgres keeps freed pages for
+reuse, so Railway keeps reporting ~18.6 GB until the tables are rewritten.
+After the backlog is deleted, connect (`railway connect Postgres`) and run:
+
+```sql
+VACUUM (FULL, VERBOSE, ANALYZE) "ImladrisMetricLineage";
+VACUUM (FULL, VERBOSE, ANALYZE) "ImladrisCanonicalMetricValue";
+VACUUM (FULL, VERBOSE, ANALYZE) "OutboxEvent";
+```
+
+`VACUUM FULL` takes an ACCESS EXCLUSIVE lock per table while it rewrites;
+with the backlog gone the surviving data is small (well under 1 GB), so each
+statement should finish in seconds to a few minutes. Expected end state:
+database ~1–2 GB on a 20–30 GB volume.
+
+Optional cleanup of leftover probe databases:
+
+```sql
+SELECT datname FROM pg_database WHERE datname LIKE 'wipguard_probe_%';
+-- for each: DROP DATABASE "wipguard_probe_<timestamp>";
+```
+
+### 4. Verify
+
+- `GET /api/health` → `checks.storage.status: "ok"`, `usagePercent` < 60.
+- Railway volume graph trends flat after the drop.
+- `[data-retention]` log lines show small per-cycle deletions
+  (steady state: a few thousand rows/day).
+- `ImladrisCanonicalMetricValue` grows by ~1 row per metricKey per day.
+
+## Open follow-ups
+
+- The outbox dispatcher dead-letters nearly everything it touches (904.8K
+  DEAD_LETTER vs ~0 DISPATCHED; last write 2026-05-06) — the event bus is
+  effectively broken/abandoned and deserves its own investigation.
+- The 500-row evidence cap on `buildImladrisMetrics` /
+  `buildInvestorDashboardExport` is a defensive bound, not a product
+  decision. If a metric legitimately needs more than 500 evidence rows
+  surfaced, revisit `MAX_LINEAGE_EVIDENCE_ROWS` (and consider showing
+  "showing 500 of N" in the UI). After the backlog drains and with the
+  periodEnd + insert-then-prune fixes, real per-value lineage counts should
+  sit well under the cap.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "retention:run": "npx tsx scripts/retention/run-all.ts",
     "ops:ads-preflight": "./scripts/ads-analytics-preflight.sh",
     "ops:backfill-google-oauth-scopes": "node ./scripts/backfill-google-oauth-scope-aliases.cjs",
+    "ops:db-disk-cleanup": "npx tsx scripts/ops/db-disk-cleanup.ts",
     "prepare": "husky",
     "prebuild": "npm run db:generate",
     "precommit:quality": "lint-staged",

--- a/scripts/ops/db-disk-cleanup.ts
+++ b/scripts/ops/db-disk-cleanup.ts
@@ -1,0 +1,297 @@
+/**
+ * One-time cleanup for the June 2026 Postgres disk incident.
+ *
+ * Drains the historical backlog that accumulated before the periodEnd fix
+ * and the data-retention sweep shipped:
+ *
+ *   1. ImladrisMetricLineage rows attached to SUPERSEDED canonical metric
+ *      values (every pre-fix sync run minted a new metric value with a full
+ *      lineage copy — ~41.5M rows / ~15 GB as of 2026-06-11). The latest
+ *      metric value per (organizationId, userId, metricKey) keeps its
+ *      lineage; superseded values keep their computed value but lose the
+ *      duplicated evidence rows.
+ *   2. Superseded canonical metric value rows older than --keep-metric-days
+ *      (their lineage is removed first so the ON DELETE CASCADE is a no-op).
+ *   3. OutboxEvent DEAD_LETTER rows older than --outbox-dead-letter-days and
+ *      DISPATCHED rows older than --outbox-dispatched-days (~905K rows /
+ *      ~660 MB as of 2026-06-11).
+ *
+ * SAFETY
+ *   - DRY-RUN BY DEFAULT: prints what would be deleted and exits.
+ *     Pass --execute to actually delete. Run it against production only
+ *     after explicit operator approval.
+ *   - All deletes are batched (default 20K rows per statement) so locks and
+ *     WAL stay bounded while the app is live.
+ *   - Deleting rows does NOT shrink the volume: Postgres keeps the freed
+ *     pages for reuse. To hand space back to the OS, run the VACUUM FULL
+ *     step printed at the end during a maintenance window (it takes an
+ *     ACCESS EXCLUSIVE lock; after this cleanup the surviving rows are
+ *     small, so the rewrite is fast).
+ *
+ * USAGE
+ *   npm run ops:db-disk-cleanup                       # dry run (counts only)
+ *   npm run ops:db-disk-cleanup -- --execute          # delete with defaults
+ *   npm run ops:db-disk-cleanup -- --execute \
+ *     --keep-lineage-days 7 --outbox-dead-letter-days 30 --batch-size 20000
+ *
+ * See docs/runbooks/postgres-disk-incident-2026-06.md for the full runbook.
+ */
+
+import { prisma } from "@/lib/prisma";
+
+interface CliOptions {
+  execute: boolean;
+  batchSize: number;
+  /** Superseded metric values older than this keep no lineage. */
+  keepLineageDays: number;
+  /** Superseded metric values older than this are deleted entirely. */
+  keepMetricDays: number;
+  outboxDeadLetterDays: number;
+  outboxDispatchedDays: number;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    execute: false,
+    batchSize: 20_000,
+    keepLineageDays: 7,
+    keepMetricDays: 365,
+    outboxDeadLetterDays: 30,
+    outboxDispatchedDays: 14,
+  };
+
+  const numberFlag = (flag: string, current: number): number => {
+    const index = argv.indexOf(flag);
+    if (index === -1) return current;
+    const parsed = Number(argv[index + 1]);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(`${flag} expects a positive number, got "${argv[index + 1]}"`);
+    }
+    return Math.floor(parsed);
+  };
+
+  options.execute = argv.includes("--execute");
+  options.batchSize = numberFlag("--batch-size", options.batchSize);
+  options.keepLineageDays = numberFlag("--keep-lineage-days", options.keepLineageDays);
+  options.keepMetricDays = numberFlag("--keep-metric-days", options.keepMetricDays);
+  options.outboxDeadLetterDays = numberFlag(
+    "--outbox-dead-letter-days",
+    options.outboxDeadLetterDays,
+  );
+  options.outboxDispatchedDays = numberFlag(
+    "--outbox-dispatched-days",
+    options.outboxDispatchedDays,
+  );
+  return options;
+}
+
+function daysAgo(days: number): Date {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+}
+
+function formatGb(bytes: number | null): string {
+  if (bytes === null) return "n/a";
+  return `${(bytes / 1024 ** 3).toFixed(2)} GiB`;
+}
+
+async function databaseSizeBytes(): Promise<number | null> {
+  try {
+    const rows = await prisma.$queryRawUnsafe<Array<{ size: bigint }>>(
+      `SELECT pg_database_size(current_database())::bigint AS size`,
+    );
+    return rows.length > 0 ? Number(rows[0].size) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function countRows(sql: string, ...params: unknown[]): Promise<number> {
+  const rows = await prisma.$queryRawUnsafe<Array<{ count: bigint }>>(sql, ...params);
+  return rows.length > 0 ? Number(rows[0].count) : 0;
+}
+
+/** Delete rows matching the predicate in batches; returns rows deleted. */
+async function deleteInBatches(input: {
+  table: string;
+  predicateSql: string;
+  params: unknown[];
+  batchSize: number;
+  label: string;
+}): Promise<number> {
+  let total = 0;
+  for (;;) {
+    const affected = await prisma.$executeRawUnsafe(
+      `DELETE FROM "${input.table}" WHERE "id" IN (SELECT "id" FROM "${input.table}" WHERE ${input.predicateSql} LIMIT $${input.params.length + 1})`,
+      ...input.params,
+      input.batchSize,
+    );
+    total += affected;
+    if (total > 0 && total % 200_000 < input.batchSize) {
+      console.info(`[db-cleanup]   ${input.label}: ${total.toLocaleString()} rows deleted so far...`);
+    }
+    if (affected < input.batchSize) return total;
+  }
+}
+
+const SUPERSEDED_PREDICATE = `
+  "periodEnd" < $1
+  AND EXISTS (
+    SELECT 1 FROM "ImladrisCanonicalMetricValue" newer
+    WHERE newer."metricKey" = "ImladrisCanonicalMetricValue"."metricKey"
+      AND newer."organizationId" IS NOT DISTINCT FROM "ImladrisCanonicalMetricValue"."organizationId"
+      AND newer."userId" IS NOT DISTINCT FROM "ImladrisCanonicalMetricValue"."userId"
+      AND newer."periodEnd" > "ImladrisCanonicalMetricValue"."periodEnd"
+  )
+`;
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const lineageCutoff = daysAgo(options.keepLineageDays);
+  const metricCutoff = daysAgo(options.keepMetricDays);
+  const deadLetterCutoff = daysAgo(options.outboxDeadLetterDays);
+  const dispatchedCutoff = daysAgo(options.outboxDispatchedDays);
+
+  console.info("[db-cleanup] mode:", options.execute ? "EXECUTE (will delete rows)" : "DRY RUN (counts only — pass --execute to delete)");
+  console.info("[db-cleanup] options:", JSON.stringify(options));
+
+  const sizeBefore = await databaseSizeBytes();
+  console.info(`[db-cleanup] database size: ${formatGb(sizeBefore)}`);
+
+  // ── 1. Superseded metric values and their lineage ────────────────────────
+  const supersededValues = await countRows(
+    `SELECT count(*)::bigint AS count FROM "ImladrisCanonicalMetricValue" WHERE ${SUPERSEDED_PREDICATE}`,
+    lineageCutoff,
+  );
+  const supersededLineage = await countRows(
+    `SELECT count(*)::bigint AS count FROM "ImladrisMetricLineage" l
+     WHERE EXISTS (
+       SELECT 1 FROM "ImladrisCanonicalMetricValue"
+       WHERE "ImladrisCanonicalMetricValue"."id" = l."metricValueId" AND ${SUPERSEDED_PREDICATE}
+     )`,
+    lineageCutoff,
+  );
+  console.info(
+    `[db-cleanup] superseded metric values (periodEnd < ${lineageCutoff.toISOString()}): ${supersededValues.toLocaleString()} rows, carrying ${supersededLineage.toLocaleString()} lineage rows`,
+  );
+
+  // Orphaned lineage (metric value no longer exists) — defensive sweep.
+  const orphanedLineage = await countRows(
+    `SELECT count(*)::bigint AS count FROM "ImladrisMetricLineage" l
+     WHERE NOT EXISTS (SELECT 1 FROM "ImladrisCanonicalMetricValue" c WHERE c."id" = l."metricValueId")`,
+  );
+  console.info(`[db-cleanup] orphaned lineage rows: ${orphanedLineage.toLocaleString()}`);
+
+  // ── 2. Outbox backlog ─────────────────────────────────────────────────────
+  const deadLetters = await countRows(
+    `SELECT count(*)::bigint AS count FROM "OutboxEvent" WHERE "status" = 'DEAD_LETTER' AND "createdAt" < $1`,
+    deadLetterCutoff,
+  );
+  const dispatched = await countRows(
+    `SELECT count(*)::bigint AS count FROM "OutboxEvent" WHERE "status" = 'DISPATCHED' AND "dispatchedAt" < $1`,
+    dispatchedCutoff,
+  );
+  console.info(`[db-cleanup] outbox DEAD_LETTER older than ${options.outboxDeadLetterDays}d: ${deadLetters.toLocaleString()} rows`);
+  console.info(`[db-cleanup] outbox DISPATCHED older than ${options.outboxDispatchedDays}d: ${dispatched.toLocaleString()} rows`);
+
+  if (!options.execute) {
+    console.info("[db-cleanup] DRY RUN complete. Re-run with --execute (after operator approval) to delete the rows above.");
+    return;
+  }
+
+  // ── Execute ───────────────────────────────────────────────────────────────
+  console.info("[db-cleanup] deleting lineage for superseded metric values (batched per metric value)...");
+  let lineageDeleted = 0;
+  for (;;) {
+    // The candidate set shrinks as lineage is deleted (the EXISTS-lineage
+    // clause stops matching), so plain LIMIT pagination converges.
+    const candidates = await prisma.$queryRawUnsafe<Array<{ id: string }>>(
+      `SELECT "id" FROM "ImladrisCanonicalMetricValue"
+       WHERE ${SUPERSEDED_PREDICATE}
+         AND EXISTS (SELECT 1 FROM "ImladrisMetricLineage" l WHERE l."metricValueId" = "ImladrisCanonicalMetricValue"."id")
+       ORDER BY "periodEnd" ASC LIMIT 500`,
+      lineageCutoff,
+    );
+    if (candidates.length === 0) break;
+    for (const candidate of candidates) {
+      lineageDeleted += await deleteInBatches({
+        table: "ImladrisMetricLineage",
+        predicateSql: `"metricValueId" = $1`,
+        params: [candidate.id],
+        batchSize: options.batchSize,
+        label: "superseded lineage",
+      });
+    }
+    console.info(`[db-cleanup]   superseded lineage: ${lineageDeleted.toLocaleString()} rows deleted so far`);
+  }
+  console.info(`[db-cleanup] superseded lineage deleted: ${lineageDeleted.toLocaleString()} rows`);
+
+  console.info("[db-cleanup] deleting orphaned lineage...");
+  const orphansDeleted = await deleteInBatches({
+    table: "ImladrisMetricLineage",
+    predicateSql: `NOT EXISTS (SELECT 1 FROM "ImladrisCanonicalMetricValue" c WHERE c."id" = "ImladrisMetricLineage"."metricValueId")`,
+    params: [],
+    batchSize: options.batchSize,
+    label: "orphaned lineage",
+  });
+  console.info(`[db-cleanup] orphaned lineage deleted: ${orphansDeleted.toLocaleString()} rows`);
+
+  console.info("[db-cleanup] deleting superseded metric values past the metric retention window...");
+  // $1 = metricCutoff: only superseded values older than --keep-metric-days
+  // are removed entirely; their lineage is already gone, so the ON DELETE
+  // CASCADE has nothing to fan out to.
+  const oldValuesDeleted = await deleteInBatches({
+    table: "ImladrisCanonicalMetricValue",
+    predicateSql: SUPERSEDED_PREDICATE,
+    params: [metricCutoff],
+    batchSize: 500, // cascade per row is tiny now, but keep batches small
+    label: "superseded metric values",
+  });
+  console.info(`[db-cleanup] superseded metric values deleted: ${oldValuesDeleted.toLocaleString()} rows`);
+
+  console.info("[db-cleanup] deleting outbox backlog...");
+  const deadLettersDeleted = await deleteInBatches({
+    table: "OutboxEvent",
+    predicateSql: `"status" = 'DEAD_LETTER' AND "createdAt" < $1`,
+    params: [deadLetterCutoff],
+    batchSize: options.batchSize,
+    label: "outbox dead letters",
+  });
+  const dispatchedDeleted = await deleteInBatches({
+    table: "OutboxEvent",
+    predicateSql: `"status" = 'DISPATCHED' AND "dispatchedAt" < $1`,
+    params: [dispatchedCutoff],
+    batchSize: options.batchSize,
+    label: "outbox dispatched",
+  });
+  console.info(
+    `[db-cleanup] outbox deleted: ${deadLettersDeleted.toLocaleString()} dead letters, ${dispatchedDeleted.toLocaleString()} dispatched`,
+  );
+
+  const sizeAfter = await databaseSizeBytes();
+  console.info(`[db-cleanup] database size (logical): ${formatGb(sizeBefore)} -> ${formatGb(sizeAfter)}`);
+  console.info(`
+[db-cleanup] DONE. IMPORTANT — the volume is NOT smaller yet:
+  Deleted pages are reusable by Postgres but are not returned to the OS,
+  so Railway still reports the same volume usage. To reclaim the space,
+  run during a quiet window (each statement takes an ACCESS EXCLUSIVE
+  lock on its table while it rewrites; with the backlog gone each should
+  finish in seconds to a few minutes):
+
+    VACUUM (FULL, VERBOSE, ANALYZE) "ImladrisMetricLineage";
+    VACUUM (FULL, VERBOSE, ANALYZE) "ImladrisCanonicalMetricValue";
+    VACUUM (FULL, VERBOSE, ANALYZE) "OutboxEvent";
+
+  Also consider dropping the leftover probe databases (wipguard_probe_*):
+    SELECT datname FROM pg_database WHERE datname LIKE 'wipguard_probe_%';
+    -- then for each: DROP DATABASE "wipguard_probe_<ts>";
+`);
+}
+
+main()
+  .catch((error) => {
+    console.error("[db-cleanup] failed", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app/api/cron/sync/route.ts
+++ b/src/app/api/cron/sync/route.ts
@@ -387,6 +387,7 @@ async function executeCronSync(input: {
       health: null as unknown,
       pruning: null as unknown,
       retention: null as unknown,
+      dataRetention: null as unknown,
     };
 
     if (analyticsSyncResult.status === "fulfilled") {
@@ -394,6 +395,9 @@ async function executeCronSync(input: {
       // top-level fields — external monitors read these separately.
       settled.analytics = analyticsSyncResult.value.refresh;
       settled.pruning = analyticsSyncResult.value.pruning;
+      // Bounded operational-data retention sweep (lineage/outbox/audit/funnel)
+      // — see src/lib/ops/data-retention.ts.
+      settled.dataRetention = analyticsSyncResult.value.dataRetention;
       failures.push(...collectAnalyticsPartialFailures(analyticsSyncResult.value));
     } else {
       const msg = analyticsSyncResult.reason instanceof Error ? analyticsSyncResult.reason.message : String(analyticsSyncResult.reason);

--- a/src/app/api/health/route.test.ts
+++ b/src/app/api/health/route.test.ts
@@ -4,6 +4,7 @@ import packageJson from "../../../../package.json";
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     $queryRaw: vi.fn(),
+    $queryRawUnsafe: vi.fn(),
   },
 }));
 
@@ -22,6 +23,10 @@ describe("GET /api/health", () => {
     const { poolMonitor } = await import("@/lib/pool-monitor");
 
     vi.mocked(prisma.$queryRaw).mockResolvedValue(undefined as never);
+    // Storage check: ~2 GB database against the default 20 GB volume.
+    vi.mocked(prisma.$queryRawUnsafe).mockResolvedValue([
+      { size: BigInt(2_000_000_000) },
+    ] as never);
     vi.mocked(poolMonitor.getHealthStatus).mockReturnValue({
       status: "healthy",
       pool: {
@@ -60,8 +65,85 @@ describe("GET /api/health", () => {
           idle: 3,
           waiting: 0,
         },
+        storage: {
+          status: "ok",
+          databaseSizeMb: 2000,
+          volumeCapacityMb: 20000,
+          usagePercent: 10,
+        },
       },
       uptime: 1234,
+    });
+  });
+
+  it("reports a storage warning without failing the health check", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { prisma } = await import("@/lib/prisma");
+    // 16 GB of 20 GB = 80% -> above the 75% warn threshold.
+    vi.mocked(prisma.$queryRawUnsafe).mockResolvedValue([
+      { size: BigInt(16_000_000_000) },
+    ] as never);
+
+    try {
+      const { GET } = await import("@/app/api/health/route");
+      const response = await GET();
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.status).toBe("ok");
+      expect(body.checks.storage).toMatchObject({
+        status: "warning",
+        databaseSizeMb: 16000,
+        usagePercent: 80,
+      });
+      expect(consoleError).toHaveBeenCalledWith(
+        "[health:storage]",
+        expect.stringContaining('"warning"'),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("returns 503 degraded when disk usage crosses the critical threshold", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { prisma } = await import("@/lib/prisma");
+    // 18.6 GB of 20 GB = 93% -> the June 2026 incident level.
+    vi.mocked(prisma.$queryRawUnsafe).mockResolvedValue([
+      { size: BigInt(18_598_000_000) },
+    ] as never);
+
+    try {
+      const { GET } = await import("@/app/api/health/route");
+      const response = await GET();
+      const body = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(body.status).toBe("degraded");
+      expect(body.checks.storage).toMatchObject({
+        status: "critical",
+        usagePercent: 93,
+      });
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("degrades the storage check to unknown when the size query fails", async () => {
+    const { prisma } = await import("@/lib/prisma");
+    vi.mocked(prisma.$queryRawUnsafe).mockRejectedValue(
+      new Error("permission denied"),
+    );
+
+    const { GET } = await import("@/app/api/health/route");
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("ok");
+    expect(body.checks.storage).toMatchObject({
+      status: "unknown",
+      error: "permission denied",
     });
   });
 

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -5,17 +5,124 @@ import { poolMonitor } from "@/lib/pool-monitor";
 
 const APP_VERSION = process.env.APP_VERSION?.trim() || packageJson.version;
 
+/** Railway Postgres volume capacity. Override via DATABASE_VOLUME_CAPACITY_MB. */
+const DEFAULT_VOLUME_CAPACITY_MB = 20_000;
+const DEFAULT_DISK_WARN_PERCENT = 75;
+const DEFAULT_DISK_CRITICAL_PERCENT = 90;
+
+function parsePositiveNumberEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  const parsed = raw ? Number(raw) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  return fallback;
+}
+
+interface StorageCheck {
+  status: "ok" | "warning" | "critical" | "unknown";
+  databaseSizeMb: number | null;
+  volumeCapacityMb: number;
+  usagePercent: number | null;
+  warnPercent: number;
+  criticalPercent: number;
+  error?: string;
+}
+
+/**
+ * Database disk-usage check.
+ *
+ * The June 2026 incident (Postgres volume silently filled to 93%) went
+ * unnoticed because nothing reported storage. This check compares
+ * pg_database_size() against the configured volume capacity and emits a
+ * structured `[health:storage]` log line at warning/critical levels so
+ * Railway log-based alerts (and anything polling /api/health) can fire
+ * long before writes start failing.
+ *
+ * NOTE: pg_database_size() measures the database only; WAL, temp files and
+ * other databases on the volume add roughly 5-10% on top. Thresholds are
+ * chosen with that headroom in mind.
+ */
+async function checkStorage(): Promise<StorageCheck> {
+  const volumeCapacityMb = parsePositiveNumberEnv(
+    "DATABASE_VOLUME_CAPACITY_MB",
+    DEFAULT_VOLUME_CAPACITY_MB,
+  );
+  const warnPercent = parsePositiveNumberEnv(
+    "DATABASE_DISK_WARN_PERCENT",
+    DEFAULT_DISK_WARN_PERCENT,
+  );
+  const criticalPercent = parsePositiveNumberEnv(
+    "DATABASE_DISK_CRITICAL_PERCENT",
+    DEFAULT_DISK_CRITICAL_PERCENT,
+  );
+
+  try {
+    const rows = await prisma.$queryRawUnsafe<Array<{ size: unknown }>>(
+      "SELECT pg_database_size(current_database())::bigint AS size",
+    );
+    const raw = Array.isArray(rows) && rows.length > 0 ? rows[0].size : null;
+    const sizeBytes = typeof raw === "bigint" ? Number(raw) : Number(raw);
+    if (!Number.isFinite(sizeBytes) || sizeBytes < 0) {
+      return {
+        status: "unknown",
+        databaseSizeMb: null,
+        volumeCapacityMb,
+        usagePercent: null,
+        warnPercent,
+        criticalPercent,
+        error: "pg_database_size returned a non-numeric value",
+      };
+    }
+
+    const databaseSizeMb = Math.round(sizeBytes / 1_000_000);
+    const usagePercent =
+      Math.round((databaseSizeMb / volumeCapacityMb) * 1000) / 10;
+    const status: StorageCheck["status"] =
+      usagePercent >= criticalPercent
+        ? "critical"
+        : usagePercent >= warnPercent
+          ? "warning"
+          : "ok";
+
+    const check: StorageCheck = {
+      status,
+      databaseSizeMb,
+      volumeCapacityMb,
+      usagePercent,
+      warnPercent,
+      criticalPercent,
+    };
+
+    if (status !== "ok") {
+      // Structured, grep-able line for Railway log alerting.
+      console.error("[health:storage]", JSON.stringify(check));
+    }
+
+    return check;
+  } catch (error) {
+    return {
+      status: "unknown",
+      databaseSizeMb: null,
+      volumeCapacityMb,
+      usagePercent: null,
+      warnPercent,
+      criticalPercent,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}
+
 /**
  * GET /api/health
  *
- * Dependency health endpoint that verifies database connectivity
- * and reports pool status.
+ * Dependency health endpoint that verifies database connectivity and
+ * reports pool + storage status.
  *
  * Returns:
- * - 200 if database is reachable and pool is healthy/warning
- * - 503 if database is unreachable or pool is critical
+ * - 200 if database is reachable and pool/storage are healthy or warning
+ * - 503 if database is unreachable, pool is critical, or disk usage has
+ *   crossed the critical threshold
  *
- * @see Issue #378
+ * @see Issue #378; docs/runbooks/postgres-disk-incident-2026-06.md
  */
 export async function GET() {
   const startTime = Date.now();
@@ -30,8 +137,9 @@ export async function GET() {
 
     const { status: poolStatus, pool: poolMetrics } =
       poolMonitor.getHealthStatus();
+    const storage = await checkStorage();
 
-    const isHealthy = poolStatus !== "critical";
+    const isHealthy = poolStatus !== "critical" && storage.status !== "critical";
 
     return NextResponse.json(
       {
@@ -52,6 +160,7 @@ export async function GET() {
             errors: poolMetrics.totalConnectionErrors,
             exhaustionEvents: poolMetrics.totalPoolExhaustionEvents,
           },
+          storage,
         },
         uptime: poolMetrics.uptimeMs,
       },

--- a/src/lib/imladris/company-readiness-setup.test.ts
+++ b/src/lib/imladris/company-readiness-setup.test.ts
@@ -314,8 +314,8 @@ describe("runCompanyReadinessSetup", () => {
     expect(materializeImladrisCanonicalMetrics).toHaveBeenCalledWith({
       prisma,
       context: CONTEXT,
-      periodStart: new Date("2026-05-02T12:00:00.000Z"),
-      periodEnd: new Date("2026-06-01T12:00:00.000Z"),
+      periodStart: new Date("2026-05-02T00:00:00.000Z"),
+      periodEnd: new Date("2026-06-01T00:00:00.000Z"),
       now: new Date("2026-06-01T12:00:00.000Z"),
     });
     expect(prisma.financialGoal.create).toHaveBeenCalledTimes(3);

--- a/src/lib/imladris/company-readiness-setup.ts
+++ b/src/lib/imladris/company-readiness-setup.ts
@@ -1,7 +1,11 @@
 import { GoalMetric, GoalStatus } from "@/generated/prisma/client";
 import { buildImladrisRawRecordsFromPayload } from "@/lib/imladris/raw-records";
 import { ingestImladrisRawRecords } from "@/lib/imladris/ingestion";
-import { materializeImladrisCanonicalMetrics, type MaterializedImladrisMetricResult } from "@/lib/imladris/materialization";
+import {
+  imladrisCanonicalPeriodEnd,
+  materializeImladrisCanonicalMetrics,
+  type MaterializedImladrisMetricResult,
+} from "@/lib/imladris/materialization";
 import { buildCompanyTrackerDashboard, type CompanyTrackerDashboardData } from "@/lib/imladris/company-tracker";
 import { getImladrisDashboardDefinition, REQUIRED_IMLADRIS_PROVIDERS } from "@/lib/imladris/catalog";
 import {
@@ -303,7 +307,10 @@ export async function runCompanyReadinessSetup(input: {
   now?: Date;
 }): Promise<CompanyReadinessSetupResult> {
   const now = input.now ?? new Date();
-  const periodEnd = now;
+  // Stable per-day boundary — periodEnd participates in the canonical metric
+  // upsert key; a raw `now` here mints a new metric value (and full lineage
+  // copy) on every invocation. See imladrisCanonicalPeriodEnd().
+  const periodEnd = imladrisCanonicalPeriodEnd(now);
   const periodStart = daysBefore(periodEnd, IMLADRIS_MATERIALIZATION_WINDOW_DAYS);
   const snapshots = await loadLatestCompanySnapshots({
     prisma: input.prisma,

--- a/src/lib/imladris/company-tracker.ts
+++ b/src/lib/imladris/company-tracker.ts
@@ -42,6 +42,20 @@ interface MetricLineageRow {
   metadata: unknown;
 }
 
+/**
+ * Aggregate view of a metric value's lineage, computed in SQL.
+ *
+ * The dashboard only ever needs the row count, the distinct source keys and
+ * the latest capture timestamp — never the raw lineage rows. Loading raw
+ * rows via `include: { lineage }` pulled tens of millions of rows into the
+ * Node heap during the June 2026 incident and OOM-crashed the app.
+ */
+interface MetricLineageSummary {
+  count: number;
+  sourceKeys: string[];
+  latestCapturedAt: string | null;
+}
+
 interface CanonicalMetricRow {
   id: string;
   metricKey: string;
@@ -55,7 +69,10 @@ interface CanonicalMetricRow {
   periodEnd: Date | string;
   userId?: string | null;
   organizationId?: string | null;
-  lineage: MetricLineageRow[];
+  /** Raw lineage rows. Only populated by legacy callers/test fixtures. */
+  lineage?: MetricLineageRow[];
+  /** SQL-side aggregate; preferred over `lineage` when present. */
+  lineageSummary?: MetricLineageSummary;
 }
 
 interface FinancialGoalRow {
@@ -313,7 +330,10 @@ export type CompanyTrackerHealthBand = CompanyHealthBand;
 
 export type CompanyTrackerPrisma = Pick<
   PrismaClientType,
-  "imladrisCanonicalMetricValue" | "financialGoal" | "analyticsSnapshot"
+  | "imladrisCanonicalMetricValue"
+  | "imladrisMetricLineage"
+  | "financialGoal"
+  | "analyticsSnapshot"
 >;
 
 const ANALYTICS_SNAPSHOT_BASE_PROVIDER_KEYS = [
@@ -1783,7 +1803,8 @@ function companyMetric(
       sourceLineageKeys: [],
     };
   }
-  const latestSourceCapturedAt = latestLineageCapturedAt(row.lineage);
+  const lineageSummary = lineageSummaryForRow(row);
+  const latestSourceCapturedAt = lineageSummary.latestCapturedAt;
   return {
     key,
     label: definition?.label ?? key,
@@ -1795,9 +1816,19 @@ function companyMetric(
     calculationVersion: row.calculationVersion,
     computedAt: toIso(row.computedAt),
     periodEnd: toIso(row.periodEnd),
-    sourceLineageCount: row.lineage?.length ?? 0,
-    sourceLineageKeys: lineageSourceKeys(row.lineage),
+    sourceLineageCount: lineageSummary.count,
+    sourceLineageKeys: lineageSummary.sourceKeys,
     ...(latestSourceCapturedAt ? { latestSourceCapturedAt } : {}),
+  };
+}
+
+/** Prefer the SQL-side aggregate; fall back to raw rows for legacy callers. */
+function lineageSummaryForRow(row: CanonicalMetricRow): MetricLineageSummary {
+  if (row.lineageSummary) return row.lineageSummary;
+  return {
+    count: row.lineage?.length ?? 0,
+    sourceKeys: lineageSourceKeys(row.lineage),
+    latestCapturedAt: latestLineageCapturedAt(row.lineage),
   };
 }
 
@@ -2663,8 +2694,8 @@ function buildBenchmarkContext(input: {
 function canonicalSourceKeys(rows: CanonicalMetricRow[]): Set<string> {
   const sourceKeys = new Set<string>();
   for (const row of rows) {
-    for (const lineage of row.lineage ?? []) {
-      if (lineage.sourceKey) sourceKeys.add(lineage.sourceKey);
+    for (const sourceKey of lineageSummaryForRow(row).sourceKeys) {
+      if (sourceKey) sourceKeys.add(sourceKey);
     }
   }
   return sourceKeys;
@@ -2872,6 +2903,62 @@ function buildBoardReadiness(input: {
   };
 }
 
+/**
+ * Compute lineage aggregates (count, distinct source keys, latest capture)
+ * for the given canonical rows in a single SQL groupBy and attach them as
+ * `lineageSummary`. Result size is bounded by rows x distinct source keys
+ * (~a dozen), independent of how many lineage rows exist in the table.
+ *
+ * Rows that already carry inline `lineage` or a `lineageSummary` (legacy
+ * callers and test fixtures) are left untouched — `lineageSummaryForRow`
+ * derives their summary directly. Only rows that need the SQL aggregate
+ * trigger the groupBy, so callers passing pre-hydrated rows never require an
+ * `imladrisMetricLineage` delegate on their prisma client.
+ */
+async function attachLineageSummaries(
+  prisma: CompanyTrackerPrisma,
+  rows: CanonicalMetricRow[],
+): Promise<void> {
+  const rowsNeedingAggregate = rows.filter(
+    (row) => row.lineageSummary === undefined && row.lineage === undefined,
+  );
+  if (rowsNeedingAggregate.length === 0) return;
+
+  const grouped = await prisma.imladrisMetricLineage.groupBy({
+    by: ["metricValueId", "sourceKey"],
+    where: { metricValueId: { in: rowsNeedingAggregate.map((row) => row.id) } },
+    _count: { _all: true },
+    _max: { capturedAt: true },
+  });
+
+  const summaries = new Map<string, MetricLineageSummary>();
+  for (const group of grouped) {
+    const summary = summaries.get(group.metricValueId) ?? {
+      count: 0,
+      sourceKeys: [],
+      latestCapturedAt: null,
+    };
+    summary.count += group._count._all;
+    const sourceKey = group.sourceKey?.trim();
+    if (sourceKey) summary.sourceKeys.push(sourceKey);
+    const capturedAt = toIso(group._max.capturedAt);
+    if (capturedAt && (!summary.latestCapturedAt || capturedAt > summary.latestCapturedAt)) {
+      summary.latestCapturedAt = capturedAt;
+    }
+    summaries.set(group.metricValueId, summary);
+  }
+
+  for (const row of rowsNeedingAggregate) {
+    const summary = summaries.get(row.id) ?? {
+      count: 0,
+      sourceKeys: [],
+      latestCapturedAt: null,
+    };
+    summary.sourceKeys.sort();
+    row.lineageSummary = summary;
+  }
+}
+
 export async function buildCompanyTrackerDashboard(input: {
   prisma: CompanyTrackerPrisma;
   context: UserContext;
@@ -2894,17 +2981,17 @@ export async function buildCompanyTrackerDashboard(input: {
       })
     : Promise.resolve([]);
   const [canonicalRows, goals, analyticsStats] = await Promise.all([
+    // IMPORTANT: do NOT `include: { lineage }` here. Lineage rows number in
+    // the thousands per metric value; loading them into Node memory crashed
+    // the app with heap OOM during the June 2026 disk incident. The lineage
+    // facts the dashboard needs (count, source keys, latest capture) are
+    // aggregated in SQL below.
     input.prisma.imladrisCanonicalMetricValue.findMany({
       where: {
         metricKey: { in: dashboard.metricKeys },
         periodEnd: { lte: now },
         computedAt: { lte: now },
         ...canonicalMetricScopeWhere(context),
-      },
-      include: {
-        lineage: {
-          orderBy: [{ createdAt: "asc" }],
-        },
       },
       orderBy: [{ periodEnd: "desc" }, { computedAt: "desc" }],
     }),
@@ -2922,6 +3009,7 @@ export async function buildCompanyTrackerDashboard(input: {
       rowMatchesContext(row, context)
     );
   });
+  await attachLineageSummaries(input.prisma, typedCanonicalRows);
   const typedGoals = activeGoalsForContext(goals as FinancialGoalRow[], context);
   const latestMetrics = latestRowsByMetric(typedCanonicalRows, context);
   const metrics = dashboard.metricKeys.map((metricKey) =>

--- a/src/lib/imladris/investor-dashboard-export.ts
+++ b/src/lib/imladris/investor-dashboard-export.ts
@@ -32,6 +32,14 @@ const INVESTOR_METRIC_KEYS = (getImladrisDashboardDefinition("company")?.metricK
 ]).filter((key) => getImladrisDerivedMetricDefinition(key) === null);
 const EXPORT_SOURCE = "imladris-investor-dashboard-export";
 const EXPORT_SCHEMA_VERSION = 1;
+/**
+ * Cap on lineage (evidence) rows loaded per canonical metric value. This
+ * export emits full per-row evidence, so without a bound a single bloated
+ * metric value can OOM-crash the process (the June 2026 incident had values
+ * carrying ~300K lineage rows). A few hundred rows exceeds any real evidence
+ * need. See docs/runbooks/postgres-disk-incident-2026-06.md.
+ */
+const MAX_LINEAGE_EVIDENCE_ROWS = 500;
 const RAW_PROVIDERS = [
   "STRIPE",
   "HUBSPOT",
@@ -3822,6 +3830,7 @@ export async function buildInvestorDashboardExport(input: {
       include: {
         lineage: {
           orderBy: [{ createdAt: "asc" }],
+          take: MAX_LINEAGE_EVIDENCE_ROWS,
         },
       },
       orderBy: [{ periodEnd: "desc" }, { computedAt: "desc" }],

--- a/src/lib/imladris/materialization.ts
+++ b/src/lib/imladris/materialization.ts
@@ -125,9 +125,31 @@ type CanonicalMetricDelegate = {
 };
 
 type MetricLineageDelegate = {
-  deleteMany(args: { where: { metricValueId: string } }): Promise<unknown>;
+  deleteMany(args: {
+    where: { metricValueId: string; createdAt?: { lt: Date } };
+  }): Promise<unknown>;
   createMany(args: { data: Array<Record<string, unknown>> }): Promise<unknown>;
 };
+
+/**
+ * Canonical materialization period boundary.
+ *
+ * The canonical metric upsert key includes `periodEnd`, so periodEnd MUST be
+ * stable across sync runs within the same period or every run inserts a new
+ * metric value row (plus a full copy of its lineage evidence) instead of
+ * updating the existing one. Passing a raw `new Date()` here is what filled
+ * the production Postgres volume in June 2026 (~41.5M lineage rows in one
+ * week — see docs/runbooks/postgres-disk-incident-2026-06.md).
+ *
+ * Truncating to the start of the current UTC day gives one metric value per
+ * metricKey per day: repeated runs within a day update in place, and history
+ * accrues at a bounded one-row-per-day rate.
+ */
+export function imladrisCanonicalPeriodEnd(now: Date): Date {
+  const periodEnd = new Date(now);
+  periodEnd.setUTCHours(0, 0, 0, 0);
+  return periodEnd;
+}
 
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -1315,28 +1337,42 @@ async function replaceLineage(input: {
   calculationVersion: string;
   asOf: Date;
 }) {
+  // Insert the fresh evidence set FIRST (with an explicit createdAt stamp),
+  // then delete everything older than the stamp. The two statements are not
+  // transactional, so this ordering matters:
+  //   - delete-then-insert loses lineage permanently if the insert fails;
+  //   - insert-then-prune at worst leaves a stale duplicate set that the
+  //     next run (or the data-retention sweep) removes.
+  // Concurrent runs against the same metricValueId converge for the same
+  // reason: each prune removes every row older than its own insert batch.
+  const insertStamp = new Date();
+  if (input.records.length > 0) {
+    await input.metricLineage.createMany({
+      data: input.records.map((record) => ({
+        metricValueId: input.metricValueId,
+        rawRecordId: record.id,
+        sourceKey: sourceKeyForProvider(record.provider),
+        sourceType: recordObjectType(record),
+        sourceId: rawRecordSourceId(record),
+        capturedAt: firstDateAtOrBefore(
+          input.asOf,
+          record.occurredAt,
+          record.sourceUpdatedAt,
+          record.sourceCreatedAt,
+        ),
+        createdAt: insertStamp,
+        metadata: {
+          provider: record.provider,
+          calculationVersion: input.calculationVersion,
+        },
+      })),
+    });
+  }
   await input.metricLineage.deleteMany({
-    where: { metricValueId: input.metricValueId },
-  });
-  if (input.records.length === 0) return;
-  await input.metricLineage.createMany({
-    data: input.records.map((record) => ({
+    where: {
       metricValueId: input.metricValueId,
-      rawRecordId: record.id,
-      sourceKey: sourceKeyForProvider(record.provider),
-      sourceType: recordObjectType(record),
-      sourceId: rawRecordSourceId(record),
-      capturedAt: firstDateAtOrBefore(
-        input.asOf,
-        record.occurredAt,
-        record.sourceUpdatedAt,
-        record.sourceCreatedAt,
-      ),
-      metadata: {
-        provider: record.provider,
-        calculationVersion: input.calculationVersion,
-      },
-    })),
+      createdAt: { lt: insertStamp },
+    },
   });
 }
 

--- a/src/lib/imladris/service.ts
+++ b/src/lib/imladris/service.ts
@@ -13,6 +13,18 @@ import { resolveIntegrationOwnerUserId } from "@/lib/integrations/ownership";
 import type { IntegrationProvider } from "@/generated/prisma/client";
 import type { PrismaClientType } from "@/lib/prisma";
 
+/**
+ * Cap on lineage (evidence) rows loaded per canonical metric value.
+ *
+ * This view emits full per-row evidence, so it can't use the SQL-aggregate
+ * shortcut the company dashboard uses. Without a cap, a single bloated
+ * metric value (the June 2026 incident had values carrying ~300K lineage
+ * rows) pulls enough rows into the Node heap to OOM-crash the app. A few
+ * hundred evidence rows is far more than any UI surfaces; the bound only
+ * truncates pathological rows. See docs/runbooks/postgres-disk-incident-2026-06.md.
+ */
+const MAX_LINEAGE_EVIDENCE_ROWS = 500;
+
 type SourceStatus = "connected" | "missing" | "partial" | "stale" | "error";
 type MetricStatus = "ready" | "missing" | "partial" | "stale" | "error";
 
@@ -1554,6 +1566,7 @@ export async function buildImladrisMetrics(input: {
       include: {
         lineage: {
           orderBy: [{ createdAt: "asc" }],
+          take: MAX_LINEAGE_EVIDENCE_ROWS,
         },
       },
       orderBy: [{ periodEnd: "desc" }, { computedAt: "desc" }],

--- a/src/lib/ops/data-retention.test.ts
+++ b/src/lib/ops/data-retention.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  loadDataRetentionConfig,
+  runDataRetentionSweep,
+  type DataRetentionConfig,
+  type DataRetentionPrisma,
+} from "./data-retention";
+
+function testConfig(overrides: Partial<DataRetentionConfig> = {}): DataRetentionConfig {
+  return {
+    enabled: true,
+    dryRun: false,
+    batchSize: 100,
+    maxRowsPerTablePerRun: 1000,
+    imladrisLineageRetentionDays: 7,
+    imladrisMetricRetentionDays: 365,
+    outboxDispatchedRetentionDays: 14,
+    outboxDeadLetterRetentionDays: 90,
+    securityAuditRetentionDays: 365,
+    funnelEventRetentionDays: 365,
+    ...overrides,
+  };
+}
+
+interface FakePrisma extends DataRetentionPrisma {
+  queries: Array<{ sql: string; values: unknown[] }>;
+  executes: Array<{ sql: string; values: unknown[] }>;
+}
+
+function fakePrisma(input: {
+  /** Metric value ids returned by candidate SELECTs (first call wins, then empty). */
+  candidateIds?: string[];
+  /** Rows affected per DELETE call, consumed in order; defaults to 0 afterwards. */
+  deleteResults?: number[];
+  /** Count returned for dry-run count queries. */
+  dryRunCount?: number;
+} = {}): FakePrisma {
+  const candidateBatches: Array<Array<{ id: string }>> = input.candidateIds
+    ? [input.candidateIds.map((id) => ({ id }))]
+    : [];
+  const deleteResults = [...(input.deleteResults ?? [])];
+
+  const prisma: FakePrisma = {
+    queries: [],
+    executes: [],
+    async $queryRawUnsafe<T>(sql: string, ...values: unknown[]): Promise<T> {
+      prisma.queries.push({ sql, values });
+      if (sql.includes("pg_database_size")) {
+        return [{ size: BigInt(123) }] as unknown as T;
+      }
+      if (sql.includes("count(*)")) {
+        return [{ count: BigInt(input.dryRunCount ?? 0) }] as unknown as T;
+      }
+      // Candidate id SELECTs
+      return (candidateBatches.shift() ?? []) as unknown as T;
+    },
+    async $executeRawUnsafe(sql: string, ...values: unknown[]): Promise<number> {
+      prisma.executes.push({ sql, values });
+      const limit = values[values.length - 1];
+      const affected = deleteResults.shift() ?? 0;
+      // A real DELETE ... LIMIT n can never affect more than n rows.
+      return typeof limit === "number" ? Math.min(affected, limit) : affected;
+    },
+  };
+  return prisma;
+}
+
+describe("loadDataRetentionConfig", () => {
+  const ENV_KEYS = [
+    "DATA_RETENTION_ENABLED",
+    "DATA_RETENTION_DRY_RUN",
+    "DATA_RETENTION_BATCH_SIZE",
+    "DATA_RETENTION_MAX_ROWS_PER_RUN",
+    "IMLADRIS_LINEAGE_RETENTION_DAYS",
+    "IMLADRIS_METRIC_RETENTION_DAYS",
+    "OUTBOX_DISPATCHED_RETENTION_DAYS",
+    "OUTBOX_DEAD_LETTER_RETENTION_DAYS",
+    "SECURITY_AUDIT_RETENTION_DAYS",
+    "FUNNEL_EVENT_RETENTION_DAYS",
+  ];
+  const saved = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = saved.get(key);
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("defaults to enabled, non-dry-run, with conservative windows", () => {
+    const config = loadDataRetentionConfig();
+    expect(config.enabled).toBe(true);
+    expect(config.dryRun).toBe(false);
+    expect(config.batchSize).toBe(20_000);
+    expect(config.maxRowsPerTablePerRun).toBe(200_000);
+    expect(config.imladrisLineageRetentionDays).toBe(7);
+    expect(config.imladrisMetricRetentionDays).toBe(365);
+    expect(config.outboxDispatchedRetentionDays).toBe(14);
+    expect(config.outboxDeadLetterRetentionDays).toBe(90);
+    expect(config.securityAuditRetentionDays).toBe(365);
+    expect(config.funnelEventRetentionDays).toBe(365);
+  });
+
+  it("honours environment overrides", () => {
+    process.env.DATA_RETENTION_ENABLED = "false";
+    process.env.DATA_RETENTION_DRY_RUN = "true";
+    process.env.DATA_RETENTION_BATCH_SIZE = "500";
+    process.env.IMLADRIS_LINEAGE_RETENTION_DAYS = "3";
+
+    const config = loadDataRetentionConfig();
+    expect(config.enabled).toBe(false);
+    expect(config.dryRun).toBe(true);
+    expect(config.batchSize).toBe(500);
+    expect(config.imladrisLineageRetentionDays).toBe(3);
+  });
+
+  it("ignores invalid numeric overrides", () => {
+    process.env.DATA_RETENTION_BATCH_SIZE = "not-a-number";
+    process.env.OUTBOX_DEAD_LETTER_RETENTION_DAYS = "-5";
+    const config = loadDataRetentionConfig();
+    expect(config.batchSize).toBe(20_000);
+    expect(config.outboxDeadLetterRetentionDays).toBe(90);
+  });
+});
+
+describe("runDataRetentionSweep", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does nothing when disabled", async () => {
+    const prisma = fakePrisma();
+    const summary = await runDataRetentionSweep({
+      prisma,
+      config: testConfig({ enabled: false }),
+    });
+
+    expect(summary.enabled).toBe(false);
+    expect(summary.steps).toHaveLength(0);
+    expect(summary.totalDeleted).toBe(0);
+    expect(prisma.executes).toHaveLength(0);
+  });
+
+  it("runs every step and reports per-step results", async () => {
+    const prisma = fakePrisma({ deleteResults: [50, 10, 0, 0, 0] });
+    const summary = await runDataRetentionSweep({
+      prisma,
+      now: new Date("2026-06-12T10:00:00.000Z"),
+      config: testConfig(),
+    });
+
+    expect(summary.enabled).toBe(true);
+    expect(summary.steps.map((step) => step.step)).toEqual([
+      "imladrisSupersededLineage",
+      "imladrisExpiredMetricValues",
+      "outboxDispatched",
+      "outboxDeadLetter",
+      "securityAuditEvents",
+      "funnelEvents",
+    ]);
+    for (const step of summary.steps) {
+      expect(step.error).toBeUndefined();
+    }
+    expect(summary.databaseSizeBytes).toBe(123);
+  });
+
+  it("deletes lineage in batches for superseded metric values", async () => {
+    const prisma = fakePrisma({
+      candidateIds: ["mv_1"],
+      // Two full batches then a partial one for mv_1's lineage.
+      deleteResults: [100, 100, 40],
+    });
+    const summary = await runDataRetentionSweep({
+      prisma,
+      now: new Date("2026-06-12T10:00:00.000Z"),
+      config: testConfig(),
+    });
+
+    const lineageStep = summary.steps.find(
+      (step) => step.step === "imladrisSupersededLineage",
+    );
+    expect(lineageStep).toMatchObject({ deleted: 240, capped: false });
+
+    const lineageDeletes = prisma.executes.filter((call) =>
+      call.sql.includes('"ImladrisMetricLineage"'),
+    );
+    expect(lineageDeletes.length).toBeGreaterThanOrEqual(3);
+    expect(lineageDeletes[0].values).toEqual(["mv_1", 100]);
+  });
+
+  it("stops at the per-table cap and reports capped=true", async () => {
+    const prisma = fakePrisma({
+      candidateIds: ["mv_1"],
+      // Every batch comes back full so only the cap stops the loop.
+      deleteResults: Array(50).fill(100),
+    });
+    const summary = await runDataRetentionSweep({
+      prisma,
+      now: new Date("2026-06-12T10:00:00.000Z"),
+      config: testConfig({ maxRowsPerTablePerRun: 250 }),
+    });
+
+    const lineageStep = summary.steps.find(
+      (step) => step.step === "imladrisSupersededLineage",
+    );
+    expect(lineageStep?.capped).toBe(true);
+    expect(lineageStep?.deleted).toBe(250);
+  });
+
+  it("counts without deleting in dry-run mode", async () => {
+    const prisma = fakePrisma({ dryRunCount: 42 });
+    const summary = await runDataRetentionSweep({
+      prisma,
+      now: new Date("2026-06-12T10:00:00.000Z"),
+      config: testConfig({ dryRun: true }),
+    });
+
+    expect(summary.dryRun).toBe(true);
+    expect(prisma.executes).toHaveLength(0);
+    const outboxStep = summary.steps.find((step) => step.step === "outboxDeadLetter");
+    expect(outboxStep?.deleted).toBe(42);
+  });
+
+  it("captures step failures without throwing", async () => {
+    const prisma = fakePrisma();
+    prisma.$executeRawUnsafe = async () => {
+      throw new Error("permission denied");
+    };
+
+    const summary = await runDataRetentionSweep({
+      prisma,
+      now: new Date("2026-06-12T10:00:00.000Z"),
+      config: testConfig(),
+    });
+
+    const failing = summary.steps.filter((step) => step.error);
+    expect(failing.length).toBeGreaterThan(0);
+    expect(failing[0].error).toContain("permission denied");
+  });
+
+  it("uses cutoffs derived from the provided now", async () => {
+    const prisma = fakePrisma();
+    const now = new Date("2026-06-12T00:00:00.000Z");
+    await runDataRetentionSweep({ prisma, now, config: testConfig() });
+
+    const dispatchedDelete = prisma.executes.find((call) =>
+      call.sql.includes("'DISPATCHED'"),
+    );
+    expect(dispatchedDelete).toBeDefined();
+    const cutoff = dispatchedDelete?.values[0] as Date;
+    expect(cutoff.toISOString()).toBe("2026-05-29T00:00:00.000Z");
+  });
+});

--- a/src/lib/ops/data-retention.ts
+++ b/src/lib/ops/data-retention.ts
@@ -1,0 +1,433 @@
+/**
+ * Database data-retention sweep.
+ *
+ * Bounded, batched deletion of operational data that otherwise grows without
+ * limit. Born out of the June 2026 disk incident: the production Postgres
+ * volume hit 93% capacity because ImladrisMetricLineage accumulated ~41.5M
+ * rows (~15 GB) in one week (every sync run created a new canonical metric
+ * value with a full copy of its evidence lineage) and OutboxEvent held ~900K
+ * dead-letter rows (~660 MB) that nothing pruned.
+ *
+ * Design rules:
+ *  - Every DELETE is batched (`id IN (SELECT id ... LIMIT n)`) so no single
+ *    statement holds long locks or produces a multi-GB WAL spike.
+ *  - Every table has a per-run row cap so a sweep cycle has a bounded cost.
+ *  - The sweep never throws: each step's failure is captured in the summary
+ *    so retention problems can't take down the surrounding sync cycle.
+ *  - Dry-run mode (DATA_RETENTION_DRY_RUN=true) reports what would be
+ *    deleted without deleting anything.
+ *
+ * Runs from runAnalyticsSync(), which is shared by the worker orchestrator
+ * (worker/sync-runner.ts -> src/lib/sync/orchestrator.ts) and the cron route
+ * (/api/cron/sync) — so retention stays alive as long as either path runs.
+ *
+ * See docs/runbooks/postgres-disk-incident-2026-06.md for the incident
+ * write-up and the one-time backlog cleanup procedure.
+ */
+
+export interface DataRetentionPrisma {
+  $queryRawUnsafe<T = unknown>(query: string, ...values: unknown[]): Promise<T>;
+  $executeRawUnsafe(query: string, ...values: unknown[]): Promise<number>;
+}
+
+export interface DataRetentionConfig {
+  enabled: boolean;
+  dryRun: boolean;
+  /** Rows per DELETE statement. */
+  batchSize: number;
+  /** Max rows deleted per table per sweep run. */
+  maxRowsPerTablePerRun: number;
+  /**
+   * Days a superseded canonical metric value keeps its lineage evidence.
+   * The latest value per (organizationId, userId, metricKey) always keeps
+   * its lineage regardless of age.
+   */
+  imladrisLineageRetentionDays: number;
+  /** Days canonical metric value rows themselves are kept. */
+  imladrisMetricRetentionDays: number;
+  /** Days successfully dispatched outbox events are kept. */
+  outboxDispatchedRetentionDays: number;
+  /** Days dead-lettered outbox events are kept. */
+  outboxDeadLetterRetentionDays: number;
+  /** Days security audit events are kept. */
+  securityAuditRetentionDays: number;
+  /** Days visitor funnel events are kept. */
+  funnelEventRetentionDays: number;
+}
+
+export interface RetentionStepResult {
+  step: string;
+  /** Rows deleted (or rows that WOULD be deleted in dry-run). */
+  deleted: number;
+  /** True when the per-table cap stopped the step before it finished. */
+  capped: boolean;
+  error?: string;
+}
+
+export interface DataRetentionSummary {
+  enabled: boolean;
+  dryRun: boolean;
+  steps: RetentionStepResult[];
+  totalDeleted: number;
+  databaseSizeBytes: number | null;
+  durationMs: number;
+}
+
+function parsePositiveInt(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  const parsed = raw ? Number(raw) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
+  return fallback;
+}
+
+export function loadDataRetentionConfig(): DataRetentionConfig {
+  return {
+    // Enabled by default: this module exists to keep production storage
+    // bounded. Set DATA_RETENTION_ENABLED=false to disable entirely.
+    enabled: process.env.DATA_RETENTION_ENABLED !== "false",
+    dryRun: process.env.DATA_RETENTION_DRY_RUN === "true",
+    batchSize: parsePositiveInt("DATA_RETENTION_BATCH_SIZE", 20_000),
+    maxRowsPerTablePerRun: parsePositiveInt(
+      "DATA_RETENTION_MAX_ROWS_PER_RUN",
+      200_000,
+    ),
+    imladrisLineageRetentionDays: parsePositiveInt(
+      "IMLADRIS_LINEAGE_RETENTION_DAYS",
+      7,
+    ),
+    imladrisMetricRetentionDays: parsePositiveInt(
+      "IMLADRIS_METRIC_RETENTION_DAYS",
+      365,
+    ),
+    outboxDispatchedRetentionDays: parsePositiveInt(
+      "OUTBOX_DISPATCHED_RETENTION_DAYS",
+      14,
+    ),
+    outboxDeadLetterRetentionDays: parsePositiveInt(
+      "OUTBOX_DEAD_LETTER_RETENTION_DAYS",
+      90,
+    ),
+    securityAuditRetentionDays: parsePositiveInt(
+      "SECURITY_AUDIT_RETENTION_DAYS",
+      365,
+    ),
+    funnelEventRetentionDays: parsePositiveInt(
+      "FUNNEL_EVENT_RETENTION_DAYS",
+      365,
+    ),
+  };
+}
+
+function daysAgo(now: Date, days: number): Date {
+  return new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+}
+
+function asCount(rows: unknown): number {
+  if (Array.isArray(rows) && rows.length > 0) {
+    const value = (rows[0] as Record<string, unknown>).count;
+    const parsed = typeof value === "bigint" ? Number(value) : Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return 0;
+}
+
+/**
+ * Delete rows matching `predicateSql` in batches of `batchSize`, stopping at
+ * `maxRows`. `predicateSql` must only reference the target table's columns
+ * and use placeholders starting at $1; `params` supplies their values.
+ *
+ * In dry-run mode, returns the number of rows that WOULD be deleted
+ * (bounded by maxRows so the count query itself stays cheap).
+ */
+async function deleteInBatches(input: {
+  prisma: DataRetentionPrisma;
+  table: string;
+  predicateSql: string;
+  params: unknown[];
+  batchSize: number;
+  maxRows: number;
+  dryRun: boolean;
+}): Promise<{ deleted: number; capped: boolean }> {
+  const { prisma, table, predicateSql, params, batchSize, maxRows, dryRun } =
+    input;
+  const limitPlaceholder = `$${params.length + 1}`;
+
+  if (dryRun) {
+    const rows = await prisma.$queryRawUnsafe<Array<{ count: unknown }>>(
+      `SELECT count(*)::bigint AS count FROM (SELECT 1 FROM "${table}" WHERE ${predicateSql} LIMIT ${limitPlaceholder}) candidates`,
+      ...params,
+      maxRows + 1,
+    );
+    const count = asCount(rows);
+    return { deleted: Math.min(count, maxRows), capped: count > maxRows };
+  }
+
+  let deleted = 0;
+  while (deleted < maxRows) {
+    const batch = Math.min(batchSize, maxRows - deleted);
+    const affected = await prisma.$executeRawUnsafe(
+      `DELETE FROM "${table}" WHERE "id" IN (SELECT "id" FROM "${table}" WHERE ${predicateSql} LIMIT ${limitPlaceholder})`,
+      ...params,
+      batch,
+    );
+    deleted += affected;
+    if (affected < batch) {
+      return { deleted, capped: false };
+    }
+  }
+  return { deleted, capped: true };
+}
+
+/**
+ * Canonical metric values that are superseded (a newer value exists for the
+ * same scope + metricKey) and older than the lineage retention window. Their
+ * lineage evidence is pruned; the metric value row itself is kept for
+ * history until imladrisMetricRetentionDays.
+ */
+const SUPERSEDED_METRIC_VALUES_SQL = `
+  SELECT mv."id"
+  FROM "ImladrisCanonicalMetricValue" mv
+  WHERE mv."periodEnd" < $1
+    AND EXISTS (
+      SELECT 1 FROM "ImladrisCanonicalMetricValue" newer
+      WHERE newer."metricKey" = mv."metricKey"
+        AND newer."organizationId" IS NOT DISTINCT FROM mv."organizationId"
+        AND newer."userId" IS NOT DISTINCT FROM mv."userId"
+        AND newer."periodEnd" > mv."periodEnd"
+    )
+    AND EXISTS (
+      SELECT 1 FROM "ImladrisMetricLineage" l WHERE l."metricValueId" = mv."id"
+    )
+  ORDER BY mv."periodEnd" ASC
+  LIMIT $2
+`;
+
+async function pruneSupersededLineage(input: {
+  prisma: DataRetentionPrisma;
+  now: Date;
+  config: DataRetentionConfig;
+}): Promise<RetentionStepResult> {
+  const { prisma, now, config } = input;
+  const step = "imladrisSupersededLineage";
+  const cutoff = daysAgo(now, config.imladrisLineageRetentionDays);
+
+  let deleted = 0;
+  let capped = false;
+
+  // Up to 200 candidate metric values per run; lineage deletion is the
+  // bounded resource (maxRowsPerTablePerRun), candidates are just pointers.
+  const candidates = await prisma.$queryRawUnsafe<Array<{ id: string }>>(
+    SUPERSEDED_METRIC_VALUES_SQL,
+    cutoff,
+    200,
+  );
+
+  for (const candidate of candidates) {
+    if (deleted >= config.maxRowsPerTablePerRun) {
+      capped = true;
+      break;
+    }
+    const result = await deleteInBatches({
+      prisma,
+      table: "ImladrisMetricLineage",
+      predicateSql: `"metricValueId" = $1`,
+      params: [candidate.id],
+      batchSize: config.batchSize,
+      maxRows: config.maxRowsPerTablePerRun - deleted,
+      dryRun: config.dryRun,
+    });
+    deleted += result.deleted;
+    capped = capped || result.capped;
+  }
+
+  return { step, deleted, capped };
+}
+
+async function pruneExpiredMetricValues(input: {
+  prisma: DataRetentionPrisma;
+  now: Date;
+  config: DataRetentionConfig;
+}): Promise<RetentionStepResult> {
+  const { prisma, now, config } = input;
+  const step = "imladrisExpiredMetricValues";
+  const cutoff = daysAgo(now, config.imladrisMetricRetentionDays);
+
+  // ImladrisMetricLineage.metricValue is ON DELETE CASCADE, so deleting a
+  // metric value cascades to its lineage. Delete one value at a time and
+  // strip its lineage in batches FIRST so a single cascade can never delete
+  // millions of rows in one transaction.
+  const candidates = await prisma.$queryRawUnsafe<Array<{ id: string }>>(
+    `SELECT "id" FROM "ImladrisCanonicalMetricValue" WHERE "periodEnd" < $1 ORDER BY "periodEnd" ASC LIMIT $2`,
+    cutoff,
+    500,
+  );
+
+  let lineageDeleted = 0;
+  let valuesDeleted = 0;
+  let capped = false;
+
+  for (const candidate of candidates) {
+    if (lineageDeleted + valuesDeleted >= config.maxRowsPerTablePerRun) {
+      capped = true;
+      break;
+    }
+    const lineage = await deleteInBatches({
+      prisma,
+      table: "ImladrisMetricLineage",
+      predicateSql: `"metricValueId" = $1`,
+      params: [candidate.id],
+      batchSize: config.batchSize,
+      maxRows: config.maxRowsPerTablePerRun - lineageDeleted - valuesDeleted,
+      dryRun: config.dryRun,
+    });
+    lineageDeleted += lineage.deleted;
+    if (lineage.capped) {
+      capped = true;
+      break;
+    }
+    if (!config.dryRun) {
+      await prisma.$executeRawUnsafe(
+        `DELETE FROM "ImladrisCanonicalMetricValue" WHERE "id" = $1`,
+        candidate.id,
+      );
+    }
+    valuesDeleted += 1;
+  }
+
+  return { step, deleted: lineageDeleted + valuesDeleted, capped };
+}
+
+export async function fetchDatabaseSizeBytes(
+  prisma: DataRetentionPrisma,
+): Promise<number | null> {
+  try {
+    const rows = await prisma.$queryRawUnsafe<Array<{ size: unknown }>>(
+      `SELECT pg_database_size(current_database())::bigint AS size`,
+    );
+    if (Array.isArray(rows) && rows.length > 0) {
+      const value = rows[0].size;
+      const parsed = typeof value === "bigint" ? Number(value) : Number(value);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run one bounded retention sweep. Never throws; failures are reported in
+ * the returned summary (and logged) so callers can surface them without
+ * aborting the surrounding sync cycle.
+ */
+export async function runDataRetentionSweep(input: {
+  prisma: DataRetentionPrisma;
+  now?: Date;
+  config?: DataRetentionConfig;
+}): Promise<DataRetentionSummary> {
+  const startedAt = Date.now();
+  const now = input.now ?? new Date();
+  const config = input.config ?? loadDataRetentionConfig();
+  const steps: RetentionStepResult[] = [];
+
+  if (!config.enabled) {
+    return {
+      enabled: false,
+      dryRun: config.dryRun,
+      steps,
+      totalDeleted: 0,
+      databaseSizeBytes: await fetchDatabaseSizeBytes(input.prisma),
+      durationMs: Date.now() - startedAt,
+    };
+  }
+
+  const runStep = async (
+    step: string,
+    fn: () => Promise<RetentionStepResult>,
+  ) => {
+    try {
+      steps.push(await fn());
+    } catch (error) {
+      steps.push({
+        step,
+        deleted: 0,
+        capped: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+
+  await runStep("imladrisSupersededLineage", () =>
+    pruneSupersededLineage({ prisma: input.prisma, now, config }),
+  );
+
+  await runStep("imladrisExpiredMetricValues", () =>
+    pruneExpiredMetricValues({ prisma: input.prisma, now, config }),
+  );
+
+  await runStep("outboxDispatched", async () => {
+    const result = await deleteInBatches({
+      prisma: input.prisma,
+      table: "OutboxEvent",
+      predicateSql: `"status" = 'DISPATCHED' AND "dispatchedAt" < $1`,
+      params: [daysAgo(now, config.outboxDispatchedRetentionDays)],
+      batchSize: config.batchSize,
+      maxRows: config.maxRowsPerTablePerRun,
+      dryRun: config.dryRun,
+    });
+    return { step: "outboxDispatched", ...result };
+  });
+
+  await runStep("outboxDeadLetter", async () => {
+    const result = await deleteInBatches({
+      prisma: input.prisma,
+      table: "OutboxEvent",
+      predicateSql: `"status" = 'DEAD_LETTER' AND "createdAt" < $1`,
+      params: [daysAgo(now, config.outboxDeadLetterRetentionDays)],
+      batchSize: config.batchSize,
+      maxRows: config.maxRowsPerTablePerRun,
+      dryRun: config.dryRun,
+    });
+    return { step: "outboxDeadLetter", ...result };
+  });
+
+  await runStep("securityAuditEvents", async () => {
+    const result = await deleteInBatches({
+      prisma: input.prisma,
+      table: "SecurityAuditEvent",
+      predicateSql: `"createdAt" < $1`,
+      params: [daysAgo(now, config.securityAuditRetentionDays)],
+      batchSize: config.batchSize,
+      maxRows: config.maxRowsPerTablePerRun,
+      dryRun: config.dryRun,
+    });
+    return { step: "securityAuditEvents", ...result };
+  });
+
+  await runStep("funnelEvents", async () => {
+    const result = await deleteInBatches({
+      prisma: input.prisma,
+      table: "FunnelEvent",
+      predicateSql: `"occurredAt" < $1`,
+      params: [daysAgo(now, config.funnelEventRetentionDays)],
+      batchSize: config.batchSize,
+      maxRows: config.maxRowsPerTablePerRun,
+      dryRun: config.dryRun,
+    });
+    return { step: "funnelEvents", ...result };
+  });
+
+  const summary: DataRetentionSummary = {
+    enabled: true,
+    dryRun: config.dryRun,
+    steps,
+    totalDeleted: steps.reduce((sum, step) => sum + step.deleted, 0),
+    databaseSizeBytes: await fetchDatabaseSizeBytes(input.prisma),
+    durationMs: Date.now() - startedAt,
+  };
+
+  // Structured log line — Railway log alerting can match on `[data-retention]`.
+  console.info("[data-retention]", JSON.stringify(summary));
+
+  return summary;
+}

--- a/src/lib/sync/analytics.test.ts
+++ b/src/lib/sync/analytics.test.ts
@@ -15,6 +15,23 @@ vi.mock("@/lib/analytics/snapshots", () => ({
 
 vi.mock("@/lib/imladris/materialization", () => ({
   materializeImladrisCanonicalMetrics: vi.fn(),
+  // Mirror the real implementation: stable start-of-UTC-day boundary.
+  imladrisCanonicalPeriodEnd: (now: Date) => {
+    const periodEnd = new Date(now);
+    periodEnd.setUTCHours(0, 0, 0, 0);
+    return periodEnd;
+  },
+}));
+
+vi.mock("@/lib/ops/data-retention", () => ({
+  runDataRetentionSweep: vi.fn(async () => ({
+    enabled: true,
+    dryRun: false,
+    steps: [],
+    totalDeleted: 0,
+    databaseSizeBytes: null,
+    durationMs: 0,
+  })),
 }));
 
 vi.mock("@/lib/sync/users", () => ({
@@ -84,8 +101,8 @@ describe("runAnalyticsSync", () => {
         userId: "user_1",
         organizationId: "org_1",
       },
-      periodStart: new Date("2026-05-02T12:00:00.000Z"),
-      periodEnd: new Date("2026-06-01T12:00:00.000Z"),
+      periodStart: new Date("2026-05-02T00:00:00.000Z"),
+      periodEnd: new Date("2026-06-01T00:00:00.000Z"),
       now: new Date("2026-06-01T12:00:00.000Z"),
     });
     expect(materializeImladrisCanonicalMetrics).toHaveBeenNthCalledWith(2, {
@@ -94,16 +111,16 @@ describe("runAnalyticsSync", () => {
         userId: "user_2",
         organizationId: null,
       },
-      periodStart: new Date("2026-05-02T12:00:00.000Z"),
-      periodEnd: new Date("2026-06-01T12:00:00.000Z"),
+      periodStart: new Date("2026-05-02T00:00:00.000Z"),
+      periodEnd: new Date("2026-06-01T00:00:00.000Z"),
       now: new Date("2026-06-01T12:00:00.000Z"),
     });
     expect(result.imladris).toEqual([
       {
         userId: "user_1",
         organizationId: "org_1",
-        periodStart: "2026-05-02T12:00:00.000Z",
-        periodEnd: "2026-06-01T12:00:00.000Z",
+        periodStart: "2026-05-02T00:00:00.000Z",
+        periodEnd: "2026-06-01T00:00:00.000Z",
         metrics: [
           expect.objectContaining({
             metricKey: "development.delivery_health",
@@ -114,8 +131,8 @@ describe("runAnalyticsSync", () => {
       {
         userId: "user_2",
         organizationId: null,
-        periodStart: "2026-05-02T12:00:00.000Z",
-        periodEnd: "2026-06-01T12:00:00.000Z",
+        periodStart: "2026-05-02T00:00:00.000Z",
+        periodEnd: "2026-06-01T00:00:00.000Z",
         metrics: [
           expect.objectContaining({
             metricKey: "development.delivery_health",
@@ -257,8 +274,8 @@ describe("runAnalyticsSync", () => {
       {
         userId: "user_1",
         organizationId: "org_1",
-        periodStart: "2026-05-02T12:00:00.000Z",
-        periodEnd: "2026-06-01T12:00:00.000Z",
+        periodStart: "2026-05-02T00:00:00.000Z",
+        periodEnd: "2026-06-01T00:00:00.000Z",
         metrics: [
           expect.objectContaining({
             metricKey: "development.delivery_health",
@@ -270,8 +287,8 @@ describe("runAnalyticsSync", () => {
       {
         userId: "user_2",
         organizationId: null,
-        periodStart: "2026-05-02T12:00:00.000Z",
-        periodEnd: "2026-06-01T12:00:00.000Z",
+        periodStart: "2026-05-02T00:00:00.000Z",
+        periodEnd: "2026-06-01T00:00:00.000Z",
         metrics: [
           expect.objectContaining({
             metricKey: "development.delivery_health",

--- a/src/lib/sync/analytics.ts
+++ b/src/lib/sync/analytics.ts
@@ -25,9 +25,14 @@ import type { PrismaClientType } from '@/lib/prisma';
 import { runAnalyticsRefresh } from '@/lib/analytics/refresh-runner';
 import { pruneAnalyticsSnapshots } from '@/lib/analytics/snapshots';
 import {
+  imladrisCanonicalPeriodEnd,
   materializeImladrisCanonicalMetrics,
   type MaterializedImladrisMetricResult,
 } from '@/lib/imladris/materialization';
+import {
+  runDataRetentionSweep,
+  type DataRetentionSummary,
+} from '@/lib/ops/data-retention';
 import { discoverConnectedUserIds } from './users';
 
 type RollingRangePreset = '7d' | '30d' | '90d';
@@ -50,6 +55,8 @@ export interface AnalyticsSyncResult {
   refresh: Awaited<ReturnType<typeof runAnalyticsRefresh>>;
   pruning: Awaited<ReturnType<typeof pruneAnalyticsSnapshots>>;
   imladris: ImladrisMaterializationSyncResult[];
+  /** Bounded retention sweep over operational tables (lineage, outbox, audit, funnel). */
+  dataRetention: DataRetentionSummary;
 }
 
 const DEFAULT_RANGE_PRESETS: RollingRangePreset[] = ['7d', '30d'];
@@ -150,7 +157,11 @@ async function runImladrisMaterializationSync(input: {
     input.prisma,
     input.userIds,
   );
-  const periodEnd = input.now;
+  // Stable per-day boundary — periodEnd is part of the canonical upsert key,
+  // so it must NOT change between runs within the same day. Passing raw
+  // `input.now` here created a new metric value (plus a full lineage copy)
+  // every sync run and filled the production disk in June 2026.
+  const periodEnd = imladrisCanonicalPeriodEnd(input.now);
   const periodStart = daysBefore(periodEnd, IMLADRIS_MATERIALIZATION_WINDOW_DAYS);
 
   return Promise.all(
@@ -216,6 +227,15 @@ export async function runAnalyticsSync(
   const olderThanDays = input.pruneOlderThanDays ?? parseDefaultRetentionDays();
   const now = input.now ?? new Date();
 
+  // Run the bounded data-retention sweep FIRST: it frees storage and must
+  // not be skipped when the (much heavier) refresh/materialization phases
+  // fail or run out of memory. The sweep never throws — failures are
+  // reported inside its summary.
+  const dataRetention = await runDataRetentionSweep({
+    prisma: input.prisma,
+    now,
+  });
+
   const refresh = await runAnalyticsRefresh({
     userIds,
     rangePresets,
@@ -239,5 +259,5 @@ export async function runAnalyticsSync(
     }),
   ]);
 
-  return { refresh, pruning, imladris };
+  return { refresh, pruning, imladris, dataRetention };
 }


### PR DESCRIPTION
## Why

Production Postgres (Railway `WIPGuard` → `Postgres`) hit **18,598 / 20,000 MB (93%)**. When it fills, writes fail and the app goes down. Growing the volume is the immediate mitigation (operator action); this PR is the durable fix.

### Root cause (measured against prod, read-only)

| Consumer | Size | Rows |
| --- | --- | --- |
| `ImladrisMetricLineage` | **15.17 GB** | ~41.5M |
| `OutboxEvent` | **664 MB** | 906K (904.8K `DEAD_LETTER`) |
| everything else | < 50 MB combined | — |

Canonical materialization passed `periodEnd = now`, but `periodEnd` is part of the `ImladrisCanonicalMetricValue` upsert key — so **every sync run (every 10 min) minted a new metric value plus a full copy of its lineage evidence** instead of updating in place. 3,408 metric values accumulated in 6 days; lineage grew ~4–6M rows/day.

The unbounded `include: { lineage }` in the dashboard/export builders then loaded tens of millions of rows into the Node heap → `Reached heap limit` OOM, which crash-looped the app **and** the `wipguard-cron-sync` worker (it POSTs `/api/cron/sync`), so the only retention job that existed (a 16 MB table) also stopped.

## What changed

**Stop the growth**
- `imladrisCanonicalPeriodEnd()` truncates `periodEnd` to start-of-UTC-day → one value per metric per day, updated in place.
- `replaceLineage()` inserts the fresh evidence set first, then prunes rows older than its own insert stamp — crash/concurrency safe (was delete-then-insert).

**Retention sweep** — `src/lib/ops/data-retention.ts`, runs from `runAnalyticsSync()` (worker orchestrator + cron route). Bounded & batched (20K rows/statement, 200K/table/run), never throws, env-configurable windows, `DATA_RETENTION_DRY_RUN` supported. Covers superseded lineage, expired metric values, outbox dispatched/dead-letter, security audit, funnel events.

**Fix the OOM**
- `buildCompanyTrackerDashboard` aggregates lineage in SQL (`groupBy`) — never loads rows.
- `buildImladrisMetrics` / `buildInvestorDashboardExport` (which emit full per-row evidence) cap nested lineage at 500 rows/metric value.

**Monitoring** — `GET /api/health` adds a `storage` check (`pg_database_size` vs `DATABASE_VOLUME_CAPACITY_MB`): `warning` ≥75%, `critical` ≥90% → HTTP 503 + grep-able `[health:storage]` log. Point an uptime monitor / Railway log alert at it.

**One-time backlog drainer** — `scripts/ops/db-disk-cleanup.ts` (`npm run ops:db-disk-cleanup`). **DRY RUN by default**; `--execute` deletes in batches. Prints the `VACUUM FULL` steps needed to actually return space to the OS.

**Runbook** — `docs/runbooks/postgres-disk-incident-2026-06.md`.

## Safety

⚠️ **No deletes were executed against production.** Deletion requires explicit operator approval (run the script with `--execute`, or let the bounded sweep drain gradually). Retention SQL was validated **read-only** against prod: 374 superseded values carry 3.48M prunable lineage rows; ~905K outbox dead letters prunable; the 24 latest-per-scope metric values are correctly preserved.

## Operator actions (see runbook)
1. Grow the volume in Railway now (buys headroom).
2. Add a Railway log alert on `[health:storage]` / point uptime monitor at `/api/health`.
3. After deploy: `npm run ops:db-disk-cleanup` (dry run) → review → `-- --execute` (approval required).
4. `VACUUM (FULL, ANALYZE)` the three tables in a maintenance window to reclaim disk.

## Tests
- New: `src/lib/ops/data-retention.test.ts` (10), storage-check cases in `src/app/api/health/route.test.ts`.
- Full suite green: **3090 passed / 260 files**. Typecheck + lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)