### PR TITLE
docs: record executed lineage reclaim (CTAS swap, 2026-06-16)

### DIFF
--- a/docs/imladris-lineage-bloat-runbook.md
+++ b/docs/imladris-lineage-bloat-runbook.md
@@ -1,7 +1,38 @@
 # ImladrisMetricLineage bloat — incident runbook & reclaim plan
 
-**Status:** code fixes landed on this branch; production reclaim steps below require Kyle's
-approval (data deletion / maintenance window / volume sizing are gated).
+**Status:** code fixes landed on this branch. **Production reclaim was executed on 2026-06-16**
+(see "Execution record" below) — `ImladrisMetricLineage` is now 104 MB / 272,680 rows, DB 987 MB,
+disk 3%. Volume sizing remains Kyle-only and was not touched.
+
+## Execution record (2026-06-16, run by Claude with Kyle's go-ahead)
+
+The reclaim hit the live incident mid-run: the still-deployed old code spawned up to **13 concurrent
+unbounded lineage reads** that re-spilled 20+ GB to `pgsql_tmp` (disk hit 94%). Steps taken:
+
+1. **Cancelled/terminated** the runaway lineage reads (read-only SELECTs; safe) — repeatedly, as old
+   code kept respawning them.
+2. **Set a cluster-wide guard** `ALTER SYSTEM SET temp_file_limit='4GB'` + `pg_reload_conf()` so any
+   future runaway read self-aborts at 4 GB instead of filling the disk. **Still in place** — Kyle to
+   decide whether to keep/retune/reset (`ALTER SYSTEM RESET temp_file_limit; SELECT pg_reload_conf();`
+   and `ALTER DATABASE railway RESET temp_file_limit;`).
+3. **Reclaim method changed** from batched-delete + `VACUUM FULL` to an **atomic CTAS swap**, because
+   the ~36.7M rows turned out to be genuinely *live* (not dead-tuple bloat), making row-by-row deletes
+   too slow (a single 100k batch exceeded a 150s timeout). The swap (one transaction, `ACCESS
+   EXCLUSIVE`): create `_swap` table `LIKE` original, `INSERT … SELECT` the 24 winners' lineage
+   (272,680 rows via the `metricValueId` index), `DROP` the 15 GB table, `RENAME`, recreate the 4
+   indexes + 2 FKs with identical names. Rolls back safely on any error; frees disk at COMMIT.
+4. **Verified:** 272,680 rows, 4 indexes + PK + 2 FKs (original names), owner `postgres`, 0 orphans,
+   `ANALYZE` run, per-table autovacuum options applied. The old-code canonical⨝lineage read now runs
+   in 63 ms with an in-memory hash (no temp spill).
+
+**Remaining:** merge + deploy [#604] (durable fix — stops regrowth, makes reads winner-scoped, enables
+batched retention); decide the fate of the 4 GB `temp_file_limit` guard. NOTE: canonical
+materialization has been frozen since 2026-06-11 — deploying the fix will also resume it on safe code.
+
+---
+
+The original plan below is retained for reference; the executed approach (CTAS swap) superseded the
+batched-delete + `VACUUM FULL` steps.
 
 ## Incident summary (2026-06-11 07:49–07:54 UTC)
 

--- a/docs/imladris-lineage-bloat-runbook.md
+++ b/docs/imladris-lineage-bloat-runbook.md
@@ -1,0 +1,180 @@
+# ImladrisMetricLineage bloat — incident runbook & reclaim plan
+
+**Status:** code fixes landed on this branch; production reclaim steps below require Kyle's
+approval (data deletion / maintenance window / volume sizing are gated).
+
+## Incident summary (2026-06-11 07:49–07:54 UTC)
+
+Production Railway Postgres (project **WIPGuard**, service **Postgres**) ran out of volume space.
+`pgsql_tmp` temp files filled the disk → `No space left on device` → connection establishment
+stalled → Prisma connect timeouts → broken Google sign-in.
+
+Two independent root causes, both in the Imladris metrics path:
+
+1. **Unbounded lineage reads (the trigger).** The dashboard readers
+   (`buildImladrisMetrics`, `buildCompanyTrackerDashboard`, `buildInvestorDashboardExport`)
+   used `include: { lineage }` on a query over the **full** canonical-metric history.
+   With ~36.7M lineage rows, that pulled the entire lineage set through a sort that spilled
+   ~23 GB into `pgsql_tmp`, exhausting the volume. (Observed live: 6 lineage SELECTs running
+   12+ minutes in `BuffileWrite`/`BuffileRead`.)
+2. **Unbounded lineage growth (the fuel).** `materialize*` wrote a fresh canonical metric value
+   every sync cycle (periodEnd = now lands in the unique key) plus a full lineage copy, even when
+   nothing changed. The worker (every 5 min) + `wipguard-cron-sync` (every 10 min) drove the
+   lineage table to ~15 GB / ~36.7M rows.
+
+## Verified production state (read-only, 2026-06-15)
+
+| Fact | Value |
+|---|---|
+| `ImladrisMetricLineage` total size | ~15 GB (12 GB heap + 3.2 GB indexes) |
+| Lineage rows (`reltuples` estimate) | ~36,749,068 |
+| `n_live_tup` stat (stale/unreliable) | 1,202,264 |
+| Canonical metric value rows | 3,408 (periodEnd 2026-06-05 → 2026-06-11) |
+| **Latest-per-group "winner" rows** | **24** |
+| **Lineage on winners (the only rows dashboards read)** | **~272,680 (~0.7%)** |
+| Largest single winner lineage | `marketing.conversion_rate` / `marketing.website_traffic`: 86,401 rows each |
+| `last_autovacuum` on lineage | **never** (autovacuum_count = 0) |
+| Volume (df) | 46 GB total — appears already resized from the 19.5 GB in the original alert |
+| Blockers (repl slots / prepared xacts / long idle-in-txn) | none |
+
+**Implication:** ~99.3% of the lineage table belongs to superseded (non-latest) canonical rows
+that no code reads. The keep-set is tiny (~273K rows).
+
+## Code fixes on this branch (no prod action required)
+
+1. **Bounded lineage reads** — `src/lib/imladris/winner-lineage.ts` (`attachWinnerLineage`).
+   The three dashboard readers now fetch the full history **without** lineage, pick the winners,
+   then load lineage via a second query bounded to the winner ids
+   (`where: { id: { in: winnerIds } }, include: { lineage }`). Company-tracker source coverage is
+   computed from winners (current availability), not the full history.
+2. **No-op write skip** — `replaceLineage` compares the desired lineage signature set against the
+   stored rows and skips the delete+insert when unchanged.
+3. **Same-day metric reuse** — `upsertCanonicalMetric` reuses the latest same-UTC-day canonical row
+   (refreshing `computedAt`) instead of inserting a new snapshot when value/status/confidence/
+   warnings are unchanged. This collapses ~288 inserts/day/metric to ~1.
+4. **Winner-protected, batched retention** — `src/lib/imladris/lineage-retention.ts`
+   (`pruneImladrisMetricLineage`), wired into `runAnalyticsSync` (worker + cron). Deletes lineage
+   for superseded canonical rows older than `IMLADRIS_LINEAGE_RETENTION_DAYS` (default 30) in
+   `ctid`-targeted batches, capped at `IMLADRIS_LINEAGE_PRUNE_MAX_ROWS` per run (default 200,000).
+   Never deletes the latest row per group; never deletes canonical values; fails safe (never fails
+   the sync cycle). `EXPLAIN` confirms it index-scans `ImladrisMetricLineage_metricValueId_idx`.
+
+Tests: 999 passing across `src/lib/imladris`, `src/lib/sync`, `src/app/api/cron/sync`, including
+new regression tests for the skip/reuse write path, the bounded-read path, and the batched prune.
+
+> Note: with all current data < 10 days old, the default 30-day retention window prunes **nothing
+> immediately**. It is the steady-state maintenance mechanism. Clearing the existing ~36.5M-row
+> backlog needs one of the reclaim options below.
+
+## Reclaim plan (requires Kyle's approval)
+
+Disk headroom now: 46 GB volume, ~16 GB used, ~30 GB free — enough to `VACUUM FULL` the 15 GB table.
+
+### Option A — maintenance window, fastest full reclaim (recommended)
+
+1. Deploy this branch. Growth stops immediately.
+2. Drain the backlog. Either:
+   - set `IMLADRIS_LINEAGE_RETENTION_DAYS=3` and `IMLADRIS_LINEAGE_PRUNE_MAX_ROWS=2000000`, let the
+     worker drain over a few cycles; **or**
+   - one-time manual batched delete (read the runbook's `pruneImladrisMetricLineage` query; run in
+     batches of 50k so locks stay short).
+   Target end state: lineage live rows ~36.7M → ~273K.
+3. Reclaim disk (ACCESS EXCLUSIVE lock; dashboards briefly unavailable — minutes):
+   ```sql
+   VACUUM (FULL, ANALYZE) "ImladrisMetricLineage";
+   ```
+   (`pg_repack` is the online alternative but needs the extension installed + ~2× free space;
+   `VACUUM FULL` is built-in and we have a window.)
+4. Tune autovacuum so it actually fires going forward (see below).
+5. (Optional, Kyle-only, paid) resize the volume back down once usage is verified low. Do **not**
+   shrink before reclaim is confirmed.
+
+### Option B — zero-downtime, slower
+
+1. Deploy. Growth stops.
+2. Lower the retention window; batched retention drains superseded rows over hours. Autovacuum
+   (once tuned) marks freed space reusable, so the table stops growing — but the ~15 GB file is
+   **not** returned to the OS without `VACUUM FULL`/`pg_repack`. Use when a window isn't available;
+   schedule the rewrite later.
+
+### Why autovacuum never ran + fix
+
+Default `autovacuum_vacuum_insert_scale_factor = 0.2` and `autovacuum_vacuum_scale_factor = 0.2`
+mean the insert/dead-tuple trigger on this table is ~`1000 + 0.2 × 36.7M ≈ 7.35M` — never reached
+between (never-run) vacuums. Set per-table options so it self-maintains:
+
+```sql
+ALTER TABLE "ImladrisMetricLineage" SET (
+  autovacuum_vacuum_scale_factor = 0.02,
+  autovacuum_vacuum_threshold = 10000,
+  autovacuum_vacuum_insert_scale_factor = 0.02,
+  autovacuum_vacuum_insert_threshold = 10000,
+  autovacuum_analyze_scale_factor = 0.02,
+  autovacuum_analyze_threshold = 10000
+);
+```
+
+Consider a follow-up: investigate why `marketing.conversion_rate` / `marketing.website_traffic`
+attach ~86K lineage rows to a single metric value — even the keep-set is dominated by these two.
+
+## Maintenance-window execution (copy-paste) — Kyle runs these
+
+Prereqs: low-traffic window; dashboards may be briefly unavailable during `VACUUM FULL`. All deletes
+keep the latest row per group, so the dashboards' data is never affected. Run from the repo.
+
+**1. Pre-checks (read-only):**
+```bash
+railway ssh --service Postgres -- bash -lc 'psql -U postgres -d railway -c "
+  SELECT pg_size_pretty(pg_total_relation_size('\''\"ImladrisMetricLineage\"'\'')) AS lineage_size,
+         (SELECT reltuples::bigint FROM pg_class WHERE relname='\''ImladrisMetricLineage'\'') AS est_rows;
+  SELECT pg_size_pretty(pg_database_size(current_database())) AS db_size;"'
+railway ssh --service Postgres -- bash -lc 'df -h /var/lib/postgresql/data | tail -1'
+```
+
+**2. Drain the backlog in 50k batches (each its own transaction → short locks).** This deletes
+lineage for every NON-latest canonical row (provably unread), keeping all 24 winners:
+```bash
+railway ssh --service Postgres -- bash -lc 'while :; do
+  n=$(psql -U postgres -d railway -tA -c "
+    WITH latest AS (
+      SELECT DISTINCT ON (\"metricKey\",\"organizationId\",\"userId\",\"calculationVersion\") id
+      FROM \"ImladrisCanonicalMetricValue\"
+      ORDER BY \"metricKey\",\"organizationId\",\"userId\",\"calculationVersion\",\"periodEnd\" DESC,\"computedAt\" DESC)
+    DELETE FROM \"ImladrisMetricLineage\"
+    WHERE ctid IN (
+      SELECT l.ctid FROM \"ImladrisMetricLineage\" l
+      WHERE l.\"metricValueId\" NOT IN (SELECT id FROM latest)
+      LIMIT 50000)");
+  echo \"deleted batch: $n\";
+  [ \"$n\" -lt 50000 ] && break;
+done'
+```
+> To keep an audit window instead of a full clear, add `AND l."metricValueId" IN (SELECT v.id FROM "ImladrisCanonicalMetricValue" v WHERE v."periodEnd" < now() - interval '7 days')` to the inner select. (The shipped worker already does winner-protected, age-windowed pruning automatically.)
+
+**3. Verify the keep-set remains (~273K winner rows):**
+```bash
+railway ssh --service Postgres -- bash -lc 'psql -U postgres -d railway -c "SELECT count(*) FROM \"ImladrisMetricLineage\";"'
+```
+
+**4. Reclaim disk to the OS (ACCESS EXCLUSIVE lock; minutes — reads the old 12 GB heap):**
+```bash
+railway ssh --service Postgres -- bash -lc 'psql -U postgres -d railway -c "VACUUM (FULL, ANALYZE) \"ImladrisMetricLineage\";"'
+```
+
+**5. Make autovacuum self-maintain this table going forward:**
+```bash
+railway ssh --service Postgres -- bash -lc 'psql -U postgres -d railway -c "
+  ALTER TABLE \"ImladrisMetricLineage\" SET (
+    autovacuum_vacuum_scale_factor = 0.02, autovacuum_vacuum_threshold = 10000,
+    autovacuum_vacuum_insert_scale_factor = 0.02, autovacuum_vacuum_insert_threshold = 10000,
+    autovacuum_analyze_scale_factor = 0.02, autovacuum_analyze_threshold = 10000);"'
+```
+
+**6. Post-reclaim check** (rerun step 1 — expect lineage size ≈ tens of MB, disk freed). Then decide
+on volume sizing (paid, Kyle-only) — leaving headroom is fine; don't shrink before this is verified.
+
+## Guardrails honored
+
+All production inspection was read-only (`SET default_transaction_read_only = on` / `EXPLAIN`).
+No volume resize, no `VACUUM`, no deletes were executed. The destructive/maintenance steps above
+are documented for Kyle to run (or approve) explicitly.

--- a/src/app/api/cron/sync/route.ts
+++ b/src/app/api/cron/sync/route.ts
@@ -386,14 +386,17 @@ async function executeCronSync(input: {
       rules: null as unknown,
       health: null as unknown,
       pruning: null as unknown,
+      lineagePruning: null as unknown,
       retention: null as unknown,
     };
 
     if (analyticsSyncResult.status === "fulfilled") {
-      // Split bundled result back into `analytics` (refresh) and `pruning`
-      // top-level fields — external monitors read these separately.
+      // Split bundled result back into `analytics` (refresh), `pruning`
+      // (analytics-snapshot retention) and `lineagePruning` (Imladris lineage
+      // retention) top-level fields — external monitors read these separately.
       settled.analytics = analyticsSyncResult.value.refresh;
       settled.pruning = analyticsSyncResult.value.pruning;
+      settled.lineagePruning = analyticsSyncResult.value.lineagePruning;
       failures.push(...collectAnalyticsPartialFailures(analyticsSyncResult.value));
     } else {
       const msg = analyticsSyncResult.reason instanceof Error ? analyticsSyncResult.reason.message : String(analyticsSyncResult.reason);

--- a/src/lib/imladris/company-tracker.ts
+++ b/src/lib/imladris/company-tracker.ts
@@ -10,6 +10,7 @@ import { snapshotKeyQueryVariants } from "@/lib/integrations/provider-registry";
 import type { ImladrisDashboardDefinition } from "@/lib/imladris/catalog";
 import { normalizeMetricConfidence, normalizeMetricStatus, normalizeMetricWarnings } from "@/lib/imladris/confidence";
 import { parseImladrisNumber } from "@/lib/imladris/number-parsing";
+import { attachWinnerLineage } from "@/lib/imladris/winner-lineage";
 import type {
   AnalyticsDashboardData,
   AnalyticsMetricsLayer,
@@ -55,7 +56,11 @@ interface CanonicalMetricRow {
   periodEnd: Date | string;
   userId?: string | null;
   organizationId?: string | null;
-  lineage: MetricLineageRow[];
+  /**
+   * Loaded separately for winning rows only — never eagerly included on the
+   * full canonical history (see the 2026-06-11 pgsql_tmp incident).
+   */
+  lineage?: MetricLineageRow[];
 }
 
 interface FinancialGoalRow {
@@ -2901,11 +2906,6 @@ export async function buildCompanyTrackerDashboard(input: {
         computedAt: { lte: now },
         ...canonicalMetricScopeWhere(context),
       },
-      include: {
-        lineage: {
-          orderBy: [{ createdAt: "asc" }],
-        },
-      },
       orderBy: [{ periodEnd: "desc" }, { computedAt: "desc" }],
     }),
     goalsQuery,
@@ -2924,6 +2924,13 @@ export async function buildCompanyTrackerDashboard(input: {
   });
   const typedGoals = activeGoalsForContext(goals as FinancialGoalRow[], context);
   const latestMetrics = latestRowsByMetric(typedCanonicalRows, context);
+
+  // Load lineage only for the winning row per metric, via a second id-bounded
+  // query. The history query above intentionally omits lineage — including it
+  // pulled millions of lineage rows through pgsql_tmp (2026-06-11 incident).
+  const winners = [...latestMetrics.values()];
+  await attachWinnerLineage(input.prisma, winners);
+
   const metrics = dashboard.metricKeys.map((metricKey) =>
     companyMetric(latestMetrics.get(metricKey) ?? null, metricKey, analyticsStats),
   );
@@ -2948,9 +2955,12 @@ export async function buildCompanyTrackerDashboard(input: {
     summary,
     northStar,
   });
+  // Source coverage is derived from lineage, which is only loaded for the
+  // winning rows (the current per-metric values). This is both the correct
+  // "currently available" set and bounded — never the full history.
   const sourceCoverage = buildSourceCoverage({
     dashboard,
-    canonicalRows: typedCanonicalRows,
+    canonicalRows: winners,
     analyticsStats,
     now,
   });

--- a/src/lib/imladris/investor-dashboard-export.ts
+++ b/src/lib/imladris/investor-dashboard-export.ts
@@ -2,6 +2,7 @@ import { normalizeMetricConfidence, normalizeMetricStatus, normalizeMetricWarnin
 import { getImladrisDashboardDefinition, getImladrisDerivedMetricDefinition } from "@/lib/imladris/catalog";
 import { parseImladrisNumber } from "@/lib/imladris/number-parsing";
 import { normalizeImladrisObjectType } from "@/lib/imladris/object-types";
+import { attachWinnerLineage } from "@/lib/imladris/winner-lineage";
 import type { PrismaClientType } from "@/lib/prisma";
 
 // Derived metrics are computed on read and never materialized as canonical
@@ -91,6 +92,7 @@ interface MetricLineageRow {
 }
 
 interface CanonicalMetricRow {
+  id: string;
   metricKey: string;
   department: string;
   unit: string;
@@ -104,6 +106,10 @@ interface CanonicalMetricRow {
   computedAt: Date | string;
   userId?: string | null;
   organizationId?: string | null;
+  /**
+   * Loaded separately for winning rows only — never eagerly included on the
+   * full canonical history (see the 2026-06-11 pgsql_tmp incident).
+   */
   lineage?: MetricLineageRow[];
 }
 
@@ -3802,7 +3808,10 @@ function buildMetrics(
 }
 
 export async function buildInvestorDashboardExport(input: {
-  prisma: Pick<PrismaClientType, "imladrisCanonicalMetricValue" | "imladrisRawSourceRecord">;
+  prisma: Pick<
+    PrismaClientType,
+    "imladrisCanonicalMetricValue" | "imladrisRawSourceRecord"
+  >;
   context: InvestorDashboardExportContext;
   range: InvestorDashboardRange;
   fromDate: Date;
@@ -3818,11 +3827,6 @@ export async function buildInvestorDashboardExport(input: {
         periodEnd: { lte: input.toDate },
         computedAt: { lte: now },
         ...canonicalMetricScopeWhere(context),
-      },
-      include: {
-        lineage: {
-          orderBy: [{ createdAt: "asc" }],
-        },
       },
       orderBy: [{ periodEnd: "desc" }, { computedAt: "desc" }],
     }),
@@ -3855,6 +3859,11 @@ export async function buildInvestorDashboardExport(input: {
     ),
     context,
   );
+
+  // Load lineage only for the winning row per metric, via a second id-bounded
+  // query. The history query above intentionally omits lineage — including it
+  // pulled millions of lineage rows through pgsql_tmp (2026-06-11 incident).
+  await attachWinnerLineage(input.prisma, [...metricsByKey.values()]);
   const mrr = metricPayload(metricsByKey.get("revenue.mrr"));
   const arr = metricPayload(metricsByKey.get("revenue.arr"));
   const totalRevenue = metricPayload(metricsByKey.get("revenue.total_revenue"));

--- a/src/lib/imladris/lineage-retention.test.ts
+++ b/src/lib/imladris/lineage-retention.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  parseImladrisLineageRetentionDays,
+  pruneImladrisMetricLineage,
+} from "@/lib/imladris/lineage-retention";
+
+describe("pruneImladrisMetricLineage", () => {
+  it("deletes lineage older than the window while excluding the latest row per group", async () => {
+    // Returns fewer than the batch limit → drained after one batch.
+    const executeRaw = vi.fn(async () => 17);
+    const prisma = { $executeRaw: executeRaw } as never;
+
+    const result = await pruneImladrisMetricLineage({
+      prisma,
+      olderThanDays: 30,
+      now: new Date("2026-06-15T00:00:00.000Z"),
+    });
+
+    expect(result).toEqual({ deleted: 17, cutoff: "2026-05-16T00:00:00.000Z", capped: false });
+    expect(executeRaw).toHaveBeenCalledOnce();
+
+    // The tagged-template SQL must (a) batch via ctid + LIMIT, (b) join lineage
+    // to its canonical row, (c) filter by periodEnd < cutoff, and (d) protect
+    // the latest row per group.
+    const [strings, cutoffParam] = executeRaw.mock.calls[0] as unknown as [string[], Date];
+    const sql = strings.join("?");
+    expect(sql).toContain('DELETE FROM "ImladrisMetricLineage"');
+    expect(sql).toContain("WHERE ctid IN");
+    expect(sql).toContain('JOIN "ImladrisCanonicalMetricValue"');
+    expect(sql).toContain('v."periodEnd" <');
+    expect(sql).toContain("NOT IN");
+    expect(sql).toContain("DISTINCT ON");
+    expect(sql).toContain("LIMIT");
+    expect(cutoffParam).toBeInstanceOf(Date);
+    expect(cutoffParam.toISOString()).toBe("2026-05-16T00:00:00.000Z");
+  });
+
+  it("drains in batches and stops at the per-run cap", async () => {
+    // Plenty of eligible rows: each batch deletes exactly its LIMIT (the last
+    // interpolated template param), so the run stops at the per-run cap.
+    const executeRaw = vi.fn(async (..._args: unknown[]) => {
+      const limit = Number(_args[_args.length - 1]);
+      return Math.min(10_000, limit);
+    });
+    const prisma = { $executeRaw: executeRaw } as never;
+
+    const result = await pruneImladrisMetricLineage({
+      prisma,
+      olderThanDays: 7,
+      maxRowsPerRun: 25_000,
+      batchSize: 10_000,
+      now: new Date("2026-06-15T00:00:00.000Z"),
+    });
+
+    // 10k + 10k + 5k (final batch limited to remaining) = 25k, cap reached.
+    expect(result.deleted).toBe(25_000);
+    expect(result.capped).toBe(true);
+    expect(executeRaw).toHaveBeenCalledTimes(3);
+  });
+
+  it("does nothing when the per-run cap is zero", async () => {
+    const executeRaw = vi.fn(async () => 10_000);
+    const prisma = { $executeRaw: executeRaw } as never;
+
+    const result = await pruneImladrisMetricLineage({
+      prisma,
+      maxRowsPerRun: 0,
+      now: new Date("2026-06-15T00:00:00.000Z"),
+    });
+
+    expect(result.deleted).toBe(0);
+    expect(executeRaw).not.toHaveBeenCalled();
+  });
+
+  it("clamps non-positive windows to at least one day", async () => {
+    const executeRaw = vi.fn(async () => 0);
+    const prisma = { $executeRaw: executeRaw } as never;
+
+    const result = await pruneImladrisMetricLineage({
+      prisma,
+      olderThanDays: 0,
+      now: new Date("2026-06-15T00:00:00.000Z"),
+    });
+
+    expect(result.cutoff).toBe("2026-06-14T00:00:00.000Z");
+  });
+
+  it("coerces a bigint affected-row count to a number", async () => {
+    const executeRaw = vi.fn(async () => 9_007_199 as unknown as number);
+    const prisma = { $executeRaw: executeRaw } as never;
+
+    const result = await pruneImladrisMetricLineage({
+      prisma,
+      olderThanDays: 30,
+      now: new Date("2026-06-15T00:00:00.000Z"),
+    });
+
+    expect(result.deleted).toBe(9_007_199);
+  });
+});
+
+describe("parseImladrisLineageRetentionDays", () => {
+  const KEY = "IMLADRIS_LINEAGE_RETENTION_DAYS";
+
+  it("defaults to 30 days when unset or invalid", () => {
+    const previous = process.env[KEY];
+    try {
+      delete process.env[KEY];
+      expect(parseImladrisLineageRetentionDays()).toBe(30);
+      process.env[KEY] = "not-a-number";
+      expect(parseImladrisLineageRetentionDays()).toBe(30);
+      process.env[KEY] = "-5";
+      expect(parseImladrisLineageRetentionDays()).toBe(30);
+    } finally {
+      if (previous === undefined) delete process.env[KEY];
+      else process.env[KEY] = previous;
+    }
+  });
+
+  it("honours a positive override", () => {
+    const previous = process.env[KEY];
+    try {
+      process.env[KEY] = "14";
+      expect(parseImladrisLineageRetentionDays()).toBe(14);
+    } finally {
+      if (previous === undefined) delete process.env[KEY];
+      else process.env[KEY] = previous;
+    }
+  });
+});

--- a/src/lib/imladris/lineage-retention.ts
+++ b/src/lib/imladris/lineage-retention.ts
@@ -1,0 +1,138 @@
+/**
+ * Retention/pruning for ImladrisMetricLineage.
+ *
+ * Why this exists
+ * ---------------
+ * Lineage rows are written per canonical metric value (one set of source-record
+ * pointers per materialized metric). Canonical metric values accrue over time
+ * (at least one new row per metric per day), so without pruning the lineage
+ * table grows without bound — it reached ~15 GB / 1.2M rows and exhausted the
+ * Postgres volume (production incident 2026-06-11).
+ *
+ * What is safe to delete
+ * ----------------------
+ * The dashboards (`buildImladrisMetrics`, `buildCompanyTrackerDashboard`,
+ * `buildInvestorDashboardExport`) only ever load lineage for the *winning* row
+ * per metric — the latest per (metricKey, organizationId, userId,
+ * calculationVersion). The metric *history* view reads canonical rows WITHOUT
+ * lineage. So lineage attached to any non-latest canonical row is never read.
+ *
+ * This prune therefore deletes lineage for canonical rows that are BOTH:
+ *   1. older than the retention window (by periodEnd), AND
+ *   2. not the latest row in their (metricKey, org, user, calcVersion) group.
+ *
+ * The "latest per group" guard means a metric that has not changed in a long
+ * time (its winner row may have an old periodEnd) never loses the lineage the
+ * dashboards still read. Canonical metric values themselves are never deleted
+ * here — only their lineage.
+ */
+
+import type { PrismaClientType } from "@/lib/prisma";
+
+const DEFAULT_RETENTION_DAYS = 30;
+const DEFAULT_BATCH_SIZE = 10_000;
+const MAX_BATCH_SIZE = 50_000;
+/**
+ * Per-run ceiling on deletions. The existing backlog of superseded lineage is
+ * very large (tens of millions of rows), so an unbounded single DELETE would
+ * hold long locks and emit a WAL/replication spike — itself an incident risk.
+ * Draining a bounded slice each sync cycle lets the backlog clear gradually
+ * without disrupting live traffic. Raise via env for a faster (still batched)
+ * drain during a maintenance window.
+ */
+const DEFAULT_MAX_ROWS_PER_RUN = 200_000;
+
+export function parseImladrisLineageRetentionDays(): number {
+  return parsePositiveIntEnv("IMLADRIS_LINEAGE_RETENTION_DAYS", DEFAULT_RETENTION_DAYS);
+}
+
+export function parseImladrisLineageMaxRowsPerRun(): number {
+  return parsePositiveIntEnv("IMLADRIS_LINEAGE_PRUNE_MAX_ROWS", DEFAULT_MAX_ROWS_PER_RUN);
+}
+
+function parsePositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  const parsed = raw ? Number(raw) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
+  return fallback;
+}
+
+export interface PruneImladrisLineageInput {
+  prisma: Pick<PrismaClientType, "$executeRaw">;
+  /** Delete lineage for superseded canonical rows whose periodEnd is older than this. */
+  olderThanDays?: number;
+  /** Maximum lineage rows to delete in this run (drains the backlog gradually). */
+  maxRowsPerRun?: number;
+  /** Rows per DELETE statement. Kept small to bound lock duration. */
+  batchSize?: number;
+  /** Test seam. Defaults to now. */
+  now?: Date;
+}
+
+export interface PruneImladrisLineageResult {
+  deleted: number;
+  cutoff: string;
+  /** Whether the per-run cap was hit (backlog likely remains for the next cycle). */
+  capped: boolean;
+}
+
+/**
+ * Deletes lineage rows belonging to old, superseded canonical metric values, in
+ * bounded batches. Never touches the latest row per metric group (the only rows
+ * the dashboards read), and never deletes canonical metric values themselves.
+ *
+ * Deletion stops when the eligible set is drained OR the per-run cap is reached,
+ * whichever comes first. Because the latest-per-group set is recomputed for each
+ * batch, a row that becomes the new "latest" mid-drain is automatically spared.
+ */
+export async function pruneImladrisMetricLineage(
+  input: PruneImladrisLineageInput,
+): Promise<PruneImladrisLineageResult> {
+  const olderThanDays = Math.max(1, Math.floor(input.olderThanDays ?? DEFAULT_RETENTION_DAYS));
+  const cutoff = new Date((input.now ?? new Date()).getTime() - olderThanDays * 86_400_000);
+  const maxRowsPerRun = Math.max(0, Math.floor(input.maxRowsPerRun ?? DEFAULT_MAX_ROWS_PER_RUN));
+  const batchSize = Math.min(
+    MAX_BATCH_SIZE,
+    Math.max(1, Math.floor(input.batchSize ?? DEFAULT_BATCH_SIZE)),
+  );
+
+  let deleted = 0;
+  while (deleted < maxRowsPerRun) {
+    const limit = Math.min(batchSize, maxRowsPerRun - deleted);
+    // ctid-targeted batch delete: select a bounded slice of eligible lineage
+    // rows (superseded parent, older than cutoff) and delete exactly those.
+    const batchDeleted = Number(
+      await input.prisma.$executeRaw`
+        DELETE FROM "ImladrisMetricLineage"
+        WHERE ctid IN (
+          SELECT l.ctid
+          FROM "ImladrisMetricLineage" AS l
+          JOIN "ImladrisCanonicalMetricValue" AS v ON l."metricValueId" = v."id"
+          WHERE v."periodEnd" < ${cutoff}
+            AND v."id" NOT IN (
+              SELECT DISTINCT ON (
+                latest."metricKey",
+                latest."organizationId",
+                latest."userId",
+                latest."calculationVersion"
+              ) latest."id"
+              FROM "ImladrisCanonicalMetricValue" AS latest
+              ORDER BY
+                latest."metricKey",
+                latest."organizationId",
+                latest."userId",
+                latest."calculationVersion",
+                latest."periodEnd" DESC,
+                latest."computedAt" DESC
+            )
+          LIMIT ${limit}
+        )
+      `,
+    ) || 0;
+
+    deleted += batchDeleted;
+    if (batchDeleted < limit) break; // eligible set drained
+  }
+
+  return { deleted, cutoff: cutoff.toISOString(), capped: deleted >= maxRowsPerRun };
+}

--- a/src/lib/imladris/materialization.test.ts
+++ b/src/lib/imladris/materialization.test.ts
@@ -81,11 +81,14 @@ function createPrismaMock() {
       ]),
     },
     imladrisCanonicalMetricValue: {
+      findFirst: vi.fn(async () => null),
+      update: vi.fn(async ({ where }) => ({ id: where.id })),
       upsert: vi.fn(async ({ create }) => ({ id: "metric_1", ...create })),
     },
     imladrisMetricLineage: {
       deleteMany: vi.fn(async () => ({ count: 0 })),
       createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+      findMany: vi.fn(async () => []),
     },
   };
 }
@@ -131,11 +134,14 @@ function createActivationPrismaMock() {
       ]),
     },
     imladrisCanonicalMetricValue: {
+      findFirst: vi.fn(async () => null),
+      update: vi.fn(async ({ where }) => ({ id: where.id })),
       upsert: vi.fn(async ({ create }) => ({ id: "metric_activation_1", ...create })),
     },
     imladrisMetricLineage: {
       deleteMany: vi.fn(async () => ({ count: 0 })),
       createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+      findMany: vi.fn(async () => []),
     },
   };
 }
@@ -267,6 +273,8 @@ function createFinancePrismaMock() {
       ]),
     },
     imladrisCanonicalMetricValue: {
+      findFirst: vi.fn(async () => null),
+      update: vi.fn(async ({ where }) => ({ id: where.id })),
       upsert: vi.fn(async ({ create }) => {
         const metricKey = String(create.metricKey);
         return {
@@ -278,6 +286,7 @@ function createFinancePrismaMock() {
     imladrisMetricLineage: {
       deleteMany: vi.fn(async () => ({ count: 0 })),
       createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+      findMany: vi.fn(async () => []),
     },
   };
 }
@@ -288,6 +297,8 @@ function createEmptyFinancePrismaMock() {
       findMany: vi.fn(async () => []),
     },
     imladrisCanonicalMetricValue: {
+      findFirst: vi.fn(async () => null),
+      update: vi.fn(async ({ where }) => ({ id: where.id })),
       upsert: vi.fn(async ({ create }) => {
         const metricKey = String(create.metricKey);
         return {
@@ -299,6 +310,7 @@ function createEmptyFinancePrismaMock() {
     imladrisMetricLineage: {
       deleteMany: vi.fn(async () => ({ count: 0 })),
       createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+      findMany: vi.fn(async () => []),
     },
   };
 }
@@ -367,11 +379,14 @@ function createSalesPrismaMock() {
       ]),
     },
     imladrisCanonicalMetricValue: {
+      findFirst: vi.fn(async () => null),
+      update: vi.fn(async ({ where }) => ({ id: where.id })),
       upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_qualified_pipeline", ...create })),
     },
     imladrisMetricLineage: {
       deleteMany: vi.fn(async () => ({ count: 0 })),
       createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+      findMany: vi.fn(async () => []),
     },
   };
 }
@@ -534,11 +549,14 @@ function createMarketingPrismaMock() {
       ]),
     },
     imladrisCanonicalMetricValue: {
+      findFirst: vi.fn(async () => null),
+      update: vi.fn(async ({ where }) => ({ id: where.id })),
       upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_pipeline_efficiency", ...create })),
     },
     imladrisMetricLineage: {
       deleteMany: vi.fn(async () => ({ count: 0 })),
       createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+      findMany: vi.fn(async () => []),
     },
   };
 }
@@ -633,6 +651,8 @@ function createCustomerSuccessPrismaMock() {
       ]),
     },
     imladrisCanonicalMetricValue: {
+      findFirst: vi.fn(async () => null),
+      update: vi.fn(async ({ where }) => ({ id: where.id })),
       upsert: vi.fn(async ({ create }) => ({
         id: `metric_${String(create.metricKey).replaceAll(".", "_")}`,
         ...create,
@@ -641,6 +661,7 @@ function createCustomerSuccessPrismaMock() {
     imladrisMetricLineage: {
       deleteMany: vi.fn(async () => ({ count: 0 })),
       createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+      findMany: vi.fn(async () => []),
     },
   };
 }
@@ -1072,11 +1093,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_development_linear_alias", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -1164,11 +1188,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_development_pr_alias", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -1258,11 +1285,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_development_uppercase_repo_pr", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -1348,11 +1378,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_development_event_alias", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -1932,11 +1965,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_development_formatted_state", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -1974,11 +2010,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_development_scalar_state", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -2017,11 +2056,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_development_false_completion", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -2059,11 +2101,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_development_state_name", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -2551,11 +2596,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_activation_snake_case", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -2609,11 +2657,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_activation_case_variant", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -2674,11 +2725,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_activation_nested_snake_case", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -2734,11 +2788,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_activation_nested_account", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -2796,11 +2853,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_activation_wrapped_account", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -2858,11 +2918,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_activation_scalar_wrapped", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -3652,6 +3715,8 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({
           id: `metric_${String(create.metricKey).replaceAll(".", "_")}`,
           ...create,
@@ -3660,6 +3725,7 @@ describe("Imladris canonical materialization", () => {
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -3753,6 +3819,8 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({
           id: `metric_${String(create.metricKey).replaceAll(".", "_")}`,
           ...create,
@@ -3761,6 +3829,7 @@ describe("Imladris canonical materialization", () => {
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -3834,6 +3903,8 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({
           id: `metric_${String(create.metricKey).replaceAll(".", "_")}`,
           ...create,
@@ -3842,6 +3913,7 @@ describe("Imladris canonical materialization", () => {
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -3923,6 +3995,8 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({
           id: `metric_${String(create.metricKey).replaceAll(".", "_")}`,
           ...create,
@@ -3931,6 +4005,7 @@ describe("Imladris canonical materialization", () => {
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -4860,11 +4935,14 @@ describe("Imladris canonical materialization", () => {
         findMany: vi.fn(async () => rawRecords),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -4920,11 +4998,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -4982,11 +5063,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -5077,11 +5161,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -5178,11 +5265,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -5233,11 +5323,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -5292,11 +5385,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -5359,11 +5455,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -5420,11 +5519,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -5481,11 +5583,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -5561,11 +5666,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -5630,11 +5738,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -5718,11 +5829,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -5799,11 +5913,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -5885,11 +6002,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -5959,11 +6079,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -6031,11 +6154,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -6110,11 +6236,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -6181,11 +6310,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -6249,11 +6381,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -6359,11 +6494,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${String(create.metricKey).replaceAll(".", "_")}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -6446,11 +6584,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${String(create.metricKey).replaceAll(".", "_")}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -6520,11 +6661,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${String(create.metricKey).replaceAll(".", "_")}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -6643,11 +6787,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${String(create.metricKey).replaceAll(".", "_")}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -6759,11 +6906,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${String(create.metricKey).replaceAll(".", "_")}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -6832,11 +6982,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -6903,11 +7056,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -6961,11 +7117,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -7022,11 +7181,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -7137,11 +7299,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -7208,11 +7373,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -7269,11 +7437,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -7330,11 +7501,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -7391,11 +7565,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -7454,11 +7631,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -7517,11 +7697,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -7580,11 +7763,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -7651,11 +7837,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -7699,11 +7888,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -7747,11 +7939,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -7793,11 +7988,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -7845,11 +8043,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -7899,11 +8100,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -7953,11 +8157,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -8207,11 +8414,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -8266,11 +8476,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -8325,11 +8538,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -8384,11 +8600,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -8442,11 +8661,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -8512,11 +8734,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -8573,11 +8798,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -8632,11 +8860,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -8693,11 +8924,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -8754,11 +8988,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -8815,11 +9052,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -8880,11 +9120,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -8956,11 +9199,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -9026,11 +9272,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -9120,11 +9369,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -9224,11 +9476,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -9328,11 +9583,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -9389,11 +9647,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -9446,11 +9707,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -9507,11 +9771,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -9577,11 +9844,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -9647,11 +9917,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -9717,11 +9990,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -9786,11 +10062,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -9857,11 +10136,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -9942,11 +10224,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -10027,11 +10312,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -10103,11 +10391,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -10189,11 +10480,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -10248,11 +10542,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -10310,11 +10607,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -10368,11 +10668,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -10426,11 +10729,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -10490,11 +10796,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -10555,11 +10864,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -10620,11 +10932,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -10685,11 +11000,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -10750,11 +11068,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -10815,11 +11136,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -10882,11 +11206,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -10948,11 +11275,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -11018,11 +11348,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -11084,11 +11417,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -11154,11 +11490,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -11220,11 +11559,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -11284,11 +11626,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -11348,11 +11693,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -11412,11 +11760,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -11487,11 +11838,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -11570,11 +11924,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -11638,11 +11995,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -11706,11 +12066,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -11781,11 +12144,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -11851,11 +12217,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -11919,11 +12288,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -11987,11 +12359,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -12055,11 +12430,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -12121,11 +12499,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -12182,11 +12563,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -12256,11 +12640,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -12333,11 +12720,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -12398,11 +12788,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -12459,11 +12852,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -12546,11 +12942,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -12627,11 +13026,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -12712,11 +13114,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -12809,11 +13214,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -12894,11 +13302,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -12967,11 +13378,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -13027,11 +13441,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -13073,11 +13490,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -13134,11 +13554,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -13195,11 +13618,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -13268,11 +13694,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -13341,11 +13770,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -13426,11 +13858,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -13483,11 +13918,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -13530,11 +13968,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -13577,11 +14018,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -13626,11 +14070,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -13711,11 +14158,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -13762,11 +14212,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -13808,11 +14261,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -13854,11 +14310,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -13919,11 +14378,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -13967,11 +14429,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14015,11 +14480,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14062,11 +14530,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14111,11 +14582,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14158,11 +14632,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14227,11 +14704,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14278,11 +14758,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14327,11 +14810,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14374,11 +14860,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14423,11 +14912,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14469,11 +14961,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14515,11 +15010,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14591,11 +15089,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14655,11 +15156,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14724,11 +15228,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14774,11 +15281,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14839,11 +15349,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14888,11 +15401,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14937,11 +15453,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -14990,11 +15509,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -15043,11 +15565,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -15091,11 +15616,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -15138,11 +15666,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -15185,11 +15716,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -15231,11 +15765,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -15277,11 +15814,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -15323,11 +15863,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -15368,11 +15911,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -15416,11 +15962,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -15464,11 +16013,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: `metric_${create.metricKey}`, ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -15755,6 +16307,8 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({
           id: `metric_${create.metricKey.replaceAll(".", "_")}`,
           ...create,
@@ -15763,6 +16317,7 @@ describe("Imladris canonical materialization", () => {
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -15861,6 +16416,8 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({
           id: `metric_${create.metricKey.replaceAll(".", "_")}`,
           ...create,
@@ -15869,6 +16426,7 @@ describe("Imladris canonical materialization", () => {
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -15929,6 +16487,8 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({
           id: `metric_${create.metricKey.replaceAll(".", "_")}`,
           ...create,
@@ -15937,6 +16497,7 @@ describe("Imladris canonical materialization", () => {
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -16137,11 +16698,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_formatted_stage", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -16181,11 +16745,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_human_stage", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -16225,11 +16792,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_sql_stage", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -16269,11 +16839,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_stage_label", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -16315,11 +16888,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_uppercase_scalar_stage", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -16361,11 +16937,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_nested_deal", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -16437,11 +17016,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_amount_aliases", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -16480,11 +17062,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_negative_deal", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -16536,11 +17121,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_spaced_deal_id", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -16593,11 +17181,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_numeric_deal_id", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -16665,11 +17256,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_duplicate_deal_id", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -16737,11 +17331,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_duplicate_touch", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -16809,11 +17406,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_slack_object_type_alias", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -16881,11 +17481,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_google_object_type_alias", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -16954,11 +17557,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_metadata_touch", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -17014,11 +17620,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_nested_deal_id", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -17075,11 +17684,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_wrapped_deal_id", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -17147,11 +17759,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_future_collaboration", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -17219,11 +17834,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_sales_stale_collaboration", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -17805,6 +18423,8 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({
           id: `metric_${String(create.metricKey).replaceAll(".", "_")}`,
           ...create,
@@ -17813,6 +18433,7 @@ describe("Imladris canonical materialization", () => {
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -17906,6 +18527,8 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({
           id: `metric_${String(create.metricKey).replaceAll(".", "_")}`,
           ...create,
@@ -17914,6 +18537,7 @@ describe("Imladris canonical materialization", () => {
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -17986,6 +18610,8 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({
           id: `metric_${String(create.metricKey).replaceAll(".", "_")}`,
           ...create,
@@ -17994,6 +18620,7 @@ describe("Imladris canonical materialization", () => {
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -18067,6 +18694,8 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({
           id: `metric_${String(create.metricKey).replaceAll(".", "_")}`,
           ...create,
@@ -18075,6 +18704,7 @@ describe("Imladris canonical materialization", () => {
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -18203,6 +18833,8 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({
           id: `metric_${String(create.metricKey).replaceAll(".", "_")}`,
           ...create,
@@ -18211,6 +18843,7 @@ describe("Imladris canonical materialization", () => {
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -18309,6 +18942,8 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({
           id: `metric_${String(create.metricKey).replaceAll(".", "_")}`,
           ...create,
@@ -18317,6 +18952,7 @@ describe("Imladris canonical materialization", () => {
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -18412,6 +19048,8 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({
           id: `metric_${String(create.metricKey).replaceAll(".", "_")}`,
           ...create,
@@ -18420,6 +19058,7 @@ describe("Imladris canonical materialization", () => {
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -18745,11 +19384,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_gsc_latest_valid_snapshot", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -18788,11 +19430,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_nested_unify", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -18832,11 +19477,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_wrapped_unify", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -18892,11 +19540,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_uppercase_unify", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -18941,11 +19592,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_blank_unify", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -18982,11 +19636,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_string_false_unify", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -19036,11 +19693,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_duplicate_unify", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -19106,11 +19766,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_snapshot_spend", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -19526,11 +20189,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_latest_snapshot_totals", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -19598,11 +20264,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_latest_valid_snapshot", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -19666,11 +20335,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_snapshot_sessions", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -19755,11 +20427,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_fractional_sessions", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -19809,11 +20484,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_semrush_snapshot", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -19917,11 +20595,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_wrapped_traffic", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -19971,11 +20652,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_webflow_snapshot", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -20025,11 +20709,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_webflow_children", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -20085,11 +20772,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_webflow_aliases", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -20143,11 +20833,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_webflow_uppercase_customer", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -20203,11 +20896,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_webflow_uppercase_form_contact", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -20259,11 +20955,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_webflow_wrapped_snapshot", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -20303,11 +21002,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_webflow_wrapped_child", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -20359,11 +21061,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_micros", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -20434,11 +21139,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_nested_micros", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -20524,11 +21232,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_wrapped_spend", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -20659,11 +21370,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_negative_inputs", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -20727,11 +21441,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_negative_deal", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -20802,11 +21519,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_duplicate_deal_id", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -20862,11 +21582,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_nested_deal", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -20922,11 +21645,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_wrapped_deal", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -20980,11 +21706,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_scalar_source", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -21038,11 +21767,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_formatted_stage", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -21111,11 +21843,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_terminal_pipeline", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -21169,11 +21904,14 @@ describe("Imladris canonical materialization", () => {
         ]),
       },
       imladrisCanonicalMetricValue: {
+        findFirst: vi.fn(async () => null),
+        update: vi.fn(async ({ where }) => ({ id: where.id })),
         upsert: vi.fn(async ({ create }) => ({ id: "metric_marketing_stage_label_pipeline", ...create })),
       },
       imladrisMetricLineage: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
         createMany: vi.fn(async ({ data }) => ({ count: data.length })),
+        findMany: vi.fn(async () => []),
       },
     };
 
@@ -24531,5 +25269,248 @@ describe("Imladris canonical materialization", () => {
       atRiskAccounts: 1,
       accountsWithBillingRisk: 1,
     });
+  });
+});
+
+// ── Regression: lineage/metric write churn (2026-06-11 disk-exhaustion incident) ──
+//
+// Before the fix, every sync cycle inserted a brand-new canonical metric value
+// (periodEnd = "now" lands in the unique key) plus a full lineage copy, even
+// when nothing changed. That unbounded growth drove ImladrisMetricLineage to
+// ~15 GB and exhausted the Postgres volume. These tests pin the dedupe
+// behaviour: identical re-materialization must reuse the row and skip lineage.
+
+type StatefulCanonicalRow = {
+  id: string;
+  metricKey: string;
+  calculationVersion: string;
+  value: unknown;
+  status: unknown;
+  confidence: number;
+  warnings: string[];
+  periodEnd: Date;
+  computedAt: Date;
+  userId: string | null;
+  organizationId: string | null;
+};
+
+type StatefulLineageRow = {
+  metricValueId: string;
+  rawRecordId: string | null;
+  sourceKey: string;
+  sourceType: string;
+  sourceId: string | null;
+  capturedAt: Date | null;
+  metadata: unknown;
+};
+
+function createStatefulImladrisStore() {
+  const canonicalRows: StatefulCanonicalRow[] = [];
+  const lineageRows: StatefulLineageRow[] = [];
+  let idSeq = 0;
+
+  const canonical = {
+    findFirst: vi.fn(async ({ where }: { where: Record<string, unknown> }) => {
+      const matches = canonicalRows
+        .filter(
+          (row) =>
+            row.organizationId === where.organizationId &&
+            row.userId === where.userId &&
+            row.metricKey === where.metricKey &&
+            row.calculationVersion === where.calculationVersion,
+        )
+        .sort((a, b) => {
+          const periodDelta = b.periodEnd.getTime() - a.periodEnd.getTime();
+          if (periodDelta !== 0) return periodDelta;
+          return b.computedAt.getTime() - a.computedAt.getTime();
+        });
+      return matches[0] ?? null;
+    }),
+    update: vi.fn(async ({ where, data }: { where: { id: string }; data: Record<string, unknown> }) => {
+      const row = canonicalRows.find((candidate) => candidate.id === where.id);
+      if (row) Object.assign(row, data);
+      return row ?? { id: where.id };
+    }),
+    upsert: vi.fn(
+      async (args: {
+        where: {
+          organizationId_userId_metricKey_periodEnd_calculationVersion: {
+            organizationId: string | null;
+            userId: string | null;
+            metricKey: string;
+            periodEnd: Date | string;
+            calculationVersion: string;
+          };
+        };
+        create: Record<string, unknown>;
+        update: Record<string, unknown>;
+      }) => {
+        const key = args.where.organizationId_userId_metricKey_periodEnd_calculationVersion;
+        let row = canonicalRows.find(
+          (candidate) =>
+            candidate.organizationId === key.organizationId &&
+            candidate.userId === key.userId &&
+            candidate.metricKey === key.metricKey &&
+            candidate.periodEnd.getTime() === new Date(key.periodEnd).getTime() &&
+            candidate.calculationVersion === key.calculationVersion,
+        );
+        if (row) {
+          Object.assign(row, args.update);
+        } else {
+          row = { id: `mv_${++idSeq}`, ...args.create } as StatefulCanonicalRow;
+          canonicalRows.push(row);
+        }
+        return row;
+      },
+    ),
+  };
+
+  const lineage = {
+    findMany: vi.fn(async ({ where }: { where: { metricValueId: string } }) =>
+      lineageRows
+        .filter((row) => row.metricValueId === where.metricValueId)
+        .map((row) => ({
+          rawRecordId: row.rawRecordId,
+          sourceKey: row.sourceKey,
+          sourceType: row.sourceType,
+          sourceId: row.sourceId,
+          capturedAt: row.capturedAt,
+          metadata: row.metadata,
+        })),
+    ),
+    deleteMany: vi.fn(async ({ where }: { where: { metricValueId: string } }) => {
+      const before = lineageRows.length;
+      for (let i = lineageRows.length - 1; i >= 0; i -= 1) {
+        if (lineageRows[i].metricValueId === where.metricValueId) lineageRows.splice(i, 1);
+      }
+      return { count: before - lineageRows.length };
+    }),
+    createMany: vi.fn(async ({ data }: { data: StatefulLineageRow[] }) => {
+      for (const entry of data) lineageRows.push({ ...entry });
+      return { count: data.length };
+    }),
+  };
+
+  return { canonicalRows, lineageRows, canonical, lineage };
+}
+
+function developmentRawRecords(): RawSourceRecordFixture[] {
+  return [
+    {
+      id: "raw_linear_1",
+      provider: IntegrationProvider.LINEAR,
+      objectType: "issue",
+      externalId: "LIN-1",
+      occurredAt: new Date("2026-05-15T10:00:00.000Z"),
+      sourceCreatedAt: new Date("2026-05-10T10:00:00.000Z"),
+      sourceUpdatedAt: new Date("2026-05-15T10:00:00.000Z"),
+      payload: {
+        id: "LIN-1",
+        state: { type: "completed" },
+        createdAt: "2026-05-10T10:00:00.000Z",
+        completedAt: "2026-05-15T10:00:00.000Z",
+      },
+    },
+    {
+      id: "raw_github_1",
+      provider: IntegrationProvider.GITHUB,
+      objectType: "pull_request",
+      externalId: "repo/pull/7",
+      occurredAt: new Date("2026-05-18T10:00:00.000Z"),
+      sourceCreatedAt: new Date("2026-05-16T10:00:00.000Z"),
+      sourceUpdatedAt: new Date("2026-05-18T10:00:00.000Z"),
+      payload: { number: 7, merged: true, created_at: "2026-05-16T10:00:00.000Z", merged_at: "2026-05-18T10:00:00.000Z" },
+    },
+    {
+      id: "raw_posthog_1",
+      provider: IntegrationProvider.POSTHOG,
+      objectType: "event",
+      externalId: "evt_1",
+      occurredAt: new Date("2026-05-19T10:00:00.000Z"),
+      sourceCreatedAt: null,
+      sourceUpdatedAt: null,
+      payload: { event: "activation_completed", distinct_id: "acct_1" },
+    },
+  ];
+}
+
+function statefulDevelopmentPrisma(store: ReturnType<typeof createStatefulImladrisStore>, rawRecords: RawSourceRecordFixture[]) {
+  return {
+    imladrisRawSourceRecord: { findMany: vi.fn(async () => rawRecords) },
+    imladrisCanonicalMetricValue: store.canonical,
+    imladrisMetricLineage: store.lineage,
+  } as never;
+}
+
+describe("Imladris materialization write-churn dedupe", () => {
+  // Mirrors production: each sync cycle sets periodEnd = now (see
+  // runImladrisMaterializationSync), so the canonical unique key advances every
+  // cycle. The dedupe must still collapse same-day, unchanged cycles.
+  const periodStart = new Date("2026-05-01T00:00:00.000Z");
+
+  it("reuses the same-day canonical row and skips lineage rewrite when nothing changed", async () => {
+    const store = createStatefulImladrisStore();
+    const prisma = statefulDevelopmentPrisma(store, developmentRawRecords());
+
+    const firstNow = new Date("2026-05-29T12:00:00.000Z");
+    const first = await materializeImladrisDevelopmentMetrics({
+      prisma,
+      context: CONTEXT,
+      periodStart,
+      periodEnd: firstNow,
+      now: firstNow,
+    });
+    const secondNow = new Date("2026-05-29T12:05:00.000Z"); // same UTC day, later cycle
+    const second = await materializeImladrisDevelopmentMetrics({
+      prisma,
+      context: CONTEXT,
+      periodStart,
+      periodEnd: secondNow,
+      now: secondNow,
+    });
+
+    // Same canonical row reused — not a second insert.
+    expect(first.metricValueId).toBe(second.metricValueId);
+    expect(store.canonicalRows).toHaveLength(1);
+    expect(store.canonical.upsert).toHaveBeenCalledTimes(1);
+    expect(store.canonical.update).toHaveBeenCalledTimes(1);
+
+    // Lineage written once, then skipped (no churn on the unchanged second run).
+    expect(store.canonical.findFirst).toHaveBeenCalledTimes(2);
+    expect(store.lineage.createMany).toHaveBeenCalledTimes(1);
+    expect(store.lineage.deleteMany).toHaveBeenCalledTimes(1);
+    const lineageCount = store.lineageRows.length;
+    expect(lineageCount).toBeGreaterThan(0);
+    // Second run must not duplicate lineage rows.
+    expect(store.lineageRows).toHaveLength(lineageCount);
+  });
+
+  it("inserts a new row and rewrites lineage when the metric value changes", async () => {
+    const store = createStatefulImladrisStore();
+
+    const firstNow = new Date("2026-05-29T12:00:00.000Z");
+    await materializeImladrisDevelopmentMetrics({
+      prisma: statefulDevelopmentPrisma(store, developmentRawRecords()),
+      context: CONTEXT,
+      periodStart,
+      periodEnd: firstNow,
+      now: firstNow,
+    });
+
+    // Drop the merged PR so delivery-health changes → no reuse.
+    const changedRecords = developmentRawRecords().filter((record) => record.id !== "raw_github_1");
+    const secondNow = new Date("2026-05-29T12:05:00.000Z");
+    await materializeImladrisDevelopmentMetrics({
+      prisma: statefulDevelopmentPrisma(store, changedRecords),
+      context: CONTEXT,
+      periodStart,
+      periodEnd: secondNow,
+      now: secondNow,
+    });
+
+    expect(store.canonicalRows).toHaveLength(2);
+    expect(store.canonical.upsert).toHaveBeenCalledTimes(2);
+    expect(store.canonical.update).not.toHaveBeenCalled();
+    expect(store.lineage.createMany).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lib/imladris/materialization.ts
+++ b/src/lib/imladris/materialization.ts
@@ -116,7 +116,25 @@ type RawSourceRecordDelegate = {
   findMany(args: Record<string, unknown>): Promise<RawSourceRecordRow[]>;
 };
 
+type CanonicalMetricReuseRow = {
+  id: string;
+  value: unknown;
+  status: unknown;
+  confidence: number;
+  warnings: string[];
+  periodEnd: Date | string;
+  computedAt: Date | string;
+};
+
 type CanonicalMetricDelegate = {
+  findFirst(args: {
+    where: Record<string, unknown>;
+    orderBy?: Array<Record<string, unknown>>;
+  }): Promise<CanonicalMetricReuseRow | null>;
+  update(args: {
+    where: { id: string };
+    data: Record<string, unknown>;
+  }): Promise<{ id: string }>;
   upsert(args: {
     where: Record<string, unknown>;
     create: Record<string, unknown>;
@@ -125,6 +143,10 @@ type CanonicalMetricDelegate = {
 };
 
 type MetricLineageDelegate = {
+  findMany(args: {
+    where: { metricValueId: string };
+    select?: Record<string, boolean>;
+  }): Promise<Array<Record<string, unknown>>>;
   deleteMany(args: { where: { metricValueId: string } }): Promise<unknown>;
   createMany(args: { data: Array<Record<string, unknown>> }): Promise<unknown>;
 };
@@ -1308,6 +1330,34 @@ function dedupeRawSourceRecords(
   );
 }
 
+function lineageRowSignature(row: {
+  rawRecordId: unknown;
+  sourceKey: unknown;
+  sourceType: unknown;
+  sourceId: unknown;
+  capturedAt: unknown;
+  provider: unknown;
+  calculationVersion: unknown;
+}): string {
+  const capturedAt = dateFrom(row.capturedAt);
+  return [
+    typeof row.rawRecordId === "string" ? row.rawRecordId : "",
+    typeof row.sourceKey === "string" ? row.sourceKey : "",
+    typeof row.sourceType === "string" ? row.sourceType : "",
+    typeof row.sourceId === "string" ? row.sourceId : "",
+    capturedAt ? String(capturedAt.getTime()) : "",
+    typeof row.provider === "string" ? row.provider : "",
+    typeof row.calculationVersion === "string" ? row.calculationVersion : "",
+  ].join("|");
+}
+
+function lineageSignatureSetsMatch(existing: string[], desired: string[]): boolean {
+  if (existing.length !== desired.length) return false;
+  const sortedExisting = [...existing].sort();
+  const sortedDesired = [...desired].sort();
+  return sortedExisting.every((signature, index) => signature === sortedDesired[index]);
+}
+
 async function replaceLineage(input: {
   metricLineage: MetricLineageDelegate;
   metricValueId: string;
@@ -1315,29 +1365,71 @@ async function replaceLineage(input: {
   calculationVersion: string;
   asOf: Date;
 }) {
+  const desired = input.records.map((record) => ({
+    metricValueId: input.metricValueId,
+    rawRecordId: record.id,
+    sourceKey: sourceKeyForProvider(record.provider),
+    sourceType: recordObjectType(record),
+    sourceId: rawRecordSourceId(record),
+    capturedAt: firstDateAtOrBefore(
+      input.asOf,
+      record.occurredAt,
+      record.sourceUpdatedAt,
+      record.sourceCreatedAt,
+    ),
+    metadata: {
+      provider: record.provider,
+      calculationVersion: input.calculationVersion,
+    },
+  }));
+
+  // Delete-and-reinsert of identical lineage was the dominant write churn on
+  // ImladrisMetricLineage (every sync cycle, per metric value). Compare the
+  // stored rows against the desired rows first and skip the rewrite when the
+  // lineage is unchanged — one indexed read instead of a full delete+insert.
+  const existing = await input.metricLineage.findMany({
+    where: { metricValueId: input.metricValueId },
+    select: {
+      rawRecordId: true,
+      sourceKey: true,
+      sourceType: true,
+      sourceId: true,
+      capturedAt: true,
+      metadata: true,
+    },
+  });
+  const existingSignatures = existing.map((row) => {
+    const metadata = asRecord(row.metadata);
+    return lineageRowSignature({
+      rawRecordId: row.rawRecordId,
+      sourceKey: row.sourceKey,
+      sourceType: row.sourceType,
+      sourceId: row.sourceId,
+      capturedAt: row.capturedAt,
+      provider: metadata.provider,
+      calculationVersion: metadata.calculationVersion,
+    });
+  });
+  const desiredSignatures = desired.map((row) =>
+    lineageRowSignature({
+      rawRecordId: row.rawRecordId,
+      sourceKey: row.sourceKey,
+      sourceType: row.sourceType,
+      sourceId: row.sourceId,
+      capturedAt: row.capturedAt,
+      provider: row.metadata.provider,
+      calculationVersion: row.metadata.calculationVersion,
+    }),
+  );
+  if (lineageSignatureSetsMatch(existingSignatures, desiredSignatures)) {
+    return;
+  }
+
   await input.metricLineage.deleteMany({
     where: { metricValueId: input.metricValueId },
   });
-  if (input.records.length === 0) return;
-  await input.metricLineage.createMany({
-    data: input.records.map((record) => ({
-      metricValueId: input.metricValueId,
-      rawRecordId: record.id,
-      sourceKey: sourceKeyForProvider(record.provider),
-      sourceType: recordObjectType(record),
-      sourceId: rawRecordSourceId(record),
-      capturedAt: firstDateAtOrBefore(
-        input.asOf,
-        record.occurredAt,
-        record.sourceUpdatedAt,
-        record.sourceCreatedAt,
-      ),
-      metadata: {
-        provider: record.provider,
-        calculationVersion: input.calculationVersion,
-      },
-    })),
-  });
+  if (desired.length === 0) return;
+  await input.metricLineage.createMany({ data: desired });
 }
 
 export async function materializeImladrisDevelopmentMetrics(
@@ -1374,39 +1466,20 @@ export async function materializeImladrisDevelopmentMetrics(
     requiredProviders,
     emptyWarning: "No Linear, GitHub, or PostHog raw records were available for this period.",
   });
-  const metricValue = await canonicalMetrics.upsert({
-    where: {
-      organizationId_userId_metricKey_periodEnd_calculationVersion: {
-        organizationId: context.organizationId,
-        userId: context.userId,
-        metricKey: "development.delivery_health",
-        periodEnd: input.periodEnd,
-        calculationVersion: DEVELOPMENT_CALCULATION_VERSION,
-      },
-    },
-    create: {
-      metricKey: "development.delivery_health",
-      department: "development",
-      unit: "score",
-      value,
-      periodStart: input.periodStart,
-      periodEnd: input.periodEnd,
-      status,
-      confidence: confidenceFor(records),
-      warnings,
-      calculationVersion: DEVELOPMENT_CALCULATION_VERSION,
-      computedAt: now,
-      userId: context.userId,
-      organizationId: context.organizationId,
-    },
-    update: {
-      value,
-      periodStart: input.periodStart,
-      status,
-      confidence: confidenceFor(records),
-      warnings,
-      computedAt: now,
-    },
+  const metricValue = await upsertCanonicalMetric({
+    canonicalMetrics,
+    context,
+    metricKey: "development.delivery_health",
+    department: "development",
+    unit: "score",
+    value,
+    periodStart: input.periodStart,
+    periodEnd: input.periodEnd,
+    status,
+    confidence: confidenceFor(records),
+    warnings,
+    calculationVersion: DEVELOPMENT_CALCULATION_VERSION,
+    now,
   });
 
   await replaceLineage({
@@ -1547,39 +1620,20 @@ export async function materializeImladrisProductActivationMetric(
           emptyWarning: "No HubSpot account cohort was available for activation-rate materialization.",
         })
       : ["No HubSpot account cohort was available for activation-rate materialization."];
-  const metricValue = await canonicalMetrics.upsert({
-    where: {
-      organizationId_userId_metricKey_periodEnd_calculationVersion: {
-        organizationId: context.organizationId,
-        userId: context.userId,
-        metricKey: "product.activation_rate",
-        periodEnd: input.periodEnd,
-        calculationVersion: PRODUCT_ACTIVATION_CALCULATION_VERSION,
-      },
-    },
-    create: {
-      metricKey: "product.activation_rate",
-      department: "development",
-      unit: "percent",
-      value,
-      periodStart: input.periodStart,
-      periodEnd: input.periodEnd,
-      status,
-      confidence: confidenceFor(records),
-      warnings,
-      calculationVersion: PRODUCT_ACTIVATION_CALCULATION_VERSION,
-      computedAt: now,
-      userId: context.userId,
-      organizationId: context.organizationId,
-    },
-    update: {
-      value,
-      periodStart: input.periodStart,
-      status,
-      confidence: confidenceFor(records),
-      warnings,
-      computedAt: now,
-    },
+  const metricValue = await upsertCanonicalMetric({
+    canonicalMetrics,
+    context,
+    metricKey: "product.activation_rate",
+    department: "development",
+    unit: "percent",
+    value,
+    periodStart: input.periodStart,
+    periodEnd: input.periodEnd,
+    status,
+    confidence: confidenceFor(records),
+    warnings,
+    calculationVersion: PRODUCT_ACTIVATION_CALCULATION_VERSION,
+    now,
   });
 
   await replaceLineage({
@@ -3870,6 +3924,49 @@ function computeFinanceValues(records: RawSourceRecordRow[], asOf: Date) {
   };
 }
 
+function stableValueSignature(value: unknown): string {
+  if (value === null || value === undefined) return String(value);
+  if (typeof value !== "object") return JSON.stringify(value) ?? String(value);
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableValueSignature(entry)).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, entryValue]) => entryValue !== undefined)
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableValueSignature(entryValue)}`);
+  return `{${entries.join(",")}}`;
+}
+
+function sameUtcDay(left: Date, right: Date): boolean {
+  return left.toISOString().slice(0, 10) === right.toISOString().slice(0, 10);
+}
+
+function canReuseLatestCanonicalMetric(
+  latest: CanonicalMetricReuseRow,
+  input: {
+    value: Record<string, unknown>;
+    periodEnd: Date;
+    status: keyof typeof ImladrisMetricStatus;
+    confidence: number;
+    warnings: string[];
+  },
+): boolean {
+  const latestPeriodEnd = dateFrom(latest.periodEnd);
+  if (!latestPeriodEnd) return false;
+  // Only reuse rows from the same UTC day so daily/monthly history series
+  // still get at least one row per day, and never "reuse forward" onto a row
+  // with a newer window than the one being materialized.
+  if (latestPeriodEnd.getTime() > input.periodEnd.getTime()) return false;
+  if (!sameUtcDay(latestPeriodEnd, input.periodEnd)) return false;
+  if (String(latest.status) !== String(input.status)) return false;
+  if (Number(latest.confidence) !== input.confidence) return false;
+  const latestWarnings = Array.isArray(latest.warnings) ? latest.warnings : [];
+  if (latestWarnings.length !== input.warnings.length) return false;
+  if (latestWarnings.some((warning, index) => warning !== input.warnings[index])) return false;
+  return stableValueSignature(latest.value) === stableValueSignature(input.value);
+}
+
 async function upsertCanonicalMetric(input: {
   canonicalMetrics: CanonicalMetricDelegate;
   context: ImladrisActorContext;
@@ -3886,6 +3983,30 @@ async function upsertCanonicalMetric(input: {
   now?: Date;
 }) {
   const context = normalizeContext(input.context);
+
+  // Every sync cycle materializes with periodEnd = "now", which lands in the
+  // unique key — so each cycle used to insert a brand-new metric value row
+  // (plus a full lineage copy) even when nothing changed. That unbounded
+  // growth took ImladrisMetricLineage to tens of millions of rows and caused
+  // the 2026-06-11 disk-exhaustion incident. When the freshly computed metric
+  // is identical to the latest stored row from the same UTC day, refresh that
+  // row's computedAt instead of creating a new snapshot.
+  const latest = await input.canonicalMetrics.findFirst({
+    where: {
+      organizationId: context.organizationId,
+      userId: context.userId,
+      metricKey: input.metricKey,
+      calculationVersion: input.calculationVersion,
+    },
+    orderBy: [{ periodEnd: "desc" }, { computedAt: "desc" }],
+  });
+  if (latest && canReuseLatestCanonicalMetric(latest, input)) {
+    return input.canonicalMetrics.update({
+      where: { id: latest.id },
+      data: { computedAt: input.now ?? new Date() },
+    });
+  }
+
   return input.canonicalMetrics.upsert({
     where: {
       organizationId_userId_metricKey_periodEnd_calculationVersion: {

--- a/src/lib/imladris/service.test.ts
+++ b/src/lib/imladris/service.test.ts
@@ -5565,3 +5565,59 @@ describe("Imladris service", () => {
     });
   });
 });
+
+// ── Regression: dashboard reads must not eagerly include lineage over history ──
+//
+// Including lineage on the full canonical-history query pulled millions of
+// lineage rows through pgsql_tmp and exhausted the Postgres volume
+// (2026-06-11 incident). The history query must omit `include`, and lineage
+// must be loaded via a second query bounded to the winning row ids.
+describe("Imladris dashboard lineage loading is bounded", () => {
+  it("does not include lineage on the full-history query and scopes lineage by winner id", async () => {
+    const now = new Date("2026-05-29T10:00:00.000Z");
+    const canonicalFindMany = vi.fn(async (args?: { where?: Record<string, unknown> }) => {
+      // History query (no id filter) returns the full set WITHOUT lineage.
+      const where = args?.where ?? {};
+      const isWinnerLookup = "id" in where;
+      const row = {
+        id: "mv_net_burn",
+        metricKey: "finance.net_burn",
+        department: "finance",
+        unit: "currency",
+        value: { amount: 125_000, currency: "USD" },
+        periodStart: new Date("2026-05-01T00:00:00.000Z"),
+        periodEnd: new Date("2026-05-29T00:00:00.000Z"),
+        status: "READY",
+        confidence: 0.88,
+        warnings: [] as string[],
+        calculationVersion: "finance-net-burn-v1",
+        computedAt: new Date("2026-05-29T09:00:00.000Z"),
+        userId: "user_1",
+        organizationId: "org_1",
+      };
+      return isWinnerLookup
+        ? [{ ...row, lineage: [{ sourceKey: "mercury", sourceType: "raw", sourceId: null, rawRecordId: "raw_1", capturedAt: now, metadata: {} }] }]
+        : [row];
+    });
+    const prisma = createPrismaMock({
+      imladrisCanonicalMetricValue: { findMany: canonicalFindMany },
+    });
+
+    await buildImladrisMetrics({ prisma, context: CONTEXT, now });
+
+    const calls = canonicalFindMany.mock.calls.map(
+      (call) => (call[0] ?? {}) as { where?: Record<string, unknown>; include?: unknown },
+    );
+    const historyCall = calls.find((args) => !("id" in (args.where ?? {})));
+    const winnerCall = calls.find((args) => "id" in (args.where ?? {}));
+
+    // The history query must NOT eagerly include lineage.
+    expect(historyCall).toBeDefined();
+    expect(historyCall).not.toHaveProperty("include");
+
+    // Lineage is loaded via a second query, bounded to winner ids.
+    expect(winnerCall).toBeDefined();
+    expect(winnerCall?.where?.id).toEqual({ in: ["mv_net_burn"] });
+    expect(winnerCall?.include).toMatchObject({ lineage: expect.anything() });
+  });
+});

--- a/src/lib/imladris/service.ts
+++ b/src/lib/imladris/service.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/imladris/derived-metrics";
 import { getImladrisHistoricalWindow } from "@/lib/imladris/ingestion";
 import { parseImladrisNumber } from "@/lib/imladris/number-parsing";
+import { attachWinnerLineage } from "@/lib/imladris/winner-lineage";
 import { snapshotKeyQueryVariants } from "@/lib/integrations/provider-registry";
 import { resolveIntegrationOwnerUserId } from "@/lib/integrations/ownership";
 import type { IntegrationProvider } from "@/generated/prisma/client";
@@ -67,6 +68,7 @@ interface MetricLineageRow {
 }
 
 interface CanonicalMetricRow {
+  id: string;
   metricKey: string;
   department: string;
   unit: string;
@@ -80,7 +82,14 @@ interface CanonicalMetricRow {
   computedAt: Date | string;
   userId?: string | null;
   organizationId?: string | null;
-  lineage: MetricLineageRow[];
+  /**
+   * Lineage is intentionally NOT eagerly included on canonical metric queries.
+   * It is loaded separately for the small set of "winner" rows only — the
+   * lineage table can hold millions of rows across historical metric values,
+   * and `include: { lineage }` over the full history caused multi-minute
+   * queries and pgsql_tmp disk exhaustion in production (2026-06-11 incident).
+   */
+  lineage?: MetricLineageRow[];
 }
 
 function scalarDateValue(value: unknown, seen = new WeakSet<object>()): unknown {
@@ -1551,11 +1560,6 @@ export async function buildImladrisMetrics(input: {
         },
         ...canonicalMetricScopeWhere(context),
       },
-      include: {
-        lineage: {
-          orderBy: [{ createdAt: "asc" }],
-        },
-      },
       orderBy: [{ periodEnd: "desc" }, { computedAt: "desc" }],
     }),
   ]);
@@ -1588,6 +1592,13 @@ export async function buildImladrisMetrics(input: {
     if (canonicalMonthKey(rowPeriodEnd) !== previousMonthKey(currentPeriodEnd)) continue;
     previousCanonicalByMetricKey.set(row.metricKey, row);
   }
+
+  // Load lineage only for the winning row per metric, via a second query
+  // bounded to those ids. The full-history query above intentionally omits
+  // lineage: `include: { lineage }` over the whole history pulls every
+  // historical lineage row (millions) through pgsql_tmp and caused the
+  // 2026-06-11 disk-exhaustion incident.
+  await attachWinnerLineage(input.prisma, [...canonicalByMetricKey.values()]);
 
   const baseMetrics = IMLADRIS_METRIC_DEFINITIONS.map((definition) => {
     const canonicalRow = canonicalByMetricKey.get(definition.key);

--- a/src/lib/imladris/winner-lineage.ts
+++ b/src/lib/imladris/winner-lineage.ts
@@ -1,0 +1,52 @@
+/**
+ * Loads ImladrisMetricLineage for a small set of "winner" canonical metric
+ * rows (the latest row per metric key) via a second, id-bounded query.
+ *
+ * Dashboard readers fetch the full canonical history to pick winners, but must
+ * NOT eagerly `include: { lineage }` on that history query: the lineage table
+ * holds millions of rows across historical metric values, and including it
+ * pulled the entire set through pgsql_tmp, exhausting the Postgres volume and
+ * stalling connection establishment (production incident 2026-06-11).
+ *
+ * This helper instead loads lineage only for the winning rows — a query bounded
+ * by primary key to ~one row per metric — and mutates each winner's `lineage`
+ * field in place.
+ */
+
+interface LineageBearingRow {
+  id: string;
+  lineage?: unknown[];
+}
+
+interface CanonicalLineageDelegate {
+  findMany(args: {
+    where: { id: { in: string[] } };
+    include: { lineage: { orderBy: Array<Record<string, "asc" | "desc">> } };
+  }): Promise<Array<{ id: string; lineage?: unknown[] }>>;
+}
+
+/**
+ * Mutates `winners[*].lineage` in place with lineage loaded from a bounded,
+ * id-scoped query. No-op when there are no winners.
+ */
+export async function attachWinnerLineage(
+  prisma: { imladrisCanonicalMetricValue: CanonicalLineageDelegate },
+  winners: LineageBearingRow[],
+): Promise<void> {
+  const winnerIds = winners
+    .map((row) => row.id)
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
+  if (winnerIds.length === 0) return;
+
+  const rowsWithLineage = await prisma.imladrisCanonicalMetricValue.findMany({
+    where: { id: { in: winnerIds } },
+    include: { lineage: { orderBy: [{ createdAt: "asc" }] } },
+  });
+
+  const lineageById = new Map<string, unknown[]>(
+    rowsWithLineage.map((row) => [row.id, row.lineage ?? []]),
+  );
+  for (const winner of winners) {
+    winner.lineage = lineageById.get(winner.id) ?? [];
+  }
+}

--- a/src/lib/sync/analytics.test.ts
+++ b/src/lib/sync/analytics.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runAnalyticsRefresh } from "@/lib/analytics/refresh-runner";
 import { pruneAnalyticsSnapshots } from "@/lib/analytics/snapshots";
 import { materializeImladrisCanonicalMetrics } from "@/lib/imladris/materialization";
+import { pruneImladrisMetricLineage } from "@/lib/imladris/lineage-retention";
 import { runAnalyticsSync } from "@/lib/sync/analytics";
 import { discoverConnectedUserIds } from "@/lib/sync/users";
 
@@ -15,6 +16,12 @@ vi.mock("@/lib/analytics/snapshots", () => ({
 
 vi.mock("@/lib/imladris/materialization", () => ({
   materializeImladrisCanonicalMetrics: vi.fn(),
+}));
+
+vi.mock("@/lib/imladris/lineage-retention", () => ({
+  pruneImladrisMetricLineage: vi.fn(),
+  parseImladrisLineageRetentionDays: vi.fn(() => 30),
+  parseImladrisLineageMaxRowsPerRun: vi.fn(() => 200_000),
 }));
 
 vi.mock("@/lib/sync/users", () => ({
@@ -42,6 +49,11 @@ describe("runAnalyticsSync", () => {
     vi.clearAllMocks();
     vi.mocked(runAnalyticsRefresh).mockResolvedValue({ refreshed: true } as never);
     vi.mocked(pruneAnalyticsSnapshots).mockResolvedValue({ deleted: 0 } as never);
+    vi.mocked(pruneImladrisMetricLineage).mockResolvedValue({
+      deleted: 0,
+      cutoff: "2026-05-02T12:00:00.000Z",
+      capped: false,
+    } as never);
     vi.mocked(materializeImladrisCanonicalMetrics).mockResolvedValue([
       {
         metricKey: "development.delivery_health",
@@ -236,6 +248,38 @@ describe("runAnalyticsSync", () => {
       ]),
     }));
     expect(materializeImladrisCanonicalMetrics).toHaveBeenCalledTimes(1);
+  });
+
+  it("prunes Imladris metric lineage each cycle and surfaces the result", async () => {
+    const prisma = createPrismaMock();
+    vi.mocked(pruneImladrisMetricLineage).mockResolvedValue({
+      deleted: 4242,
+      cutoff: "2026-05-02T12:00:00.000Z",
+      capped: false,
+    } as never);
+
+    const result = await runAnalyticsSync({ prisma: prisma as never });
+
+    expect(pruneImladrisMetricLineage).toHaveBeenCalledOnce();
+    expect(pruneImladrisMetricLineage).toHaveBeenCalledWith(
+      expect.objectContaining({ prisma, olderThanDays: 30, maxRowsPerRun: 200_000 }),
+    );
+    expect(result.lineagePruning).toEqual({
+      deleted: 4242,
+      cutoff: "2026-05-02T12:00:00.000Z",
+      capped: false,
+    });
+  });
+
+  it("never fails the sync cycle when lineage pruning throws", async () => {
+    const prisma = createPrismaMock();
+    vi.mocked(pruneImladrisMetricLineage).mockRejectedValue(new Error("deadlock detected"));
+
+    const result = await runAnalyticsSync({ prisma: prisma as never });
+
+    // The cycle still resolves; lineage pruning degrades to a zero-delete result.
+    expect(result.lineagePruning.deleted).toBe(0);
+    expect(materializeImladrisCanonicalMetrics).toHaveBeenCalled();
   });
 
   it("continues canonical materialization when provider refresh reports failures and surfaces a warning", async () => {

--- a/src/lib/sync/analytics.ts
+++ b/src/lib/sync/analytics.ts
@@ -28,6 +28,11 @@ import {
   materializeImladrisCanonicalMetrics,
   type MaterializedImladrisMetricResult,
 } from '@/lib/imladris/materialization';
+import {
+  parseImladrisLineageMaxRowsPerRun,
+  parseImladrisLineageRetentionDays,
+  pruneImladrisMetricLineage,
+} from '@/lib/imladris/lineage-retention';
 import { discoverConnectedUserIds } from './users';
 
 type RollingRangePreset = '7d' | '30d' | '90d';
@@ -49,6 +54,7 @@ export interface AnalyticsSyncInput {
 export interface AnalyticsSyncResult {
   refresh: Awaited<ReturnType<typeof runAnalyticsRefresh>>;
   pruning: Awaited<ReturnType<typeof pruneAnalyticsSnapshots>>;
+  lineagePruning: Awaited<ReturnType<typeof pruneImladrisMetricLineage>>;
   imladris: ImladrisMaterializationSyncResult[];
 }
 
@@ -239,5 +245,22 @@ export async function runAnalyticsSync(
     }),
   ]);
 
-  return { refresh, pruning, imladris };
+  // Prune ImladrisMetricLineage AFTER materialization so the just-written
+  // "latest per metric" rows are protected by the prune's latest-row guard.
+  // Tolerate failures: lineage retention must never fail the sync cycle.
+  let lineagePruning: AnalyticsSyncResult['lineagePruning'];
+  try {
+    lineagePruning = await pruneImladrisMetricLineage({
+      prisma: input.prisma,
+      olderThanDays: parseImladrisLineageRetentionDays(),
+      maxRowsPerRun: parseImladrisLineageMaxRowsPerRun(),
+      now,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('analytics_sync.imladris_lineage_prune_failed', { error: message });
+    lineagePruning = { deleted: 0, cutoff: new Date(now.getTime()).toISOString(), capped: false };
+  }
+
+  return { refresh, pruning, lineagePruning, imladris };
 }


### PR DESCRIPTION
## Commits
- docs: record executed lineage reclaim (CTAS swap, 2026-06-16)
- Fix ImladrisMetricLineage bloat that exhausted prod Postgres volume

## Files changed
 docs/imladris-lineage-bloat-runbook.md        | 211 ++++++
 src/app/api/cron/sync/route.ts                |   7 +-
 src/lib/imladris/company-tracker.ts           |  24 +-
 src/lib/imladris/investor-dashboard-export.ts |  21 +-
 src/lib/imladris/lineage-retention.test.ts    | 130 ++++
 src/lib/imladris/lineage-retention.ts         | 138 ++++
 src/lib/imladris/materialization.test.ts      | 981 ++++++++++++++++++++++++++
 src/lib/imladris/materialization.ts           | 293 +++++---
 src/lib/imladris/service.test.ts              |  56 ++
 src/lib/imladris/service.ts                   |  23 +-
 src/lib/imladris/winner-lineage.ts            |  52 ++
 src/lib/sync/analytics.test.ts                |  44 ++
 src/lib/sync/analytics.ts                     |  25 +-
 13 files changed, 1897 insertions(+), 108 deletions(-)
---
### Postgres-volume / Imladris-lineage incident cluster
This is one of **6 overlapping branches** from the same incident that could **not** be auto-consolidated (all have unique patches; 4 of 5 conflict on the lineage/pruning code). Pick the canonical approach for the shared pruning/growth-control logic, then rebase the rest in sequence. Suggested order:
1. `fix/db-connect-resilience` — connection resilience (I/O stalls; orthogonal, merges clean)
2. `feat/db-pruning` — scheduled retention pruning + `/api/health/db` probe + indexes
3. `claude/cool-greider-41cea8` — thin canonical metric values + DB growth controls
4. `claude/zen-meitner-16de46` — raw-source-record retention pruning
5. `claude/vigorous-cannon-e0c038` — lineage bloat reclaim (CTAS swap) + runbook
6. `claude/quizzical-banach-9da052` — lineage source handling + live-dashboard fixes

_Surfaced during repo cleanup; was unmerged with no PR._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
