### PR TITLE
Skip rewriting unchanged Imladris raw records on re-sync

### DIFF
--- a/src/lib/imladris/ingestion.test.ts
+++ b/src/lib/imladris/ingestion.test.ts
@@ -19,6 +19,9 @@ function createPrismaMock() {
         update: vi.fn(async ({ data }) => ({ ...syncRun, ...data })),
       },
       imladrisRawSourceRecord: {
+        findMany: vi.fn(
+          async () => [] as Array<{ objectType: string; externalId: string; payloadHash: string }>,
+        ),
         upsert: vi.fn(async ({ create }) => create),
       },
     },
@@ -2878,5 +2881,59 @@ describe("Imladris raw ingestion", () => {
         organizationId: null,
       }),
     });
+  });
+
+  it("skips the upsert when the stored payload hash is unchanged", async () => {
+    // First ingest captures the payloadHash the pipeline computes for this record.
+    const first = createPrismaMock();
+    await ingestImladrisRawRecords({
+      prisma: first.prisma as never,
+      provider: IntegrationProvider.LINEAR,
+      context: { userId: "user_1", organizationId: "org_1" },
+      records: [{ objectType: "issue", externalId: "LIN-42", payload: { id: "LIN-42", state: "Done" } }],
+    });
+    const writtenHash = first.prisma.imladrisRawSourceRecord.upsert.mock.calls[0][0].create
+      .payloadHash as string;
+    expect(writtenHash).toBeTruthy();
+
+    // Second ingest of the identical payload: findMany reports the same hash, so
+    // the write must be skipped while the record still counts as accepted.
+    const second = createPrismaMock();
+    second.prisma.imladrisRawSourceRecord.findMany.mockResolvedValueOnce([
+      { objectType: "issue", externalId: "LIN-42", payloadHash: writtenHash },
+    ]);
+
+    const result = await ingestImladrisRawRecords({
+      prisma: second.prisma as never,
+      provider: IntegrationProvider.LINEAR,
+      context: { userId: "user_1", organizationId: "org_1" },
+      records: [{ objectType: "issue", externalId: "LIN-42", payload: { id: "LIN-42", state: "Done" } }],
+    });
+
+    expect(second.prisma.imladrisRawSourceRecord.upsert).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      status: "SUCCESS",
+      acceptedCount: 1,
+      errorCount: 0,
+      unchangedCount: 1,
+    });
+  });
+
+  it("still upserts when the stored payload hash differs", async () => {
+    const { prisma } = createPrismaMock();
+    prisma.imladrisRawSourceRecord.findMany.mockResolvedValueOnce([
+      { objectType: "issue", externalId: "LIN-42", payloadHash: "stale-hash" },
+    ]);
+
+    const result = await ingestImladrisRawRecords({
+      prisma: prisma as never,
+      provider: IntegrationProvider.LINEAR,
+      context: { userId: "user_1", organizationId: "org_1" },
+      records: [{ objectType: "issue", externalId: "LIN-42", payload: { id: "LIN-42", state: "Started" } }],
+    });
+
+    expect(prisma.imladrisRawSourceRecord.upsert).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ status: "SUCCESS", acceptedCount: 1, errorCount: 0 });
+    expect(result).not.toHaveProperty("unchangedCount");
   });
 });

--- a/src/lib/imladris/ingestion.ts
+++ b/src/lib/imladris/ingestion.ts
@@ -35,6 +35,13 @@ export interface IngestImladrisRawRecordsResult {
   recordCount: number;
   acceptedCount: number;
   errorCount: number;
+  /**
+   * Number of distinct records whose payload was byte-for-byte identical to the
+   * stored row (matched by `payloadHash`) and therefore skipped the write. These
+   * still count toward `acceptedCount` — they are reported separately only for
+   * observability into how much write churn the hash-skip avoids.
+   */
+  unchangedCount?: number;
   statusPersistenceErrors?: string[];
 }
 
@@ -44,6 +51,15 @@ type SourceSyncRunDelegate = {
 };
 
 type RawSourceRecordDelegate = {
+  findMany(args: {
+    where: {
+      provider: IntegrationProvider;
+      scopeKey: string;
+      objectType?: { in: string[] };
+      externalId?: { in: string[] };
+    };
+    select: { objectType: true; externalId: true; payloadHash: true };
+  }): Promise<Array<{ objectType: string; externalId: string; payloadHash: string }>>;
   upsert(args: {
     where: {
       provider_objectType_externalId_scopeKey: {
@@ -652,9 +668,47 @@ export async function ingestImladrisRawRecords(
     }
   }
 
+  // Hash-based write-skipping: batch-fetch the payloadHash of every row we are
+  // about to write so we can skip the upsert entirely when nothing changed.
+  // Without this, every cron cycle rewrites identical JSONB payloads and leaves
+  // a trail of dead tuples on this (large, JSONB-heavy) table.
+  const existingHashByKey = new Map<string, string>();
+  if (normalizedRecords.size > 0) {
+    try {
+      const groups = [...normalizedRecords.values()];
+      const existing = await rawRecords.findMany({
+        where: {
+          provider: input.provider,
+          scopeKey: rawRecordScopeKey,
+          objectType: { in: [...new Set(groups.map((group) => group.record.objectType))] },
+          externalId: { in: [...new Set(groups.map((group) => group.record.externalId))] },
+        },
+        select: { objectType: true, externalId: true, payloadHash: true },
+      });
+      for (const row of existing) {
+        existingHashByKey.set(`${row.objectType}:${row.externalId}`, row.payloadHash);
+      }
+    } catch (error) {
+      // A failed lookup is non-fatal: fall back to always upserting (prior
+      // behaviour), just without the write-skip optimization.
+      console.warn("imladris_raw_ingestion.hash_prefetch_failed", {
+        provider: input.provider,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   let acceptedCount = 0;
+  let unchangedCount = 0;
   for (const { record, inputCount } of normalizedRecords.values()) {
     try {
+      if (existingHashByKey.get(`${record.objectType}:${record.externalId}`) === record.payloadHash) {
+        // Stored payload is identical — skip the write but still count the
+        // record as accepted so ImladrisSourceSyncRun stats stay truthful.
+        acceptedCount += inputCount;
+        unchangedCount += 1;
+        continue;
+      }
       const sourceCreatedAt = observableDate(record.sourceCreatedAt, startedAt);
       const sourceUpdatedAt = observableDate(record.sourceUpdatedAt, startedAt);
       const occurredAt = observableDate(record.occurredAt, startedAt);
@@ -738,6 +792,9 @@ export async function ingestImladrisRawRecords(
     recordCount: input.records.length,
     acceptedCount,
     errorCount,
+    // Omit when zero so callers/tests that assert the prior result shape are
+    // unaffected; present only when the hash-skip actually avoided writes.
+    ...(unchangedCount > 0 ? { unchangedCount } : {}),
     statusPersistenceErrors,
   };
 }


### PR DESCRIPTION
## What & why

`ingestImladrisRawRecords` computed a SHA-256 `payloadHash` for every record and then **ignored it** — every cron cycle re-`upsert`ed identical JSONB payloads into the large, JSONB-heavy `ImladrisRawSourceRecord` table, generating Postgres **dead tuples even when nothing changed**.

This PR batch-fetches the existing `payloadHash` for the rows about to be written and **skips the upsert when the stored payload is byte-identical**. Skipped records still count toward `acceptedCount` so `ImladrisSourceSyncRun` stats stay truthful; a new optional `unchangedCount` reports how many writes were avoided. A failed prefetch falls back to the prior always-upsert behavior, so the optimization can never block ingestion.

## Relationship to the existing retention work

This **complements, and does not duplicate**, the row-deletion retention that landed in #582/#584. That work bounds growth by *deleting old rows*; this stops the *write churn* from rewriting rows that didn't change. Main never touched `ingestion.ts`, so this is purely additive.

> Note: this PR was originally a broader change that also added a parallel retention/pruning module. After #582/#584 merged a dedicated `db-pruning` system to `main`, that part was redundant and has been dropped — this PR is now scoped to just the ingestion write-skip.

## Scope

- `src/lib/imladris/ingestion.ts` — hash prefetch + write-skip (+ optional `unchangedCount`).
- `src/lib/imladris/ingestion.test.ts` — skip when hash unchanged; still upsert when changed.

Two files, +114 lines, rebased on current `main`.

## Verification

- `vitest`: `ingestion.test.ts` (56) + `raw-records.test.ts` (136) = **192 passing**.
- `tsc --noEmit` clean; `eslint` clean (pre-commit hook).

https://claude.ai/code/session_01Da9qodW2TZyCjozhW7bDgX