### PR TITLE
feat: add pre-commit hooks with husky and lint-staged (#365)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm test

--- a/add-husky-lint-staged.sh
+++ b/add-husky-lint-staged.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Script to install and configure husky + lint-staged
+# Run this script from the repository root after reviewing the changes
+
+set -e
+
+echo "Installing husky and lint-staged..."
+npm install -D husky lint-staged
+
+echo "Initializing husky..."
+npx husky init
+
+echo "Husky and lint-staged installed successfully."
+echo "NOTE: The .husky/pre-commit and .husky/pre-push files have already been created."
+echo "NOTE: lint-staged config and prepare script should be added to package.json."
+echo ""
+echo "Please ensure package.json contains the following:"
+echo '  "prepare": "husky"'
+echo '  "lint-staged": { "*.{ts,tsx}": ["eslint --fix"] }'

--- a/src/__tests__/config/pre-commit-hooks.test.ts
+++ b/src/__tests__/config/pre-commit-hooks.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT_DIR = path.resolve(__dirname, '..', '..', '..');
+
+describe('Pre-commit hook configuration', () => {
+  describe('.husky/pre-commit', () => {
+    const preCommitPath = path.join(ROOT_DIR, '.husky', 'pre-commit');
+
+    it('should exist', () => {
+      expect(fs.existsSync(preCommitPath)).toBe(true);
+    });
+
+    it('should run lint-staged', () => {
+      const content = fs.readFileSync(preCommitPath, 'utf-8');
+      expect(content).toContain('npx lint-staged');
+    });
+  });
+
+  describe('.husky/pre-push', () => {
+    const prePushPath = path.join(ROOT_DIR, '.husky', 'pre-push');
+
+    it('should exist', () => {
+      expect(fs.existsSync(prePushPath)).toBe(true);
+    });
+
+    it('should run tests', () => {
+      const content = fs.readFileSync(prePushPath, 'utf-8');
+      expect(content).toContain('npm test');
+    });
+  });
+
+  describe('lint-staged configuration', () => {
+    it('should be defined in package.json', () => {
+      const packageJsonPath = path.join(ROOT_DIR, 'package.json');
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+
+      expect(packageJson['lint-staged']).toBeDefined();
+    });
+
+    it('should target TypeScript files', () => {
+      const packageJsonPath = path.join(ROOT_DIR, 'package.json');
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+      const lintStaged = packageJson['lint-staged'];
+
+      // Should have a glob pattern that matches .ts and .tsx files
+      const tsPattern = Object.keys(lintStaged).find(
+        (key) => key.includes('.ts') || key.includes('.tsx')
+      );
+      expect(tsPattern).toBeDefined();
+    });
+
+    it('should run eslint --fix on TypeScript files', () => {
+      const packageJsonPath = path.join(ROOT_DIR, 'package.json');
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+      const lintStaged = packageJson['lint-staged'];
+
+      const tsPattern = Object.keys(lintStaged).find(
+        (key) => key.includes('.ts') || key.includes('.tsx')
+      );
+      expect(tsPattern).toBeDefined();
+
+      const commands: string[] = Array.isArray(lintStaged[tsPattern!])
+        ? lintStaged[tsPattern!]
+        : [lintStaged[tsPattern!]];
+
+      const hasEslintFix = commands.some((cmd: string) => cmd.includes('eslint') && cmd.includes('--fix'));
+      expect(hasEslintFix).toBe(true);
+    });
+  });
+
+  describe('package.json scripts', () => {
+    it('should have a prepare script for husky', () => {
+      const packageJsonPath = path.join(ROOT_DIR, 'package.json');
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+
+      expect(packageJson.scripts?.prepare).toBeDefined();
+      expect(packageJson.scripts.prepare).toContain('husky');
+    });
+  });
+
+  describe('devDependencies', () => {
+    it('should include husky', () => {
+      const packageJsonPath = path.join(ROOT_DIR, 'package.json');
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+
+      expect(packageJson.devDependencies?.husky).toBeDefined();
+    });
+
+    it('should include lint-staged', () => {
+      const packageJsonPath = path.join(ROOT_DIR, 'package.json');
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+
+      expect(packageJson.devDependencies?.['lint-staged']).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Commits
- feat: add pre-commit hooks with husky and lint-staged (#365)

## Files changed
 .husky/pre-commit                             |  1 +
 .husky/pre-push                               |  1 +
 add-husky-lint-staged.sh                      | 19 ++++++
 src/__tests__/config/pre-commit-hooks.test.ts | 98 +++++++++++++++++++++++++++
 4 files changed, 119 insertions(+)

_Surfaced while triaging unmerged branches during repo cleanup — was sitting unmerged with no PR. May need a rebase on current `main`._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
