### PR TITLE
fix(auth): stop next-auth debug logger from leaking OAuth client secret

### DIFF
--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -126,8 +126,24 @@ describe("auth options", () => {
   });
 
   it("keeps next-auth debug logging opt-in so provider secrets stay out of logs", async () => {
+    const mutableEnv = process.env as Record<string, string | undefined>;
+    delete mutableEnv.NEXTAUTH_DEBUG;
     const authOptions = await loadAuthOptions();
     expect(authOptions.debug).toBe(false);
+    // The flag alone is not enough: next-auth's setLogger() overrides the
+    // debug no-op with any custom logger.debug AFTER applying the flag, so a
+    // custom debug method must not exist at all unless explicitly opted in.
+    expect(authOptions.logger?.debug).toBeUndefined();
+  });
+
+  it("enables the debug logger only when NEXTAUTH_DEBUG=true", async () => {
+    const mutableEnv = process.env as Record<string, string | undefined>;
+    mutableEnv.NEXTAUTH_DEBUG = "true";
+    const authOptions = await loadAuthOptions();
+    delete mutableEnv.NEXTAUTH_DEBUG;
+
+    expect(authOptions.debug).toBe(true);
+    expect(typeof authOptions.logger?.debug).toBe("function");
   });
 
   it("bootstraps a development organization for credential logins without one", async () => {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -183,9 +183,18 @@ export const authOptions: NextAuthOptions = {
     warn(code) {
       console.warn("[next-auth][warn]", code);
     },
-    debug(code, metadata) {
-      console.log("[next-auth][debug]", code, metadata);
-    },
+    // The debug method must be OMITTED unless explicitly opted in: next-auth's
+    // setLogger() applies the `debug: false` no-op FIRST and then overrides it
+    // with any custom logger.debug, so a custom debug logger runs even when
+    // `debug` is false — leaking the provider config (client secret included)
+    // into production logs. Verified against prod logs on 2026-06-11.
+    ...(process.env.NEXTAUTH_DEBUG === "true"
+      ? {
+          debug(code: string, metadata?: unknown) {
+            console.log("[next-auth][debug]", code, metadata);
+          },
+        }
+      : {}),
   },
   session: {
     strategy: "jwt",


### PR DESCRIPTION
## Summary
The next-auth debug logger ran **even with `debug: false`**, logging provider config — including the OAuth **client secret** — into production logs. next-auth's `setLogger()` applies the `debug:false` no-op first, then overrides it with any custom `logger.debug`, so the custom debug logger always ran.

This omits the custom `debug` logger entirely unless `NEXTAUTH_DEBUG=true` is explicitly set, closing the leak. Verified against prod logs (2026-06-11).

## Changes
- `src/lib/auth.ts` — gate the debug logger behind `NEXTAUTH_DEBUG=true` (+15 / -3)
- `src/lib/__tests__/auth.test.ts` — regression test (+16)

## Context
Surfaced while triaging stale branches during repo cleanup; this fix was sitting unmerged with no PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
