### PR TITLE
observability(retention): structured prune telemetry + early-warning alerts

### DIFF
--- a/src/lib/sync/analytics.test.ts
+++ b/src/lib/sync/analytics.test.ts
@@ -5,6 +5,7 @@ import { pruneOutboxEvents } from "@/lib/events/outbox-retention";
 import { pruneImladrisMetricLineage } from "@/lib/imladris/lineage-retention";
 import { pruneImladrisMetricValues } from "@/lib/imladris/metric-value-retention";
 import { materializeImladrisCanonicalMetrics } from "@/lib/imladris/materialization";
+import { emitRetentionTelemetry } from "@/lib/sync/retention-telemetry";
 import { runAnalyticsSync } from "@/lib/sync/analytics";
 import { discoverConnectedUserIds } from "@/lib/sync/users";
 
@@ -36,6 +37,13 @@ vi.mock("@/lib/sync/users", () => ({
   discoverConnectedUserIds: vi.fn(),
 }));
 
+// Retention telemetry is unit-tested directly in
+// ./retention-telemetry.test.ts; here it is mocked so these tests stay focused
+// on sync orchestration. The wiring (args + call ordering) is asserted below.
+vi.mock("@/lib/sync/retention-telemetry", () => ({
+  emitRetentionTelemetry: vi.fn(async () => undefined),
+}));
+
 function createPrismaMock() {
   return {
     user: {
@@ -47,6 +55,10 @@ function createPrismaMock() {
     integrationConnection: {
       findMany: vi.fn(async () => []),
     },
+    // Retention telemetry (src/lib/sync/retention-telemetry.ts) issues read-only
+    // catalog queries via $queryRaw. Default to empty rows so telemetry emits
+    // null stats without throwing; individual tests override as needed.
+    $queryRaw: vi.fn(async () => []),
   };
 }
 
@@ -91,6 +103,7 @@ describe("runAnalyticsSync", () => {
       },
     ] as never);
     vi.mocked(discoverConnectedUserIds).mockResolvedValue(["user_1", "user_2"]);
+    vi.mocked(emitRetentionTelemetry).mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -416,6 +429,36 @@ describe("runAnalyticsSync", () => {
     expect(lastMaterializeOrder).toBeDefined();
     expect(lineageOrder).toBeGreaterThan(lastMaterializeOrder as number);
     expect(metricValueOrder).toBeGreaterThan(lineageOrder);
+
+    // Retention telemetry receives the prune outcomes and runs after pruning.
+    expect(emitRetentionTelemetry).toHaveBeenCalledWith(
+      {
+        prisma,
+        lineagePruning: lineageResult,
+        metricValuePruning: metricValueResult,
+        outboxPruning: outboxResult,
+      },
+      new Date("2026-06-01T12:00:00.000Z"),
+    );
+    const telemetryOrder = vi.mocked(emitRetentionTelemetry).mock.invocationCallOrder[0];
+    const outboxOrder = vi.mocked(pruneOutboxEvents).mock.invocationCallOrder[0];
+    expect(telemetryOrder).toBeGreaterThan(outboxOrder);
+  });
+
+  it("forwards prune errors to retention telemetry so they are still observed", async () => {
+    const prisma = createPrismaMock();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(pruneImladrisMetricLineage).mockRejectedValueOnce(new Error("boom"));
+
+    await runAnalyticsSync({ prisma: prisma as never });
+
+    expect(emitRetentionTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lineagePruning: { error: "boom" },
+      }),
+      new Date("2026-06-01T12:00:00.000Z"),
+    );
+    consoleError.mockRestore();
   });
 
   it("captures growth-control pruning failures without failing the sync", async () => {

--- a/src/lib/sync/analytics.ts
+++ b/src/lib/sync/analytics.ts
@@ -40,6 +40,7 @@ import {
   materializeImladrisCanonicalMetrics,
   type MaterializedImladrisMetricResult,
 } from '@/lib/imladris/materialization';
+import { emitRetentionTelemetry } from './retention-telemetry';
 import { discoverConnectedUserIds } from './users';
 
 type RollingRangePreset = '7d' | '30d' | '90d';
@@ -325,6 +326,16 @@ export async function runAnalyticsSync(
     console.error('analytics_sync.outbox_pruning_failed', { error: message });
     return { error: message };
   });
+
+  // Structured retention telemetry + early-warning alerts for the tables
+  // behind the 2026-06-10 disk-full outage (see ./retention-telemetry.ts).
+  // Runs for BOTH callers (cron route + worker orchestrator) since both go
+  // through runAnalyticsSync. Wholly non-throwing — observability must never
+  // abort the sync.
+  await emitRetentionTelemetry(
+    { prisma: input.prisma, lineagePruning, metricValuePruning, outboxPruning },
+    now,
+  );
 
   // Strip full metric values from the result — they're already persisted to
   // the DB. Keeping them in the response body retains hundreds of MB across

--- a/src/lib/sync/retention-telemetry.test.ts
+++ b/src/lib/sync/retention-telemetry.test.ts
@@ -1,0 +1,312 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  collectRetentionDbStats,
+  emitRetentionTelemetry,
+} from "@/lib/sync/retention-telemetry";
+
+const NOW = new Date("2026-06-16T12:00:00.000Z");
+
+/**
+ * The telemetry module issues three $queryRaw calls in this fixed order:
+ *   1. pg_database_size            -> [{ bytes }]
+ *   2. pg_class.reltuples estimate -> [{ rows }]
+ *   3. MIN(computedAt) w/ lineage  -> [{ oldest }]
+ * This mock returns those rows by call index so tests can shape each read.
+ */
+function createPrismaMock(rows: {
+  dbBytes?: unknown;
+  lineageRows?: unknown;
+  oldest?: unknown;
+  throwOn?: 1 | 2 | 3;
+}) {
+  let call = 0;
+  return {
+    $queryRaw: vi.fn(async () => {
+      call += 1;
+      if (rows.throwOn === call) throw new Error(`query ${call} failed`);
+      if (call === 1) return [{ bytes: rows.dbBytes ?? null }];
+      if (call === 2) return [{ rows: rows.lineageRows ?? null }];
+      return [{ oldest: rows.oldest ?? null }];
+    }),
+  };
+}
+
+function parseLastLog(spy: ReturnType<typeof vi.spyOn>, index: number) {
+  const call = spy.mock.calls[index];
+  return JSON.parse(call[1] as string) as Record<string, unknown>;
+}
+
+const baseLineage = {
+  deletedRows: 100,
+  prunedMetricValues: 5,
+  batches: 2,
+  cutoff: "2026-06-02T12:00:00.000Z",
+  completed: true,
+  durationMs: 50,
+};
+const baseMetricValue = {
+  deletedRows: 30,
+  batches: 1,
+  cutoff: "2026-06-02T12:00:00.000Z",
+  completed: true,
+  durationMs: 20,
+};
+const baseOutbox = {
+  deletedDispatched: 7,
+  deletedDeadLetter: 2,
+  batches: 1,
+  dispatchedCutoff: "2026-06-02T12:00:00.000Z",
+  deadLetterCutoff: "2026-05-17T12:00:00.000Z",
+  completed: true,
+  durationMs: 10,
+};
+
+describe("collectRetentionDbStats", () => {
+  it("parses byte, row, and oldest-age stats from the catalog queries", async () => {
+    const prisma = createPrismaMock({
+      dbBytes: 8_000_000_000,
+      lineageRows: 22_000_000.7,
+      // 10 days before NOW.
+      oldest: new Date("2026-06-06T12:00:00.000Z"),
+    });
+
+    const stats = await collectRetentionDbStats(prisma as never, NOW);
+
+    expect(stats.dbBytes).toBe(8_000_000_000);
+    expect(stats.lineageRows).toBe(22_000_001); // reltuples rounded
+    expect(stats.oldestLineageAgeDays).toBe(10);
+  });
+
+  it("accepts an ISO string for the oldest timestamp", async () => {
+    const prisma = createPrismaMock({ oldest: "2026-06-15T12:00:00.000Z" });
+    const stats = await collectRetentionDbStats(prisma as never, NOW);
+    expect(stats.oldestLineageAgeDays).toBe(1);
+  });
+
+  it("falls back to null per-query without throwing when a read fails", async () => {
+    const prisma = createPrismaMock({ dbBytes: 100, lineageRows: 5, throwOn: 3 });
+    const stats = await collectRetentionDbStats(prisma as never, NOW);
+    expect(stats.dbBytes).toBe(100);
+    expect(stats.lineageRows).toBe(5);
+    expect(stats.oldestLineageAgeDays).toBeNull();
+  });
+
+  it("returns null oldest age when no lineage-bearing rows exist", async () => {
+    const prisma = createPrismaMock({ oldest: null });
+    const stats = await collectRetentionDbStats(prisma as never, NOW);
+    expect(stats.oldestLineageAgeDays).toBeNull();
+  });
+});
+
+describe("emitRetentionTelemetry", () => {
+  let info: ReturnType<typeof vi.spyOn>;
+  let error: ReturnType<typeof vi.spyOn>;
+  const originalRetentionDays = process.env.IMLADRIS_LINEAGE_RETENTION_DAYS;
+  const originalGraceDays = process.env.RETENTION_LINEAGE_ALERT_GRACE_DAYS;
+
+  beforeEach(() => {
+    info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    delete process.env.IMLADRIS_LINEAGE_RETENTION_DAYS;
+    delete process.env.RETENTION_LINEAGE_ALERT_GRACE_DAYS;
+  });
+
+  afterEach(() => {
+    info.mockRestore();
+    error.mockRestore();
+    if (originalRetentionDays == null) delete process.env.IMLADRIS_LINEAGE_RETENTION_DAYS;
+    else process.env.IMLADRIS_LINEAGE_RETENTION_DAYS = originalRetentionDays;
+    if (originalGraceDays == null) delete process.env.RETENTION_LINEAGE_ALERT_GRACE_DAYS;
+    else process.env.RETENTION_LINEAGE_ALERT_GRACE_DAYS = originalGraceDays;
+  });
+
+  it("emits one [retention:metrics] info line with delete counts and DB stats", async () => {
+    const prisma = createPrismaMock({
+      dbBytes: 9_000_000_000,
+      lineageRows: 1_000_000,
+      oldest: new Date("2026-06-13T12:00:00.000Z"), // 3 days
+    });
+
+    await emitRetentionTelemetry(
+      {
+        prisma: prisma as never,
+        lineagePruning: baseLineage,
+        metricValuePruning: baseMetricValue,
+        outboxPruning: baseOutbox,
+      },
+      NOW,
+    );
+
+    expect(info).toHaveBeenCalledTimes(1);
+    expect(info.mock.calls[0][0]).toBe("[retention:metrics]");
+    const payload = parseLastLog(info, 0);
+    expect(payload).toEqual({
+      lineageDeleted: 100,
+      metricValueDeleted: 30,
+      outboxDeleted: 9, // dispatched + dead-letter
+      dbBytes: 9_000_000_000,
+      lineageRows: 1_000_000,
+      oldestLineageAgeDays: 3,
+      lineageRetentionDays: 14,
+    });
+    // No alerts under healthy conditions.
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("reports null delete counts when a prune outcome is an error", async () => {
+    const prisma = createPrismaMock({ oldest: null });
+
+    await emitRetentionTelemetry(
+      {
+        prisma: prisma as never,
+        lineagePruning: { error: "lineage prune exploded" },
+        metricValuePruning: baseMetricValue,
+        outboxPruning: baseOutbox,
+      },
+      NOW,
+    );
+
+    const payload = parseLastLog(info, 0);
+    expect(payload.lineageDeleted).toBeNull();
+    expect(payload.metricValueDeleted).toBe(30);
+    // A null (unknown) delete count must NOT trigger the should-have-pruned
+    // alert — that requires lineageDeleted === 0.
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("fires the should-have-pruned alert when old lineage survives a zero-delete cycle", async () => {
+    const prisma = createPrismaMock({
+      dbBytes: 9_000_000_000,
+      lineageRows: 22_000_000,
+      oldest: new Date("2026-05-01T12:00:00.000Z"), // 46 days, well past 14 + 1
+    });
+
+    await emitRetentionTelemetry(
+      {
+        prisma: prisma as never,
+        lineagePruning: { ...baseLineage, deletedRows: 0 },
+        metricValuePruning: baseMetricValue,
+        outboxPruning: baseOutbox,
+      },
+      NOW,
+    );
+
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error.mock.calls[0][0]).toBe("[retention:alert]");
+    const payload = parseLastLog(error, 0);
+    expect(payload).toMatchObject({
+      reason: "lineage_not_pruning",
+      oldestLineageAgeDays: 46,
+      lineageRetentionDays: 14,
+      alertThresholdDays: 15,
+      lineageDeleted: 0,
+    });
+  });
+
+  it("does NOT fire the should-have-pruned alert when the cycle deleted rows", async () => {
+    const prisma = createPrismaMock({
+      oldest: new Date("2026-05-01T12:00:00.000Z"), // 46 days
+    });
+
+    await emitRetentionTelemetry(
+      {
+        prisma: prisma as never,
+        lineagePruning: { ...baseLineage, deletedRows: 500 }, // actively draining backlog
+        metricValuePruning: baseMetricValue,
+        outboxPruning: baseOutbox,
+      },
+      NOW,
+    );
+
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire the alert for age within the TTL + grace window", async () => {
+    const prisma = createPrismaMock({
+      oldest: new Date("2026-06-01T12:00:00.000Z"), // 15 days, == 14 + 1, not strictly greater
+    });
+
+    await emitRetentionTelemetry(
+      {
+        prisma: prisma as never,
+        lineagePruning: { ...baseLineage, deletedRows: 0 },
+        metricValuePruning: baseMetricValue,
+        outboxPruning: baseOutbox,
+      },
+      NOW,
+    );
+
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("honors IMLADRIS_LINEAGE_RETENTION_DAYS and grace env overrides", async () => {
+    process.env.IMLADRIS_LINEAGE_RETENTION_DAYS = "30";
+    process.env.RETENTION_LINEAGE_ALERT_GRACE_DAYS = "2";
+    const prisma = createPrismaMock({
+      oldest: new Date("2026-05-10T12:00:00.000Z"), // 37 days > 30 + 2
+    });
+
+    await emitRetentionTelemetry(
+      {
+        prisma: prisma as never,
+        lineagePruning: { ...baseLineage, deletedRows: 0 },
+        metricValuePruning: baseMetricValue,
+        outboxPruning: baseOutbox,
+      },
+      NOW,
+    );
+
+    const metricsPayload = parseLastLog(info, 0);
+    expect(metricsPayload.lineageRetentionDays).toBe(30);
+    const alertPayload = parseLastLog(error, 0);
+    expect(alertPayload).toMatchObject({
+      reason: "lineage_not_pruning",
+      lineageRetentionDays: 30,
+      alertThresholdDays: 32,
+    });
+  });
+
+  it("emits budget-exhaustion alerts for incomplete prune passes", async () => {
+    const prisma = createPrismaMock({ oldest: null });
+
+    await emitRetentionTelemetry(
+      {
+        prisma: prisma as never,
+        lineagePruning: { ...baseLineage, completed: false, durationMs: 60_000 },
+        metricValuePruning: baseMetricValue,
+        outboxPruning: { ...baseOutbox, completed: false, durationMs: 15_000 },
+      },
+      NOW,
+    );
+
+    const reasons = (error.mock.calls as unknown[][])
+      .filter((call) => call[0] === "[retention:alert]")
+      .map((call) => (JSON.parse(call[1] as string) as { reason: string }).reason);
+    expect(reasons).toContain("lineage_budget_exhausted");
+    expect(reasons).toContain("outbox_budget_exhausted");
+    expect(reasons).not.toContain("metric_value_budget_exhausted");
+  });
+
+  it("never throws even if every read fails", async () => {
+    const prisma = { $queryRaw: vi.fn(async () => { throw new Error("db down"); }) };
+
+    await expect(
+      emitRetentionTelemetry(
+        {
+          prisma: prisma as never,
+          lineagePruning: baseLineage,
+          metricValuePruning: baseMetricValue,
+          outboxPruning: baseOutbox,
+        },
+        NOW,
+      ),
+    ).resolves.toBeUndefined();
+
+    // Stats are null but the info line still emits.
+    const payload = parseLastLog(info, 0);
+    expect(payload.dbBytes).toBeNull();
+    expect(payload.lineageRows).toBeNull();
+    expect(payload.oldestLineageAgeDays).toBeNull();
+    expect(payload.lineageDeleted).toBe(100);
+  });
+});

--- a/src/lib/sync/retention-telemetry.ts
+++ b/src/lib/sync/retention-telemetry.ts
@@ -1,0 +1,265 @@
+/**
+ * Retention pruning telemetry + early-warning alerts.
+ *
+ * Background: the 2026-06-10 Postgres volume-full + OOM incident was caused by
+ * ImladrisMetricLineage growing unbounded to ~22M rows / ~8GB (91% of the DB)
+ * with NOTHING reporting it. Retention pruning now runs every sync cycle
+ * (~10 min) — see src/lib/sync/analytics.ts and the three pruners in
+ * src/lib/imladris/* and src/lib/events/outbox-retention.ts — but a pruner that
+ * silently stops deleting (e.g. a query-plan regression, a bad cutoff, an index
+ * drop) would let the table regrow exactly as before, invisibly.
+ *
+ * This module turns each cycle's prune results into:
+ *   1. One structured info line per cycle (`[retention:metrics]`) carrying the
+ *      delete counts, total DB bytes, the cheap lineage row estimate, and the
+ *      age of the oldest lineage still present — a grep-able time series for
+ *      Railway log dashboards.
+ *   2. A loud error line (`[retention:alert]`) when lineage that should have
+ *      aged out is still present AND the lineage pruner deleted nothing this
+ *      cycle — the silent-regrowth failure mode that caused the outage.
+ *   3. Budget-exhaustion warnings (`[retention:alert]`, reason
+ *      `*_budget_exhausted`) when a pruner hit its time budget with rows still
+ *      eligible — the early signal that a backlog is outpacing the per-cycle
+ *      budget.
+ *
+ * Matches the existing `[tag] + JSON.stringify(...)` logging convention (see
+ * `[health:storage]` in src/app/api/health/route.ts and
+ * `[visitor-funnel.enrichment.metric]` in the cron route). Read queries reuse
+ * the proven catalog-query patterns from src/app/api/health/db/route.ts
+ * (`pg_database_size(...)::float8`, `GREATEST(c.reltuples, 0)::float8` over
+ * pg_class) — `::float8` deserializes to a JS number, sidestepping BigInt.
+ *
+ * Every read query is best-effort: a failure here must NEVER break the sync, so
+ * stats fall back to null and telemetry still emits what it has.
+ */
+
+import type { PrismaClientType } from "@/lib/prisma";
+import type { PruneImladrisMetricLineageResult } from "@/lib/imladris/lineage-retention";
+import type { PruneImladrisMetricValuesResult } from "@/lib/imladris/metric-value-retention";
+import type { PruneOutboxEventsResult } from "@/lib/events/outbox-retention";
+import type { GrowthPruneOutcome } from "@/lib/sync/analytics";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_LINEAGE_RETENTION_DAYS = 14;
+/**
+ * Grace buffer added to the lineage TTL before the should-have-pruned alert
+ * fires. Pruning is time-budgeted and the cutoff drifts within a cycle, so a
+ * row sitting a few hours past the TTL is normal; the alert is for lineage
+ * clearly stranded BEYOND the window. Defaults to
+ * RETENTION_LINEAGE_ALERT_GRACE_DAYS (env) or 1.
+ */
+const DEFAULT_ALERT_GRACE_DAYS = 1;
+
+/** The dominant growth table behind the 2026-06-10 outage. */
+const LINEAGE_TABLE = "ImladrisMetricLineage";
+
+export interface RetentionTelemetryInput {
+  prisma: PrismaClientType;
+  lineagePruning: GrowthPruneOutcome<PruneImladrisMetricLineageResult>;
+  metricValuePruning: GrowthPruneOutcome<PruneImladrisMetricValuesResult>;
+  outboxPruning: GrowthPruneOutcome<PruneOutboxEventsResult>;
+}
+
+/** Database-level stats sampled once per cycle. Any field is null on failure. */
+interface RetentionDbStats {
+  /** pg_database_size(current_database()) in bytes. */
+  dbBytes: number | null;
+  /** pg_class.reltuples estimate for the lineage table (cheap, no seq scan). */
+  lineageRows: number | null;
+  /**
+   * Age in days (1 decimal) of the oldest ImladrisCanonicalMetricValue that
+   * still carries lineage, by computedAt — the exact column the lineage pruner
+   * filters on. null when no lineage-bearing rows exist.
+   */
+  oldestLineageAgeDays: number | null;
+}
+
+function positiveIntFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  const parsed = raw ? Number(raw) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
+  return fallback;
+}
+
+function isPruneError(value: unknown): value is { error: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { error?: unknown }).error === "string"
+  );
+}
+
+function firstFiniteNumber(row: Record<string, unknown> | undefined, key: string): number | null {
+  const raw = row?.[key];
+  if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+  if (typeof raw === "bigint") return Number(raw);
+  return null;
+}
+
+function roundTo1(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+/**
+ * Sample the database stats for one cycle. Each query is isolated so one
+ * failing read does not lose the others, and the whole thing is non-throwing:
+ * the sync must not break because telemetry could not read a catalog table.
+ */
+export async function collectRetentionDbStats(
+  prisma: PrismaClientType,
+  now: Date,
+): Promise<RetentionDbStats> {
+  let dbBytes: number | null = null;
+  let lineageRows: number | null = null;
+  let oldestLineageAgeDays: number | null = null;
+
+  try {
+    const rows = await prisma.$queryRaw<Array<Record<string, unknown>>>`
+      SELECT pg_database_size(current_database())::float8 AS bytes
+    `;
+    dbBytes = firstFiniteNumber(rows?.[0], "bytes");
+  } catch {
+    dbBytes = null;
+  }
+
+  try {
+    // Cheap planner estimate — NOT a COUNT(*) seq-scan over a multi-million-row
+    // table. Mirrors src/app/api/health/db/route.ts.
+    const rows = await prisma.$queryRaw<Array<Record<string, unknown>>>`
+      SELECT GREATEST(c.reltuples, 0)::float8 AS rows
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public' AND c.relkind = 'r' AND c.relname = ${LINEAGE_TABLE}
+      LIMIT 1
+    `;
+    const rounded = firstFiniteNumber(rows?.[0], "rows");
+    lineageRows = rounded === null ? null : Math.round(rounded);
+  } catch {
+    lineageRows = null;
+  }
+
+  try {
+    // Oldest lineage still present, expressed as the age of the metric value it
+    // hangs off. computedAt is exactly what lineage-retention.ts filters on, so
+    // this is the faithful "is anything past the TTL still here?" signal. The
+    // EXISTS probe rides the ImladrisMetricLineage.metricValueId index, so only
+    // lineage-bearing rows count (lineage-free rows are irrelevant here).
+    const rows = await prisma.$queryRaw<Array<Record<string, unknown>>>`
+      SELECT MIN(mv."computedAt") AS oldest
+      FROM "ImladrisCanonicalMetricValue" mv
+      WHERE EXISTS (
+        SELECT 1 FROM "ImladrisMetricLineage" l WHERE l."metricValueId" = mv."id"
+      )
+    `;
+    const oldest = rows?.[0]?.oldest;
+    if (oldest instanceof Date) {
+      oldestLineageAgeDays = roundTo1((now.getTime() - oldest.getTime()) / DAY_MS);
+    } else if (typeof oldest === "string") {
+      const parsed = new Date(oldest);
+      if (!Number.isNaN(parsed.getTime())) {
+        oldestLineageAgeDays = roundTo1((now.getTime() - parsed.getTime()) / DAY_MS);
+      }
+    }
+  } catch {
+    oldestLineageAgeDays = null;
+  }
+
+  return { dbBytes, lineageRows, oldestLineageAgeDays };
+}
+
+/**
+ * Emit one cycle's retention telemetry: always the `[retention:metrics]` info
+ * line, plus `[retention:alert]` error lines for the should-have-pruned and
+ * budget-exhaustion conditions. Wholly non-throwing — telemetry must never
+ * break the sync.
+ */
+export async function emitRetentionTelemetry(
+  input: RetentionTelemetryInput,
+  now: Date = new Date(),
+): Promise<void> {
+  try {
+    const { lineagePruning, metricValuePruning, outboxPruning } = input;
+
+    const lineageDeleted = isPruneError(lineagePruning) ? null : lineagePruning.deletedRows;
+    const metricValueDeleted = isPruneError(metricValuePruning)
+      ? null
+      : metricValuePruning.deletedRows;
+    const outboxDeleted = isPruneError(outboxPruning)
+      ? null
+      : outboxPruning.deletedDispatched + outboxPruning.deletedDeadLetter;
+
+    const stats = await collectRetentionDbStats(input.prisma, now);
+    const lineageRetentionDays = positiveIntFromEnv(
+      "IMLADRIS_LINEAGE_RETENTION_DAYS",
+      DEFAULT_LINEAGE_RETENTION_DAYS,
+    );
+
+    // (1) One structured info line per cycle — the grep-able time series.
+    console.info(
+      "[retention:metrics]",
+      JSON.stringify({
+        lineageDeleted,
+        metricValueDeleted,
+        outboxDeleted,
+        dbBytes: stats.dbBytes,
+        lineageRows: stats.lineageRows,
+        oldestLineageAgeDays: stats.oldestLineageAgeDays,
+        lineageRetentionDays,
+      }),
+    );
+
+    // (2) Should-have-pruned alert: lineage clearly past the TTL (+ grace) is
+    // still present AND this cycle deleted nothing — the silent-regrowth mode
+    // that caused the 2026-06-10 outage. Only fires when both signals are
+    // known (a prune error is already surfaced separately by the cron route).
+    const graceDays = positiveIntFromEnv(
+      "RETENTION_LINEAGE_ALERT_GRACE_DAYS",
+      DEFAULT_ALERT_GRACE_DAYS,
+    );
+    const alertThresholdDays = lineageRetentionDays + graceDays;
+    if (
+      stats.oldestLineageAgeDays !== null &&
+      stats.oldestLineageAgeDays > alertThresholdDays &&
+      lineageDeleted === 0
+    ) {
+      console.error(
+        "[retention:alert]",
+        JSON.stringify({
+          reason: "lineage_not_pruning",
+          oldestLineageAgeDays: stats.oldestLineageAgeDays,
+          lineageRetentionDays,
+          alertThresholdDays,
+          lineageDeleted,
+          lineageRows: stats.lineageRows,
+          dbBytes: stats.dbBytes,
+        }),
+      );
+    }
+
+    // (3) Budget-exhaustion signals: a pruner hit its time budget with rows
+    // still eligible (completed === false). Early warning that a backlog is
+    // outpacing the per-cycle budget — raise the budget/batch env or
+    // investigate before it becomes a regrowth.
+    for (const [field, reason, outcome] of [
+      ["lineagePruning", "lineage_budget_exhausted", lineagePruning],
+      ["metricValuePruning", "metric_value_budget_exhausted", metricValuePruning],
+      ["outboxPruning", "outbox_budget_exhausted", outboxPruning],
+    ] as const) {
+      if (!isPruneError(outcome) && outcome.completed === false) {
+        console.error(
+          "[retention:alert]",
+          JSON.stringify({
+            reason,
+            field,
+            durationMs: outcome.durationMs,
+            batches: outcome.batches,
+          }),
+        );
+      }
+    }
+  } catch (error) {
+    // Telemetry is strictly best-effort: never let it abort the sync.
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("[retention:alert]", JSON.stringify({ reason: "telemetry_failed", error: message }));
+  }
+}


### PR DESCRIPTION
## Why

The 2026-06-10 Postgres volume-full + OOM incident was caused by `ImladrisMetricLineage` growing unbounded to ~22M rows / ~8GB (91% of the DB) with **nothing reporting it**. Retention pruning now runs every sync cycle (~10 min), but a pruner that silently stops deleting (query-plan regression, bad cutoff, dropped index) would refill the volume just as invisibly. This PR adds the missing observability so that failure mode is loud and early.

## What

A small, focused telemetry module (`src/lib/sync/retention-telemetry.ts`) wired into `runAnalyticsSync` **after** the three pruning results are available. It lives there (not in the cron route) so **both** callers — the `/api/cron/sync` route and the worker orchestrator (`src/lib/sync/orchestrator.ts`) — are covered by one implementation. Every read query is best-effort and the whole emit path is non-throwing: observability must never abort a sync.

### New structured log markers

Matches the existing `[tag] + JSON.stringify(...)` convention (cf. `[health:storage]`, `[visitor-funnel.enrichment.metric]`).

| Marker | Level | When | Payload |
| --- | --- | --- | --- |
| `[retention:metrics]` | `console.info` | every cycle (once) | `lineageDeleted`, `metricValueDeleted`, `outboxDeleted`, `dbBytes`, `lineageRows`, `oldestLineageAgeDays`, `lineageRetentionDays` |
| `[retention:alert]` `reason:"lineage_not_pruning"` | `console.error` | oldest lineage clearly past TTL **and** `lineageDeleted === 0` | `oldestLineageAgeDays`, `lineageRetentionDays`, `alertThresholdDays`, `lineageDeleted`, `lineageRows`, `dbBytes` |
| `[retention:alert]` `reason:"<area>_budget_exhausted"` | `console.error` | a pruner hit its time budget with rows still eligible (`completed === false`) | `field`, `durationMs`, `batches` |
| `[retention:alert]` `reason:"telemetry_failed"` | `console.error` | telemetry itself errored (defensive) | `error` |

### Metric sourcing (cheap + faithful)

- **`dbBytes`** — `SELECT pg_database_size(current_database())::float8` (reuses the `/api/health/db` pattern; `::float8` deserializes to a JS number, no BigInt).
- **`lineageRows`** — `GREATEST(c.reltuples, 0)::float8` from `pg_class` for `ImladrisMetricLineage`. The **cheap planner estimate**, explicitly *not* a `COUNT(*)` seq-scan over the multi-million-row table.
- **`oldestLineageAgeDays`** — `MIN(mv."computedAt")` over `ImladrisCanonicalMetricValue` rows that still carry lineage (`EXISTS` on `ImladrisMetricLineage`, rides the `metricValueId` index). `computedAt` is exactly the column `lineage-retention.ts` filters on, so this is the faithful "is anything past the TTL still here?" signal.

### Env-configurable thresholds (sensible defaults)

| Env | Default | Meaning |
| --- | --- | --- |
| `IMLADRIS_LINEAGE_RETENTION_DAYS` | `14` | Lineage TTL (already consumed by the pruner; read here for the alert). |
| `RETENTION_LINEAGE_ALERT_GRACE_DAYS` | `1` | Grace buffer added to the TTL before the should-have-pruned alert fires. Pruning is time-budgeted and the cutoff drifts within a cycle, so the alert targets lineage stranded **beyond** the window — avoids boundary flapping. |

The should-have-pruned alert fires only when `oldestLineageAgeDays > IMLADRIS_LINEAGE_RETENTION_DAYS + RETENTION_LINEAGE_ALERT_GRACE_DAYS` **and** `lineageDeleted === 0`. A null (unknown) delete count — e.g. when the prune errored — does not trigger it; prune errors are already surfaced separately by the cron route / orchestrator partial-failure path.

## Budget-exhaustion signal — done, not deferred

All three pruner result types already expose a well-typed `completed: boolean`, so item 3 required **no pruner changes**. Telemetry reads `completed === false` and emits a `*_budget_exhausted` alert per affected pruner.

## Files changed

- `src/lib/sync/retention-telemetry.ts` (new) — `collectRetentionDbStats` + `emitRetentionTelemetry`.
- `src/lib/sync/analytics.ts` — one import + one non-throwing call after the pruners (11 lines).
- `src/lib/sync/retention-telemetry.test.ts` (new) — 12 unit tests: stat parsing, null fallbacks, the info line, alert fire / no-fire (deleted rows, within grace, env overrides), budget-exhaustion, and never-throws.
- `src/lib/sync/analytics.test.ts` — adds `$queryRaw` to the prisma mock, mocks the telemetry module, and asserts wiring (args, call ordering after pruning, prune-errors forwarded).

## Checks run locally

- `npx tsc --noEmit -p tsconfig.json` — **0 errors**.
- `npm run lint` (full repo) — **0 errors** (pre-existing warnings only, none in touched files).
- `npx vitest run src/lib/sync/ src/app/api/cron/sync/ src/app/api/health/` — **69 passed / 69**.
- Skipped the slow `next build` per scope — CI runs it.

## Notes / not in scope

- Telemetry is log-only (Railway log-based alerting / anything scraping logs). No new endpoint, no notification fan-out, no schema change.
- The oldest-age query intentionally counts only lineage-bearing rows; lineage-free metric values are irrelevant to the regrowth signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
