### PR TITLE
Unblock deploy: defer CONCURRENTLY migrations (fix false comment match)

### DIFF
--- a/__tests__/migrate-check.test.ts
+++ b/__tests__/migrate-check.test.ts
@@ -13,6 +13,8 @@ const migrate = require("../migrate.cjs") as {
     appliedNames: string[]
   ) => string[];
   listMigrationDirs: () => string[];
+  migrationContainsConcurrently: (dir: string) => boolean;
+  sqlUsesConcurrently: (sql: string) => boolean;
 };
 
 const MIGRATIONS_DIR = join(__dirname, "..", "prisma", "migrations");
@@ -57,5 +59,54 @@ describe("migrate.cjs --check helpers", () => {
     expect(migrate.computePendingMigrations(["20260101_a"], [])).toEqual([
       "20260101_a",
     ]);
+  });
+});
+
+describe("migrate.cjs CONCURRENTLY detection (deferred migrations)", () => {
+  it("detects CONCURRENTLY in real statements", () => {
+    expect(
+      migrate.sqlUsesConcurrently(
+        'CREATE INDEX CONCURRENTLY IF NOT EXISTS "x_idx" ON "X"("createdAt");'
+      )
+    ).toBe(true);
+    expect(migrate.sqlUsesConcurrently("create index concurrently on t(c);")).toBe(
+      true
+    );
+  });
+
+  it("does NOT flag CONCURRENTLY that appears only in a comment", () => {
+    // This is the false positive that previously blocked a transaction-safe
+    // migration: the runner refused it because a comment mentioned the word.
+    const lineComment = [
+      "-- an operator MAY pre-create with CREATE INDEX CONCURRENTLY IF NOT EXISTS",
+      'CREATE INDEX IF NOT EXISTS "x_idx" ON "X"("createdAt");',
+    ].join("\n");
+    expect(migrate.sqlUsesConcurrently(lineComment)).toBe(false);
+
+    const blockComment = [
+      "/* could be built CONCURRENTLY out of band */",
+      'CREATE INDEX IF NOT EXISTS "y_idx" ON "Y"("startedAt");',
+    ].join("\n");
+    expect(migrate.sqlUsesConcurrently(blockComment)).toBe(false);
+  });
+
+  it("plain migrations without CONCURRENTLY are not deferred", () => {
+    expect(
+      migrate.sqlUsesConcurrently('CREATE TABLE "T" ("id" TEXT PRIMARY KEY);')
+    ).toBe(false);
+  });
+
+  it("flags the retention prune-index migration as CONCURRENTLY (deferred)", () => {
+    // The real migration on disk uses CREATE INDEX CONCURRENTLY, so the runner
+    // must defer it (skip at boot, apply out-of-band).
+    expect(
+      migrate.migrationContainsConcurrently(
+        "20260615120000_add_retention_prune_indexes"
+      )
+    ).toBe(true);
+  });
+
+  it("returns false for a non-existent migration dir", () => {
+    expect(migrate.migrationContainsConcurrently("does_not_exist")).toBe(false);
   });
 });

--- a/docs/runbooks/concurrent-index-migrations.md
+++ b/docs/runbooks/concurrent-index-migrations.md
@@ -1,0 +1,56 @@
+# Runbook: deferred `CONCURRENTLY` migrations
+
+## Why this exists
+
+The custom migration runner (`migrate.cjs`) wraps every migration in a
+`BEGIN/COMMIT` transaction. Postgres forbids `CREATE INDEX CONCURRENTLY` (and
+other `CONCURRENTLY` DDL) inside a transaction, so the runner **defers** any
+migration whose SQL uses `CONCURRENTLY`:
+
+- It is **skipped** at `preDeployCommand` / boot (logged as `defer: <name> uses
+  CONCURRENTLY …`) and **never recorded** as applied — so a deploy is never
+  blocked by it.
+- `migrate.cjs --check` excludes it from the "pending" set (reported separately
+  as `deferred CONCURRENTLY migration(s)`), so the fast boot path stays "current".
+- It must be applied **out-of-band** (below), then recorded.
+
+> Detection strips SQL comments first, so a migration that merely *mentions*
+> `CONCURRENTLY` in a comment is **not** deferred. (That false positive once
+> blocked a transaction-safe migration and took down every deploy.)
+
+## Applying a deferred migration out-of-band
+
+These index builds are non-locking (`CONCURRENTLY`) and idempotent
+(`IF NOT EXISTS`), so they are safe to run on the live database during normal
+traffic.
+
+1. Open a psql session on the production database (Railway dashboard → Postgres
+   → Connect, or `railway connect Postgres`).
+2. Run the statements from the migration file, e.g.
+   `prisma/migrations/20260615120000_add_retention_prune_indexes/migration.sql`:
+   ```sql
+   CREATE INDEX CONCURRENTLY IF NOT EXISTS "SecurityAuditEvent_createdAt_idx" ON "SecurityAuditEvent"("createdAt");
+   CREATE INDEX CONCURRENTLY IF NOT EXISTS "ImladrisSourceSyncRun_startedAt_idx" ON "ImladrisSourceSyncRun"("startedAt");
+   CREATE INDEX CONCURRENTLY IF NOT EXISTS "ImladrisRawSourceRecord_createdAt_idx" ON "ImladrisRawSourceRecord"("createdAt");
+   ```
+   Run each on its own (CONCURRENTLY can't be inside a transaction/`psql -1`).
+3. If a build fails it can leave an `INVALID` index — drop it and retry:
+   ```sql
+   SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid;
+   -- DROP INDEX CONCURRENTLY "<invalid_index>"; then re-run the CREATE.
+   ```
+4. (Optional) Record it so `--check` stops listing it as deferred:
+   ```sql
+   INSERT INTO "_prisma_migrations" (id, checksum, finished_at, migration_name, applied_steps_count)
+   VALUES (gen_random_uuid(), 'out-of-band', now(), '20260615120000_add_retention_prune_indexes', 1);
+   ```
+   (Idempotent `IF NOT EXISTS` means skipping this step is harmless — the
+   deploy is never blocked either way.)
+
+## Authoring new index migrations
+
+- Prefer `CREATE INDEX CONCURRENTLY IF NOT EXISTS` for any index on a large
+  table — it avoids the write-blocking `SHARE` lock a plain `CREATE INDEX`
+  takes. Accept that it will be **deferred** and applied out-of-band per above.
+- Use a plain `CREATE INDEX` only for small/new tables where a brief lock is
+  fine and you want it applied automatically at deploy.

--- a/migrate.cjs
+++ b/migrate.cjs
@@ -284,6 +284,38 @@ function computePendingMigrations(localDirs, appliedNames) {
 }
 
 /**
+ * True if SQL uses CONCURRENTLY in an actual statement (not just a comment).
+ * Comments are stripped first so a migration that merely *mentions*
+ * CONCURRENTLY in a `--` or block comment is NOT misclassified — that false
+ * positive previously blocked an entirely transaction-safe migration.
+ */
+function sqlUsesConcurrently(sql) {
+  const withoutComments = sql
+    .replace(/\/\*[\s\S]*?\*\//g, " ") // block comments
+    .replace(/--[^\n]*/g, " "); // line comments
+  return /\bCONCURRENTLY\b/i.test(withoutComments);
+}
+
+/**
+ * True if a migration's SQL uses CONCURRENTLY (e.g. CREATE INDEX
+ * CONCURRENTLY). Such statements cannot run inside a transaction, and this
+ * runner wraps every migration in BEGIN/COMMIT — so it cannot apply them.
+ *
+ * These migrations are DEFERRED: skipped at preDeploy/boot (never recorded as
+ * applied here) so a deploy is never blocked, then applied OUT-OF-BAND and
+ * recorded in _prisma_migrations. See docs/runbooks/concurrent-index-migrations.md.
+ */
+function migrationContainsConcurrently(dir) {
+  try {
+    return sqlUsesConcurrently(
+      fs.readFileSync(path.join(MIGRATIONS_DIR, dir, "migration.sql"), "utf-8"),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Read-only schema currency check (`node migrate.cjs --check`).
  *
  * Exit codes: 0 = every local migration is applied, 2 = migrations pending,
@@ -313,10 +345,23 @@ async function check() {
       const applied = await pool.query(
         'SELECT migration_name FROM "_prisma_migrations" WHERE rolled_back_at IS NULL',
       );
-      const pending = computePendingMigrations(
+      const pendingAll = computePendingMigrations(
         localDirs,
         applied.rows.map((row) => row.migration_name),
       );
+      // Deferred CONCURRENTLY migrations are applied out-of-band, never at
+      // boot, so they must not keep this fast-path check returning "pending"
+      // forever (which would defeat the skip-when-current optimization). Report
+      // them, but don't gate boot on them.
+      const deferred = pendingAll.filter(migrationContainsConcurrently);
+      const pending = pendingAll.filter(
+        (dir) => !migrationContainsConcurrently(dir),
+      );
+      if (deferred.length > 0) {
+        console.log(
+          `Schema check: ${deferred.length} deferred CONCURRENTLY migration(s) (apply out-of-band): ${deferred.join(", ")}`,
+        );
+      }
       if (pending.length > 0) {
         console.log(
           `Schema check: ${pending.length} pending migration(s): ${pending.join(", ")}`,
@@ -380,11 +425,17 @@ async function run() {
 
       const sqlFile = path.join(MIGRATIONS_DIR, dir, "migration.sql");
       const sql = fs.readFileSync(sqlFile, "utf-8");
-      if (/\bCONCURRENTLY\b/i.test(sql)) {
-        console.error(
-          `Migration ${dir} contains CONCURRENTLY; refusing to run outside a transaction`,
+      if (sqlUsesConcurrently(sql)) {
+        // CONCURRENTLY can't run inside a transaction and this runner wraps
+        // every migration in BEGIN/COMMIT. DEFER rather than fail the deploy:
+        // skip here without recording it applied, so it stays pending until
+        // applied out-of-band (then recorded). Previously this exited 1 and
+        // blocked every deploy once such a migration landed.
+        // See docs/runbooks/concurrent-index-migrations.md.
+        console.warn(
+          `  defer: ${dir} uses CONCURRENTLY — must be applied out-of-band, skipping`,
         );
-        process.exit(1);
+        continue;
       }
       const checksum = crypto
         .createHash("sha256")
@@ -459,6 +510,8 @@ if (require.main === module) {
 module.exports = {
   computePendingMigrations,
   listMigrationDirs,
+  migrationContainsConcurrently,
+  sqlUsesConcurrently,
   splitMigrationSql,
   splitSqlStatements,
 };

--- a/prisma/migrations/20260615120000_add_retention_prune_indexes/migration.sql
+++ b/prisma/migrations/20260615120000_add_retention_prune_indexes/migration.sql
@@ -3,19 +3,21 @@
 -- cutoff, but no existing index on these tables leads with a plain timestamp
 -- column, so the prune would otherwise seq-scan.
 --
--- IF NOT EXISTS makes this migration idempotent: on the large existing tables
--- an operator MAY pre-create these indexes by hand with
---   CREATE INDEX CONCURRENTLY IF NOT EXISTS "<name>" ON "<table>"("<col>");
--- during a low-traffic window to avoid the brief write-lock a non-concurrent
--- CREATE INDEX takes (this migration runs inside a transaction — the custom
--- runner in migrate.cjs refuses CONCURRENTLY — so the build holds a SHARE
--- lock for its duration). If pre-created, the statements below no-op.
+-- These build CONCURRENTLY so creating them on the (large, post-incident)
+-- target tables does NOT take a write-blocking lock. CONCURRENTLY cannot run
+-- inside a transaction, and the custom runner (migrate.cjs) wraps each
+-- migration in BEGIN/COMMIT — so the runner DEFERS this migration: it is
+-- skipped at preDeploy/boot (never blocks a deploy) and must be applied
+-- OUT-OF-BAND, then recorded in _prisma_migrations.
+-- See docs/runbooks/concurrent-index-migrations.md.
+--
+-- IF NOT EXISTS keeps it idempotent so an out-of-band run (or re-run) no-ops.
 
 -- CreateIndex
-CREATE INDEX IF NOT EXISTS "SecurityAuditEvent_createdAt_idx" ON "SecurityAuditEvent"("createdAt");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "SecurityAuditEvent_createdAt_idx" ON "SecurityAuditEvent"("createdAt");
 
 -- CreateIndex
-CREATE INDEX IF NOT EXISTS "ImladrisSourceSyncRun_startedAt_idx" ON "ImladrisSourceSyncRun"("startedAt");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "ImladrisSourceSyncRun_startedAt_idx" ON "ImladrisSourceSyncRun"("startedAt");
 
 -- CreateIndex
-CREATE INDEX IF NOT EXISTS "ImladrisRawSourceRecord_createdAt_idx" ON "ImladrisRawSourceRecord"("createdAt");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "ImladrisRawSourceRecord_createdAt_idx" ON "ImladrisRawSourceRecord"("createdAt");


### PR DESCRIPTION
## Why

The deploy of `main` (which carries the OOM fix #594, the lineage-read OOM fix #599, and the DB-pruning engine #582) **fails at the migration step**:

```
Migration 20260615120000_add_retention_prune_indexes contains CONCURRENTLY; refusing to run outside a transaction
Stopping Container
```

Railway kept the last-good build serving, so prod is up-but-degraded — but **none of the three fixes can go live** until this is resolved.

## Root cause

Two issues in the custom migration runner `migrate.cjs`:

1. **False positive.** The CONCURRENTLY guard tested the **raw SQL**, so it matched the word `CONCURRENTLY` inside a **comment** of #582's migration. That migration actually used plain `CREATE INDEX IF NOT EXISTS` (transaction-safe), but the guard `process.exit(1)`'d and blocked every deploy.
2. **Hard-fail instead of defer.** Even for a *real* CONCURRENTLY migration, exiting non-zero blocks the whole deploy.

## Fix

- `sqlUsesConcurrently()` **strips comments** before testing, so only real `CONCURRENTLY` statements are flagged (regression test included: a comment-only mention is not flagged).
- CONCURRENTLY migrations are now **deferred**, not fatal: skipped at preDeploy/boot (never recorded applied) and excluded from the `--check` pending set, so a deploy is never blocked. They're applied **out-of-band** (lock-free) per the new [`docs/runbooks/concurrent-index-migrations.md`](docs/runbooks/concurrent-index-migrations.md).
- The prune-index migration is converted to `CREATE INDEX CONCURRENTLY IF NOT EXISTS` so building it on the large post-incident tables takes **no write lock** — matching the chosen "defer the migration, add the index out-of-band" path.

## Effect

`main` can deploy now; the three prune indexes are created out-of-band afterward (procedure in the runbook). Without the index the prune just seq-scans (slower, bounded by its time budgets) — correctness is unaffected.

## Verified
- `__tests__/migrate-check.test.ts` (10 tests), incl. comment-only CONCURRENTLY is **not** flagged and the real prune-index migration **is** deferred.
- `node --check migrate.cjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)