### PR TITLE
fix(analytics): update onClose ref in effect

### DIFF
--- a/src/components/analytics/dismiss-undo-toast.tsx
+++ b/src/components/analytics/dismiss-undo-toast.tsx
@@ -16,7 +16,9 @@ export function DismissUndoToast({
   durationMs = 5000,
 }: DismissUndoToastProps) {
   const onCloseRef = useRef(onClose);
-  onCloseRef.current = onClose;
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
 
   useEffect(() => {
     const timer = setTimeout(() => {

--- a/src/components/analytics/path-detail-drawer.test.tsx
+++ b/src/components/analytics/path-detail-drawer.test.tsx
@@ -1,0 +1,184 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PathDetailDrawer } from "./path-detail-drawer";
+import type { MatchedJourney } from "@/lib/analytics/path-matching";
+
+const mockJourneys: MatchedJourney[] = [
+  {
+    id: "1",
+    dealName: "Acme Corp",
+    contactEmail: "acme@example.com",
+    value: 50000,
+    currentStage: "Closed Won",
+    daysInPipeline: 45,
+    lastTouch: new Date(Date.now() - 3 * 86400000).toISOString(), // 3 days ago
+  },
+  {
+    id: "2",
+    dealName: "Beta Inc",
+    contactEmail: null,
+    value: 30000,
+    currentStage: "Negotiation",
+    daysInPipeline: 20,
+    lastTouch: new Date(Date.now() - 1 * 86400000).toISOString(), // yesterday
+  },
+];
+
+const pathStages = ["Google Ads", "Sales Pipeline", "Billing/Trial"];
+const onClose = vi.fn();
+
+describe("PathDetailDrawer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <PathDetailDrawer
+        open={false}
+        onClose={onClose}
+        pathStages={pathStages}
+        journeys={mockJourneys}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders drawer panel when open", () => {
+    render(
+      <PathDetailDrawer
+        open={true}
+        onClose={onClose}
+        pathStages={pathStages}
+        journeys={mockJourneys}
+      />
+    );
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByText("Path Detail")).toBeTruthy();
+  });
+
+  it("shows path stages in the header", () => {
+    render(
+      <PathDetailDrawer
+        open={true}
+        onClose={onClose}
+        pathStages={pathStages}
+        journeys={mockJourneys}
+      />
+    );
+    expect(screen.getByText("Google Ads")).toBeTruthy();
+    expect(screen.getByText("Sales Pipeline")).toBeTruthy();
+    expect(screen.getByText("Billing/Trial")).toBeTruthy();
+  });
+
+  it("shows matched journeys in the table", () => {
+    render(
+      <PathDetailDrawer
+        open={true}
+        onClose={onClose}
+        pathStages={pathStages}
+        journeys={mockJourneys}
+      />
+    );
+    expect(screen.getByText("Acme Corp")).toBeTruthy();
+    expect(screen.getByText("Beta Inc")).toBeTruthy();
+    expect(screen.getByText("Closed Won")).toBeTruthy();
+    expect(screen.getByText("Negotiation")).toBeTruthy();
+  });
+
+  it("shows empty state when no journeys match", () => {
+    render(
+      <PathDetailDrawer
+        open={true}
+        onClose={onClose}
+        pathStages={pathStages}
+        journeys={[]}
+      />
+    );
+    expect(screen.getByText("No matching deals found")).toBeTruthy();
+  });
+
+  it("shows loading state when isLoading is true", () => {
+    const { container } = render(
+      <PathDetailDrawer
+        open={true}
+        onClose={onClose}
+        pathStages={pathStages}
+        journeys={[]}
+        isLoading={true}
+      />
+    );
+    // Loading skeleton divs
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("calls onClose when close button is clicked", () => {
+    render(
+      <PathDetailDrawer
+        open={true}
+        onClose={onClose}
+        pathStages={pathStages}
+        journeys={mockJourneys}
+      />
+    );
+    const closeBtn = screen.getByLabelText("Close");
+    fireEvent.click(closeBtn);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when backdrop is clicked", () => {
+    const { container } = render(
+      <PathDetailDrawer
+        open={true}
+        onClose={onClose}
+        pathStages={pathStages}
+        journeys={mockJourneys}
+      />
+    );
+    // Backdrop is the first div inside the fixed overlay (aria-hidden)
+    const backdrop = container.querySelector("[aria-hidden='true']");
+    expect(backdrop).toBeTruthy();
+    fireEvent.click(backdrop!);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onClose on Escape key", () => {
+    render(
+      <PathDetailDrawer
+        open={true}
+        onClose={onClose}
+        pathStages={pathStages}
+        journeys={mockJourneys}
+      />
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("has proper ARIA attributes on the dialog", () => {
+    render(
+      <PathDetailDrawer
+        open={true}
+        onClose={onClose}
+        pathStages={pathStages}
+        journeys={mockJourneys}
+      />
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(dialog.getAttribute("aria-labelledby")).toBeTruthy();
+  });
+
+  it("shows deal count in the body", () => {
+    render(
+      <PathDetailDrawer
+        open={true}
+        onClose={onClose}
+        pathStages={pathStages}
+        journeys={mockJourneys}
+      />
+    );
+    expect(screen.getByText(/2 deals matched this path/)).toBeTruthy();
+  });
+});

--- a/src/components/analytics/path-detail-drawer.tsx
+++ b/src/components/analytics/path-detail-drawer.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { X, ArrowRight } from "lucide-react";
+import type { MatchedJourney } from "@/lib/analytics/path-matching";
+
+interface PathDetailDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  pathStages: string[];
+  journeys: MatchedJourney[];
+  isLoading?: boolean;
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function relativeDate(isoDate: string): string {
+  const diff = Date.now() - new Date(isoDate).getTime();
+  const days = Math.floor(diff / 86_400_000);
+  if (days === 0) return "today";
+  if (days === 1) return "yesterday";
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+export function PathDetailDrawer({
+  open,
+  onClose,
+  pathStages,
+  journeys,
+  isLoading,
+}: PathDetailDrawerProps) {
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const titleId = "path-drawer-title";
+
+  useEffect(() => {
+    if (!open) return;
+    drawerRef.current?.focus();
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Drawer panel */}
+      <div
+        ref={drawerRef}
+        tabIndex={-1}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="absolute right-0 top-0 h-full w-full max-w-lg bg-background border-l border-border shadow-xl flex flex-col outline-none"
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between border-b border-border p-4 gap-3">
+          <div className="min-w-0">
+            <p id={titleId} className="text-sm font-semibold text-foreground">
+              Path Detail
+            </p>
+            <div className="mt-1.5 flex flex-wrap items-center gap-1 text-xs text-muted-foreground">
+              {pathStages.map((stage, i) => (
+                <span key={i} className="flex items-center gap-1">
+                  {i > 0 && <ArrowRight className="h-3 w-3 shrink-0 text-muted-foreground/50" />}
+                  <span className="rounded-full bg-muted px-2 py-0.5 font-medium text-foreground">
+                    {stage}
+                  </span>
+                </span>
+              ))}
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="shrink-0 rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {isLoading ? (
+            <div className="space-y-3">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div key={i} className="h-12 rounded-md bg-muted animate-pulse" />
+              ))}
+            </div>
+          ) : journeys.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <p className="text-sm font-medium text-muted-foreground">No matching deals found</p>
+              <p className="mt-1 text-xs text-muted-foreground/70">
+                No deals took this exact path sequence.
+              </p>
+            </div>
+          ) : (
+            <>
+              <p className="mb-3 text-xs text-muted-foreground">
+                {journeys.length} deal{journeys.length !== 1 ? "s" : ""} matched this path
+              </p>
+              <div className="overflow-x-auto">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b border-border text-left text-muted-foreground">
+                      <th className="pb-2 pr-3 font-medium">Deal</th>
+                      <th className="pb-2 pr-3 text-right font-medium">Value</th>
+                      <th className="pb-2 pr-3 font-medium">Stage</th>
+                      <th className="pb-2 pr-3 text-right font-medium">Days</th>
+                      <th className="pb-2 text-right font-medium">Last Touch</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {journeys.map((j) => (
+                      <tr
+                        key={j.id}
+                        className="border-b border-border/40 even:bg-muted/30 last:border-0"
+                      >
+                        <td className="py-2.5 pr-3">
+                          <div className="max-w-[160px] truncate font-medium text-foreground">
+                            {j.dealName}
+                          </div>
+                          {j.contactEmail && (
+                            <div className="max-w-[160px] truncate text-muted-foreground">
+                              {j.contactEmail}
+                            </div>
+                          )}
+                        </td>
+                        <td className="py-2.5 pr-3 text-right tabular-nums font-medium text-emerald-600 dark:text-emerald-400">
+                          {j.value > 0 ? formatCurrency(j.value) : "—"}
+                        </td>
+                        <td className="py-2.5 pr-3">
+                          <span className="rounded-full bg-muted px-2 py-0.5 text-foreground">
+                            {j.currentStage}
+                          </span>
+                        </td>
+                        <td className="py-2.5 pr-3 text-right tabular-nums text-muted-foreground">
+                          {j.daysInPipeline}d
+                        </td>
+                        <td className="py-2.5 text-right tabular-nums text-muted-foreground">
+                          {relativeDate(j.lastTouch)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/analytics/path-exploration-drilldown.test.tsx
+++ b/src/components/analytics/path-exploration-drilldown.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PathExploration } from "./sub-dashboards/path-exploration";
+import type { CustomerJourneyRecord, JourneyPath } from "@/lib/analytics/types";
+
+// Minimal mock paths
+const mockPaths: JourneyPath[] = [
+  {
+    sequence: ["google-ads", "hubspot", "stripe"] as never,
+    count: 5,
+    kanbanCards: 2,
+    freeTrials: 1,
+    demos: 3,
+    avgDaysToClose: 30,
+    avgValue: 15000,
+  },
+  {
+    sequence: ["meta-ads", "hubspot"] as never,
+    count: 2,
+    kanbanCards: 0,
+    freeTrials: 0,
+    demos: 1,
+    avgDaysToClose: 20,
+    avgValue: 8000,
+  },
+];
+
+function makeJourney(id: string, channels: string[]): CustomerJourneyRecord {
+  return {
+    dealId: id,
+    dealName: `Deal ${id}`,
+    contactEmail: `contact-${id}@example.com`,
+    currentStage: "Closed Won",
+    value: 12000,
+    touchpoints: channels.map((ch, i) => ({
+      timestamp: `2026-01-0${i + 1}T00:00:00Z`,
+      phase: "crm",
+      channel: ch as never,
+      type: "engagement",
+      detail: ch,
+      value: null,
+    })),
+    firstTouch: "2026-01-01T00:00:00Z",
+    lastTouch: "2026-01-10T00:00:00Z",
+    daysInPipeline: 10,
+  };
+}
+
+const mockJourneys: CustomerJourneyRecord[] = [
+  makeJourney("j1", ["google-ads", "hubspot", "stripe"]),
+  makeJourney("j2", ["meta-ads", "hubspot"]),
+  makeJourney("j3", ["google-ads", "hubspot"]),
+];
+
+describe("PathExploration Drilldown", () => {
+  it("renders path rows in a table", () => {
+    render(<PathExploration paths={mockPaths} journeys={mockJourneys} />);
+    // Rows have role="button"
+    const rows = document.querySelectorAll('[role="button"]');
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("opens drawer when a path row is clicked", () => {
+    render(<PathExploration paths={mockPaths} journeys={mockJourneys} />);
+    const rows = document.querySelectorAll('[role="button"]');
+    fireEvent.click(rows[0]);
+    // Drawer should be open — check for dialog role
+    const dialog = document.querySelector('[role="dialog"]');
+    expect(dialog).toBeTruthy();
+  });
+
+  it("shows matching journeys in the drawer after click", () => {
+    render(<PathExploration paths={mockPaths} journeys={mockJourneys} />);
+    const rows = document.querySelectorAll('[role="button"]');
+    fireEvent.click(rows[0]);
+    // Should show deal names for journeys matching "google-ads → hubspot → stripe"
+    expect(screen.getByText("Deal j1")).toBeTruthy();
+  });
+
+  it("closes drawer when close button is clicked", () => {
+    render(<PathExploration paths={mockPaths} journeys={mockJourneys} />);
+    const rows = document.querySelectorAll('[role="button"]');
+    fireEvent.click(rows[0]);
+
+    const closeBtn = screen.getByLabelText("Close");
+    fireEvent.click(closeBtn);
+
+    const dialog = document.querySelector('[role="dialog"]');
+    expect(dialog).toBeNull();
+  });
+
+  it("closes drawer on Escape key", () => {
+    render(<PathExploration paths={mockPaths} journeys={mockJourneys} />);
+    const rows = document.querySelectorAll('[role="button"]');
+    fireEvent.click(rows[0]);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    const dialog = document.querySelector('[role="dialog"]');
+    expect(dialog).toBeNull();
+  });
+
+  it("closes drawer when backdrop is clicked", () => {
+    render(<PathExploration paths={mockPaths} journeys={mockJourneys} />);
+    const rows = document.querySelectorAll('[role="button"]');
+    fireEvent.click(rows[0]);
+
+    // Backdrop is the first div in the fixed overlay container
+    const backdrop = document.querySelector('.fixed.inset-0 > [aria-hidden="true"]');
+    expect(backdrop).toBeTruthy();
+    fireEvent.click(backdrop!);
+
+    const dialog = document.querySelector('[role="dialog"]');
+    expect(dialog).toBeNull();
+  });
+
+  it("shows empty state message when no journeys match", () => {
+    render(<PathExploration paths={mockPaths} journeys={[]} />);
+    const rows = document.querySelectorAll('[role="button"]');
+    fireEvent.click(rows[0]);
+    expect(screen.getByText(/No matching deals found/i)).toBeTruthy();
+  });
+
+  it("path rows are keyboard accessible with Enter key", () => {
+    render(<PathExploration paths={mockPaths} journeys={mockJourneys} />);
+    const rows = document.querySelectorAll('[role="button"]');
+    fireEvent.keyDown(rows[0], { key: "Enter" });
+    const dialog = document.querySelector('[role="dialog"]');
+    expect(dialog).toBeTruthy();
+  });
+
+  it("shows empty state when paths array is empty", () => {
+    render(<PathExploration paths={[]} />);
+    expect(screen.getByText("No journey path data available.")).toBeTruthy();
+  });
+});

--- a/src/components/analytics/path-sankey-diagram.test.tsx
+++ b/src/components/analytics/path-sankey-diagram.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PathSankeyDiagram } from "./path-sankey-diagram";
+
+const paths = [
+  { stages: ["Google Ads", "Sales Pipeline", "Billing/Trial"], count: 8 },
+  { stages: ["Meta Ads", "Sales Pipeline", "Billing/Trial"], count: 5 },
+  { stages: ["Organic Traffic", "Sales Pipeline"], count: 3 },
+];
+
+describe("PathSankeyDiagram", () => {
+  it("renders an SVG with the diagram role and label", () => {
+    render(<PathSankeyDiagram paths={paths} />);
+    const svg = document.querySelector("svg");
+    expect(svg).toBeTruthy();
+    expect(svg?.getAttribute("role")).toBe("img");
+    expect(svg?.getAttribute("aria-label")).toBeTruthy();
+  });
+
+  it("shows empty state when paths array is empty", () => {
+    render(<PathSankeyDiagram paths={[]} />);
+    expect(screen.getByText("No path data available to visualize.")).toBeTruthy();
+  });
+
+  it("renders nodes for each unique stage+column combination", () => {
+    const { container } = render(<PathSankeyDiagram paths={paths} />);
+    const rects = container.querySelectorAll("rect");
+    // Should have at least one rect per node
+    expect(rects.length).toBeGreaterThan(0);
+  });
+
+  it("calls onPathClick with source and target labels when a link is clicked", () => {
+    const onPathClick = vi.fn();
+    const { container } = render(
+      <PathSankeyDiagram paths={paths} onPathClick={onPathClick} />,
+    );
+    const linkPaths = container.querySelectorAll("path");
+    expect(linkPaths.length).toBeGreaterThan(0);
+    fireEvent.click(linkPaths[0]);
+    expect(onPathClick).toHaveBeenCalledOnce();
+    const [stages] = onPathClick.mock.calls[0];
+    expect(Array.isArray(stages)).toBe(true);
+    expect(stages.length).toBe(2);
+  });
+
+  it("changes link opacity on hover", () => {
+    const { container } = render(<PathSankeyDiagram paths={paths} />);
+    const linkPath = container.querySelector("path");
+    if (!linkPath) return;
+
+    // Before hover: fillOpacity should be 0.25
+    expect(linkPath.getAttribute("fill-opacity")).toBe("0.25");
+
+    fireEvent.mouseEnter(linkPath);
+    // After hover: fillOpacity should be higher
+    expect(linkPath.getAttribute("fill-opacity")).toBe("0.55");
+
+    fireEvent.mouseLeave(linkPath);
+    expect(linkPath.getAttribute("fill-opacity")).toBe("0.25");
+  });
+
+  it("renders link tooltips with count information", () => {
+    const { container } = render(<PathSankeyDiagram paths={paths} />);
+    const titles = container.querySelectorAll("title");
+    expect(titles.length).toBeGreaterThan(0);
+    const titleTexts = Array.from(titles).map((t) => t.textContent ?? "");
+    expect(titleTexts.some((t) => t.includes("→"))).toBe(true);
+  });
+});

--- a/src/components/analytics/path-sankey-diagram.tsx
+++ b/src/components/analytics/path-sankey-diagram.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { computeSankeyLayout, type PathData } from "@/lib/analytics/sankey-layout";
+
+const DIAGRAM_WIDTH = 800;
+const DIAGRAM_HEIGHT = 360;
+const NODE_WIDTH = 20;
+const NODE_PADDING = 14;
+
+const STAGE_COLORS: Record<string, string> = {
+  "Google Ads": "hsl(210, 70%, 55%)",
+  "Meta Ads": "hsl(220, 75%, 60%)",
+  "Reddit Ads": "hsl(25, 85%, 58%)",
+  "Organic Traffic": "hsl(145, 60%, 45%)",
+  "Sales Pipeline": "hsl(45, 80%, 52%)",
+  "Billing/Trial": "hsl(270, 60%, 60%)",
+  "Kanban App": "hsl(330, 65%, 58%)",
+  "Support (Pylon)": "hsl(190, 65%, 50%)",
+};
+
+function getStageColor(stage: string): string {
+  if (STAGE_COLORS[stage]) return STAGE_COLORS[stage];
+  const hash = stage.split("").reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  return `hsl(${hash % 360}, 60%, 52%)`;
+}
+
+interface PathSankeyDiagramProps {
+  paths: PathData[];
+  topN?: number;
+  onPathClick?: (stages: string[]) => void;
+  className?: string;
+}
+
+export function PathSankeyDiagram({
+  paths,
+  topN = 10,
+  onPathClick,
+  className,
+}: PathSankeyDiagramProps) {
+  const [hoveredLink, setHoveredLink] = useState<string | null>(null);
+
+  const layout = useMemo(
+    () =>
+      computeSankeyLayout(paths, {
+        width: DIAGRAM_WIDTH,
+        height: DIAGRAM_HEIGHT,
+        nodeWidth: NODE_WIDTH,
+        nodePadding: NODE_PADDING,
+        topN,
+      }),
+    [paths, topN],
+  );
+
+  if (!paths.length || !layout.nodes.length) {
+    return (
+      <div
+        className={`flex items-center justify-center h-48 text-sm text-muted-foreground ${className ?? ""}`}
+      >
+        <p>No path data available to visualize.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={className}>
+      <svg
+        viewBox={`0 0 ${DIAGRAM_WIDTH} ${DIAGRAM_HEIGHT}`}
+        width="100%"
+        role="img"
+        aria-label="Flow diagram showing top deal paths through pipeline stages"
+        className="overflow-visible"
+      >
+        {/* Links */}
+        {layout.links.map((link) => {
+          const isHovered = hoveredLink === link.id;
+          const color = getStageColor(link.sourceLabel);
+          return (
+            <g key={link.id}>
+              <path
+                d={link.path}
+                fill={color}
+                fillOpacity={isHovered ? 0.55 : 0.25}
+                stroke={color}
+                strokeOpacity={0}
+                style={{ cursor: onPathClick ? "pointer" : "default", transition: "fill-opacity 0.15s" }}
+                onMouseEnter={() => setHoveredLink(link.id)}
+                onMouseLeave={() => setHoveredLink(null)}
+                onClick={() => {
+                  if (onPathClick) {
+                    onPathClick([link.sourceLabel, link.targetLabel]);
+                  }
+                }}
+              >
+                <title>
+                  {link.sourceLabel} → {link.targetLabel}: {link.value} deal{link.value !== 1 ? "s" : ""}
+                </title>
+              </path>
+            </g>
+          );
+        })}
+
+        {/* Nodes */}
+        {layout.nodes.map((node) => {
+          const color = getStageColor(node.label);
+          return (
+            <g key={node.id}>
+              <rect
+                x={node.x}
+                y={node.y}
+                width={NODE_WIDTH}
+                height={Math.max(node.height, 4)}
+                fill={color}
+                rx={3}
+                ry={3}
+              />
+              {/* Label to the right for last column, left for others */}
+              <text
+                x={node.column === 0 ? node.x + NODE_WIDTH + 6 : node.x - 6}
+                y={node.y + Math.max(node.height, 4) / 2}
+                dominantBaseline="middle"
+                textAnchor={node.column === 0 ? "start" : "end"}
+                fontSize={11}
+                fill="currentColor"
+                className="text-foreground"
+                style={{ userSelect: "none" }}
+              >
+                {node.label}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/src/components/analytics/sub-dashboards/path-exploration.tsx
+++ b/src/components/analytics/sub-dashboards/path-exploration.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import type { JourneyPath, CustomerJourneyRecord } from "@/lib/analytics/types";
-import { DrilldownPanel, DrilldownDrawer } from "../drilldown-panel";
+import type { CustomerJourneyRecord, JourneyPath } from "@/lib/analytics/types";
+import { DashboardSectionCard } from "../dashboard-section-card";
 import {
   Megaphone,
   Search,
@@ -13,21 +13,22 @@ import {
   Headset,
   ArrowRight,
   MousePointerClick,
-  Route,
-  Calendar,
-  DollarSign,
 } from "lucide-react";
+import { matchJourneysToPath } from "@/lib/analytics/path-matching";
+import { PathDetailDrawer } from "@/components/analytics/path-detail-drawer";
+import { PathSankeyDiagram } from "@/components/analytics/path-sankey-diagram";
+import type { PathData } from "@/lib/analytics/sankey-layout";
 
 interface PathExplorationProps {
   paths: JourneyPath[];
-  /** Optional: journey records for drill-down matching. */
   journeys?: CustomerJourneyRecord[];
 }
 
 // Helper to get styling and icons for different traffic sources/steps
 function getStepFormat(stepName: string) {
+  // Normalize string for safety
   const normalized = stepName.toLowerCase();
-
+  
   if (normalized.includes("google ads")) {
     return { icon: Megaphone, colorClass: "bg-blue-500/15 text-blue-600 dark:text-blue-400 border-blue-500/20" };
   }
@@ -52,7 +53,8 @@ function getStepFormat(stepName: string) {
   if (normalized.includes("support")) {
     return { icon: Headset, colorClass: "bg-cyan-500/15 text-cyan-600 dark:text-cyan-400 border-cyan-500/20" };
   }
-
+  
+  // Default
   return { icon: ArrowRight, colorClass: "bg-secondary text-secondary-foreground border-border/40" };
 }
 
@@ -68,25 +70,18 @@ function formatChannelName(ch: string): string {
   return ch;
 }
 
-function fmt$(n: number) {
-  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
-  return `$${n.toFixed(0)}`;
-}
-
 export function PathExploration({ paths, journeys }: PathExplorationProps) {
-  const [selectedPathIdx, setSelectedPathIdx] = useState<number | null>(null);
+  const [selectedPath, setSelectedPath] = useState<{ rawSequence: string[]; displaySequence: string[] } | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const chartData = useMemo(() => {
     return paths.slice(0, 10).map((path, idx) => {
-      // path.sequence is the runtime field (array of channel IDs)
-      const rawSequence: string[] = (path as unknown as { sequence: string[] }).sequence ?? [];
-      const sequenceNames = rawSequence.map(formatChannelName);
+      const sequenceNames = path.sequence.map(formatChannelName);
       return {
         id: `path-${idx}`,
-        rawSequence,
-        sequenceStr: sequenceNames.join(" \u2192 "),
+        sequenceStr: sequenceNames.join(" → "),
         sequenceArray: sequenceNames,
+        rawSequence: path.sequence as string[],
         count: path.count,
         kanbanCards: path.kanbanCards,
         freeTrials: path.freeTrials,
@@ -97,53 +92,58 @@ export function PathExploration({ paths, journeys }: PathExplorationProps) {
     });
   }, [paths]);
 
-  // Match journeys to the selected path
-  const matchingJourneys = useMemo(() => {
-    if (selectedPathIdx == null || !journeys) return [];
-    const row = chartData[selectedPathIdx];
-    if (!row) return [];
-    const pathKey = row.rawSequence.join(" \u2192 ");
-    return journeys.filter((j) => {
-      const channels = [...new Set(j.touchpoints.map((tp) => tp.channel))];
-      return channels.join(" \u2192 ") === pathKey;
-    });
-  }, [selectedPathIdx, journeys, chartData]);
+  const sankeyPaths = useMemo<PathData[]>(() => {
+    return chartData.map((row) => ({
+      stages: row.sequenceArray,
+      count: row.count,
+    }));
+  }, [chartData]);
 
-  const selectedRow = selectedPathIdx != null ? chartData[selectedPathIdx] : null;
+  const matchedJourneys = useMemo(() => {
+    if (!selectedPath || !journeys?.length) return [];
+    return matchJourneysToPath(journeys, selectedPath.rawSequence as never);
+  }, [selectedPath, journeys]);
+
+  function openDrawerForPath(rawSequence: string[], displaySequence: string[]) {
+    setSelectedPath({ rawSequence, displaySequence });
+    setDrawerOpen(true);
+  }
+
+  function closeDrawer() {
+    setDrawerOpen(false);
+    setSelectedPath(null);
+  }
 
   if (!chartData || chartData.length === 0) {
     return (
-      <DrilldownPanel
-        title="Path Exploration"
-        subtitle="Top conversion paths by customer journey"
-        isEmpty
-        emptyMessage="No journey path data available."
-      >
-        <span />
-      </DrilldownPanel>
+      <DashboardSectionCard title="Path Exploration">
+        <div className="flex items-center justify-center py-16 text-sm text-muted-foreground">
+          No journey path data available.
+        </div>
+      </DashboardSectionCard>
     );
   }
 
   return (
     <>
-      <DrilldownPanel
-        title="Path Exploration"
-        subtitle="Top conversion paths by customer journey"
-        csvExport={{
-          filename: `path-exploration-${new Date().toISOString().slice(0, 10)}.csv`,
-          headers: ["Path", "Accounts", "Kanban Actions", "Free Trials", "Demos", "Avg Days to Close", "Average Value"],
-          rows: () =>
-            chartData.map((row) => [
-              row.sequenceStr,
-              String(row.count),
-              String(row.kanbanCards),
-              String(row.freeTrials),
-              String(row.demos),
-              String(row.avgDays),
-              String(row.value),
-            ]),
-        }}
-      >
+      <DashboardSectionCard title="Path Exploration">
+        {/* Sankey visualization */}
+        <div className="mb-6">
+          <p className="mb-2 text-xs text-muted-foreground">
+            Top path flow — click a connection to see matching deals
+          </p>
+          <PathSankeyDiagram
+            paths={sankeyPaths}
+            topN={10}
+            onPathClick={(stages) => {
+              const key = stages.join("|");
+              const matchedRow = chartData.find((row) => row.sequenceArray.join("|") === key);
+              openDrawerForPath(matchedRow?.rawSequence ?? stages, stages);
+            }}
+            className="rounded-lg border border-border/40 bg-muted/20 px-4 py-3"
+          />
+        </div>
+
         <div className="overflow-x-auto pb-4">
           <table className="w-full text-sm">
             <thead>
@@ -157,37 +157,32 @@ export function PathExploration({ paths, journeys }: PathExplorationProps) {
               </tr>
             </thead>
             <tbody>
-              {chartData.map((row, idx) => (
-                <tr
+              {chartData.map((row) => (
+                <tr 
                   key={row.id}
-                  role={journeys ? "button" : undefined}
-                  tabIndex={journeys ? 0 : undefined}
-                  onClick={journeys ? () => setSelectedPathIdx(idx) : undefined}
-                  onKeyDown={
-                    journeys
-                      ? (e) => {
-                          if (e.key === "Enter" || e.key === " ") {
-                            e.preventDefault();
-                            setSelectedPathIdx(idx);
-                          }
-                        }
-                      : undefined
-                  }
-                  className={`group border-b border-border/40 transition-all hover:bg-gradient-to-r hover:from-muted/40 hover:to-transparent${
-                    journeys ? " cursor-pointer" : ""
-                  }`}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`View deals for path: ${row.sequenceStr}`}
+                  className="group border-b border-border/40 transition-all hover:bg-gradient-to-r hover:from-muted/40 hover:to-transparent cursor-pointer focus-visible:outline-none focus-visible:bg-muted/40"
+                  onClick={() => openDrawerForPath(row.rawSequence, row.sequenceArray)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      openDrawerForPath(row.rawSequence, row.sequenceArray);
+                    }
+                  }}
                 >
                   <td className="py-4 pl-4">
                     <div className="flex flex-wrap items-center gap-x-1.5 gap-y-2 font-medium">
-                      {row.sequenceArray.map((step, stepIdx, arr) => {
+                      {row.sequenceStr.split(" → ").map((step, idx, arr) => {
                         const { icon: Icon, colorClass } = getStepFormat(step);
                         return (
-                          <span key={`${row.id}-${stepIdx}`} className="flex items-center gap-1.5 shrink-0">
+                          <span key={`${row.id}-${idx}`} className="flex items-center gap-1.5 shrink-0">
                             <span className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs shadow-sm transition-transform group-hover:scale-[1.02] ${colorClass}`}>
                               <Icon className="h-3 w-3" />
                               {step}
                             </span>
-                            {stepIdx < arr.length - 1 && (
+                            {idx < arr.length - 1 && (
                               <ArrowRight className="h-3 w-3 text-muted-foreground/50 mx-0.5" />
                             )}
                           </span>
@@ -233,81 +228,14 @@ export function PathExploration({ paths, journeys }: PathExplorationProps) {
             </tbody>
           </table>
         </div>
-      </DrilldownPanel>
+      </DashboardSectionCard>
 
-      {/* Path detail drawer */}
-      <DrilldownDrawer
-        open={selectedPathIdx != null}
-        onClose={() => setSelectedPathIdx(null)}
-        title="Path Detail"
-        subtitle={selectedRow ? `${selectedRow.sequenceStr} \u2014 ${selectedRow.count} accounts` : ""}
-      >
-        {selectedRow && (
-          <div className="space-y-4">
-            {/* Path summary stats */}
-            <div className="grid grid-cols-2 gap-3">
-              <div className="rounded-lg border border-border/60 px-3 py-2">
-                <p className="text-[11px] text-muted-foreground">Accounts</p>
-                <p className="text-lg font-semibold text-foreground">{selectedRow.count}</p>
-              </div>
-              <div className="rounded-lg border border-border/60 px-3 py-2">
-                <p className="text-[11px] text-muted-foreground">Avg Value</p>
-                <p className="text-lg font-semibold text-foreground">${selectedRow.value.toLocaleString()}</p>
-              </div>
-              <div className="rounded-lg border border-border/60 px-3 py-2">
-                <p className="text-[11px] text-muted-foreground">Avg Days to Close</p>
-                <p className="text-lg font-semibold text-foreground">{selectedRow.avgDays}d</p>
-              </div>
-              <div className="rounded-lg border border-border/60 px-3 py-2">
-                <p className="text-[11px] text-muted-foreground">Demos</p>
-                <p className="text-lg font-semibold text-foreground">{selectedRow.demos}</p>
-              </div>
-            </div>
-
-            {/* Matching journeys list */}
-            <div>
-              <h4 className="mb-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                Matching Journeys ({matchingJourneys.length})
-              </h4>
-              {matchingJourneys.length === 0 ? (
-                <p className="py-4 text-center text-xs text-muted-foreground">
-                  {journeys ? "No matching journeys found for this path." : "Journey data not available for drill-down."}
-                </p>
-              ) : (
-                <div className="space-y-2">
-                  {matchingJourneys.slice(0, 30).map((j) => (
-                    <div key={j.dealId} className="rounded-lg border border-border/60 px-3 py-2.5">
-                      <p className="text-sm font-medium text-foreground">{j.dealName}</p>
-                      <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
-                        <span className="flex items-center gap-1">
-                          <Route className="h-3 w-3" />
-                          {j.touchpoints.length} touches
-                        </span>
-                        <span className="flex items-center gap-1">
-                          <Calendar className="h-3 w-3" />
-                          {j.daysInPipeline}d in pipeline
-                        </span>
-                        <span className="flex items-center gap-1">
-                          <DollarSign className="h-3 w-3" />
-                          {fmt$(j.value)}
-                        </span>
-                      </div>
-                      <p className="mt-1 text-[11px] text-muted-foreground">
-                        {j.currentStage} · {j.contactEmail ?? "No contact"}
-                      </p>
-                    </div>
-                  ))}
-                  {matchingJourneys.length > 30 && (
-                    <p className="text-center text-xs text-muted-foreground">
-                      Showing 30 of {matchingJourneys.length} journeys.
-                    </p>
-                  )}
-                </div>
-              )}
-            </div>
-          </div>
-        )}
-      </DrilldownDrawer>
+      <PathDetailDrawer
+        open={drawerOpen}
+        onClose={closeDrawer}
+        pathStages={selectedPath?.displaySequence ?? []}
+        journeys={matchedJourneys}
+      />
     </>
   );
 }

--- a/src/lib/analytics/path-matching.test.ts
+++ b/src/lib/analytics/path-matching.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { matchJourneysToPath } from "./path-matching";
+import type { CustomerJourneyRecord } from "@/lib/analytics/types";
+
+function makeJourney(overrides: Partial<CustomerJourneyRecord> & { channels: string[] }): CustomerJourneyRecord {
+  const { channels, ...rest } = overrides;
+  return {
+    dealId: "deal-1",
+    dealName: "Test Deal",
+    contactEmail: null,
+    currentStage: "Closed Won",
+    value: 10000,
+    touchpoints: channels.map((ch, i) => ({
+      timestamp: `2026-01-0${i + 1}T00:00:00Z`,
+      phase: "crm",
+      channel: ch as never,
+      type: "engagement",
+      detail: ch,
+      value: null,
+    })),
+    firstTouch: "2026-01-01T00:00:00Z",
+    lastTouch: "2026-01-10T00:00:00Z",
+    daysInPipeline: 10,
+    ...rest,
+  };
+}
+
+const journeys: CustomerJourneyRecord[] = [
+  makeJourney({ dealId: "1", dealName: "Acme Corp", value: 50000, channels: ["google-ads", "hubspot", "stripe"] }),
+  makeJourney({ dealId: "2", dealName: "Beta Inc", value: 30000, channels: ["meta-ads", "hubspot"] }),
+  makeJourney({ dealId: "3", dealName: "Gamma LLC", value: 75000, channels: ["google-ads", "meta-ads", "hubspot", "stripe"] }),
+  makeJourney({ dealId: "4", dealName: "Delta Co", value: 20000, channels: ["hubspot"] }),
+];
+
+describe("matchJourneysToPath", () => {
+  it("returns journeys whose channel sequence starts with the target path", () => {
+    // Journey "2" has sequence ["meta-ads", "hubspot"] — exact match
+    // Journey "3" has sequence ["google-ads", "meta-ads", "hubspot", "stripe"] — contains it as subseq
+    const result = matchJourneysToPath(journeys, ["meta-ads", "hubspot"] as never);
+    const ids = result.map((j) => j.id);
+    expect(ids).toContain("2");
+    expect(ids).toContain("3");
+  });
+
+  it("does not return journeys whose channel sequence does not contain the target", () => {
+    // Journey "4" only has ["hubspot"], no meta-ads
+    const result = matchJourneysToPath(journeys, ["meta-ads", "hubspot"] as never);
+    const ids = result.map((j) => j.id);
+    expect(ids).not.toContain("4");
+  });
+
+  it("returns multiple journeys when several match", () => {
+    const result = matchJourneysToPath(journeys, ["hubspot"] as never);
+    expect(result.length).toBe(4);
+  });
+
+  it("returns empty array when no journeys match", () => {
+    const result = matchJourneysToPath(journeys, ["pylon"] as never);
+    expect(result.length).toBe(0);
+  });
+
+  it("returns empty array for empty path", () => {
+    const result = matchJourneysToPath(journeys, []);
+    expect(result.length).toBe(0);
+  });
+
+  it("returns empty array for empty journeys", () => {
+    const result = matchJourneysToPath([], ["hubspot"] as never);
+    expect(result.length).toBe(0);
+  });
+
+  it("handles single-stage path", () => {
+    const result = matchJourneysToPath(journeys, ["stripe"] as never);
+    const ids = result.map((j) => j.id);
+    expect(ids).toContain("1");
+    expect(ids).toContain("3");
+    expect(ids).not.toContain("2");
+    expect(ids).not.toContain("4");
+  });
+
+  it("returns only display fields, not full journey", () => {
+    const result = matchJourneysToPath(journeys, ["google-ads", "hubspot"] as never);
+    expect(result.length).toBeGreaterThan(0);
+    const first = result[0];
+    expect(first.id).toBeTruthy();
+    expect(first.dealName).toBeTruthy();
+    expect(typeof first.value).toBe("number");
+    expect(typeof first.daysInPipeline).toBe("number");
+    expect("touchpoints" in first).toBe(false);
+    expect("stageHistory" in first).toBe(false);
+  });
+
+  it("deduplicates repeated channels before matching", () => {
+    const withRepeats = [
+      makeJourney({ dealId: "5", channels: ["hubspot", "stripe", "hubspot", "google-ads"] }),
+    ];
+    // Deduped sequence is: hubspot, stripe, google-ads
+    const result = matchJourneysToPath(withRepeats, ["stripe", "google-ads"] as never);
+    expect(result.length).toBe(1);
+  });
+
+  it("does not match non-contiguous subsequences", () => {
+    // Journey has google-ads → hubspot → stripe
+    // Looking for google-ads → stripe (non-contiguous, skipping hubspot)
+    const result = matchJourneysToPath(
+      [makeJourney({ dealId: "6", channels: ["google-ads", "hubspot", "stripe"] })],
+      ["google-ads", "stripe"] as never,
+    );
+    // google-ads and stripe are NOT contiguous in that journey, so no match
+    expect(result.length).toBe(0);
+  });
+});

--- a/src/lib/analytics/path-matching.ts
+++ b/src/lib/analytics/path-matching.ts
@@ -1,0 +1,69 @@
+import type { CustomerJourneyRecord, TouchpointChannel } from "@/lib/analytics/types";
+
+export interface MatchedJourney {
+  id: string;
+  dealName: string;
+  contactEmail: string | null;
+  value: number;
+  currentStage: string;
+  daysInPipeline: number;
+  lastTouch: string;
+}
+
+/**
+ * Derives the ordered, deduplicated channel sequence from a journey's touchpoints.
+ * Mirrors the logic in buildTopPaths in customer-journey.ts.
+ */
+function getJourneySequence(journey: CustomerJourneyRecord): TouchpointChannel[] {
+  const seen = new Set<TouchpointChannel>();
+  const result: TouchpointChannel[] = [];
+  for (const tp of journey.touchpoints) {
+    if (!seen.has(tp.channel)) {
+      seen.add(tp.channel);
+      result.push(tp.channel);
+    }
+  }
+  return result;
+}
+
+/**
+ * Given a list of customer journey records and a target path (ordered channel sequence),
+ * returns all journeys whose deduplicated channel sequence contains the path as a
+ * contiguous subsequence.
+ *
+ * Mirrors the grouping logic in buildTopPaths so clicking a path row shows the
+ * journeys that contributed to it.
+ */
+export function matchJourneysToPath(
+  journeys: CustomerJourneyRecord[],
+  pathChannels: TouchpointChannel[],
+): MatchedJourney[] {
+  if (!pathChannels.length || !journeys.length) return [];
+
+  return journeys
+    .filter((journey) => {
+      const seq = getJourneySequence(journey);
+      if (seq.length < pathChannels.length) return false;
+
+      for (let i = 0; i <= seq.length - pathChannels.length; i++) {
+        let match = true;
+        for (let j = 0; j < pathChannels.length; j++) {
+          if (seq[i + j] !== pathChannels[j]) {
+            match = false;
+            break;
+          }
+        }
+        if (match) return true;
+      }
+      return false;
+    })
+    .map(({ dealId, dealName, contactEmail, value, currentStage, daysInPipeline, lastTouch }) => ({
+      id: dealId,
+      dealName,
+      contactEmail,
+      value,
+      currentStage,
+      daysInPipeline,
+      lastTouch,
+    }));
+}

--- a/src/lib/analytics/sankey-layout.ts
+++ b/src/lib/analytics/sankey-layout.ts
@@ -1,0 +1,194 @@
+export interface PathData {
+  stages: string[];
+  count: number;
+  value?: number;
+}
+
+export interface SankeyConfig {
+  width: number;
+  height: number;
+  nodeWidth: number;
+  nodePadding: number;
+  topN: number;
+}
+
+export interface SankeyNode {
+  id: string;
+  label: string;
+  column: number;
+  x: number;
+  y: number;
+  height: number;
+  totalFlow: number;
+}
+
+export interface SankeyLink {
+  id: string;
+  sourceId: string;
+  targetId: string;
+  sourceLabel: string;
+  targetLabel: string;
+  value: number;
+  sourceY: number;
+  targetY: number;
+  path: string;
+}
+
+export interface SankeyLayout {
+  nodes: SankeyNode[];
+  links: SankeyLink[];
+  totalFlow: number;
+}
+
+export function computeSankeyLayout(
+  paths: PathData[],
+  config: SankeyConfig,
+): SankeyLayout {
+  const { width, height, nodeWidth, nodePadding, topN } = config;
+
+  if (!paths.length) return { nodes: [], links: [], totalFlow: 0 };
+
+  // Take top N paths by count
+  const topPaths = [...paths].sort((a, b) => b.count - a.count).slice(0, topN);
+
+  // Find max path length (number of columns)
+  const maxCols = Math.max(...topPaths.map((p) => p.stages.length));
+  if (maxCols < 2) return { nodes: [], links: [], totalFlow: 0 };
+
+  // Build node map: key = "stageName|column"
+  const nodeMap = new Map<string, { totalFlow: number; column: number; label: string }>();
+
+  for (const path of topPaths) {
+    for (let col = 0; col < path.stages.length; col++) {
+      const key = `${path.stages[col]}|${col}`;
+      const existing = nodeMap.get(key) ?? { totalFlow: 0, column: col, label: path.stages[col] };
+      existing.totalFlow += path.count;
+      nodeMap.set(key, existing);
+    }
+  }
+
+  // Group nodes by column to compute vertical positions
+  const byColumn = new Map<number, Array<{ key: string; totalFlow: number; label: string }>>();
+  for (const [key, node] of nodeMap) {
+    const col = node.column;
+    if (!byColumn.has(col)) byColumn.set(col, []);
+    byColumn.get(col)!.push({ key, totalFlow: node.totalFlow, label: node.label });
+  }
+
+  const totalFlow = topPaths.reduce((sum, p) => sum + p.count, 0);
+  const availableHeight = height - nodePadding * (maxCols - 1);
+
+  // Assign x/y positions to nodes
+  const nodes: SankeyNode[] = [];
+  const nodePositions = new Map<string, SankeyNode>();
+
+  for (let col = 0; col < maxCols; col++) {
+    const colNodes = byColumn.get(col) ?? [];
+    const colTotal = colNodes.reduce((sum, n) => sum + n.totalFlow, 0);
+
+    // X position: evenly spaced across width
+    const x = maxCols === 1 ? 0 : col * ((width - nodeWidth) / (maxCols - 1));
+
+    // Distribute node heights proportionally to their flow
+    const totalNodeHeight = availableHeight * (colTotal / totalFlow);
+    const nodeCount = colNodes.length;
+    const totalPadding = nodePadding * (nodeCount - 1);
+    const netHeight = Math.max(totalNodeHeight - totalPadding, nodeCount * 10);
+
+    let yOffset = (height - netHeight - totalPadding) / 2;
+
+    // Sort nodes by flow descending for stable layout
+    colNodes.sort((a, b) => b.totalFlow - a.totalFlow);
+
+    for (const colNode of colNodes) {
+      const nodeHeight = Math.max((colNode.totalFlow / colTotal) * netHeight, 10);
+      const node: SankeyNode = {
+        id: colNode.key,
+        label: colNode.label,
+        column: col,
+        x,
+        y: yOffset,
+        height: nodeHeight,
+        totalFlow: colNode.totalFlow,
+      };
+      nodes.push(node);
+      nodePositions.set(colNode.key, node);
+      yOffset += nodeHeight + nodePadding;
+    }
+  }
+
+  // Build links between consecutive stage pairs
+  const linkMap = new Map<string, { value: number; sourceId: string; targetId: string; sourceLabel: string; targetLabel: string }>();
+
+  for (const path of topPaths) {
+    for (let i = 0; i < path.stages.length - 1; i++) {
+      const srcKey = `${path.stages[i]}|${i}`;
+      const tgtKey = `${path.stages[i + 1]}|${i + 1}`;
+      const linkKey = `${srcKey}→${tgtKey}`;
+      const existing = linkMap.get(linkKey) ?? { value: 0, sourceId: srcKey, targetId: tgtKey, sourceLabel: path.stages[i], targetLabel: path.stages[i + 1] };
+      existing.value += path.count;
+      linkMap.set(linkKey, existing);
+    }
+  }
+
+  // Track used offsets on each node for link positioning
+  const sourceOffsets = new Map<string, number>();
+  const targetOffsets = new Map<string, number>();
+
+  const links: SankeyLink[] = [];
+  for (const [linkKey, link] of linkMap) {
+    const srcNode = nodePositions.get(link.sourceId);
+    const tgtNode = nodePositions.get(link.targetId);
+    if (!srcNode || !tgtNode) continue;
+
+    const srcOffset = sourceOffsets.get(link.sourceId) ?? 0;
+    const tgtOffset = targetOffsets.get(link.targetId) ?? 0;
+
+    const linkHeight = Math.max((link.value / srcNode.totalFlow) * srcNode.height, 2);
+
+    const sourceY = srcNode.y + srcOffset;
+    const targetY = tgtNode.y + tgtOffset;
+
+    sourceOffsets.set(link.sourceId, srcOffset + linkHeight);
+    targetOffsets.set(link.targetId, tgtOffset + linkHeight);
+
+    links.push({
+      id: linkKey,
+      sourceId: link.sourceId,
+      targetId: link.targetId,
+      sourceLabel: link.sourceLabel,
+      targetLabel: link.targetLabel,
+      value: link.value,
+      sourceY,
+      targetY,
+      path: buildLinkPath(srcNode.x, sourceY, linkHeight, tgtNode.x, targetY, linkHeight, nodeWidth),
+    });
+  }
+
+  return { nodes, links, totalFlow };
+}
+
+function buildLinkPath(
+  sx: number,
+  sy: number,
+  sh: number,
+  tx: number,
+  ty: number,
+  th: number,
+  nodeWidth: number,
+): string {
+  const x0 = sx + nodeWidth;
+  const x1 = tx;
+  const xi = (x0 + x1) / 2;
+  const y0top = sy;
+  const y0bot = sy + sh;
+  const y1top = ty;
+  const y1bot = ty + th;
+  return [
+    `M${x0},${y0top}`,
+    `C${xi},${y0top} ${xi},${y1top} ${x1},${y1top}`,
+    `L${x1},${y1bot}`,
+    `C${xi},${y1bot} ${xi},${y0bot} ${x0},${y0bot}`,
+    "Z",
+  ].join(" ");
+}

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -1012,7 +1012,7 @@ export interface TouchpointSummary {
 }
 
 export interface JourneyPath {
-  segments: Array<{ phase: BuyerJourneyPhase; channels: TouchpointChannel[] }>;
+  sequence: TouchpointChannel[];
   count: number;
   kanbanCards: number;
   freeTrials: number;


### PR DESCRIPTION
## Commits
- fix(analytics): update onClose ref in effect
- test(#146): add PathDetailDrawer component tests
- feat(#146): interactive path drill-downs & sankey visualization

## Files changed
 src/components/analytics/dismiss-undo-toast.tsx    |   4 +-
 .../analytics/path-detail-drawer.test.tsx          | 184 ++++++++++++++++
 src/components/analytics/path-detail-drawer.tsx    | 171 +++++++++++++++
 .../analytics/path-exploration-drilldown.test.tsx  | 136 ++++++++++++
 .../analytics/path-sankey-diagram.test.tsx         |  69 ++++++
 src/components/analytics/path-sankey-diagram.tsx   | 136 ++++++++++++
 .../analytics/sub-dashboards/path-exploration.tsx  | 234 +++++++--------------
 src/lib/analytics/path-matching.test.ts            | 112 ++++++++++
 src/lib/analytics/path-matching.ts                 |  69 ++++++
 src/lib/analytics/sankey-layout.ts                 | 194 +++++++++++++++++
 src/lib/analytics/types.ts                         |   2 +-
 11 files changed, 1156 insertions(+), 155 deletions(-)

_Surfaced while triaging unmerged branches during repo cleanup. May need a rebase on current `main`._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
