### PR TITLE
fix: decouple customer success enums from prisma client

### DIFF
--- a/src/lib/customer-success/prisma-enums.ts
+++ b/src/lib/customer-success/prisma-enums.ts
@@ -1,0 +1,103 @@
+// Mirror of Prisma enums -- keep in sync with prisma/schema.prisma
+
+export const CustomerExternalProvider = {
+  INTERNAL: "INTERNAL",
+  HUBSPOT: "HUBSPOT",
+  STRIPE: "STRIPE",
+  PYLON: "PYLON",
+  CODA: "CODA",
+  SLACK: "SLACK",
+  GOOGLE_WORKSPACE: "GOOGLE_WORKSPACE",
+} as const;
+
+export type CustomerExternalProvider =
+  (typeof CustomerExternalProvider)[keyof typeof CustomerExternalProvider];
+
+export const CustomerRecordStatus = {
+  ACTIVE: "ACTIVE",
+  ARCHIVED: "ARCHIVED",
+  MERGED: "MERGED",
+} as const;
+
+export type CustomerRecordStatus =
+  (typeof CustomerRecordStatus)[keyof typeof CustomerRecordStatus];
+
+export const CustomerSuccessAlertSeverity = {
+  LOW: "LOW",
+  MEDIUM: "MEDIUM",
+  HIGH: "HIGH",
+  CRITICAL: "CRITICAL",
+} as const;
+
+export type CustomerSuccessAlertSeverity =
+  (typeof CustomerSuccessAlertSeverity)[keyof typeof CustomerSuccessAlertSeverity];
+
+export const CustomerSuccessAlertSource = {
+  HEALTH: "HEALTH",
+  SUPPORT: "SUPPORT",
+  COMMERCIAL: "COMMERCIAL",
+  RELATIONSHIP: "RELATIONSHIP",
+  WORKFLOW: "WORKFLOW",
+} as const;
+
+export type CustomerSuccessAlertSource =
+  (typeof CustomerSuccessAlertSource)[keyof typeof CustomerSuccessAlertSource];
+
+export const CustomerSuccessAlertStatus = {
+  OPEN: "OPEN",
+  IN_PROGRESS: "IN_PROGRESS",
+  RESOLVED: "RESOLVED",
+  DISMISSED: "DISMISSED",
+} as const;
+
+export type CustomerSuccessAlertStatus =
+  (typeof CustomerSuccessAlertStatus)[keyof typeof CustomerSuccessAlertStatus];
+
+export const CustomerSuccessOutreachStatus = {
+  DRAFT: "DRAFT",
+  QUEUED: "QUEUED",
+  SENT: "SENT",
+  FAILED: "FAILED",
+  CANCELED: "CANCELED",
+} as const;
+
+export type CustomerSuccessOutreachStatus =
+  (typeof CustomerSuccessOutreachStatus)[keyof typeof CustomerSuccessOutreachStatus];
+
+export const CustomerSuccessPlanStatus = {
+  DRAFT: "DRAFT",
+  ACTIVE: "ACTIVE",
+  COMPLETED: "COMPLETED",
+  ARCHIVED: "ARCHIVED",
+} as const;
+
+export type CustomerSuccessPlanStatus =
+  (typeof CustomerSuccessPlanStatus)[keyof typeof CustomerSuccessPlanStatus];
+
+export const CustomerSuccessNoteSource = {
+  MANUAL: "MANUAL",
+  MEETING: "MEETING",
+  SUPPORT: "SUPPORT",
+  CRM: "CRM",
+  AI: "AI",
+  SYSTEM: "SYSTEM",
+} as const;
+
+export type CustomerSuccessNoteSource =
+  (typeof CustomerSuccessNoteSource)[keyof typeof CustomerSuccessNoteSource];
+
+export const CustomerSuccessNoteVisibility = {
+  INTERNAL: "INTERNAL",
+  RESTRICTED: "RESTRICTED",
+} as const;
+
+export type CustomerSuccessNoteVisibility =
+  (typeof CustomerSuccessNoteVisibility)[keyof typeof CustomerSuccessNoteVisibility];
+
+export const CustomerSuccessOutreachChannel = {
+  EMAIL: "EMAIL",
+  SLACK: "SLACK",
+} as const;
+
+export type CustomerSuccessOutreachChannel =
+  (typeof CustomerSuccessOutreachChannel)[keyof typeof CustomerSuccessOutreachChannel];

--- a/src/lib/customer-success/service.ts
+++ b/src/lib/customer-success/service.ts
@@ -1,4 +1,9 @@
 import {
+  MeetingStatus,
+  Prisma,
+  TaskStatus,
+} from "@/generated/prisma/client";
+import {
   CustomerExternalProvider,
   CustomerRecordStatus,
   CustomerSuccessNoteSource,
@@ -9,9 +14,7 @@ import {
   CustomerSuccessOutreachChannel,
   CustomerSuccessOutreachStatus,
   CustomerSuccessPlanStatus,
-  MeetingStatus,
-  Prisma,
-} from "@/generated/prisma/client";
+} from "@/lib/customer-success/prisma-enums";
 import { buildOutboxIdempotencyKey, publishDomainEvent } from "@/lib/event-bus";
 import { prisma } from "@/lib/prisma";
 import { runWithContextAsync } from "@/lib/request-context";


### PR DESCRIPTION
## Commits
- fix: decouple customer success enums from prisma client

## Files changed
 src/lib/customer-success/prisma-enums.ts | 75 ++++++++++++++++++++++++++++++++
 src/lib/customer-success/service.ts      | 10 +++--
 2 files changed, 81 insertions(+), 4 deletions(-)

_Surfaced while triaging unmerged branches during repo cleanup — was sitting unmerged with no PR. May need a rebase on current `main`._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
