### PR TITLE
Stop pool-monitor latching /api/health to a permanent false 503

### DIFF
--- a/src/lib/__tests__/pool-monitor.test.ts
+++ b/src/lib/__tests__/pool-monitor.test.ts
@@ -141,7 +141,7 @@ describe("PoolMonitor", () => {
     expect(health.status).toBe("critical");
   });
 
-  it("should return critical status when exhaustion events have occurred", () => {
+  it("should return critical status when exhaustion events occurred recently", () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
 
     PoolMonitorModule.poolMonitor.attach(mockPool as unknown as Pool, 25);
@@ -149,6 +149,28 @@ describe("PoolMonitor", () => {
 
     const health = PoolMonitorModule.poolMonitor.getHealthStatus();
     expect(health.status).toBe("critical");
+  });
+
+  it("should recover from critical once an exhaustion event ages out", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+    try {
+      PoolMonitorModule.poolMonitor.attach(mockPool as unknown as Pool, 25);
+      PoolMonitorModule.poolMonitor.recordWaitTime(6000); // triggers exhaustion
+
+      expect(PoolMonitorModule.poolMonitor.getHealthStatus().status).toBe(
+        "critical"
+      );
+
+      // Past the recency window the latch releases, while the cumulative
+      // counter stays visible for observability.
+      vi.advanceTimersByTime(61_000);
+      const health = PoolMonitorModule.poolMonitor.getHealthStatus();
+      expect(health.status).toBe("healthy");
+      expect(health.pool.totalPoolExhaustionEvents).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("should track uptime", async () => {

--- a/src/lib/pool-monitor.ts
+++ b/src/lib/pool-monitor.ts
@@ -36,10 +36,21 @@ export interface PoolMetrics {
   uptimeMs: number;
 }
 
+/**
+ * How long after a pool-exhaustion event the health status stays "critical".
+ * Exhaustion previously latched critical forever (a non-zero cumulative
+ * counter), so a single >5 s connection wait early in a container's life made
+ * /api/health report a false, permanent 503 for the rest of that process —
+ * wrong for any monitor/alert/health check consuming it. Recency-based instead,
+ * so the status reflects live conditions while the event stays in the counter.
+ */
+const EXHAUSTION_CRITICAL_WINDOW_MS = 60_000;
+
 class PoolMonitor {
   private totalConnectionsCreated = 0;
   private totalConnectionErrors = 0;
   private totalPoolExhaustionEvents = 0;
+  private lastExhaustionAt: number | null = null;
   private connectionWaitTimes: number[] = [];
   private lastError: string | null = null;
   private lastErrorAt: string | null = null;
@@ -116,6 +127,7 @@ class PoolMonitor {
     // Detect pool exhaustion: if wait time exceeds 5 seconds
     if (waitMs > 5000) {
       this.totalPoolExhaustionEvents++;
+      this.lastExhaustionAt = Date.now();
       console.warn(
         `[PoolMonitor] Pool exhaustion detected! Wait time: ${waitMs}ms (event #${this.totalPoolExhaustionEvents})`
       );
@@ -176,7 +188,13 @@ class PoolMonitor {
       }
     }
 
-    if (metrics.totalPoolExhaustionEvents > 0) {
+    // Recent exhaustion marks the pool critical; older events stay visible in
+    // the cumulative counter but no longer latch the status (a latched 503
+    // would keep /api/health reporting failure long after one transient stall).
+    if (
+      this.lastExhaustionAt !== null &&
+      Date.now() - this.lastExhaustionAt < EXHAUSTION_CRITICAL_WINDOW_MS
+    ) {
       status = "critical";
     }
 


### PR DESCRIPTION
## Problem

`PoolMonitor.getHealthStatus()` marks the pool **`critical`** whenever the cumulative `totalPoolExhaustionEvents` counter is non-zero:

```ts
if (metrics.totalPoolExhaustionEvents > 0) {
  status = "critical";
}
```

That counter only ever increments. So a **single** connection wait over 5s — one transient stall early in a container's life — pins `/api/health` to a **503 for the entire process lifetime**, long after conditions recover. Any monitor, alert, or platform health check reading `/api/health` is stuck seeing failure after the first blip.

## Fix

Record the timestamp of the last exhaustion event and only treat the pool as `critical` for a recency window (`EXHAUSTION_CRITICAL_WINDOW_MS`, 60s) afterward. The cumulative counter is untouched and still surfaces in `getMetrics()` for observability — only the **latching** of health status changes.

~40 lines, one file + a regression test (`should recover from critical once an exhaustion event ages out`).

## Context

Salvaged from a connection-resilience investigation into the 2026-06-11 deploy-time connect-timeout outage. The retry + pool warm-up pieces of that work landed independently in **#594**; this health-status latch was the one gap #594 didn't touch (`src/lib/pool-monitor.ts` was last changed in #378). Verified: `tsc` clean, eslint clean, full suite **3177/3177** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)