### PR TITLE
Correct /api/health volumeCapacityMb to the 50GB Postgres volume

### DIFF
--- a/src/app/api/health/route.test.ts
+++ b/src/app/api/health/route.test.ts
@@ -23,9 +23,9 @@ describe("GET /api/health", () => {
     const { poolMonitor } = await import("@/lib/pool-monitor");
 
     vi.mocked(prisma.$queryRaw).mockResolvedValue(undefined as never);
-    // Storage check: ~2 GB database against the default 20 GB volume.
+    // Storage check: ~5 GB database against the default 50 GB volume.
     vi.mocked(prisma.$queryRawUnsafe).mockResolvedValue([
-      { size: BigInt(2_000_000_000) },
+      { size: BigInt(5_000_000_000) },
     ] as never);
     vi.mocked(poolMonitor.getHealthStatus).mockReturnValue({
       status: "healthy",
@@ -67,8 +67,8 @@ describe("GET /api/health", () => {
         },
         storage: {
           status: "ok",
-          databaseSizeMb: 2000,
-          volumeCapacityMb: 20000,
+          databaseSizeMb: 5000,
+          volumeCapacityMb: 50000,
           usagePercent: 10,
         },
       },
@@ -79,9 +79,9 @@ describe("GET /api/health", () => {
   it("reports a storage warning without failing the health check", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const { prisma } = await import("@/lib/prisma");
-    // 16 GB of 20 GB = 80% -> above the 75% warn threshold.
+    // 40 GB of 50 GB = 80% -> above the 75% warn threshold.
     vi.mocked(prisma.$queryRawUnsafe).mockResolvedValue([
-      { size: BigInt(16_000_000_000) },
+      { size: BigInt(40_000_000_000) },
     ] as never);
 
     try {
@@ -93,7 +93,7 @@ describe("GET /api/health", () => {
       expect(body.status).toBe("ok");
       expect(body.checks.storage).toMatchObject({
         status: "warning",
-        databaseSizeMb: 16000,
+        databaseSizeMb: 40000,
         usagePercent: 80,
       });
       expect(consoleError).toHaveBeenCalledWith(
@@ -108,9 +108,9 @@ describe("GET /api/health", () => {
   it("returns 503 degraded when disk usage crosses the critical threshold", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const { prisma } = await import("@/lib/prisma");
-    // 18.6 GB of 20 GB = 93% -> the June 2026 incident level.
+    // 46.5 GB of 50 GB = 93% -> the June 2026 incident level.
     vi.mocked(prisma.$queryRawUnsafe).mockResolvedValue([
-      { size: BigInt(18_598_000_000) },
+      { size: BigInt(46_500_000_000) },
     ] as never);
 
     try {

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -5,8 +5,12 @@ import { poolMonitor } from "@/lib/pool-monitor";
 
 const APP_VERSION = process.env.APP_VERSION?.trim() || packageJson.version;
 
-/** Railway Postgres volume capacity. Override via DATABASE_VOLUME_CAPACITY_MB. */
-const DEFAULT_VOLUME_CAPACITY_MB = 20_000;
+/**
+ * Railway Postgres volume capacity in MB. The prod `postgres-volume` was grown
+ * to 50 GB (June 2026), so the default reflects the real volume. Override
+ * per-environment via DATABASE_VOLUME_CAPACITY_MB.
+ */
+const DEFAULT_VOLUME_CAPACITY_MB = 50_000;
 const DEFAULT_DISK_WARN_PERCENT = 75;
 const DEFAULT_DISK_CRITICAL_PERCENT = 90;
 


### PR DESCRIPTION
## What & why

The `/api/health` disk-usage check (added in #599) reports `volumeCapacityMb` and derives `usagePercent` plus warn/critical disk-usage alert thresholds from it. It defaulted to **20000 MB (20 GB)**, but the production Postgres volume has since been grown to **50 GB**.

`railway volume list` (production):

```
Volume: postgres-volume
Attached to: Postgres
Storage used: 17716MB / 50000MB
```

Because the capacity was understated, `usagePercent` was overstated ~2.5x and the 75% / 90% thresholds tripped far too early. Concretely, at the current 17.7 GB the check computed **88.6% → "warning"** (against 20 GB) when the volume is actually only **35.4% → "ok"** full (against 50 GB) — i.e. it was already emitting false `[health:storage]` warnings in prod.

## Changes

- Bump `DEFAULT_VOLUME_CAPACITY_MB` `20_000` → `50_000` in `src/app/api/health/route.ts`. It stays overridable per-environment via `DATABASE_VOLUME_CAPACITY_MB`, consistent with how `warnPercent` / `criticalPercent` defaults are configured in the same file.
- Update `src/app/api/health/route.test.ts` to the 50 GB volume, preserving the same ok / warning / critical coverage (10% / 80% / 93%).

## Production env var

`DATABASE_VOLUME_CAPACITY_MB=50000` has been set on Railway **production** (service `WIPGuard-app`) — it was previously unset, so prod was using the old 20000 code default. This makes prod accurate immediately, regardless of the code default.

## Verification

- `npx vitest run src/app/api/health/route.test.ts` → **5/5 pass**
- `npx tsc --noEmit` → **clean (exit 0)**
- `eslint --max-warnings=0` on the changed files → **clean**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
