### PR TITLE
Fix migrate.cjs blocking all deploys: CONCURRENTLY false-match in a comment (prod still OOMing)

### DIFF
--- a/__tests__/migrate-check.test.ts
+++ b/__tests__/migrate-check.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { existsSync, readdirSync } from "fs";
+import { existsSync, readdirSync, readFileSync } from "fs";
 import { createRequire } from "node:module";
 import { join } from "path";
 
@@ -13,6 +13,9 @@ const migrate = require("../migrate.cjs") as {
     appliedNames: string[]
   ) => string[];
   listMigrationDirs: () => string[];
+  migrationUsesConcurrently: (sql: string) => boolean;
+  stripSqlComments: (sql: string) => string;
+  blankQuotedRegions: (sql: string) => string;
 };
 
 const MIGRATIONS_DIR = join(__dirname, "..", "prisma", "migrations");
@@ -57,5 +60,78 @@ describe("migrate.cjs --check helpers", () => {
     expect(migrate.computePendingMigrations(["20260101_a"], [])).toEqual([
       "20260101_a",
     ]);
+  });
+});
+
+describe("migrate.cjs CONCURRENTLY guard", () => {
+  // The runner applies each migration inside a transaction, so it must refuse
+  // CONCURRENTLY DDL (Postgres forbids it in a transaction block) — but only
+  // when CONCURRENTLY is a real keyword, never when it merely appears in a
+  // comment or quoted text. A false positive blocks an otherwise-safe deploy
+  // (this is the 2026-06-16 incident: the retention-index migration mentioned
+  // CONCURRENTLY in an operator note and every deploy refused to apply it).
+
+  it("allows a migration that only mentions CONCURRENTLY in comments", () => {
+    expect(
+      migrate.migrationUsesConcurrently(
+        "-- pre-create by hand: CREATE INDEX CONCURRENTLY ...\n" +
+          'CREATE INDEX IF NOT EXISTS "x_idx" ON "X"("createdAt");'
+      )
+    ).toBe(false);
+    expect(
+      migrate.migrationUsesConcurrently(
+        '/* you MAY use CONCURRENTLY in a low-traffic window */\nCREATE INDEX "y" ON "Y"("c");'
+      )
+    ).toBe(false);
+  });
+
+  it("ignores CONCURRENTLY inside string literals, identifiers, and dollar quotes", () => {
+    expect(
+      migrate.migrationUsesConcurrently(
+        "INSERT INTO notes(body) VALUES ('run CONCURRENTLY later');"
+      )
+    ).toBe(false);
+    expect(
+      migrate.migrationUsesConcurrently('CREATE INDEX "idx CONCURRENTLY" ON t(c);')
+    ).toBe(false);
+    expect(
+      migrate.migrationUsesConcurrently("DO $$ BEGIN PERFORM 'CONCURRENTLY'; END $$;")
+    ).toBe(false);
+  });
+
+  it("still refuses CONCURRENTLY in an executable statement", () => {
+    expect(
+      migrate.migrationUsesConcurrently("CREATE INDEX CONCURRENTLY foo ON t(c);")
+    ).toBe(true);
+    expect(
+      migrate.migrationUsesConcurrently(
+        "-- note about CONCURRENTLY\nDROP INDEX CONCURRENTLY bar;"
+      )
+    ).toBe(true);
+    expect(
+      migrate.migrationUsesConcurrently("REINDEX INDEX CONCURRENTLY foo;")
+    ).toBe(true);
+  });
+
+  it("does not refuse any migration currently checked into prisma/migrations", () => {
+    // Regression guard for the incident: every committed migration must be
+    // applyable by the in-transaction runner. If a future migration genuinely
+    // needs CONCURRENTLY, this will fail loudly and force an explicit decision
+    // (pre-create by hand, or teach the runner an out-of-transaction path).
+    const dirs = migrate.listMigrationDirs();
+    const offenders = dirs.filter((dir) => {
+      const sql = readFileSync(join(MIGRATIONS_DIR, dir, "migration.sql"), "utf-8");
+      return migrate.migrationUsesConcurrently(sql);
+    });
+    expect(offenders).toEqual([]);
+  });
+
+  it("stripSqlComments removes comments but preserves string contents", () => {
+    expect(migrate.stripSqlComments("SELECT 1; -- trailing\n")).not.toMatch(
+      /trailing/
+    );
+    expect(migrate.stripSqlComments("SELECT '-- not a comment';")).toMatch(
+      /-- not a comment/
+    );
   });
 });

--- a/migrate.cjs
+++ b/migrate.cjs
@@ -199,6 +199,180 @@ function stripLeadingSqlComments(statement) {
   return remaining;
 }
 
+/**
+ * Return `sql` with all comments removed (line `--` and block `/* *​/`),
+ * leaving string literals, quoted identifiers, and dollar-quoted bodies
+ * intact. Used to test for keywords (e.g. CONCURRENTLY) in *executable* SQL
+ * without false-matching the same word inside an explanatory comment.
+ *
+ * Replaces each comment with a single space so adjacent tokens never fuse.
+ */
+function stripSqlComments(sql) {
+  let out = "";
+  let index = 0;
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+  let dollarTag = null;
+
+  while (index < sql.length) {
+    const current = sql[index];
+    const next = sql[index + 1];
+
+    if (dollarTag) {
+      if (sql.startsWith(dollarTag, index)) {
+        out += dollarTag;
+        index += dollarTag.length;
+        dollarTag = null;
+        continue;
+      }
+      out += current;
+      index++;
+      continue;
+    }
+
+    if (inSingleQuote) {
+      out += current;
+      if (current === "'" && next === "'") {
+        out += next;
+        index += 2;
+        continue;
+      }
+      if (current === "'") inSingleQuote = false;
+      index++;
+      continue;
+    }
+
+    if (inDoubleQuote) {
+      out += current;
+      if (current === '"' && next === '"') {
+        out += next;
+        index += 2;
+        continue;
+      }
+      if (current === '"') inDoubleQuote = false;
+      index++;
+      continue;
+    }
+
+    if (current === "-" && next === "-") {
+      const newline = sql.indexOf("\n", index);
+      if (newline === -1) {
+        index = sql.length;
+      } else {
+        out += "\n";
+        index = newline + 1;
+      }
+      continue;
+    }
+
+    if (current === "/" && next === "*") {
+      const end = sql.indexOf("*/", index + 2);
+      index = end === -1 ? sql.length : end + 2;
+      out += " ";
+      continue;
+    }
+
+    if (current === "'") {
+      inSingleQuote = true;
+      out += current;
+      index++;
+      continue;
+    }
+
+    if (current === '"') {
+      inDoubleQuote = true;
+      out += current;
+      index++;
+      continue;
+    }
+
+    if (current === "$") {
+      const match = sql.slice(index).match(/^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/);
+      if (match) {
+        dollarTag = match[0];
+        out += dollarTag;
+        index += dollarTag.length;
+        continue;
+      }
+    }
+
+    out += current;
+    index++;
+  }
+
+  return out;
+}
+
+/**
+ * Replace the *contents* of single-quoted strings, double-quoted identifiers,
+ * and dollar-quoted bodies with whitespace, leaving the delimiters and all
+ * other SQL intact. Assumes comments are already removed (run after
+ * stripSqlComments). Lets a keyword scan ignore text that only appears as data
+ * (e.g. an INSERT value of 'run CONCURRENTLY later').
+ */
+function blankQuotedRegions(sql) {
+  let out = "";
+  let index = 0;
+
+  while (index < sql.length) {
+    const current = sql[index];
+
+    if (current === "$") {
+      const match = sql.slice(index).match(/^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/);
+      if (match) {
+        const tag = match[0];
+        const end = sql.indexOf(tag, index + tag.length);
+        if (end === -1) {
+          out += tag;
+          index = sql.length;
+        } else {
+          out += tag + " " + tag;
+          index = end + tag.length;
+        }
+        continue;
+      }
+    }
+
+    if (current === "'" || current === '"') {
+      const quote = current;
+      out += quote;
+      index++;
+      while (index < sql.length) {
+        if (sql[index] === quote && sql[index + 1] === quote) {
+          index += 2; // escaped quote inside the literal
+          continue;
+        }
+        if (sql[index] === quote) break;
+        index++;
+      }
+      out += quote;
+      index++; // consume the closing quote (or run past EOF harmlessly)
+      continue;
+    }
+
+    out += current;
+    index++;
+  }
+
+  return out;
+}
+
+/**
+ * True when the migration runs `CONCURRENTLY` in an *executable* statement.
+ * The custom runner applies each migration inside a transaction, and Postgres
+ * forbids CREATE/DROP/REINDEX ... CONCURRENTLY in a transaction block — so such
+ * a migration genuinely cannot be applied here and must be refused.
+ *
+ * Comments and quoted text are neutralized first so CONCURRENTLY is only
+ * detected as a bare keyword. A migration may *mention* CONCURRENTLY in an
+ * operator note (e.g. "you MAY pre-create this by hand with CREATE INDEX
+ * CONCURRENTLY ...") while its real statements are plain, transaction-safe
+ * `CREATE INDEX IF NOT EXISTS`; testing the raw text would wrongly refuse it.
+ */
+function migrationUsesConcurrently(sql) {
+  return /\bCONCURRENTLY\b/i.test(blankQuotedRegions(stripSqlComments(sql)));
+}
+
 function isEnumAddValueStatement(statement) {
   return /^ALTER\s+TYPE\b[\s\S]*\bADD\s+VALUE\b/i.test(
     stripLeadingSqlComments(statement),
@@ -380,9 +554,12 @@ async function run() {
 
       const sqlFile = path.join(MIGRATIONS_DIR, dir, "migration.sql");
       const sql = fs.readFileSync(sqlFile, "utf-8");
-      if (/\bCONCURRENTLY\b/i.test(sql)) {
+      if (migrationUsesConcurrently(sql)) {
         console.error(
-          `Migration ${dir} contains CONCURRENTLY; refusing to run outside a transaction`,
+          `Migration ${dir} runs CONCURRENTLY in an executable statement; ` +
+            `the in-transaction runner cannot apply it. Pre-create the index ` +
+            `by hand (CREATE INDEX CONCURRENTLY ...) or move it to its own ` +
+            `out-of-transaction step.`,
         );
         process.exit(1);
       }
@@ -457,8 +634,11 @@ if (require.main === module) {
 }
 
 module.exports = {
+  blankQuotedRegions,
   computePendingMigrations,
   listMigrationDirs,
+  migrationUsesConcurrently,
   splitMigrationSql,
   splitSqlStatements,
+  stripSqlComments,
 };


### PR DESCRIPTION
## TL;DR — this is why prod is still OOMing

The OOM fix (#599, bound lineage reads) is on `main` but **has never reached production**. Every deploy carrying it fails in `preDeployCommand`:

```
Migration 20260615120000_add_retention_prune_indexes contains CONCURRENTLY;
refusing to run outside a transaction
Starting Container
Stopping Container
```

So Railway keeps the last-good image serving — deploy `28d5185c` from **03:57 UTC**, which predates #599 (04:21 UTC) — and prod stays on leaky code. Two new deploys (05:30, 05:31 UTC) both FAILED for this reason.

## Root cause

The migration's executable SQL is plain, transaction-safe:

```sql
CREATE INDEX IF NOT EXISTS "SecurityAuditEvent_createdAt_idx" ON "SecurityAuditEvent"("createdAt");
-- ...two more, all IF NOT EXISTS, no CONCURRENTLY
```

The word `CONCURRENTLY` appears **only in a comment** — an operator note suggesting you *may* pre-create the indexes by hand during a low-traffic window. But `migrate.cjs` tested the **raw file text** (comments included):

```js
if (/\bCONCURRENTLY\b/i.test(sql)) { /* refuse, exit 1 */ }
```

→ false match on the comment → every deploy aborts.

## Fix

Detect `CONCURRENTLY` only as a **bare executable keyword**. Before testing, `migrationUsesConcurrently()` now:
1. `stripSqlComments()` — removes `--` and `/* */` comments (preserving string/identifier/dollar-quoted contents),
2. `blankQuotedRegions()` — blanks the *contents* of `'…'`, `"…"`, and `$tag$…$tag$`.

A real `CREATE/DROP/REINDEX … CONCURRENTLY` is **still refused** — the in-transaction runner genuinely can't apply it (Postgres forbids CONCURRENTLY in a transaction block). The error message now also points at the fix (pre-create by hand, or add an out-of-transaction step).

## Tests (`__tests__/migrate-check.test.ts`)

- comment-only / string-literal / quoted-identifier / dollar-quoted mentions → allowed
- real `CREATE INDEX CONCURRENTLY`, `DROP INDEX CONCURRENTLY`, `REINDEX … CONCURRENTLY` → still refused
- `stripSqlComments` removes comments but preserves string contents
- **regression guard:** scans every committed migration in `prisma/migrations` and asserts none trips the check (so this incident can't silently recur)

## Deploy / verify

1. Merge → Railway redeploys `main` (now with #599) → `preDeployCommand` migrates cleanly → cutover succeeds.
2. Confirm the new deploy reaches **SUCCESS/RUNNING** (not FAILED).
3. `/api/health` `uptime` climbs past **30+ min** without resetting → OOM crash loop broken.

## Scope

Surgical: `migrate.cjs` (+182/−2) and its test. No app/runtime code, no schema change, no new migration. The retention-index migration is untouched and applies as the author intended (brief `SHARE` lock during the in-transaction index build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
