### PR TITLE
Strip metric values from analytics sync response (salvaged from #595)

### DIFF
--- a/src/lib/sync/analytics.test.ts
+++ b/src/lib/sync/analytics.test.ts
@@ -143,24 +143,16 @@ describe("runAnalyticsSync", () => {
         organizationId: "org_1",
         periodStart: "2026-05-02T12:00:00.000Z",
         periodEnd: "2026-06-01T12:00:00.000Z",
-        metrics: [
-          expect.objectContaining({
-            metricKey: "development.delivery_health",
-            rawRecordCount: 3,
-          }),
-        ],
+        metricsCount: 1,
+        metricKeys: ["development.delivery_health"],
       },
       {
         userId: "user_2",
         organizationId: null,
         periodStart: "2026-05-02T12:00:00.000Z",
         periodEnd: "2026-06-01T12:00:00.000Z",
-        metrics: [
-          expect.objectContaining({
-            metricKey: "development.delivery_health",
-            rawRecordCount: 3,
-          }),
-        ],
+        metricsCount: 1,
+        metricKeys: ["development.delivery_health"],
       },
     ]);
   });
@@ -268,9 +260,8 @@ describe("runAnalyticsSync", () => {
       imladris: expect.arrayContaining([
         expect.objectContaining({
           userId: "user_1",
-          metrics: expect.arrayContaining([
-            expect.objectContaining({ metricKey: "development.delivery_health" }),
-          ]),
+          metricsCount: 1,
+          metricKeys: ["development.delivery_health"],
         }),
       ]),
     }));
@@ -298,11 +289,8 @@ describe("runAnalyticsSync", () => {
         organizationId: "org_1",
         periodStart: "2026-05-02T12:00:00.000Z",
         periodEnd: "2026-06-01T12:00:00.000Z",
-        metrics: [
-          expect.objectContaining({
-            metricKey: "development.delivery_health",
-          }),
-        ],
+        metricsCount: 1,
+        metricKeys: ["development.delivery_health"],
         warning:
           "Analytics refresh reported 2 provider failures; canonical materialization used available raw records.",
       },
@@ -311,11 +299,8 @@ describe("runAnalyticsSync", () => {
         organizationId: null,
         periodStart: "2026-05-02T12:00:00.000Z",
         periodEnd: "2026-06-01T12:00:00.000Z",
-        metrics: [
-          expect.objectContaining({
-            metricKey: "development.delivery_health",
-          }),
-        ],
+        metricsCount: 1,
+        metricKeys: ["development.delivery_health"],
         warning:
           "Analytics refresh reported 2 provider failures; canonical materialization used available raw records.",
       },
@@ -347,16 +332,14 @@ describe("runAnalyticsSync", () => {
     expect(result.imladris).toEqual([
       expect.objectContaining({
         userId: "user_1",
-        metrics: [
-          expect.objectContaining({
-            metricKey: "development.delivery_health",
-          }),
-        ],
+        metricsCount: 1,
+        metricKeys: ["development.delivery_health"],
       }),
       expect.objectContaining({
         userId: "user_2",
         organizationId: null,
-        metrics: [],
+        metricsCount: 0,
+        metricKeys: [],
         error: "canonical write failed",
       }),
     ]);

--- a/src/lib/sync/analytics.ts
+++ b/src/lib/sync/analytics.ts
@@ -69,7 +69,11 @@ export type GrowthPruneOutcome<T> = T | { error: string };
 export interface AnalyticsSyncResult {
   refresh: Awaited<ReturnType<typeof runAnalyticsRefresh>>;
   pruning: Awaited<ReturnType<typeof pruneAnalyticsSnapshots>>;
-  imladris: ImladrisMaterializationSyncResult[];
+  // Lightweight summary (full metric values stripped) so the cron route's
+  // after() closure no longer retains hundreds of MB of metric values across
+  // cycles — they are already persisted to the DB. Salvaged from #595 after
+  // the broader OOM fix landed in #594.
+  imladris: ImladrisMaterializationSyncSummary[];
   /**
    * Growth controls for the two unbounded tables behind the 2026-06-10
    * disk-full outage. Named *Pruning (not *Retention) because the cron sync
@@ -100,6 +104,23 @@ interface ImladrisMaterializationSyncResult {
   periodStart: string;
   periodEnd: string;
   metrics: MaterializedImladrisMetricResult[];
+  error?: string;
+  warning?: string;
+}
+
+/**
+ * What callers actually need from materialization: identity, period, and which
+ * metrics were produced. The full metric values are deliberately omitted —
+ * they are already persisted, and retaining them in the cron route's after()
+ * closure leaked hundreds of MB across sync cycles.
+ */
+interface ImladrisMaterializationSyncSummary {
+  userId: string;
+  organizationId: string | null;
+  periodStart: string;
+  periodEnd: string;
+  metricsCount: number;
+  metricKeys: string[];
   error?: string;
   warning?: string;
 }
@@ -305,5 +326,26 @@ export async function runAnalyticsSync(
     return { error: message };
   });
 
-  return { refresh, pruning, imladris, lineagePruning, metricValuePruning, outboxPruning };
+  // Strip full metric values from the result — they're already persisted to
+  // the DB. Keeping them in the response body retains hundreds of MB across
+  // cron cycles (held by the route's after() closure). Salvaged from #595.
+  const imladrisSummary: ImladrisMaterializationSyncSummary[] = imladris.map((entry) => ({
+    userId: entry.userId,
+    organizationId: entry.organizationId,
+    periodStart: entry.periodStart,
+    periodEnd: entry.periodEnd,
+    metricsCount: entry.metrics.length,
+    metricKeys: entry.metrics.map((metric) => metric.metricKey),
+    ...(entry.warning ? { warning: entry.warning } : {}),
+    ...(entry.error ? { error: entry.error } : {}),
+  }));
+
+  return {
+    refresh,
+    pruning,
+    imladris: imladrisSummary,
+    lineagePruning,
+    metricValuePruning,
+    outboxPruning,
+  };
 }


### PR DESCRIPTION
## Summary

Salvages the one piece of [#595](https://github.com/khenson99/WIPGuard/pull/595) that wasn't redundant after the broader OOM crash-loop fix landed in [#594](https://github.com/khenson99/WIPGuard/pull/594).

`runAnalyticsSync` returned the full canonical metric values in its `imladris` field. The cron route hands that result to `after()`, whose closure then retained those values across sync cycles (hundreds of MB). The values are already persisted to the DB — callers only need a summary.

This changes `AnalyticsSyncResult.imladris` from `ImladrisMaterializationSyncResult[]` (full `metrics`) to a lightweight `ImladrisMaterializationSyncSummary[]` (`metricsCount` + `metricKeys`, with `error`/`warning` preserved). `collectAnalyticsPartialFailures` reads only `error`/`warning`, so the partial-failure path is unaffected.

## Context

#594 already shipped the core OOM fix (serialized materialization + `withSyncAdvisoryLock` to prevent overlapping cron runs + heap stopgap), so #595 is being closed as superseded. This is the only additive change from it.

## Tests

Full suite green (269 files / 3,176 tests); typecheck clean. Updated `analytics.test.ts` to assert the summary shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)