### PR TITLE
Trim snapshot-write payload round-trip + V8 heap headroom stopgap

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -42,4 +42,12 @@ esac
 
 echo "Starting server..."
 export HOSTNAME=${HOSTNAME:-0.0.0.0}
-exec node server.js
+
+# --max-old-space-size: defense-in-depth heap headroom, NOT a leak fix. Sizes
+# the V8 old-space to the Railway container instead of V8's ~4 GB default, so
+# that if an analytics/lineage read regresses, the app degrades slowly rather
+# than crash-looping (the 2026-06 OOM was a hard 4 GB heap-limit fatal). Keep
+# below the container memory limit — leave ~2 GB for non-heap RSS. Override via
+# NODE_MAX_OLD_SPACE_MB. (No --expose-gc: nothing calls gc() in this codebase.)
+NODE_MAX_OLD_SPACE_MB="${NODE_MAX_OLD_SPACE_MB:-6144}"
+exec node --max-old-space-size="${NODE_MAX_OLD_SPACE_MB}" server.js

--- a/src/lib/analytics/snapshots.ts
+++ b/src/lib/analytics/snapshots.ts
@@ -91,6 +91,11 @@ export async function storeAnalyticsSnapshot(input: SnapshotUpsertInput): Promis
       capturedAt: new Date(),
       expiresAt: input.expiresAt,
     },
+    // The caller ignores the return value. Without an explicit select Prisma
+    // round-trips the just-written `payload` (often tens of MB) back into a JS
+    // object on every write — a large transient allocation per provider per
+    // cycle. Returning only `id` avoids deserializing the payload at all.
+    select: { id: true },
   });
 }
 
@@ -129,6 +134,9 @@ export async function storeAnalyticsSnapshotFailure(input: SnapshotFailureInput)
       capturedAt: new Date(),
       expiresAt: input.expiresAt,
     },
+    // Return only `id`; the caller ignores the row and there is no payload to
+    // round-trip here, but this keeps both upserts consistent and cheap.
+    select: { id: true },
   });
 }
 


### PR DESCRIPTION
## Context

Two small, additive heap-hygiene changes. **This is not an OOM-crash-loop fix** — the crash loop was the unbounded `include: { lineage }` reads (fixed in #599) plus the DB growth controls (#582/#584). This PR is the salvaged, still-useful remainder of the now-superseded port in #595, rebased fresh onto current `main`.

## Changes

- **`snapshots.ts`** — add `select: { id: true }` to both `analyticsSnapshot` upserts. The callers ignore the return value, but without an explicit `select` Prisma deserializes the just-written `payload` (often tens of MB) back into a JS object on every write — a large transient allocation per provider per refresh cycle. Returning only `id` skips it.
- **`docker-entrypoint.sh`** — start node with `--max-old-space-size` (default `6144`, override via `NODE_MAX_OLD_SPACE_MB`) so V8's old-space tracks the Railway container instead of the ~4 GB default. Defense-in-depth: if an analytics/lineage read regresses, the app degrades slowly instead of a hard heap-limit fatal. Explicitly **no** `--expose-gc` — nothing in the codebase calls `gc()`.

Both are orthogonal to the lineage-read fix and safe alongside it.

## Sizing note

`6144` assumes the container has ≥8 GB (the June OOM was V8's ~4 GB default fatal, not the container cap, so there's headroom). If `WIPGuard-app`'s Railway memory limit is lower, set `NODE_MAX_OLD_SPACE_MB` to (limit − ~2 GB) so non-heap RSS has room.

## Tests

Snapshot + refresh-runner + analytics-route suites green; `tsc --noEmit` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
