### PR TITLE
fix(migrate): CONCURRENTLY guard false-positives on comments → every deploy fails

### DIFF
--- a/__tests__/migrate-check.test.ts
+++ b/__tests__/migrate-check.test.ts
@@ -13,7 +13,13 @@ const migrate = require("../migrate.cjs") as {
     appliedNames: string[]
   ) => string[];
   listMigrationDirs: () => string[];
+  stripSqlComments: (sql: string) => string;
 };
+
+// Mirrors the guard in migrate.cjs's run(): a migration is refused only when
+// CONCURRENTLY appears in executable SQL (after comments are stripped).
+const containsConcurrently = (sql: string) =>
+  /\bCONCURRENTLY\b/i.test(migrate.stripSqlComments(sql));
 
 const MIGRATIONS_DIR = join(__dirname, "..", "prisma", "migrations");
 
@@ -57,5 +63,53 @@ describe("migrate.cjs --check helpers", () => {
     expect(migrate.computePendingMigrations(["20260101_a"], [])).toEqual([
       "20260101_a",
     ]);
+  });
+});
+
+describe("migrate.cjs CONCURRENTLY detection (comment-aware)", () => {
+  // Regression: a migration that only *mentioned* CONCURRENTLY in a comment
+  // was wrongly refused, failing every production deploy at boot.
+  it("ignores CONCURRENTLY inside a line comment", () => {
+    expect(
+      containsConcurrently(
+        '-- you may CREATE INDEX CONCURRENTLY by hand\nCREATE INDEX "x" ON "t"("c");'
+      )
+    ).toBe(false);
+  });
+
+  it("ignores CONCURRENTLY inside a block comment", () => {
+    expect(
+      containsConcurrently(
+        '/* operators MAY pre-create CONCURRENTLY */\nCREATE INDEX "x" ON "t"("c");'
+      )
+    ).toBe(false);
+  });
+
+  it("still refuses a real CREATE INDEX CONCURRENTLY statement", () => {
+    expect(
+      containsConcurrently('CREATE INDEX CONCURRENTLY "x" ON "t"("c");')
+    ).toBe(true);
+  });
+
+  it("does not flag the retention prune-indexes migration (comment-only mention)", () => {
+    const sql = require("fs").readFileSync(
+      join(
+        MIGRATIONS_DIR,
+        "20260615120000_add_retention_prune_indexes",
+        "migration.sql"
+      ),
+      "utf-8"
+    );
+    expect(sql).toMatch(/CONCURRENTLY/i); // present in the comment
+    expect(containsConcurrently(sql)).toBe(false); // but not in executable SQL
+  });
+
+  it("preserves executable DDL while stripping comments", () => {
+    const stripped = migrate.stripSqlComments(
+      '-- header\nCREATE INDEX "i" ON "t"("c"); /* trailing */'
+    );
+    expect(stripped).toContain('CREATE INDEX "i" ON "t"("c");');
+    expect(stripped).not.toContain("header");
+    expect(stripped).not.toContain("trailing");
   });
 });

--- a/migrate.cjs
+++ b/migrate.cjs
@@ -175,6 +175,125 @@ function splitSqlStatements(sql) {
   return statements;
 }
 
+// Returns `sql` with line (`--`) and block (`/* */`) comments removed, while
+// preserving string literals and dollar-quoted bodies verbatim. Mirrors the
+// state machine in splitSqlStatements so keyword detection (e.g. CONCURRENTLY)
+// ignores commentary. Newlines from line comments are preserved.
+function stripSqlComments(sql) {
+  let out = "";
+  let index = 0;
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+  let dollarTag = null;
+
+  while (index < sql.length) {
+    const current = sql[index];
+    const next = sql[index + 1];
+
+    if (dollarTag) {
+      if (sql.startsWith(dollarTag, index)) {
+        out += dollarTag;
+        index += dollarTag.length;
+        dollarTag = null;
+        continue;
+      }
+      out += current;
+      index++;
+      continue;
+    }
+
+    if (inLineComment) {
+      if (current === "\n") {
+        inLineComment = false;
+        out += current;
+      }
+      index++;
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (current === "*" && next === "/") {
+        inBlockComment = false;
+        index += 2;
+        continue;
+      }
+      index++;
+      continue;
+    }
+
+    if (inSingleQuote) {
+      out += current;
+      if (current === "'" && next === "'") {
+        out += next;
+        index += 2;
+        continue;
+      }
+      if (current === "'") {
+        inSingleQuote = false;
+      }
+      index++;
+      continue;
+    }
+
+    if (inDoubleQuote) {
+      out += current;
+      if (current === '"' && next === '"') {
+        out += next;
+        index += 2;
+        continue;
+      }
+      if (current === '"') {
+        inDoubleQuote = false;
+      }
+      index++;
+      continue;
+    }
+
+    if (current === "-" && next === "-") {
+      inLineComment = true;
+      index += 2;
+      continue;
+    }
+
+    if (current === "/" && next === "*") {
+      inBlockComment = true;
+      index += 2;
+      continue;
+    }
+
+    if (current === "'") {
+      inSingleQuote = true;
+      out += current;
+      index++;
+      continue;
+    }
+
+    if (current === '"') {
+      inDoubleQuote = true;
+      out += current;
+      index++;
+      continue;
+    }
+
+    if (current === "$") {
+      const match = sql.slice(index).match(/^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/);
+      if (match) {
+        dollarTag = match[0];
+        out += dollarTag;
+        index += dollarTag.length;
+        continue;
+      }
+    }
+
+    out += current;
+    index++;
+  }
+
+  return out;
+}
+
 function stripLeadingSqlComments(statement) {
   let remaining = statement.trimStart();
 
@@ -380,7 +499,12 @@ async function run() {
 
       const sqlFile = path.join(MIGRATIONS_DIR, dir, "migration.sql");
       const sql = fs.readFileSync(sqlFile, "utf-8");
-      if (/\bCONCURRENTLY\b/i.test(sql)) {
+      // Detect CONCURRENTLY in executable SQL only — never in comments. A bare
+      // substring check over the whole file tripped on migrations that merely
+      // *mention* CONCURRENTLY in a comment (e.g. documenting an optional
+      // manual pre-create), refusing a valid transactional migration and
+      // failing every deploy at boot. Strip comments before testing.
+      if (/\bCONCURRENTLY\b/i.test(stripSqlComments(sql))) {
         console.error(
           `Migration ${dir} contains CONCURRENTLY; refusing to run outside a transaction`,
         );
@@ -461,4 +585,5 @@ module.exports = {
   listMigrationDirs,
   splitMigrationSql,
   splitSqlStatements,
+  stripSqlComments,
 };


### PR DESCRIPTION
## 🚨 This unblocks production deploys

**Every deploy is currently failing at the migrate step**, so #599 (bounded lineage reads) and all later commits are **not live**. The app keeps running pre-fix code, the unbounded `include:{lineage}` reads keep saturating Postgres (10+ concurrent 4–5 min queries spilling to disk → connection timeouts), and the bloated disk can't be safely reclaimed.

### Root cause
`migrate.cjs` refuses any migration whose **raw text** matches `/\bCONCURRENTLY\b/i` — including matches **inside comments**:

```js
if (/\bCONCURRENTLY\b/i.test(sql)) { console.error(...); process.exit(1); }
```

Migration `20260615120000_add_retention_prune_indexes` (from #584) uses plain `CREATE INDEX IF NOT EXISTS`, but its **comment** documents an optional manual `CREATE INDEX CONCURRENTLY` pre-create. That comment trips the guard → `process.exit(1)` on boot. Deploy log:

```
Migration 20260615120000_add_retention_prune_indexes contains CONCURRENTLY; refusing to run outside a transaction
Starting Container / Stopping Container
```

### Fix
Add a comment-aware `stripSqlComments()` (mirrors the existing `splitSqlStatements` state machine — handles `--` / `/* */` comments, single/double quotes, dollar-quoting) and run the `CONCURRENTLY` check against the **comment-stripped** SQL. A genuine `CREATE INDEX CONCURRENTLY` statement is still refused; a comment mention is not.

### Tests
`__tests__/migrate-check.test.ts` gains 5 cases (line-comment mention ignored, block-comment mention ignored, real concurrent statement still refused, the actual retention migration not flagged, comment-stripping preserves executable DDL). **10/10 pass.** `migrate.cjs` is eslint-ignored (root build script).

### After this merges
Deploys succeed → the prune-index migration applies (plain `CREATE INDEX`, brief share lock) → #599's bounded reads go live → DB load drops → the `VACUUM FULL` disk reclaim becomes safe and fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)