### PR TITLE
Company dashboard reliability: honest empty states + Linear timeout + source attribution

### DIFF
--- a/src/components/imladris/attention.ts
+++ b/src/components/imladris/attention.ts
@@ -43,7 +43,10 @@ export function buildAttention(model: ImladrisModel, idx: number): AttentionItem
   // 2. anomalies + goal pacing
   model.metrics.forEach((m) => {
     const snap = snapshot(m, idx);
-    const d = deltaPct(snap.value, snap.prev);
+    // A metric with no live value can't be an anomaly or off-target signal.
+    if (snap.value == null) return;
+    const value = snap.value;
+    const d = deltaPct(value, snap.prev);
     if (d != null) {
       const up = d > 0;
       const bad = m.good === "down" ? up : !up;
@@ -60,18 +63,18 @@ export function buildAttention(model: ImladrisModel, idx: number): AttentionItem
       }
     }
     if (m.target != null) {
-      const st = paceState(snap.value, m.target, m.good);
+      const st = paceState(value, m.target, m.good);
       if (st === "behind") {
         const gap =
           m.good === "down"
-            ? ((snap.value - m.target) / m.target) * 100
-            : ((m.target - snap.value) / m.target) * 100;
+            ? ((value - m.target) / m.target) * 100
+            : ((m.target - value) / m.target) * 100;
         if (gap >= 6) {
           items.push({
             sev: gap >= 18 ? "warning" : "info",
             tag: "Off target",
             title: `${m.label} behind plan`,
-            desc: `${fmtMetric(m, snap.value)} vs ${m.targetLabel || fmtByUnit(m.target, m.unit)} target.`,
+            desc: `${fmtMetric(m, value)} vs ${m.targetLabel || fmtByUnit(m.target, m.unit)} target.`,
             metricKey: m.key,
             mag: gap,
           });

--- a/src/components/imladris/company-dashboard-view.tsx
+++ b/src/components/imladris/company-dashboard-view.tsx
@@ -131,7 +131,8 @@ function CompanyHeadline({
   if (!arr) return null;
 
   const arrSnap = snapshot(arr, idx);
-  const netNew = arrSnap.prev != null ? arrSnap.value - arrSnap.prev : null;
+  const netNew =
+    arrSnap.value != null && arrSnap.prev != null ? arrSnap.value - arrSnap.prev : null;
   const arrHasTrend = hasTrend(model, arr);
 
   return (

--- a/src/components/imladris/format.ts
+++ b/src/components/imladris/format.ts
@@ -33,19 +33,22 @@ export function fmtMetric(metric: Pick<NormalizedMetric, "unit">, value: number 
 }
 
 export interface Snapshot {
-  value: number;
+  value: number | null;
   prev: number | null;
   idx: number;
 }
 
 export function snapshot(metric: Pick<NormalizedMetric, "history">, idx?: number | null): Snapshot {
   const h = metric.history;
+  // Live-or-error: a metric with no published value has an empty history and
+  // must read as an honest empty state ("—"), never a fabricated number.
+  if (h.length === 0) return { value: null, prev: null, idx: 0 };
   const i = idx == null ? h.length - 1 : Math.max(0, Math.min(idx, h.length - 1));
   return { value: h[i], prev: i > 0 ? h[i - 1] : null, idx: i };
 }
 
-export function deltaPct(value: number, prev: number | null): number | null {
-  if (prev == null || prev === 0) return null;
+export function deltaPct(value: number | null, prev: number | null): number | null {
+  if (value == null || prev == null || prev === 0) return null;
   return ((value - prev) / Math.abs(prev)) * 100;
 }
 
@@ -83,11 +86,11 @@ export function monthShort(ym: string): string {
 
 /** Direction-aware pacing state for a metric vs its target. */
 export function paceState(
-  value: number,
+  value: number | null,
   target: number | null | undefined,
   good: "up" | "down",
 ): "on" | "behind" | null {
-  if (target == null) return null;
+  if (value == null || target == null) return null;
   return good === "down"
     ? value <= target * 1.05 ? "on" : "behind"
     : value >= target * 0.92 ? "on" : "behind";

--- a/src/components/imladris/live-adapter.test.ts
+++ b/src/components/imladris/live-adapter.test.ts
@@ -128,6 +128,47 @@ describe("loadImladrisData — live-or-error gating", () => {
   });
 });
 
+describe("loadImladrisData — no seeded sample values leak in live mode", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("clears the seeded value when the API returns a metric without a value (renders empty, not a demo number)", async () => {
+    installFetch((url) => {
+      if (url.includes("/api/imladris/metrics") && !url.includes("history")) {
+        return {
+          ok: true,
+          json: {
+            metrics: [
+              { key: "revenue.arr", value: { amount: 5_000_000 }, status: "ready" },
+              // Matched canonical metric, but the source errored so there's no value.
+              { key: "revenue.mrr", value: null, status: "error" },
+            ],
+          },
+        };
+      }
+      return respondAllOk(url);
+    });
+    const result = await loadImladrisData();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const mrr = result.data.metricByKey["revenue.mrr"];
+    // NOT the seeded 353_000 — an honest empty state instead of a fabricated number.
+    expect(mrr.value).toBeNull();
+    expect(mrr.history).toEqual([]);
+    expect(mrr.status).toBe("error");
+  });
+
+  it("does not surface seeded values for metrics absent from the live /metrics payload", async () => {
+    installFetch(respondAllOk); // payload only carries revenue.arr + finance.net_burn
+    const result = await loadImladrisData();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const mrr = result.data.metricByKey["revenue.mrr"];
+    expect(mrr.value).toBeNull();
+    expect(mrr.history).toEqual([]);
+  });
+});
+
 describe("loadImladrisData — trend gating (live-or-error for sparklines)", () => {
   beforeEach(() => vi.clearAllMocks());
   afterEach(() => vi.unstubAllGlobals());

--- a/src/components/imladris/live-adapter.test.ts
+++ b/src/components/imladris/live-adapter.test.ts
@@ -118,6 +118,40 @@ describe("loadImladrisData — live-or-error gating", () => {
     expect(result.data.metricByKey["revenue.arr"].sources).toEqual(["stripe", "hubspot"]);
   });
 
+  it("keeps a metric's declared source dependencies even when lineage omits them (no 'feeds 0 metrics')", async () => {
+    installFetch((url) => {
+      if (url.includes("/api/imladris/metrics") && !url.includes("history")) {
+        return {
+          ok: true,
+          json: {
+            metrics: [
+              {
+                key: "marketing.website_traffic",
+                value: { count: 42_000 },
+                status: "partial",
+                // Server caps lineage evidence rows (MAX_LINEAGE_EVIDENCE_ROWS),
+                // so high-volume providers (GA/GSC) can fall outside the window
+                // and aren't cited here. They must NOT be dropped from sources.
+                sourceLineage: [{ sourceKey: "SEMRUSH" }, { sourceKey: "WEBFLOW" }],
+              },
+            ],
+          },
+        };
+      }
+      return respondAllOk(url);
+    });
+    const result = await loadImladrisData();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const sources = result.data.metricByKey["marketing.website_traffic"].sources;
+    // Declared dependencies survive even though lineage omitted them.
+    expect(sources).toContain("googleAnalytics");
+    expect(sources).toContain("googleSearchConsole");
+    // Lineage-cited providers are still present.
+    expect(sources).toContain("semrush");
+    expect(sources).toContain("webflow");
+  });
+
   it("reads source record counts from latestSyncRun.recordCount and marks degraded state", async () => {
     installFetch(respondAllOk);
     const result = await loadImladrisData();

--- a/src/components/imladris/live-adapter.ts
+++ b/src/components/imladris/live-adapter.ts
@@ -204,7 +204,8 @@ function flatFillRest(model: ImladrisModel, len: number): void {
   model.metrics.forEach((m) => {
     if (m.liveTrend) return;
     m.liveTrend = false;
-    m.history = new Array<number>(len).fill(m.value == null ? 0 : m.value);
+    // No live value ⇒ empty history ⇒ renders "—" (never a seeded sample value).
+    m.history = m.value == null ? [] : new Array<number>(len).fill(m.value);
   });
 }
 
@@ -352,6 +353,15 @@ export async function loadImladrisData(): Promise<LoadResult> {
 
   const model = buildImladrisModel();
   model.mode = "live";
+  // Live-or-error: the seed model contributes STRUCTURE only (labels, units,
+  // targets, cohort scaffolding) — never its sample VALUES. Clear every seeded
+  // value up front so any metric the API omits, or returns without a value,
+  // renders as an honest empty state ("—") instead of a fabricated demo number.
+  for (const m of model.metrics) {
+    m.value = null;
+    m.history = [];
+    m.liveTrend = false;
+  }
 
   const metricsPayload = metricsR.value as MetricsApiResponse;
   const matched = mergeMetrics(model, metricsPayload);
@@ -380,7 +390,7 @@ export async function loadImladrisData(): Promise<LoadResult> {
   if (!trends.available) {
     model.metrics.forEach((m) => {
       m.liveTrend = false;
-      m.history = [m.value == null ? 0 : m.value];
+      m.history = m.value == null ? [] : [m.value];
     });
     model.months = [model.currentMonth || IMLADRIS_FALLBACK_MONTH(model)];
   }

--- a/src/components/imladris/live-adapter.ts
+++ b/src/components/imladris/live-adapter.ts
@@ -127,14 +127,20 @@ function mergeMetrics(model: ImladrisModel, payload: MetricsApiResponse): number
       m.warnings = lm.warnings.filter((w): w is string => typeof w === "string");
     }
     // Production route returns `sourceLineage`; the prototype spec read `lineage`.
+    // UNION lineage-discovered providers with the metric's declared dependencies
+    // (the catalog/seed set) — never SHRINK to the lineage subset. The server
+    // caps lineage evidence rows (MAX_LINEAGE_EVIDENCE_ROWS), so a high-volume
+    // provider's rows can fall outside that window; replacing `sources` with the
+    // truncated subset is what made real dependencies (GitHub, Google Analytics,
+    // Search Console) show "feeds 0 metrics" on the sources board.
     const lineage = lm.sourceLineage ?? lm.lineage;
     if (Array.isArray(lineage) && lineage.length) {
-      const keys: ImladrisProviderKey[] = [];
+      const keys: ImladrisProviderKey[] = [...m.sources];
       lineage.forEach((row) => {
         const k = providerKey(row.sourceKey ?? row.sourceType ?? row.source);
         if (k && keys.indexOf(k) < 0) keys.push(k);
       });
-      if (keys.length) m.sources = keys;
+      m.sources = keys;
     }
     if (typeof lm.calculationVersion === "string") m.calculationVersion = lm.calculationVersion;
   });

--- a/src/components/imladris/primitives.tsx
+++ b/src/components/imladris/primitives.tsx
@@ -28,7 +28,7 @@ import type {
 } from "./types";
 
 export interface DeltaChipProps {
-  value: number;
+  value: number | null;
   prev: number | null;
   good: "up" | "down";
   compareLabel?: string;
@@ -76,14 +76,14 @@ export function TrustChip({ status }: { status: MetricStatus }) {
 }
 
 export interface PaceBarProps {
-  value: number;
+  value: number | null;
   target: number | null | undefined;
   good: "up" | "down";
   unit: MetricUnit;
 }
 
 export function PaceBar({ value, target, good, unit }: PaceBarProps) {
-  if (target == null) return null;
+  if (target == null || value == null) return null;
   const scaleMax = Math.max(value, target) * 1.14;
   const fillW = Math.max(0, Math.min(1, value / scaleMax)) * 100;
   const tickPos = Math.max(0, Math.min(1, target / scaleMax)) * 100;

--- a/src/components/imladris/types.ts
+++ b/src/components/imladris/types.ts
@@ -64,7 +64,8 @@ export interface NormalizedMetric {
   dept: string;
   unit: MetricUnit;
   good: GoodDirection;
-  value: number;
+  /** Live mode: `null` when the metrics API published no value for this metric. */
+  value: number | null;
   history: number[];
   liveTrend: boolean;
   status: MetricStatus;

--- a/src/lib/analytics/refresh-runner.ts
+++ b/src/lib/analytics/refresh-runner.ts
@@ -63,7 +63,12 @@ function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
 }
 
 function timeoutMsForRefreshJob(providerKey: string): number {
-  if (providerKey === "stripe") return 25_000;
+  // Providers whose syncs paginate over large datasets need more than the 10s
+  // default. Stripe (billing history) and Linear both routinely exceed it —
+  // Linear's fetch became more round-trip-heavy after #591 shrank its GraphQL
+  // page sizes to fit the complexity cap, so it serially pages issues +
+  // per-project issues and overran 10s ("Timed out after 10000ms").
+  if (providerKey === "stripe" || providerKey === "linear") return 25_000;
   return 10_000;
 }
 


### PR DESCRIPTION
Fixes the company dashboard (`/operating/company`) where **every stat showed a "Source error" and a wrong number**. Three independent, clearly-scoped commits.

---

### 1. Live tiles no longer render demo seed values (the "incorrect numbers")
The live adapter clones the demo seed model and only overwrote a metric's value when the API returned a number. A metric the API omitted — or returned **without a value** (its source errored) — kept the seeded sample figure (ARR $4.24m, MRR $353k, …) under a "Source error" badge. Now the seed contributes **structure only** in live mode; a metric with no live value renders an honest `—` (empty history), per the adapter's "never sample data" contract.
- `live-adapter`: clear seeded `value`/`history`/`liveTrend` on entering live mode
- `value`/`Snapshot.value` widened to `number | null`; `deltaPct`/`paceState`/`PaceBar` guard null; attention feed + net-new guard null

### 2. Linear analytics refresh gets the 25s budget Stripe already has
Linear showed "Timed out after 10000ms" on the source-health board. `timeoutMsForRefreshJob` gave only Stripe 25s; Linear's serial issue + per-project-issue pagination (more round-trips after #591 shrank page sizes to fit the GraphQL complexity cap) overran the 10s default. Extends 25s to Linear; fetcher is already correctly bounded.

### 3. A metric's sources are no longer shrunk to the capped lineage subset ("feeds 0 metrics")
GitHub / Google Analytics / Search Console reported "feeds 0 metrics" despite syncing thousands of records. `mergeMetrics` replaced each metric's declared dependencies with only the providers in the live `sourceLineage`, which the server caps at `MAX_LINEAGE_EVIDENCE_ROWS` (500, from the 2026-06 OOM fix) — so a high-volume provider's rows fall outside the window and get dropped. Now unions lineage with declared dependencies instead of replacing.

---

### Verification
- `npx vitest run` — **dashboard suites pass (1051)**, incl. 3 new live-adapter tests
- `npx tsc --noEmit` clean · `eslint` clean

### Operational note (not a code fix)
The "Source error" badges themselves are **accurate**: `imladrisSourceSyncRun` is created with a pessimistic `status: ERROR` and only flipped to `SUCCESS` at the end of ingestion ([`ingestion.ts`](src/lib/imladris/ingestion.ts)), so runs interrupted by today's OOM crash-loop / per-provider timeouts stay `ERROR` with records already fetched. They clear on the next clean sync cycle: `POST /api/cron/sync?wait=1` with header `x-cron-secret: $CRON_SYNC_SECRET` (the Railway `cron-sync` service), then re-check `/operating/sources`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)