### PR TITLE
fix(imladris): bound lineage reads to stop OOM + add DB disk health check

### DIFF
--- a/src/app/api/health/route.test.ts
+++ b/src/app/api/health/route.test.ts
@@ -4,6 +4,7 @@ import packageJson from "../../../../package.json";
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     $queryRaw: vi.fn(),
+    $queryRawUnsafe: vi.fn(),
   },
 }));
 
@@ -22,6 +23,10 @@ describe("GET /api/health", () => {
     const { poolMonitor } = await import("@/lib/pool-monitor");
 
     vi.mocked(prisma.$queryRaw).mockResolvedValue(undefined as never);
+    // Storage check: ~2 GB database against the default 20 GB volume.
+    vi.mocked(prisma.$queryRawUnsafe).mockResolvedValue([
+      { size: BigInt(2_000_000_000) },
+    ] as never);
     vi.mocked(poolMonitor.getHealthStatus).mockReturnValue({
       status: "healthy",
       pool: {
@@ -60,8 +65,85 @@ describe("GET /api/health", () => {
           idle: 3,
           waiting: 0,
         },
+        storage: {
+          status: "ok",
+          databaseSizeMb: 2000,
+          volumeCapacityMb: 20000,
+          usagePercent: 10,
+        },
       },
       uptime: 1234,
+    });
+  });
+
+  it("reports a storage warning without failing the health check", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { prisma } = await import("@/lib/prisma");
+    // 16 GB of 20 GB = 80% -> above the 75% warn threshold.
+    vi.mocked(prisma.$queryRawUnsafe).mockResolvedValue([
+      { size: BigInt(16_000_000_000) },
+    ] as never);
+
+    try {
+      const { GET } = await import("@/app/api/health/route");
+      const response = await GET();
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.status).toBe("ok");
+      expect(body.checks.storage).toMatchObject({
+        status: "warning",
+        databaseSizeMb: 16000,
+        usagePercent: 80,
+      });
+      expect(consoleError).toHaveBeenCalledWith(
+        "[health:storage]",
+        expect.stringContaining('"warning"'),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("returns 503 degraded when disk usage crosses the critical threshold", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { prisma } = await import("@/lib/prisma");
+    // 18.6 GB of 20 GB = 93% -> the June 2026 incident level.
+    vi.mocked(prisma.$queryRawUnsafe).mockResolvedValue([
+      { size: BigInt(18_598_000_000) },
+    ] as never);
+
+    try {
+      const { GET } = await import("@/app/api/health/route");
+      const response = await GET();
+      const body = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(body.status).toBe("degraded");
+      expect(body.checks.storage).toMatchObject({
+        status: "critical",
+        usagePercent: 93,
+      });
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("degrades the storage check to unknown when the size query fails", async () => {
+    const { prisma } = await import("@/lib/prisma");
+    vi.mocked(prisma.$queryRawUnsafe).mockRejectedValue(
+      new Error("permission denied"),
+    );
+
+    const { GET } = await import("@/app/api/health/route");
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("ok");
+    expect(body.checks.storage).toMatchObject({
+      status: "unknown",
+      error: "permission denied",
     });
   });
 

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -5,17 +5,124 @@ import { poolMonitor } from "@/lib/pool-monitor";
 
 const APP_VERSION = process.env.APP_VERSION?.trim() || packageJson.version;
 
+/** Railway Postgres volume capacity. Override via DATABASE_VOLUME_CAPACITY_MB. */
+const DEFAULT_VOLUME_CAPACITY_MB = 20_000;
+const DEFAULT_DISK_WARN_PERCENT = 75;
+const DEFAULT_DISK_CRITICAL_PERCENT = 90;
+
+function parsePositiveNumberEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  const parsed = raw ? Number(raw) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  return fallback;
+}
+
+interface StorageCheck {
+  status: "ok" | "warning" | "critical" | "unknown";
+  databaseSizeMb: number | null;
+  volumeCapacityMb: number;
+  usagePercent: number | null;
+  warnPercent: number;
+  criticalPercent: number;
+  error?: string;
+}
+
+/**
+ * Database disk-usage check.
+ *
+ * The June 2026 incident (Postgres volume silently filled to 93%) went
+ * unnoticed because nothing reported storage. This check compares
+ * pg_database_size() against the configured volume capacity and emits a
+ * structured `[health:storage]` log line at warning/critical levels so
+ * Railway log-based alerts (and anything polling /api/health) can fire
+ * long before writes start failing.
+ *
+ * NOTE: pg_database_size() measures the database only; WAL, temp files and
+ * other databases on the volume add roughly 5-10% on top. Thresholds are
+ * chosen with that headroom in mind.
+ */
+async function checkStorage(): Promise<StorageCheck> {
+  const volumeCapacityMb = parsePositiveNumberEnv(
+    "DATABASE_VOLUME_CAPACITY_MB",
+    DEFAULT_VOLUME_CAPACITY_MB,
+  );
+  const warnPercent = parsePositiveNumberEnv(
+    "DATABASE_DISK_WARN_PERCENT",
+    DEFAULT_DISK_WARN_PERCENT,
+  );
+  const criticalPercent = parsePositiveNumberEnv(
+    "DATABASE_DISK_CRITICAL_PERCENT",
+    DEFAULT_DISK_CRITICAL_PERCENT,
+  );
+
+  try {
+    const rows = await prisma.$queryRawUnsafe<Array<{ size: unknown }>>(
+      "SELECT pg_database_size(current_database())::bigint AS size",
+    );
+    const raw = Array.isArray(rows) && rows.length > 0 ? rows[0].size : null;
+    const sizeBytes = typeof raw === "bigint" ? Number(raw) : Number(raw);
+    if (!Number.isFinite(sizeBytes) || sizeBytes < 0) {
+      return {
+        status: "unknown",
+        databaseSizeMb: null,
+        volumeCapacityMb,
+        usagePercent: null,
+        warnPercent,
+        criticalPercent,
+        error: "pg_database_size returned a non-numeric value",
+      };
+    }
+
+    const databaseSizeMb = Math.round(sizeBytes / 1_000_000);
+    const usagePercent =
+      Math.round((databaseSizeMb / volumeCapacityMb) * 1000) / 10;
+    const status: StorageCheck["status"] =
+      usagePercent >= criticalPercent
+        ? "critical"
+        : usagePercent >= warnPercent
+          ? "warning"
+          : "ok";
+
+    const check: StorageCheck = {
+      status,
+      databaseSizeMb,
+      volumeCapacityMb,
+      usagePercent,
+      warnPercent,
+      criticalPercent,
+    };
+
+    if (status !== "ok") {
+      // Structured, grep-able line for Railway log alerting.
+      console.error("[health:storage]", JSON.stringify(check));
+    }
+
+    return check;
+  } catch (error) {
+    return {
+      status: "unknown",
+      databaseSizeMb: null,
+      volumeCapacityMb,
+      usagePercent: null,
+      warnPercent,
+      criticalPercent,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}
+
 /**
  * GET /api/health
  *
- * Dependency health endpoint that verifies database connectivity
- * and reports pool status.
+ * Dependency health endpoint that verifies database connectivity and
+ * reports pool + storage status.
  *
  * Returns:
- * - 200 if database is reachable and pool is healthy/warning
- * - 503 if database is unreachable or pool is critical
+ * - 200 if database is reachable and pool/storage are healthy or warning
+ * - 503 if database is unreachable, pool is critical, or disk usage has
+ *   crossed the critical threshold
  *
- * @see Issue #378
+ * @see Issue #378; docs/runbooks/postgres-disk-incident-2026-06.md
  */
 export async function GET() {
   const startTime = Date.now();
@@ -30,8 +137,9 @@ export async function GET() {
 
     const { status: poolStatus, pool: poolMetrics } =
       poolMonitor.getHealthStatus();
+    const storage = await checkStorage();
 
-    const isHealthy = poolStatus !== "critical";
+    const isHealthy = poolStatus !== "critical" && storage.status !== "critical";
 
     return NextResponse.json(
       {
@@ -52,6 +160,7 @@ export async function GET() {
             errors: poolMetrics.totalConnectionErrors,
             exhaustionEvents: poolMetrics.totalPoolExhaustionEvents,
           },
+          storage,
         },
         uptime: poolMetrics.uptimeMs,
       },

--- a/src/lib/imladris/company-tracker.ts
+++ b/src/lib/imladris/company-tracker.ts
@@ -42,6 +42,20 @@ interface MetricLineageRow {
   metadata: unknown;
 }
 
+/**
+ * Aggregate view of a metric value's lineage, computed in SQL.
+ *
+ * The dashboard only ever needs the row count, the distinct source keys and
+ * the latest capture timestamp — never the raw lineage rows. Loading raw
+ * rows via `include: { lineage }` pulled tens of millions of rows into the
+ * Node heap during the June 2026 incident and OOM-crashed the app.
+ */
+interface MetricLineageSummary {
+  count: number;
+  sourceKeys: string[];
+  latestCapturedAt: string | null;
+}
+
 interface CanonicalMetricRow {
   id: string;
   metricKey: string;
@@ -55,7 +69,10 @@ interface CanonicalMetricRow {
   periodEnd: Date | string;
   userId?: string | null;
   organizationId?: string | null;
-  lineage: MetricLineageRow[];
+  /** Raw lineage rows. Only populated by legacy callers/test fixtures. */
+  lineage?: MetricLineageRow[];
+  /** SQL-side aggregate; preferred over `lineage` when present. */
+  lineageSummary?: MetricLineageSummary;
 }
 
 interface FinancialGoalRow {
@@ -313,7 +330,10 @@ export type CompanyTrackerHealthBand = CompanyHealthBand;
 
 export type CompanyTrackerPrisma = Pick<
   PrismaClientType,
-  "imladrisCanonicalMetricValue" | "financialGoal" | "analyticsSnapshot"
+  | "imladrisCanonicalMetricValue"
+  | "imladrisMetricLineage"
+  | "financialGoal"
+  | "analyticsSnapshot"
 >;
 
 const ANALYTICS_SNAPSHOT_BASE_PROVIDER_KEYS = [
@@ -1783,7 +1803,8 @@ function companyMetric(
       sourceLineageKeys: [],
     };
   }
-  const latestSourceCapturedAt = latestLineageCapturedAt(row.lineage);
+  const lineageSummary = lineageSummaryForRow(row);
+  const latestSourceCapturedAt = lineageSummary.latestCapturedAt;
   return {
     key,
     label: definition?.label ?? key,
@@ -1795,9 +1816,19 @@ function companyMetric(
     calculationVersion: row.calculationVersion,
     computedAt: toIso(row.computedAt),
     periodEnd: toIso(row.periodEnd),
-    sourceLineageCount: row.lineage?.length ?? 0,
-    sourceLineageKeys: lineageSourceKeys(row.lineage),
+    sourceLineageCount: lineageSummary.count,
+    sourceLineageKeys: lineageSummary.sourceKeys,
     ...(latestSourceCapturedAt ? { latestSourceCapturedAt } : {}),
+  };
+}
+
+/** Prefer the SQL-side aggregate; fall back to raw rows for legacy callers. */
+function lineageSummaryForRow(row: CanonicalMetricRow): MetricLineageSummary {
+  if (row.lineageSummary) return row.lineageSummary;
+  return {
+    count: row.lineage?.length ?? 0,
+    sourceKeys: lineageSourceKeys(row.lineage),
+    latestCapturedAt: latestLineageCapturedAt(row.lineage),
   };
 }
 
@@ -2663,8 +2694,8 @@ function buildBenchmarkContext(input: {
 function canonicalSourceKeys(rows: CanonicalMetricRow[]): Set<string> {
   const sourceKeys = new Set<string>();
   for (const row of rows) {
-    for (const lineage of row.lineage ?? []) {
-      if (lineage.sourceKey) sourceKeys.add(lineage.sourceKey);
+    for (const sourceKey of lineageSummaryForRow(row).sourceKeys) {
+      if (sourceKey) sourceKeys.add(sourceKey);
     }
   }
   return sourceKeys;
@@ -2872,6 +2903,62 @@ function buildBoardReadiness(input: {
   };
 }
 
+/**
+ * Compute lineage aggregates (count, distinct source keys, latest capture)
+ * for the given canonical rows in a single SQL groupBy and attach them as
+ * `lineageSummary`. Result size is bounded by rows x distinct source keys
+ * (~a dozen), independent of how many lineage rows exist in the table.
+ *
+ * Rows that already carry inline `lineage` or a `lineageSummary` (legacy
+ * callers and test fixtures) are left untouched — `lineageSummaryForRow`
+ * derives their summary directly. Only rows that need the SQL aggregate
+ * trigger the groupBy, so callers passing pre-hydrated rows never require an
+ * `imladrisMetricLineage` delegate on their prisma client.
+ */
+async function attachLineageSummaries(
+  prisma: CompanyTrackerPrisma,
+  rows: CanonicalMetricRow[],
+): Promise<void> {
+  const rowsNeedingAggregate = rows.filter(
+    (row) => row.lineageSummary === undefined && row.lineage === undefined,
+  );
+  if (rowsNeedingAggregate.length === 0) return;
+
+  const grouped = await prisma.imladrisMetricLineage.groupBy({
+    by: ["metricValueId", "sourceKey"],
+    where: { metricValueId: { in: rowsNeedingAggregate.map((row) => row.id) } },
+    _count: { _all: true },
+    _max: { capturedAt: true },
+  });
+
+  const summaries = new Map<string, MetricLineageSummary>();
+  for (const group of grouped) {
+    const summary = summaries.get(group.metricValueId) ?? {
+      count: 0,
+      sourceKeys: [],
+      latestCapturedAt: null,
+    };
+    summary.count += group._count._all;
+    const sourceKey = group.sourceKey?.trim();
+    if (sourceKey) summary.sourceKeys.push(sourceKey);
+    const capturedAt = toIso(group._max.capturedAt);
+    if (capturedAt && (!summary.latestCapturedAt || capturedAt > summary.latestCapturedAt)) {
+      summary.latestCapturedAt = capturedAt;
+    }
+    summaries.set(group.metricValueId, summary);
+  }
+
+  for (const row of rowsNeedingAggregate) {
+    const summary = summaries.get(row.id) ?? {
+      count: 0,
+      sourceKeys: [],
+      latestCapturedAt: null,
+    };
+    summary.sourceKeys.sort();
+    row.lineageSummary = summary;
+  }
+}
+
 export async function buildCompanyTrackerDashboard(input: {
   prisma: CompanyTrackerPrisma;
   context: UserContext;
@@ -2894,17 +2981,17 @@ export async function buildCompanyTrackerDashboard(input: {
       })
     : Promise.resolve([]);
   const [canonicalRows, goals, analyticsStats] = await Promise.all([
+    // IMPORTANT: do NOT `include: { lineage }` here. Lineage rows number in
+    // the thousands per metric value; loading them into Node memory crashed
+    // the app with heap OOM during the June 2026 disk incident. The lineage
+    // facts the dashboard needs (count, source keys, latest capture) are
+    // aggregated in SQL below.
     input.prisma.imladrisCanonicalMetricValue.findMany({
       where: {
         metricKey: { in: dashboard.metricKeys },
         periodEnd: { lte: now },
         computedAt: { lte: now },
         ...canonicalMetricScopeWhere(context),
-      },
-      include: {
-        lineage: {
-          orderBy: [{ createdAt: "asc" }],
-        },
       },
       orderBy: [{ periodEnd: "desc" }, { computedAt: "desc" }],
     }),
@@ -2922,6 +3009,7 @@ export async function buildCompanyTrackerDashboard(input: {
       rowMatchesContext(row, context)
     );
   });
+  await attachLineageSummaries(input.prisma, typedCanonicalRows);
   const typedGoals = activeGoalsForContext(goals as FinancialGoalRow[], context);
   const latestMetrics = latestRowsByMetric(typedCanonicalRows, context);
   const metrics = dashboard.metricKeys.map((metricKey) =>

--- a/src/lib/imladris/investor-dashboard-export.ts
+++ b/src/lib/imladris/investor-dashboard-export.ts
@@ -32,6 +32,14 @@ const INVESTOR_METRIC_KEYS = (getImladrisDashboardDefinition("company")?.metricK
 ]).filter((key) => getImladrisDerivedMetricDefinition(key) === null);
 const EXPORT_SOURCE = "imladris-investor-dashboard-export";
 const EXPORT_SCHEMA_VERSION = 1;
+/**
+ * Cap on lineage (evidence) rows loaded per canonical metric value. This
+ * export emits full per-row evidence, so without a bound a single bloated
+ * metric value can OOM-crash the process (the June 2026 incident had values
+ * carrying ~300K lineage rows). A few hundred rows exceeds any real evidence
+ * need. See docs/runbooks/postgres-disk-incident-2026-06.md.
+ */
+const MAX_LINEAGE_EVIDENCE_ROWS = 500;
 const RAW_PROVIDERS = [
   "STRIPE",
   "HUBSPOT",
@@ -3822,6 +3830,7 @@ export async function buildInvestorDashboardExport(input: {
       include: {
         lineage: {
           orderBy: [{ createdAt: "asc" }],
+          take: MAX_LINEAGE_EVIDENCE_ROWS,
         },
       },
       orderBy: [{ periodEnd: "desc" }, { computedAt: "desc" }],

--- a/src/lib/imladris/service.ts
+++ b/src/lib/imladris/service.ts
@@ -13,6 +13,18 @@ import { resolveIntegrationOwnerUserId } from "@/lib/integrations/ownership";
 import type { IntegrationProvider } from "@/generated/prisma/client";
 import type { PrismaClientType } from "@/lib/prisma";
 
+/**
+ * Cap on lineage (evidence) rows loaded per canonical metric value.
+ *
+ * This view emits full per-row evidence, so it can't use the SQL-aggregate
+ * shortcut the company dashboard uses. Without a cap, a single bloated
+ * metric value (the June 2026 incident had values carrying ~300K lineage
+ * rows) pulls enough rows into the Node heap to OOM-crash the app. A few
+ * hundred evidence rows is far more than any UI surfaces; the bound only
+ * truncates pathological rows. See docs/runbooks/postgres-disk-incident-2026-06.md.
+ */
+const MAX_LINEAGE_EVIDENCE_ROWS = 500;
+
 type SourceStatus = "connected" | "missing" | "partial" | "stale" | "error";
 type MetricStatus = "ready" | "missing" | "partial" | "stale" | "error";
 
@@ -1554,6 +1566,7 @@ export async function buildImladrisMetrics(input: {
       include: {
         lineage: {
           orderBy: [{ createdAt: "asc" }],
+          take: MAX_LINEAGE_EVIDENCE_ROWS,
         },
       },
       orderBy: [{ periodEnd: "desc" }, { computedAt: "desc" }],


### PR DESCRIPTION
Complements **#584** (lineage/outbox/metric-value retention). #584 drains the row backlog over time but left two gaps this PR closes: the **unbounded lineage reads that OOM-crash the app**, and the **absence of disk monitoring**.

## The OOM (still latent on main after #584)

`buildCompanyTrackerDashboard`, `buildImladrisMetrics`, and `buildInvestorDashboardExport` all do `include: { lineage }` with no bound. With the lineage backlog (tens of millions of rows from the `periodEnd = now` churn), these pull enough rows into the Node heap to hit `Reached heap limit` — the crash loop that took prod down. #584's retention shrinks the backlog gradually but doesn't stop these reads from OOMing in the meantime or re-OOMing under load.

- **`buildCompanyTrackerDashboard`** → aggregate lineage facts (count, distinct source keys, latest `capturedAt`) in **SQL via `groupBy`** instead of loading rows. Result size is bounded by `rows × distinct source keys`, independent of lineage table size. Rows that already carry inline `lineage` (legacy callers / test fixtures) are left untouched.
- **`buildImladrisMetrics` / `buildInvestorDashboardExport`** emit full per-row evidence and can't aggregate → cap the nested lineage load at `MAX_LINEAGE_EVIDENCE_ROWS` (500) per metric value. Far above any real evidence need; bounds heap on pathological values.

## Disk monitoring (none today)

`GET /api/health` now includes a `storage` check: `pg_database_size` vs `DATABASE_VOLUME_CAPACITY_MB` (default 20000). `warning` ≥75%, `critical` ≥90% → HTTP **503** + grep-able `[health:storage]` log line. Degrades to `unknown` if the size query fails (never breaks the health check). Point a Railway log alert / uptime monitor at it so a 93%-full volume can't go unnoticed again.

## Not included (deliberately)
Retention, the `periodEnd` change, the one-time cleanup script, and the incident runbook from my earlier draft — all **superseded by #584**, which owns the retention strategy (intraday thinning + per-source write cap). This PR is intentionally scoped to the complementary gaps.

## Tests
- Storage-check cases added to `src/app/api/health/route.test.ts`.
- Full `sync` / `imladris` / `events` suites green (**1009 tests**) alongside #584's retention. Typecheck + lint clean.

Supersedes #597 (which was cut before #584 landed and conflicted with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)