### PR TITLE
Cron-OOM follow-ups: enable --expose-gc, safe Prisma reset, fix pool monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,13 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 ENV PORT=3000
+# Enable manual GC (global.gc()) and pin the V8 old-space ceiling.
+# The cron sync (src/app/api/cron/sync/route.ts) calls gc() between phases and
+# after each cycle to release query/adapter buffers; WITHOUT --expose-gc those
+# calls are silent no-ops and the per-cycle memory strategy does nothing.
+# Size --max-old-space-size to ~75-80% of the container's memory limit; 4096
+# matches the ~4 GB ceiling the sync was tuned against (confirm container RAM).
+ENV NODE_OPTIONS="--expose-gc --max-old-space-size=4096"
 
 # Force cache invalidation
 ARG BUILDTIME=2026-02-13T2130

--- a/src/lib/pool-monitor.ts
+++ b/src/lib/pool-monitor.ts
@@ -103,6 +103,20 @@ class PoolMonitor {
   }
 
   /**
+   * Detach from the current pool so a freshly-created pool can re-attach.
+   *
+   * attach() above no-ops when a monitor is already attached, so after a pool
+   * rotation (see resetPrismaClient) the monitor would otherwise stay bound to
+   * the old, drained pool and report stale /api/health metrics. Call this when
+   * swapping pools; the next attach() rebinds to the new pool.
+   */
+  detach(): void {
+    this.isAttached = false;
+    this.pool = null;
+    this.maxPoolSize = 0;
+  }
+
+  /**
    * Record a connection wait time for metrics tracking.
    * Call this when a query completes to track how long it waited for a connection.
    */

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -87,33 +87,63 @@ export const prisma = new Proxy({} as PrismaClientType, {
 });
 
 /**
- * Disconnect the Prisma client and drain the pg pool, then clear the
- * cached singleton so the next query creates a fresh client.
- *
- * Call this between heavy batch operations (e.g. cron sync cycles) to
- * release accumulated Prisma/pg adapter state that accumulates across
- * hundreds of queries (prepared statements, result buffers, etc.).
+ * Grace period before a rotated-out pool/client is drained, so web/auth
+ * requests that resolved the previous client moments before a reset can
+ * finish on it instead of erroring on a closed pool.
  */
-export async function resetPrismaClient(): Promise<void> {
+const RESET_DRAIN_GRACE_MS = 10_000;
+
+/**
+ * Rotate the Prisma client: swap in a fresh client+pool for all new work,
+ * then drain the previous client/pool after a short grace period.
+ *
+ * Call this between heavy batch operations (e.g. cron sync cycles) to release
+ * accumulated Prisma/pg adapter state (prepared statements, result buffers,
+ * query plan caches) that V8 GC alone cannot reclaim.
+ *
+ * Safety: the cron route shares this singleton with web/auth traffic in the
+ * SAME process. We must NOT hard-close the old pool synchronously — that would
+ * abort in-flight queries from concurrent requests that resolved the old client
+ * just before the reset. Instead we (1) clear the singleton so every new query
+ * lazily builds a fresh client+pool, (2) detach pool monitoring so the new pool
+ * re-attaches (attach() no-ops while already attached), and (3) drain the old
+ * pool on an unref'd timer after a grace window — pool.end() itself also waits
+ * for checked-out clients to be released.
+ */
+export function resetPrismaClient(): Promise<void> {
   const client = globalForPrisma.prisma;
   const pool = globalForPrisma.pgPool;
   globalForPrisma.prisma = undefined;
   globalForPrisma.pgPool = undefined;
 
-  if (client) {
-    try {
-      await (client as unknown as { $disconnect?: () => Promise<void> }).$disconnect?.();
-    } catch (e) {
-      console.warn("[Prisma] $disconnect error during reset:", e);
-    }
-  }
-  if (pool) {
-    try {
-      await pool.end();
-    } catch (e) {
-      console.warn("[Prisma] pool.end error during reset:", e);
-    }
-  }
+  // Re-bind monitoring to the next pool; otherwise the attach() guard leaves
+  // /api/health connectionPool metrics stuck on the old, drained pool.
+  poolMonitor.detach();
+
+  if (!client && !pool) return Promise.resolve();
+
+  const timer = setTimeout(() => {
+    void (async () => {
+      if (client) {
+        try {
+          await (client as unknown as { $disconnect?: () => Promise<void> }).$disconnect?.();
+        } catch (e) {
+          console.warn("[Prisma] $disconnect error during reset:", e);
+        }
+      }
+      if (pool) {
+        try {
+          await pool.end();
+        } catch (e) {
+          console.warn("[Prisma] pool.end error during reset:", e);
+        }
+      }
+    })();
+  }, RESET_DRAIN_GRACE_MS);
+  // Don't keep the event loop alive solely for the deferred drain.
+  (timer as unknown as { unref?: () => void }).unref?.();
+
+  return Promise.resolve();
 }
 
 export default prisma;


### PR DESCRIPTION
Stacked on `fix/cron-sync-oom-serialize` (base `31bc55b7`). Addresses the three real gaps from the review of that branch. **All three are low-risk and self-contained** — no changes to the cron route's control flow.

## Fixes

### 1. 🔴 The per-cycle GC was a silent no-op
`src/app/api/cron/sync/route.ts` calls `global.gc()` between phases (and after each cycle) and the comment says it *requires* `--expose-gc` — but that flag was set in **no** config. So the entire per-cycle GC strategy did nothing. Added `NODE_OPTIONS="--expose-gc --max-old-space-size=4096"` to the runtime image so the existing `gc()` hints actually reclaim memory. **This is the linchpin** — without it, none of the branch's GC tuning runs.
> ⚠️ Confirm the container's RAM is ≥ ~5 GB; `--max-old-space-size` should be ~75–80% of the limit. 4096 matches the ~4 GB ceiling the sync was tuned against.

### 2. 🔴 `resetPrismaClient()` could abort concurrent web/auth queries
The cron sync shares the **global** Prisma singleton with the dashboard and the auth JWT callback (every request) in the **same process**. The old reset hard-closed the pool (`$disconnect()` + `pool.end()`) synchronously, which can abort in-flight queries from requests that resolved the old client moments earlier — surfacing as intermittent 500s / login blips right after each cron cycle under daytime load. Now: clear the singleton so all new work builds a fresh client+pool immediately, then drain the old one on an unref'd timer after a grace window.

### 3. 🟡 Pool monitoring went stale after the first reset
`poolMonitor.attach()` no-ops while already attached, so the post-reset pool was never monitored and `/api/health` `connectionPool` metrics froze after cycle 1. Added `poolMonitor.detach()`, called during reset, so the fresh pool re-attaches.

## Deliberately not changed
- **#5 (serialize heavy phases):** already implemented on this branch (`settleAsync`, sequential with `gc()` between phases). No action.
- **#4 (remove `next/after()`):** considered and **rejected**. `after()` is required for Railway's fast-cron-response contract (the author hit cron timeouts with synchronous execution), and the test suite is built around it. The ~470 MB/cycle once blamed on `after()` is the Prisma adapter state now freed by the reset; once #1 makes GC effective, the small `after()` closure (captures only `startedAt`/`ownerUserId`/`userIds`) is not the leak.

## Verification
- `tsc --noEmit` clean; `eslint --max-warnings=0` clean on changed files.
- `pool-monitor.test.ts` and `health/route.test.ts` pass.
- ⚠️ **Pre-existing (not from this PR):** `cron/sync/route.test.ts` has 5 failures at the base commit `31bc55b7` — tests still assert `200` while the route returns `202` for background mode. Verified identical failures with my changes stashed. Left for the branch author to reconcile alongside the 200→202 change.

## How to confirm the fix works post-deploy
Heap snapshots are awkward on the standalone image, so the cheap signal: watch `/api/health` `uptime` climb past ~40 min (survive 2+ cron cycles) with RSS bounded. That distinguishes "leak gone" from "leak slower."

🤖 Generated with [Claude Code](https://claude.com/claude-code)