### PR TITLE
test(sync): fix stale analytics.test after retention merges (green up main)

### DIFF
--- a/src/lib/sync/analytics.test.ts
+++ b/src/lib/sync/analytics.test.ts
@@ -143,24 +143,16 @@ describe("runAnalyticsSync", () => {
         organizationId: "org_1",
         periodStart: "2026-05-02T12:00:00.000Z",
         periodEnd: "2026-06-01T12:00:00.000Z",
-        metrics: [
-          expect.objectContaining({
-            metricKey: "development.delivery_health",
-            rawRecordCount: 3,
-          }),
-        ],
+        metricsCount: 1,
+        metricKeys: ["development.delivery_health"],
       },
       {
         userId: "user_2",
         organizationId: null,
         periodStart: "2026-05-02T12:00:00.000Z",
         periodEnd: "2026-06-01T12:00:00.000Z",
-        metrics: [
-          expect.objectContaining({
-            metricKey: "development.delivery_health",
-            rawRecordCount: 3,
-          }),
-        ],
+        metricsCount: 1,
+        metricKeys: ["development.delivery_health"],
       },
     ]);
   });
@@ -268,9 +260,7 @@ describe("runAnalyticsSync", () => {
       imladris: expect.arrayContaining([
         expect.objectContaining({
           userId: "user_1",
-          metrics: expect.arrayContaining([
-            expect.objectContaining({ metricKey: "development.delivery_health" }),
-          ]),
+          metricKeys: expect.arrayContaining(["development.delivery_health"]),
         }),
       ]),
     }));
@@ -298,11 +288,8 @@ describe("runAnalyticsSync", () => {
         organizationId: "org_1",
         periodStart: "2026-05-02T12:00:00.000Z",
         periodEnd: "2026-06-01T12:00:00.000Z",
-        metrics: [
-          expect.objectContaining({
-            metricKey: "development.delivery_health",
-          }),
-        ],
+        metricsCount: 1,
+        metricKeys: ["development.delivery_health"],
         warning:
           "Analytics refresh reported 2 provider failures; canonical materialization used available raw records.",
       },
@@ -311,11 +298,8 @@ describe("runAnalyticsSync", () => {
         organizationId: null,
         periodStart: "2026-05-02T12:00:00.000Z",
         periodEnd: "2026-06-01T12:00:00.000Z",
-        metrics: [
-          expect.objectContaining({
-            metricKey: "development.delivery_health",
-          }),
-        ],
+        metricsCount: 1,
+        metricKeys: ["development.delivery_health"],
         warning:
           "Analytics refresh reported 2 provider failures; canonical materialization used available raw records.",
       },
@@ -347,16 +331,14 @@ describe("runAnalyticsSync", () => {
     expect(result.imladris).toEqual([
       expect.objectContaining({
         userId: "user_1",
-        metrics: [
-          expect.objectContaining({
-            metricKey: "development.delivery_health",
-          }),
-        ],
+        metricsCount: 1,
+        metricKeys: ["development.delivery_health"],
       }),
       expect.objectContaining({
         userId: "user_2",
         organizationId: null,
-        metrics: [],
+        metricsCount: 0,
+        metricKeys: [],
         error: "canonical write failed",
       }),
     ]);


### PR DESCRIPTION
**Greens up `main`.** After the concurrent retention/growth-control merges (#582 / #584), `src/lib/sync/analytics.test.ts` was left red (4 failing tests) — unrelated to any single PR, just a shape change that didn't get its test reconciled.

`runAnalyticsSync` returns `imladris` entries as `ImladrisMaterializationSyncSummary` (`metricsCount` + `metricKeys`) — the intentional memory optimization that omits full metric values from the response (they're already persisted to the DB; keeping them held hundreds of MB across cron cycles). The test still asserted the old full `metrics: [...]` array.

**Test-only change**: assert `metricsCount` / `metricKeys`, matching both the declared return type (`AnalyticsSyncResult.imladris: ImladrisMaterializationSyncSummary[]`) and the actual runtime output. Verified no non-test consumer reads `.metrics` on the sync result — the cron route only inspects `.error` — so the summary shape is canonical and the code is correct.

`src/lib/sync` + `src/lib/events` + `src/lib/imladris` + `src/app/api/cron` suites all green locally (1030 tests). Surfaced while verifying #599 landed cleanly; #599 itself only touched health/dashboard read paths and did not cause this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)