### PR TITLE
Reconcile with db-growth-controls (#584)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,3 +130,24 @@ IMLADRIS_METRIC_VALUE_PRUNE_BUDGET_MS=15000
 OUTBOX_DISPATCHED_RETENTION_DAYS=14
 OUTBOX_DEAD_LETTER_RETENTION_DAYS=30
 OUTBOX_PRUNE_BUDGET_MS=15000
+
+# Database retention/pruning job (see docs/runbooks/db-pruning.md). Standalone
+# daily cron (POST /api/cron/db-prune, railway/cron-db-prune), DECOUPLED from
+# the sync cycle so it runs even when sync is failing. Prunes a disjoint set of
+# tables from the growth controls above. All optional — defaults shown.
+# Raw-record window is floor-clamped to stay strictly outside the 13-month
+# Imladris lookback regardless of the value set here.
+DB_PRUNE_RAW_RECORD_RETENTION_DAYS=425
+DB_PRUNE_SYNC_RUN_RETENTION_DAYS=90
+DB_PRUNE_METRIC_HISTORY_RETENTION_DAYS=425
+DB_PRUNE_SECURITY_AUDIT_RETENTION_DAYS=425
+# Batched deletes: rows per statement, max batches per table per run, and the
+# wall-clock budget for the whole run (resumes next day if capped).
+DB_PRUNE_BATCH_SIZE=1000
+DB_PRUNE_MAX_BATCHES_PER_TABLE=200
+DB_PRUNE_TIME_BUDGET_MS=240000
+# Kill switch / rollout aid: forces every run (including scheduled) to dry-run.
+DB_PRUNE_FORCE_DRY_RUN=false
+# /api/health/db reports degraded (503) once database+WAL bytes cross this many
+# GB (default 15 on the 20GB volume). Alert on it as a secondary disk signal.
+DB_HEALTH_SIZE_DEGRADED_GB=15

--- a/docs/runbooks/db-pruning.md
+++ b/docs/runbooks/db-pruning.md
@@ -3,16 +3,41 @@
 Context: on 2026-06-10 the production Postgres volume filled at ~10GB, Postgres
 crash-looped in WAL recovery on "No space left on device", and every DB-backed
 feature (including Google sign-in) went down. The volume was grown to 20GB, but
-nothing bounded table growth. This runbook documents what grows, the retention
-policy that bounds it, and how to operate the pruning job.
+nothing bounded table growth.
+
+## Relationship to `docs/db-growth-controls.md`
+
+This job is **complementary** to the controls in
+[`docs/db-growth-controls.md`](db-growth-controls.md), and the two delete
+**disjoint** sets of tables — there is no overlap in what gets removed:
+
+- **db-growth-controls (runs inside the sync cycle)** bounds the tables that
+  grew without bound and caused the outage: `ImladrisMetricLineage` (8.1 GB /
+  91% of the DB at the outage — superseded lineage generations) via a 14-day
+  TTL + per-source write cap, plus `ImladrisCanonicalMetricValue` thinning and
+  `OutboxEvent` retention.
+- **This job (a standalone daily cron)** bounds the *other* append-only tables
+  — `ImladrisRawSourceRecord`, `ImladrisSourceSyncRun`, `MetricHistory`,
+  `SecurityAuditEvent`, `AnalyticsSnapshot` — and adds the size/WAL visibility
+  endpoint (`/api/health/db`) that neither system had before.
+
+Two deliberate design choices follow from the outage: (1) this job is
+**decoupled from the sync cycle**, so retention keeps running even when sync is
+failing (the failure mode that let the original table grow unnoticed); and
+(2) there is a **synergy with the lineage TTL** — once db-growth-controls ages
+out superseded lineage, the old `ImladrisRawSourceRecord` rows that lineage
+used to reference fall outside the 13-month window with no remaining lineage,
+so this job can finally reclaim them.
 
 ## What consumes space (write-path analysis)
 
-No table in the schema had a delete path except `AnalyticsSnapshot` (whose
-pruner only runs as a side effect of the `/api/cron/sync` analytics sync — so
-pruning stops exactly when sync starts failing, e.g. while the DB is degraded).
-The cron sync fires every 10 minutes (`railway/cron-sync`, `*/10 * * * *`),
-which sets the write rates below.
+The tables below are the ones this job manages. (`ImladrisMetricLineage`,
+`ImladrisCanonicalMetricValue`, and `OutboxEvent` — the dominant growers — are
+handled by db-growth-controls, not here.) Before this work, the only delete
+path among these was `AnalyticsSnapshot` (whose pruner only runs as a side
+effect of the `/api/cron/sync` analytics sync — so pruning stops exactly when
+sync starts failing). The cron sync fires every 10 minutes
+(`railway/cron-sync`, `*/10 * * * *`), which sets the write rates below.
 
 | Table | Write path | Growth shape | Heavy columns |
 | --- | --- | --- | --- |
@@ -22,10 +47,11 @@ which sets the write rates below.
 | `AnalyticsSnapshot` | per provider/preset/sync; new row per `toDate` | bounded at 30d **only while sync succeeds** | `payload Json` |
 | `SecurityAuditEvent` | every auth/permission decision (`src/lib/security-audit.ts`) | proportional to traffic; reads cap at the latest 200 | `details Json`, `userAgent` |
 
-Other append-only tables exist (`OutboxEvent`, `WorkflowTriggerEvent`,
-`FunnelEvent`, `IntegrationReceipt`, `SubmissionEvent`) with no sweeper. They
-are lower-rate by code path; watch their real sizes via `/api/health/db` and
-extend the policy if they show up in the top tables.
+`OutboxEvent` is handled by db-growth-controls. Other append-only tables
+(`WorkflowTriggerEvent`, `FunnelEvent`, `IntegrationReceipt`,
+`SubmissionEvent`) still have no sweeper; they are lower-rate by code path —
+watch their real sizes via `/api/health/db` and extend the policy if they show
+up in the top tables.
 
 To verify sizes against the live database (read-only):
 

--- a/docs/runbooks/db-pruning.md
+++ b/docs/runbooks/db-pruning.md
@@ -1,0 +1,144 @@
+# Database retention & pruning
+
+Context: on 2026-06-10 the production Postgres volume filled at ~10GB, Postgres
+crash-looped in WAL recovery on "No space left on device", and every DB-backed
+feature (including Google sign-in) went down. The volume was grown to 20GB, but
+nothing bounded table growth. This runbook documents what grows, the retention
+policy that bounds it, and how to operate the pruning job.
+
+## What consumes space (write-path analysis)
+
+No table in the schema had a delete path except `AnalyticsSnapshot` (whose
+pruner only runs as a side effect of the `/api/cron/sync` analytics sync — so
+pruning stops exactly when sync starts failing, e.g. while the DB is degraded).
+The cron sync fires every 10 minutes (`railway/cron-sync`, `*/10 * * * *`),
+which sets the write rates below.
+
+| Table | Write path | Growth shape | Heavy columns |
+| --- | --- | --- | --- |
+| `ImladrisRawSourceRecord` | upserted per `(provider, objectType, externalId, scopeKey)` on every provider sync (`src/lib/imladris/ingestion.ts`) | grows with total source-object cardinality across ~18 providers; rows are never deleted | `payload Json` (full provider object) |
+| `ImladrisSourceSyncRun` | one row created per provider per ingestion call — every 10-minute cron tick | O(1k) rows/day, ~1M rows/year | `checkpoint Json`, `lastError Text` |
+| `MetricHistory` | `createMany` of ~50 metrics × 3 range presets per user per sync tick (`src/lib/analytics/metric-history.ts`) | ~20k+ rows/day per active user | row count (reads only ever take the latest ~12 per key) |
+| `AnalyticsSnapshot` | per provider/preset/sync; new row per `toDate` | bounded at 30d **only while sync succeeds** | `payload Json` |
+| `SecurityAuditEvent` | every auth/permission decision (`src/lib/security-audit.ts`) | proportional to traffic; reads cap at the latest 200 | `details Json`, `userAgent` |
+
+Other append-only tables exist (`OutboxEvent`, `WorkflowTriggerEvent`,
+`FunnelEvent`, `IntegrationReceipt`, `SubmissionEvent`) with no sweeper. They
+are lower-rate by code path; watch their real sizes via `/api/health/db` and
+extend the policy if they show up in the top tables.
+
+To verify sizes against the live database (read-only):
+
+```sql
+SELECT pg_size_pretty(pg_database_size(current_database()));
+
+SELECT c.relname,
+       pg_size_pretty(pg_total_relation_size(c.oid)) AS total,
+       pg_size_pretty(pg_relation_size(c.oid))       AS heap,
+       GREATEST(c.reltuples, 0)::bigint              AS approx_rows
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public' AND c.relkind = 'r'
+ORDER BY pg_total_relation_size(c.oid) DESC
+LIMIT 15;
+```
+
+## Product invariants the policy must not break
+
+1. **13-month Imladris lookback.** `getImladrisHistoricalWindow()`
+   (`src/lib/imladris/ingestion.ts`) is `now − 13 months`; materialization
+   selects raw records whose `occurredAt`/`sourceCreatedAt`/`sourceUpdatedAt`
+   fall inside a period within that window. Canonical metric values and their
+   lineage for that window must survive.
+2. **Standing finance objects are read at any age.** `financeWindowWhere`
+   (`src/lib/imladris/materialization.ts`) selects
+   `FINANCE_STANDING_OBJECT_TYPES` (subscription, deal, balance, snapshot,
+   active_customer_ref, …) with `timestamp <= periodEnd` — i.e. arbitrarily
+   old rows feed point-in-time finance metrics. These object types are never
+   pruned.
+3. **Lineage is not FK-protected.** `ImladrisMetricLineage.rawRecordId` is
+   `onDelete: SetNull` — deleting a referenced raw record silently destroys
+   lineage. The pruner must (and does) exclude lineage-referenced rows with an
+   explicit `NOT EXISTS`, evaluated inside the `DELETE` statement itself so a
+   concurrent materialization cannot race it.
+4. **Sync-run deletion cascades to raw records.** `ImladrisRawSourceRecord.
+   syncRunId` is `onDelete: Cascade`, and a never-re-upserted record still
+   points at its *original* run. Only sync runs with **zero** remaining raw
+   records are deleted, after raw-record pruning has run.
+5. **Monthly P&L history snapshots are permanent.** The
+   `financial-planning`/`monthly` `AnalyticsSnapshot` rows are the long-term
+   financial history and are exempt (same exemption as the existing
+   `pruneAnalyticsSnapshots`).
+
+## Retention policy
+
+All windows are env-configurable and clamped to a floor so misconfiguration
+can never violate the invariants above. Defaults:
+
+| Table | Env var | Default | Floor | Extra protection |
+| --- | --- | --- | --- | --- |
+| `ImladrisRawSourceRecord` | `DB_PRUNE_RAW_RECORD_RETENTION_DAYS` | 425d | 410d (> any 13-month span + margin) | every timestamp (`occurredAt`, `sourceCreatedAt`, `sourceUpdatedAt`, `createdAt`, `updatedAt`) must be older than the cutoff; no `ImladrisMetricLineage` reference; `objectType` not a standing finance type |
+| `ImladrisSourceSyncRun` | `DB_PRUNE_SYNC_RUN_RETENTION_DAYS` | 90d | 30d | only runs with no remaining raw records |
+| `MetricHistory` | `DB_PRUNE_METRIC_HISTORY_RETENTION_DAYS` | 425d | 30d | — |
+| `SecurityAuditEvent` | `DB_PRUNE_SECURITY_AUDIT_RETENTION_DAYS` | 425d | 90d | — |
+| `AnalyticsSnapshot` | `ANALYTICS_SNAPSHOT_RETENTION_DAYS` (existing) | 30d | 7d | monthly P&L history context exempt |
+
+Because a record is only prunable when **all** of its timestamps are stale,
+anything still being returned by a provider sync keeps a fresh `updatedAt`
+and is untouchable regardless of its business date.
+
+## How the job runs
+
+- **Endpoint:** `POST /api/cron/db-prune` — authorized by the same
+  `x-cron-secret` header / `CRON_SYNC_SECRET` (or `INTEGRATION_SYNC_SECRET`)
+  used by `/api/cron/sync`. Background by default (202), `?wait=1` to block.
+- **Schedule:** `railway/cron-db-prune` — a Railway cron service (same
+  curl-image pattern as `railway/cron-sync`) hitting the endpoint daily at
+  03:47 UTC. Point `TARGET_URL` at
+  `https://<app-host>/api/cron/db-prune?wait=1`.
+- **Batched deletes:** every delete is `DELETE … WHERE id IN (SELECT … LIMIT
+  batch)` in its own short transaction — no long-running locks. Batch size via
+  `DB_PRUNE_BATCH_SIZE` (default 1000), per-table batch cap via
+  `DB_PRUNE_MAX_BATCHES_PER_TABLE` (default 200), wall-clock budget via
+  `DB_PRUNE_TIME_BUDGET_MS` (default 240000). A run that hits a cap reports
+  `truncated: true` and simply continues the next day — the job is idempotent.
+- **Dry run:** body `{ "dryRun": true }` or query `?dryRun=1` counts
+  prunable rows without deleting. `DB_PRUNE_FORCE_DRY_RUN=true` forces every
+  run (including scheduled ones) into dry-run mode — use it as a kill switch
+  or during rollout.
+- **Structured logs:** each batch and each table summary is logged as
+  `[db-prune] <json>` (table, deleted, batches, cutoff, dryRun, durationMs),
+  visible in Railway logs for WIPGuard-app.
+
+This job is the **only** code path that deletes retention-managed rows
+(plus the pre-existing snapshot pruning inside `/api/cron/sync`).
+
+## Visibility & alerting
+
+`GET /api/health/db` (unauthenticated, coarse — booleans/counts only, same
+conventions as `/api/health/auth`) reports:
+
+- total database size in bytes, and the configured degraded threshold
+  (`DB_HEALTH_SIZE_DEGRADED_GB`, default 15 — i.e. 75% of the 20GB volume;
+  set it below the volume size because WAL/temp files live outside
+  `pg_database_size`),
+- the top tables by `pg_total_relation_size` (total/heap/index+toast bytes,
+  approximate row count).
+
+Returns HTTP 503 with `status: "degraded"` when the size threshold is
+exceeded or the DB is unreachable — point an uptime check at it so the disk
+is alarmed long before it fills.
+
+## Rollout
+
+1. Deploy. Run a manual dry run and review the counts:
+   `curl -X POST "$APP/api/cron/db-prune?wait=1&dryRun=1" -H "x-cron-secret: $SECRET"`
+2. Create the `wipguard-cron-db-prune` Railway service from
+   `railway/cron-db-prune` (set `TARGET_URL`, `CRON_SYNC_SECRET`). Optionally
+   set `DB_PRUNE_FORCE_DRY_RUN=true` on WIPGuard-app for a few scheduled runs
+   and compare logs.
+3. Remove `DB_PRUNE_FORCE_DRY_RUN` to enable real deletes. The first runs
+   delete in daily capped slices until the backlog converges; raise
+   `DB_PRUNE_MAX_BATCHES_PER_TABLE` temporarily (or loop `?wait=1` runs
+   manually) to drain faster.
+4. Add an uptime/alert check on `GET /api/health/db` expecting HTTP 200.

--- a/docs/runbooks/db-pruning.md
+++ b/docs/runbooks/db-pruning.md
@@ -102,6 +102,9 @@ and is untouchable regardless of its business date.
   `DB_PRUNE_MAX_BATCHES_PER_TABLE` (default 200), wall-clock budget via
   `DB_PRUNE_TIME_BUDGET_MS` (default 240000). A run that hits a cap reports
   `truncated: true` and simply continues the next day — the job is idempotent.
+  The per-table order rotates by calendar day so that, if one table's deletes
+  are pathologically slow and exhaust the time budget, it can't starve the
+  same later tables on every run.
 - **Dry run:** body `{ "dryRun": true }` or query `?dryRun=1` counts
   prunable rows without deleting. `DB_PRUNE_FORCE_DRY_RUN=true` forces every
   run (including scheduled ones) into dry-run mode — use it as a kill switch
@@ -118,16 +121,46 @@ This job is the **only** code path that deletes retention-managed rows
 `GET /api/health/db` (unauthenticated, coarse — booleans/counts only, same
 conventions as `/api/health/auth`) reports:
 
-- total database size in bytes, and the configured degraded threshold
-  (`DB_HEALTH_SIZE_DEGRADED_GB`, default 15 — i.e. 75% of the 20GB volume;
-  set it below the volume size because WAL/temp files live outside
-  `pg_database_size`),
-- the top tables by `pg_total_relation_size` (total/heap/index+toast bytes,
-  approximate row count).
+- `databaseBytes` (`pg_database_size`), `walBytes`, and `monitoredBytes`
+  (= database + WAL) against the configured degraded threshold
+  (`DB_HEALTH_SIZE_DEGRADED_GB`, default 15 — i.e. 75% of the 20GB volume),
+- `walReadable` — `pg_ls_waldir()` needs the `pg_monitor` role; if the app's
+  DB user lacks it, `walBytes` is null, `walReadable` is false, and WAL is
+  **not** counted toward the threshold,
+- the top tables by `pg_total_relation_size` (total / tableBytes [heap+TOAST,
+  where JSON payloads live] / indexBytes / approximate row count).
 
-Returns HTTP 503 with `status: "degraded"` when the size threshold is
-exceeded or the DB is unreachable — point an uptime check at it so the disk
-is alarmed long before it fills.
+Returns HTTP 503 with `status: "degraded"` when `monitoredBytes` exceeds the
+threshold or the DB is unreachable.
+
+**WAL caveat — important.** The 2026-06-10 fill was driven by WAL during
+recovery, and `pg_database_size` counts relations only. This endpoint now
+folds WAL into `monitoredBytes` *when the role can read it*, but temp files
+and replication-slot retention are still invisible to any in-DB query. Treat
+**Railway's volume-usage metric as the primary disk alarm** and this endpoint
+as the structural/secondary signal; a green check with `walReadable: false`
+has not seen WAL at all.
+
+## Indexes
+
+The prune predicates filter a single timestamp (`createdAt` / `startedAt`)
+per table. `MetricHistory` and `AnalyticsSnapshot` already have a `capturedAt`
+index; migration `20260615120000_add_retention_prune_indexes` adds
+`createdAt`/`startedAt` indexes to `SecurityAuditEvent`,
+`ImladrisSourceSyncRun`, and `ImladrisRawSourceRecord` (no existing index on
+those leads with a plain timestamp, so the prune would otherwise seq-scan).
+
+The migration runs inside a transaction (the `migrate.cjs` runner refuses
+`CONCURRENTLY`), so on the large existing tables a non-concurrent
+`CREATE INDEX` briefly holds a `SHARE` lock (blocks writes during the build).
+To avoid that on the next deploy, an operator MAY pre-create them by hand in a
+low-traffic window — the migration's `IF NOT EXISTS` then no-ops:
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "ImladrisRawSourceRecord_createdAt_idx" ON "ImladrisRawSourceRecord"("createdAt");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "ImladrisSourceSyncRun_startedAt_idx"   ON "ImladrisSourceSyncRun"("startedAt");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "SecurityAuditEvent_createdAt_idx"      ON "SecurityAuditEvent"("createdAt");
+```
 
 ## Rollout
 

--- a/prisma/migrations/20260615120000_add_retention_prune_indexes/migration.sql
+++ b/prisma/migrations/20260615120000_add_retention_prune_indexes/migration.sql
@@ -1,0 +1,21 @@
+-- Indexes supporting the database retention/pruning job (src/lib/db-pruning/).
+-- Each prune predicate filters a single timestamp (createdAt / startedAt) <
+-- cutoff, but no existing index on these tables leads with a plain timestamp
+-- column, so the prune would otherwise seq-scan.
+--
+-- IF NOT EXISTS makes this migration idempotent: on the large existing tables
+-- an operator MAY pre-create these indexes by hand with
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS "<name>" ON "<table>"("<col>");
+-- during a low-traffic window to avoid the brief write-lock a non-concurrent
+-- CREATE INDEX takes (this migration runs inside a transaction — the custom
+-- runner in migrate.cjs refuses CONCURRENTLY — so the build holds a SHARE
+-- lock for its duration). If pre-created, the statements below no-op.
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "SecurityAuditEvent_createdAt_idx" ON "SecurityAuditEvent"("createdAt");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "ImladrisSourceSyncRun_startedAt_idx" ON "ImladrisSourceSyncRun"("startedAt");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "ImladrisRawSourceRecord_createdAt_idx" ON "ImladrisRawSourceRecord"("createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -510,6 +510,10 @@ model SecurityAuditEvent {
   @@index([category, createdAt])
   @@index([action, createdAt])
   @@index([actorId, createdAt])
+  // Supports the retention prune predicate (createdAt < cutoff); the
+  // composites above lead with category/action/actorId and cannot seek on
+  // createdAt alone. See src/lib/db-pruning/.
+  @@index([createdAt])
 }
 
 // ============================================================
@@ -2426,6 +2430,10 @@ model ImladrisSourceSyncRun {
   @@index([provider, startedAt])
   @@index([organizationId, provider, startedAt])
   @@index([userId, provider, startedAt])
+  // Supports the retention prune predicate (startedAt < cutoff); the
+  // composites above lead with provider and cannot seek on startedAt
+  // alone. See src/lib/db-pruning/.
+  @@index([startedAt])
 }
 
 model ImladrisRawSourceRecord {
@@ -2452,6 +2460,10 @@ model ImladrisRawSourceRecord {
   @@index([provider, objectType, occurredAt])
   @@index([scopeKey, provider, objectType])
   @@index([organizationId, provider, objectType])
+  // Supports the retention prune predicate (createdAt < cutoff) on the
+  // largest table; no existing index leads with a plain timestamp. See
+  // src/lib/db-pruning/.
+  @@index([createdAt])
 }
 
 model ImladrisCanonicalMetricValue {

--- a/railway/cron-db-prune/Dockerfile
+++ b/railway/cron-db-prune/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.20
+
+RUN apk add --no-cache curl ca-certificates
+
+COPY run.sh /run.sh
+RUN chmod +x /run.sh
+
+CMD ["/run.sh"]

--- a/railway/cron-db-prune/railway.json
+++ b/railway/cron-db-prune/railway.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "cronSchedule": "47 3 * * *",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}

--- a/railway/cron-db-prune/run.sh
+++ b/railway/cron-db-prune/run.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Daily database retention/pruning trigger.
+#
+# Deploy as a Railway cron service (see railway.json for the schedule) with:
+#   TARGET_URL          e.g. https://<app-host>/api/cron/db-prune?wait=1
+#   CRON_SYNC_SECRET    same secret the app's /api/cron/* routes check
+#
+# Use ?wait=1 in TARGET_URL so the cron container's exit code reflects the
+# prune result and Railway's ON_FAILURE restart policy can retry it.
+set -eu
+
+: "${TARGET_URL:?TARGET_URL is required}"
+
+HEADER_NAME="${CRON_HEADER_NAME:-x-cron-secret}"
+SECRET="${CRON_SYNC_SECRET:-${INTEGRATION_SYNC_SECRET:-}}"
+
+if [ -z "${SECRET}" ]; then
+  echo "Missing CRON_SYNC_SECRET or INTEGRATION_SYNC_SECRET"
+  exit 1
+fi
+
+echo "POST ${TARGET_URL}"
+curl -fsS -X POST "${TARGET_URL}" \
+  -H "${HEADER_NAME}: ${SECRET}" \
+  -H "content-type: application/json" \
+  --data '{}'
+echo "ok"

--- a/src/app/api/cron/db-prune/route.test.ts
+++ b/src/app/api/cron/db-prune/route.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const afterCallbacks: Array<() => void | Promise<void>> = [];
+
+vi.mock("next/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next/server")>();
+  return {
+    ...actual,
+    after: vi.fn((callback: () => void | Promise<void>) => {
+      afterCallbacks.push(callback);
+    }),
+  };
+});
+
+vi.mock("@/lib/prisma", () => ({ prisma: {} }));
+
+vi.mock("@/lib/db-pruning/prune", () => ({
+  runDbPrune: vi.fn(),
+}));
+
+const ENV_KEYS = [
+  "CRON_SYNC_SECRET",
+  "INTEGRATION_SYNC_SECRET",
+  "DB_PRUNE_FORCE_DRY_RUN",
+] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+function makeRequest(input: {
+  url?: string;
+  secret?: string;
+  body?: unknown;
+}): NextRequest {
+  return new Request(input.url ?? "http://localhost/api/cron/db-prune", {
+    method: "POST",
+    headers: {
+      ...(input.secret ? { "x-cron-secret": input.secret } : {}),
+      "content-type": "application/json",
+    },
+    ...(input.body !== undefined ? { body: JSON.stringify(input.body) } : {}),
+  }) as unknown as NextRequest;
+}
+
+function okRunResult(overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    dryRun: false,
+    startedAt: "2026-06-10T00:00:00.000Z",
+    finishedAt: "2026-06-10T00:00:05.000Z",
+    durationMs: 5000,
+    totalRows: 123,
+    truncated: false,
+    policy: {},
+    tables: [],
+    ...overrides,
+  };
+}
+
+describe("POST /api/cron/db-prune", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.resetModules();
+    afterCallbacks.length = 0;
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    process.env.CRON_SYNC_SECRET = "cron-secret";
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+  });
+
+  it("rejects requests without the cron secret", async () => {
+    const { POST } = await import("@/app/api/cron/db-prune/route");
+    const response = await POST(makeRequest({}));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects requests with a wrong secret", async () => {
+    const { POST } = await import("@/app/api/cron/db-prune/route");
+    const response = await POST(makeRequest({ secret: "wrong" }));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects every request when no secret is configured", async () => {
+    delete process.env.CRON_SYNC_SECRET;
+    const { POST } = await import("@/app/api/cron/db-prune/route");
+    const response = await POST(makeRequest({ secret: "anything" }));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("queues a background run by default and responds 202", async () => {
+    const { runDbPrune } = await import("@/lib/db-pruning/prune");
+    vi.mocked(runDbPrune).mockResolvedValue(okRunResult() as never);
+
+    const { POST } = await import("@/app/api/cron/db-prune/route");
+    const response = await POST(makeRequest({ secret: "cron-secret" }));
+    const body = (await response.json()) as { queued: boolean; dryRun: boolean };
+
+    expect(response.status).toBe(202);
+    expect(body.queued).toBe(true);
+    expect(body.dryRun).toBe(false);
+    expect(runDbPrune).not.toHaveBeenCalled();
+
+    expect(afterCallbacks).toHaveLength(1);
+    await afterCallbacks[0]();
+    expect(runDbPrune).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(runDbPrune).mock.calls[0][0]).toMatchObject({ dryRun: false });
+  });
+
+  it("runs inline with ?wait=1 and returns the full result", async () => {
+    const { runDbPrune } = await import("@/lib/db-pruning/prune");
+    vi.mocked(runDbPrune).mockResolvedValue(okRunResult() as never);
+
+    const { POST } = await import("@/app/api/cron/db-prune/route");
+    const response = await POST(
+      makeRequest({
+        url: "http://localhost/api/cron/db-prune?wait=1",
+        secret: "cron-secret",
+      }),
+    );
+    const body = (await response.json()) as { ok: boolean; totalRows: number };
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.totalRows).toBe(123);
+  });
+
+  it("returns 500 when an inline run reports table errors", async () => {
+    const { runDbPrune } = await import("@/lib/db-pruning/prune");
+    vi.mocked(runDbPrune).mockResolvedValue(okRunResult({ ok: false }) as never);
+
+    const { POST } = await import("@/app/api/cron/db-prune/route");
+    const response = await POST(
+      makeRequest({
+        url: "http://localhost/api/cron/db-prune?wait=1",
+        secret: "cron-secret",
+      }),
+    );
+
+    expect(response.status).toBe(500);
+  });
+
+  it("returns 500 when an inline run throws", async () => {
+    const { runDbPrune } = await import("@/lib/db-pruning/prune");
+    vi.mocked(runDbPrune).mockRejectedValue(new Error("boom"));
+
+    const { POST } = await import("@/app/api/cron/db-prune/route");
+    const response = await POST(
+      makeRequest({
+        url: "http://localhost/api/cron/db-prune?wait=1",
+        secret: "cron-secret",
+      }),
+    );
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("boom");
+  });
+
+  it("honors ?dryRun=1", async () => {
+    const { runDbPrune } = await import("@/lib/db-pruning/prune");
+    vi.mocked(runDbPrune).mockResolvedValue(okRunResult({ dryRun: true }) as never);
+
+    const { POST } = await import("@/app/api/cron/db-prune/route");
+    const response = await POST(
+      makeRequest({
+        url: "http://localhost/api/cron/db-prune?wait=1&dryRun=1",
+        secret: "cron-secret",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(runDbPrune).mock.calls[0][0]).toMatchObject({ dryRun: true });
+  });
+
+  it("honors a JSON body dryRun flag", async () => {
+    const { runDbPrune } = await import("@/lib/db-pruning/prune");
+    vi.mocked(runDbPrune).mockResolvedValue(okRunResult({ dryRun: true }) as never);
+
+    const { POST } = await import("@/app/api/cron/db-prune/route");
+    await POST(
+      makeRequest({
+        url: "http://localhost/api/cron/db-prune?wait=1",
+        secret: "cron-secret",
+        body: { dryRun: true },
+      }),
+    );
+
+    expect(vi.mocked(runDbPrune).mock.calls[0][0]).toMatchObject({ dryRun: true });
+  });
+
+  it("forces dry run for every request when DB_PRUNE_FORCE_DRY_RUN=true", async () => {
+    process.env.DB_PRUNE_FORCE_DRY_RUN = "true";
+    const { runDbPrune } = await import("@/lib/db-pruning/prune");
+    vi.mocked(runDbPrune).mockResolvedValue(okRunResult({ dryRun: true }) as never);
+
+    const { POST } = await import("@/app/api/cron/db-prune/route");
+    await POST(
+      makeRequest({
+        url: "http://localhost/api/cron/db-prune?wait=1",
+        secret: "cron-secret",
+      }),
+    );
+
+    expect(vi.mocked(runDbPrune).mock.calls[0][0]).toMatchObject({ dryRun: true });
+  });
+});

--- a/src/app/api/cron/db-prune/route.ts
+++ b/src/app/api/cron/db-prune/route.ts
@@ -1,0 +1,101 @@
+export const dynamic = "force-dynamic";
+
+import { after, NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { runDbPrune } from "@/lib/db-pruning/prune";
+import { resolveDbPrunePolicy } from "@/lib/db-pruning/policy";
+
+/**
+ * POST /api/cron/db-prune
+ *
+ * Scheduled database retention job — deletes rows outside the retention
+ * policy in short batched transactions. Triggered daily by the
+ * railway/cron-db-prune service (same curl-image pattern as
+ * railway/cron-sync). See docs/runbooks/db-pruning.md.
+ *
+ * Auth matches /api/cron/sync: `x-cron-secret` (or
+ * `x-integration-sync-secret`) against CRON_SYNC_SECRET /
+ * INTEGRATION_SYNC_SECRET.
+ *
+ * Modes:
+ *   - default: queued in the background, responds 202 immediately
+ *   - `?wait=1`: runs inline and returns the full result
+ *   - `?dryRun=1` or body `{ "dryRun": true }`: counts prunable rows
+ *     without deleting; DB_PRUNE_FORCE_DRY_RUN=true forces this for
+ *     every run (kill switch / rollout aid)
+ */
+
+function isAuthorized(request: NextRequest): boolean {
+  const expected =
+    process.env.CRON_SYNC_SECRET?.trim() || process.env.INTEGRATION_SYNC_SECRET?.trim();
+  if (!expected) return false;
+  const provided =
+    request.headers.get("x-cron-secret")?.trim() ||
+    request.headers.get("x-integration-sync-secret")?.trim() ||
+    "";
+  return Boolean(provided && provided === expected);
+}
+
+function isTruthyFlag(value: string | null | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "1" || normalized === "true";
+}
+
+function shouldWaitForCompletion(request: NextRequest): boolean {
+  return isTruthyFlag(new URL(request.url).searchParams.get("wait"));
+}
+
+async function requestedDryRun(request: NextRequest): Promise<boolean> {
+  if (isTruthyFlag(new URL(request.url).searchParams.get("dryRun"))) {
+    return true;
+  }
+  try {
+    const body = (await request.json()) as { dryRun?: unknown } | null;
+    return body?.dryRun === true || isTruthyFlag(typeof body?.dryRun === "string" ? body.dryRun : null);
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const startedAt = new Date().toISOString();
+  const policy = resolveDbPrunePolicy();
+  const dryRun = policy.forceDryRun || (await requestedDryRun(request));
+
+  if (shouldWaitForCompletion(request)) {
+    try {
+      const result = await runDbPrune({ prisma, dryRun, policy });
+      return NextResponse.json(result, { status: result.ok ? 200 : 500 });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Database prune failed";
+      console.error("POST /api/cron/db-prune error:", error);
+      return NextResponse.json({ error: message }, { status: 500 });
+    }
+  }
+
+  after(async () => {
+    try {
+      const result = await runDbPrune({ prisma, dryRun, policy });
+      if (!result.ok) {
+        console.error("POST /api/cron/db-prune background degraded:", JSON.stringify(result));
+      }
+    } catch (error) {
+      console.error("POST /api/cron/db-prune background error:", error);
+    }
+  });
+
+  return NextResponse.json(
+    {
+      ok: true,
+      queued: true,
+      mode: "background",
+      dryRun,
+      startedAt,
+    },
+    { status: 202 },
+  );
+}

--- a/src/app/api/health/db/route.test.ts
+++ b/src/app/api/health/db/route.test.ts
@@ -12,14 +12,16 @@ const GB = 1024 ** 3;
 
 function mockSizes(input: {
   totalBytes: number;
+  walBytes?: number | "unreadable";
   tables?: Array<{
     table_name: string;
     total_bytes: number;
-    heap_bytes: number;
-    index_and_toast_bytes: number;
+    table_bytes: number;
+    index_bytes: number;
     approx_rows: number;
   }>;
 }) {
+  // Query order in the route: database size, top tables, then WAL.
   queryRaw
     .mockResolvedValueOnce([{ total_bytes: input.totalBytes }])
     .mockResolvedValueOnce(
@@ -27,12 +29,21 @@ function mockSizes(input: {
         {
           table_name: "ImladrisRawSourceRecord",
           total_bytes: 4 * GB,
-          heap_bytes: 3 * GB,
-          index_and_toast_bytes: 1 * GB,
+          table_bytes: 3 * GB,
+          index_bytes: 1 * GB,
           approx_rows: 1_200_000,
         },
       ],
     );
+  if (input.walBytes === "unreadable") {
+    queryRaw.mockRejectedValueOnce(
+      Object.assign(new Error("permission denied for function pg_ls_waldir"), {
+        code: "42501",
+      }),
+    );
+  } else {
+    queryRaw.mockResolvedValueOnce([{ wal_bytes: input.walBytes ?? 0 }]);
+  }
 }
 
 describe("GET /api/health/db", () => {
@@ -50,7 +61,7 @@ describe("GET /api/health/db", () => {
   });
 
   it("reports ok with sizes and top tables when under the threshold", async () => {
-    mockSizes({ totalBytes: 8 * GB });
+    mockSizes({ totalBytes: 8 * GB, walBytes: 1 * GB });
 
     const { GET } = await import("@/app/api/health/db/route");
     const response = await GET();
@@ -59,7 +70,10 @@ describe("GET /api/health/db", () => {
       checks: {
         database: {
           reachable: boolean;
-          totalBytes: number;
+          databaseBytes: number;
+          walBytes: number | null;
+          walReadable: boolean;
+          monitoredBytes: number;
           degradedThresholdBytes: number;
           overThreshold: boolean;
         };
@@ -70,7 +84,10 @@ describe("GET /api/health/db", () => {
     expect(response.status).toBe(200);
     expect(body.status).toBe("ok");
     expect(body.checks.database.reachable).toBe(true);
-    expect(body.checks.database.totalBytes).toBe(8 * GB);
+    expect(body.checks.database.databaseBytes).toBe(8 * GB);
+    expect(body.checks.database.walBytes).toBe(1 * GB);
+    expect(body.checks.database.walReadable).toBe(true);
+    expect(body.checks.database.monitoredBytes).toBe(9 * GB);
     // Default threshold: 15GB.
     expect(body.checks.database.degradedThresholdBytes).toBe(15 * GB);
     expect(body.checks.database.overThreshold).toBe(false);
@@ -78,8 +95,8 @@ describe("GET /api/health/db", () => {
       {
         table: "ImladrisRawSourceRecord",
         totalBytes: 4 * GB,
-        heapBytes: 3 * GB,
-        indexAndToastBytes: 1 * GB,
+        tableBytes: 3 * GB,
+        indexBytes: 1 * GB,
         approxRows: 1_200_000,
       },
     ]);
@@ -99,6 +116,50 @@ describe("GET /api/health/db", () => {
     expect(response.status).toBe(503);
     expect(body.status).toBe("degraded");
     expect(body.checks.database.overThreshold).toBe(true);
+  });
+
+  it("counts WAL toward the threshold (the actual outage cause)", async () => {
+    // Relations alone (12GB) are under 15GB, but WAL (5GB) pushes the
+    // monitored total to 17GB — must degrade.
+    mockSizes({ totalBytes: 12 * GB, walBytes: 5 * GB });
+
+    const { GET } = await import("@/app/api/health/db/route");
+    const response = await GET();
+    const body = (await response.json()) as {
+      status: string;
+      checks: { database: { monitoredBytes: number; overThreshold: boolean } };
+    };
+
+    expect(response.status).toBe(503);
+    expect(body.status).toBe("degraded");
+    expect(body.checks.database.monitoredBytes).toBe(17 * GB);
+    expect(body.checks.database.overThreshold).toBe(true);
+  });
+
+  it("degrades gracefully when WAL is not readable (no pg_monitor)", async () => {
+    mockSizes({ totalBytes: 8 * GB, walBytes: "unreadable" });
+
+    const { GET } = await import("@/app/api/health/db/route");
+    const response = await GET();
+    const body = (await response.json()) as {
+      status: string;
+      checks: {
+        database: {
+          reachable: boolean;
+          walBytes: number | null;
+          walReadable: boolean;
+          monitoredBytes: number;
+        };
+      };
+    };
+
+    // The probe still works — WAL is just invisible.
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("ok");
+    expect(body.checks.database.reachable).toBe(true);
+    expect(body.checks.database.walReadable).toBe(false);
+    expect(body.checks.database.walBytes).toBeNull();
+    expect(body.checks.database.monitoredBytes).toBe(8 * GB);
   });
 
   it("honors DB_HEALTH_SIZE_DEGRADED_GB overrides", async () => {

--- a/src/app/api/health/db/route.test.ts
+++ b/src/app/api/health/db/route.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const queryRaw = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    $queryRaw: (...args: unknown[]) => queryRaw(...args),
+  },
+}));
+
+const GB = 1024 ** 3;
+
+function mockSizes(input: {
+  totalBytes: number;
+  tables?: Array<{
+    table_name: string;
+    total_bytes: number;
+    heap_bytes: number;
+    index_and_toast_bytes: number;
+    approx_rows: number;
+  }>;
+}) {
+  queryRaw
+    .mockResolvedValueOnce([{ total_bytes: input.totalBytes }])
+    .mockResolvedValueOnce(
+      input.tables ?? [
+        {
+          table_name: "ImladrisRawSourceRecord",
+          total_bytes: 4 * GB,
+          heap_bytes: 3 * GB,
+          index_and_toast_bytes: 1 * GB,
+          approx_rows: 1_200_000,
+        },
+      ],
+    );
+}
+
+describe("GET /api/health/db", () => {
+  const savedThreshold = process.env.DB_HEALTH_SIZE_DEGRADED_GB;
+
+  beforeEach(() => {
+    vi.resetModules();
+    queryRaw.mockReset();
+    delete process.env.DB_HEALTH_SIZE_DEGRADED_GB;
+  });
+
+  afterEach(() => {
+    if (savedThreshold === undefined) delete process.env.DB_HEALTH_SIZE_DEGRADED_GB;
+    else process.env.DB_HEALTH_SIZE_DEGRADED_GB = savedThreshold;
+  });
+
+  it("reports ok with sizes and top tables when under the threshold", async () => {
+    mockSizes({ totalBytes: 8 * GB });
+
+    const { GET } = await import("@/app/api/health/db/route");
+    const response = await GET();
+    const body = (await response.json()) as {
+      status: string;
+      checks: {
+        database: {
+          reachable: boolean;
+          totalBytes: number;
+          degradedThresholdBytes: number;
+          overThreshold: boolean;
+        };
+        topTables: Array<{ table: string; totalBytes: number; approxRows: number }>;
+      };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("ok");
+    expect(body.checks.database.reachable).toBe(true);
+    expect(body.checks.database.totalBytes).toBe(8 * GB);
+    // Default threshold: 15GB.
+    expect(body.checks.database.degradedThresholdBytes).toBe(15 * GB);
+    expect(body.checks.database.overThreshold).toBe(false);
+    expect(body.checks.topTables).toEqual([
+      {
+        table: "ImladrisRawSourceRecord",
+        totalBytes: 4 * GB,
+        heapBytes: 3 * GB,
+        indexAndToastBytes: 1 * GB,
+        approxRows: 1_200_000,
+      },
+    ]);
+    expect(response.headers.get("Cache-Control")).toContain("no-store");
+  });
+
+  it("degrades (503) once the database size crosses the threshold", async () => {
+    mockSizes({ totalBytes: 16 * GB });
+
+    const { GET } = await import("@/app/api/health/db/route");
+    const response = await GET();
+    const body = (await response.json()) as {
+      status: string;
+      checks: { database: { overThreshold: boolean } };
+    };
+
+    expect(response.status).toBe(503);
+    expect(body.status).toBe("degraded");
+    expect(body.checks.database.overThreshold).toBe(true);
+  });
+
+  it("honors DB_HEALTH_SIZE_DEGRADED_GB overrides", async () => {
+    process.env.DB_HEALTH_SIZE_DEGRADED_GB = "2";
+    mockSizes({ totalBytes: 3 * GB });
+
+    const { GET } = await import("@/app/api/health/db/route");
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+  });
+
+  it("falls back to the default threshold for unparseable overrides", async () => {
+    process.env.DB_HEALTH_SIZE_DEGRADED_GB = "lots";
+    mockSizes({ totalBytes: 8 * GB });
+
+    const { GET } = await import("@/app/api/health/db/route");
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+  });
+
+  it("degrades with a compact error code when the database is unreachable", async () => {
+    queryRaw.mockRejectedValue(
+      Object.assign(new Error("no space left on device"), { code: "53100" }),
+    );
+
+    const { GET } = await import("@/app/api/health/db/route");
+    const response = await GET();
+    const body = (await response.json()) as {
+      status: string;
+      checks: { database: { reachable: boolean; errorCode: string } };
+    };
+
+    expect(response.status).toBe(503);
+    expect(body.status).toBe("degraded");
+    expect(body.checks.database.reachable).toBe(false);
+    expect(body.checks.database.errorCode).toBe("53100");
+    // Coarse output only — the raw error message is never echoed back.
+    expect(JSON.stringify(body)).not.toContain("no space left");
+  });
+});

--- a/src/app/api/health/db/route.ts
+++ b/src/app/api/health/db/route.ts
@@ -1,0 +1,117 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * GET /api/health/db
+ *
+ * Database size readiness probe. The 2026-06-10 outage was the Postgres
+ * volume filling up (WAL recovery crash-loop on "No space left on device"),
+ * which took down everything DB-backed including sign-in — so, like
+ * /api/health/auth, this endpoint is intentionally unauthenticated and
+ * intentionally coarse: byte counts, table names, and booleans only — no
+ * env values, hostnames, or row contents.
+ *
+ * Returns `status: "degraded"` (HTTP 503) once the database size crosses
+ * DB_HEALTH_SIZE_DEGRADED_GB (default 15 — i.e. 75% of the 20GB volume;
+ * keep it well below the volume size because WAL and temp files live
+ * outside pg_database_size). Point an uptime/alert check at this endpoint
+ * so the disk pages someone long before it fills.
+ */
+
+const DEFAULT_DEGRADED_GB = 15;
+const TOP_TABLE_LIMIT = 10;
+const BYTES_PER_GB = 1024 ** 3;
+
+interface DatabaseSizeRow {
+  total_bytes: number;
+}
+
+interface TableSizeRow {
+  table_name: string;
+  total_bytes: number;
+  heap_bytes: number;
+  index_and_toast_bytes: number;
+  approx_rows: number;
+}
+
+function degradedThresholdBytes(): number {
+  const raw = process.env.DB_HEALTH_SIZE_DEGRADED_GB?.trim();
+  const parsed = raw ? Number(raw) : NaN;
+  const gb = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_DEGRADED_GB;
+  return Math.round(gb * BYTES_PER_GB);
+}
+
+function compactErrorCode(error: unknown): string {
+  if (error && typeof error === "object") {
+    const code = (error as { code?: unknown }).code;
+    if (typeof code === "string" && code.length > 0) return code;
+    if (error instanceof Error && error.name !== "Error") return error.name;
+  }
+  return "UNKNOWN";
+}
+
+export async function GET() {
+  const thresholdBytes = degradedThresholdBytes();
+  const checks: Record<string, unknown> = {};
+  const startedAt = Date.now();
+
+  try {
+    const [size] = await prisma.$queryRaw<DatabaseSizeRow[]>`
+      SELECT pg_database_size(current_database())::float8 AS total_bytes
+    `;
+    const tables = await prisma.$queryRaw<TableSizeRow[]>`
+      SELECT
+        c.relname AS table_name,
+        pg_total_relation_size(c.oid)::float8 AS total_bytes,
+        pg_relation_size(c.oid)::float8 AS heap_bytes,
+        (pg_total_relation_size(c.oid) - pg_relation_size(c.oid))::float8 AS index_and_toast_bytes,
+        GREATEST(c.reltuples, 0)::float8 AS approx_rows
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public' AND c.relkind = 'r'
+      ORDER BY pg_total_relation_size(c.oid) DESC
+      LIMIT ${TOP_TABLE_LIMIT}
+    `;
+
+    const totalBytes = Math.round(size?.total_bytes ?? 0);
+    checks.database = {
+      reachable: true,
+      latencyMs: Date.now() - startedAt,
+      totalBytes,
+      degradedThresholdBytes: thresholdBytes,
+      overThreshold: totalBytes >= thresholdBytes,
+    };
+    checks.topTables = tables.map((table) => ({
+      table: table.table_name,
+      totalBytes: Math.round(table.total_bytes),
+      heapBytes: Math.round(table.heap_bytes),
+      indexAndToastBytes: Math.round(table.index_and_toast_bytes),
+      approxRows: Math.round(table.approx_rows),
+    }));
+  } catch (error) {
+    checks.database = {
+      reachable: false,
+      latencyMs: Date.now() - startedAt,
+      errorCode: compactErrorCode(error),
+    };
+  }
+
+  const database = checks.database as { reachable: boolean; overThreshold?: boolean };
+  const healthy = database.reachable && database.overThreshold === false;
+
+  return NextResponse.json(
+    {
+      status: healthy ? "ok" : "degraded",
+      timestamp: new Date().toISOString(),
+      checks,
+    },
+    {
+      status: healthy ? 200 : 503,
+      headers: {
+        "Cache-Control": "no-store, no-cache, must-revalidate",
+      },
+    },
+  );
+}

--- a/src/app/api/health/db/route.ts
+++ b/src/app/api/health/db/route.ts
@@ -13,11 +13,16 @@ import { prisma } from "@/lib/prisma";
  * intentionally coarse: byte counts, table names, and booleans only — no
  * env values, hostnames, or row contents.
  *
- * Returns `status: "degraded"` (HTTP 503) once the database size crosses
- * DB_HEALTH_SIZE_DEGRADED_GB (default 15 — i.e. 75% of the 20GB volume;
- * keep it well below the volume size because WAL and temp files live
- * outside pg_database_size). Point an uptime/alert check at this endpoint
- * so the disk pages someone long before it fills.
+ * Returns `status: "degraded"` (HTTP 503) once the monitored size crosses
+ * DB_HEALTH_SIZE_DEGRADED_GB (default 15 — i.e. 75% of the 20GB volume).
+ *
+ * WAL caveat: the 2026-06-10 disk fill was driven by WAL during recovery,
+ * and pg_database_size() counts relations only — not WAL, temp files, or
+ * replication-slot retention. When the DB role can read pg_ls_waldir()
+ * (pg_monitor), WAL bytes ARE included in the monitored total and the
+ * threshold; otherwise `walReadable` is false and WAL is invisible here.
+ * Treat Railway's volume-usage metric as the PRIMARY disk alarm and this
+ * endpoint as the structural/secondary signal.
  */
 
 const DEFAULT_DEGRADED_GB = 15;
@@ -28,11 +33,15 @@ interface DatabaseSizeRow {
   total_bytes: number;
 }
 
+interface WalSizeRow {
+  wal_bytes: number;
+}
+
 interface TableSizeRow {
   table_name: string;
   total_bytes: number;
-  heap_bytes: number;
-  index_and_toast_bytes: number;
+  table_bytes: number;
+  index_bytes: number;
   approx_rows: number;
 }
 
@@ -65,8 +74,8 @@ export async function GET() {
       SELECT
         c.relname AS table_name,
         pg_total_relation_size(c.oid)::float8 AS total_bytes,
-        pg_relation_size(c.oid)::float8 AS heap_bytes,
-        (pg_total_relation_size(c.oid) - pg_relation_size(c.oid))::float8 AS index_and_toast_bytes,
+        pg_table_size(c.oid)::float8 AS table_bytes,
+        pg_indexes_size(c.oid)::float8 AS index_bytes,
         GREATEST(c.reltuples, 0)::float8 AS approx_rows
       FROM pg_class c
       JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -75,19 +84,40 @@ export async function GET() {
       LIMIT ${TOP_TABLE_LIMIT}
     `;
 
-    const totalBytes = Math.round(size?.total_bytes ?? 0);
+    // WAL is read separately and tolerantly: pg_ls_waldir() needs the
+    // pg_monitor role, which the app's DB user may not have. A failure here
+    // must not fail the whole probe — we just report walReadable: false.
+    let walBytes: number | null = null;
+    try {
+      const [wal] = await prisma.$queryRaw<WalSizeRow[]>`
+        SELECT COALESCE(SUM(size), 0)::float8 AS wal_bytes FROM pg_ls_waldir()
+      `;
+      walBytes = Math.round(wal?.wal_bytes ?? 0);
+    } catch {
+      walBytes = null;
+    }
+
+    const databaseBytes = Math.round(size?.total_bytes ?? 0);
+    // Monitor relations + WAL (when visible) against the threshold — WAL is
+    // exactly what filled the disk during the outage.
+    const monitoredBytes = databaseBytes + (walBytes ?? 0);
     checks.database = {
       reachable: true,
       latencyMs: Date.now() - startedAt,
-      totalBytes,
+      databaseBytes,
+      walBytes,
+      walReadable: walBytes !== null,
+      monitoredBytes,
       degradedThresholdBytes: thresholdBytes,
-      overThreshold: totalBytes >= thresholdBytes,
+      overThreshold: monitoredBytes >= thresholdBytes,
     };
     checks.topTables = tables.map((table) => ({
       table: table.table_name,
       totalBytes: Math.round(table.total_bytes),
-      heapBytes: Math.round(table.heap_bytes),
-      indexAndToastBytes: Math.round(table.index_and_toast_bytes),
+      // Heap + TOAST: the actual row data, including JSON payloads (which
+      // live in TOAST and dominate ImladrisRawSourceRecord).
+      tableBytes: Math.round(table.table_bytes),
+      indexBytes: Math.round(table.index_bytes),
       approxRows: Math.round(table.approx_rows),
     }));
   } catch (error) {

--- a/src/lib/db-pruning/policy.test.ts
+++ b/src/lib/db-pruning/policy.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { getImladrisHistoricalWindow } from "@/lib/imladris/ingestion";
+import {
+  ANALYTICS_SNAPSHOT_RETENTION_DEFAULT_DAYS,
+  BATCH_SIZE_DEFAULT,
+  BATCH_SIZE_MAX,
+  BATCH_SIZE_MIN,
+  cutoffForRetentionDays,
+  MAX_BATCHES_PER_TABLE_DEFAULT,
+  METRIC_HISTORY_RETENTION_DEFAULT_DAYS,
+  RAW_RECORD_RETENTION_DEFAULT_DAYS,
+  RAW_RECORD_RETENTION_FLOOR_DAYS,
+  resolveDbPrunePolicy,
+  SECURITY_AUDIT_RETENTION_DEFAULT_DAYS,
+  SECURITY_AUDIT_RETENTION_FLOOR_DAYS,
+  SYNC_RUN_RETENTION_DEFAULT_DAYS,
+  SYNC_RUN_RETENTION_FLOOR_DAYS,
+  TIME_BUDGET_MS_DEFAULT,
+} from "@/lib/db-pruning/policy";
+
+describe("resolveDbPrunePolicy", () => {
+  it("returns documented defaults when no env vars are set", () => {
+    const policy = resolveDbPrunePolicy({});
+
+    expect(policy).toEqual({
+      rawRecordRetentionDays: RAW_RECORD_RETENTION_DEFAULT_DAYS,
+      syncRunRetentionDays: SYNC_RUN_RETENTION_DEFAULT_DAYS,
+      metricHistoryRetentionDays: METRIC_HISTORY_RETENTION_DEFAULT_DAYS,
+      securityAuditRetentionDays: SECURITY_AUDIT_RETENTION_DEFAULT_DAYS,
+      analyticsSnapshotRetentionDays: ANALYTICS_SNAPSHOT_RETENTION_DEFAULT_DAYS,
+      batchSize: BATCH_SIZE_DEFAULT,
+      maxBatchesPerTable: MAX_BATCHES_PER_TABLE_DEFAULT,
+      timeBudgetMs: TIME_BUDGET_MS_DEFAULT,
+      forceDryRun: false,
+    });
+  });
+
+  it("honors env overrides above the floors", () => {
+    const policy = resolveDbPrunePolicy({
+      DB_PRUNE_RAW_RECORD_RETENTION_DAYS: "500",
+      DB_PRUNE_SYNC_RUN_RETENTION_DAYS: "45",
+      DB_PRUNE_METRIC_HISTORY_RETENTION_DAYS: "200",
+      DB_PRUNE_SECURITY_AUDIT_RETENTION_DAYS: "365",
+      ANALYTICS_SNAPSHOT_RETENTION_DAYS: "60",
+      DB_PRUNE_BATCH_SIZE: "500",
+      DB_PRUNE_MAX_BATCHES_PER_TABLE: "50",
+      DB_PRUNE_TIME_BUDGET_MS: "60000",
+      DB_PRUNE_FORCE_DRY_RUN: "true",
+    });
+
+    expect(policy.rawRecordRetentionDays).toBe(500);
+    expect(policy.syncRunRetentionDays).toBe(45);
+    expect(policy.metricHistoryRetentionDays).toBe(200);
+    expect(policy.securityAuditRetentionDays).toBe(365);
+    expect(policy.analyticsSnapshotRetentionDays).toBe(60);
+    expect(policy.batchSize).toBe(500);
+    expect(policy.maxBatchesPerTable).toBe(50);
+    expect(policy.timeBudgetMs).toBe(60000);
+    expect(policy.forceDryRun).toBe(true);
+  });
+
+  it("clamps misconfigured retention windows to their floors", () => {
+    const policy = resolveDbPrunePolicy({
+      DB_PRUNE_RAW_RECORD_RETENTION_DAYS: "30",
+      DB_PRUNE_SYNC_RUN_RETENTION_DAYS: "1",
+      DB_PRUNE_SECURITY_AUDIT_RETENTION_DAYS: "1",
+    });
+
+    expect(policy.rawRecordRetentionDays).toBe(RAW_RECORD_RETENTION_FLOOR_DAYS);
+    expect(policy.syncRunRetentionDays).toBe(SYNC_RUN_RETENTION_FLOOR_DAYS);
+    expect(policy.securityAuditRetentionDays).toBe(SECURITY_AUDIT_RETENTION_FLOOR_DAYS);
+  });
+
+  it("falls back to defaults for unparseable values", () => {
+    const policy = resolveDbPrunePolicy({
+      DB_PRUNE_RAW_RECORD_RETENTION_DAYS: "not-a-number",
+      DB_PRUNE_BATCH_SIZE: "-5",
+      DB_PRUNE_FORCE_DRY_RUN: "banana",
+    });
+
+    expect(policy.rawRecordRetentionDays).toBe(RAW_RECORD_RETENTION_DEFAULT_DAYS);
+    expect(policy.batchSize).toBe(BATCH_SIZE_DEFAULT);
+    expect(policy.forceDryRun).toBe(false);
+  });
+
+  it("clamps batch size into its safe range", () => {
+    expect(resolveDbPrunePolicy({ DB_PRUNE_BATCH_SIZE: "1" }).batchSize).toBe(BATCH_SIZE_MIN);
+    expect(resolveDbPrunePolicy({ DB_PRUNE_BATCH_SIZE: "999999" }).batchSize).toBe(
+      BATCH_SIZE_MAX,
+    );
+  });
+});
+
+describe("13-month lookback invariant", () => {
+  it("keeps the raw-record cutoff strictly outside every possible Imladris historical window", () => {
+    // Sweep a few years of "now" values, including month-length edge cases
+    // (leap February, 31st-of-month day clamping in setUTCMonth).
+    const starts = [
+      new Date("2026-06-10T12:00:00.000Z"),
+      new Date("2026-01-31T23:59:59.000Z"),
+      new Date("2025-03-31T00:00:00.000Z"),
+      new Date("2024-02-29T08:30:00.000Z"),
+      new Date("2027-12-31T23:00:00.000Z"),
+    ];
+
+    for (const base of starts) {
+      for (let offsetDays = 0; offsetDays < 366; offsetDays += 7) {
+        const now = new Date(base.getTime() + offsetDays * 24 * 60 * 60 * 1000);
+        const { windowStart } = getImladrisHistoricalWindow(now);
+
+        // Even at the clamped floor (the most aggressive configuration the
+        // policy permits), the cutoff is strictly older than the window start.
+        const flooredPolicy = resolveDbPrunePolicy({
+          DB_PRUNE_RAW_RECORD_RETENTION_DAYS: "1",
+        });
+        const cutoff = cutoffForRetentionDays(now, flooredPolicy.rawRecordRetentionDays);
+
+        expect(cutoff.getTime()).toBeLessThan(windowStart.getTime());
+      }
+    }
+  });
+
+  it("keeps the default raw-record cutoff outside the window too", () => {
+    const now = new Date("2026-06-10T00:00:00.000Z");
+    const { windowStart } = getImladrisHistoricalWindow(now);
+    const policy = resolveDbPrunePolicy({});
+    const cutoff = cutoffForRetentionDays(now, policy.rawRecordRetentionDays);
+
+    expect(cutoff.getTime()).toBeLessThan(windowStart.getTime());
+  });
+});

--- a/src/lib/db-pruning/policy.ts
+++ b/src/lib/db-pruning/policy.ts
@@ -1,0 +1,146 @@
+/**
+ * Retention policy for the database pruning job.
+ *
+ * Every window is env-configurable but clamped to a floor so that a
+ * misconfigured (or fat-fingered) environment variable can never violate a
+ * product invariant. The critical floor is the raw-record window: Imladris
+ * materialization reads raw source records across a 13-month historical
+ * lookback (`getImladrisHistoricalWindow` in src/lib/imladris/ingestion.ts),
+ * so raw records may never be deleted inside that window.
+ *
+ * See docs/runbooks/db-pruning.md for the full design.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * 13 consecutive calendar months span at most 403 days (13 × 31 is a strict
+ * upper bound). The floor adds a 7-day safety margin on top so the pruning
+ * cutoff is always strictly older than any possible 13-month window start.
+ */
+export const RAW_RECORD_RETENTION_FLOOR_DAYS = 410;
+export const RAW_RECORD_RETENTION_DEFAULT_DAYS = 425;
+
+export const SYNC_RUN_RETENTION_FLOOR_DAYS = 30;
+export const SYNC_RUN_RETENTION_DEFAULT_DAYS = 90;
+
+export const METRIC_HISTORY_RETENTION_FLOOR_DAYS = 30;
+export const METRIC_HISTORY_RETENTION_DEFAULT_DAYS = 425;
+
+export const SECURITY_AUDIT_RETENTION_FLOOR_DAYS = 90;
+export const SECURITY_AUDIT_RETENTION_DEFAULT_DAYS = 425;
+
+export const ANALYTICS_SNAPSHOT_RETENTION_FLOOR_DAYS = 7;
+export const ANALYTICS_SNAPSHOT_RETENTION_DEFAULT_DAYS = 30;
+
+export const BATCH_SIZE_DEFAULT = 1_000;
+export const BATCH_SIZE_MIN = 100;
+export const BATCH_SIZE_MAX = 10_000;
+
+export const MAX_BATCHES_PER_TABLE_DEFAULT = 200;
+export const MAX_BATCHES_PER_TABLE_MIN = 1;
+export const MAX_BATCHES_PER_TABLE_MAX = 10_000;
+
+export const TIME_BUDGET_MS_DEFAULT = 240_000;
+export const TIME_BUDGET_MS_MIN = 10_000;
+export const TIME_BUDGET_MS_MAX = 3_600_000;
+
+export interface DbPrunePolicy {
+  rawRecordRetentionDays: number;
+  syncRunRetentionDays: number;
+  metricHistoryRetentionDays: number;
+  securityAuditRetentionDays: number;
+  analyticsSnapshotRetentionDays: number;
+  batchSize: number;
+  maxBatchesPerTable: number;
+  timeBudgetMs: number;
+  /** Kill switch: forces every run (including scheduled ones) into dry-run. */
+  forceDryRun: boolean;
+}
+
+type EnvLike = Record<string, string | undefined>;
+
+function parsePositiveInt(raw: string | undefined): number | null {
+  const trimmed = raw?.trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return Math.floor(parsed);
+}
+
+function clampedEnvInt(input: {
+  env: EnvLike;
+  key: string;
+  defaultValue: number;
+  floor: number;
+  ceiling?: number;
+}): number {
+  const parsed = parsePositiveInt(input.env[input.key]) ?? input.defaultValue;
+  const floored = Math.max(input.floor, parsed);
+  return input.ceiling === undefined ? floored : Math.min(input.ceiling, floored);
+}
+
+export function resolveDbPrunePolicy(env: EnvLike = process.env): DbPrunePolicy {
+  return {
+    rawRecordRetentionDays: clampedEnvInt({
+      env,
+      key: "DB_PRUNE_RAW_RECORD_RETENTION_DAYS",
+      defaultValue: RAW_RECORD_RETENTION_DEFAULT_DAYS,
+      floor: RAW_RECORD_RETENTION_FLOOR_DAYS,
+    }),
+    syncRunRetentionDays: clampedEnvInt({
+      env,
+      key: "DB_PRUNE_SYNC_RUN_RETENTION_DAYS",
+      defaultValue: SYNC_RUN_RETENTION_DEFAULT_DAYS,
+      floor: SYNC_RUN_RETENTION_FLOOR_DAYS,
+    }),
+    metricHistoryRetentionDays: clampedEnvInt({
+      env,
+      key: "DB_PRUNE_METRIC_HISTORY_RETENTION_DAYS",
+      defaultValue: METRIC_HISTORY_RETENTION_DEFAULT_DAYS,
+      floor: METRIC_HISTORY_RETENTION_FLOOR_DAYS,
+    }),
+    securityAuditRetentionDays: clampedEnvInt({
+      env,
+      key: "DB_PRUNE_SECURITY_AUDIT_RETENTION_DAYS",
+      defaultValue: SECURITY_AUDIT_RETENTION_DEFAULT_DAYS,
+      floor: SECURITY_AUDIT_RETENTION_FLOOR_DAYS,
+    }),
+    analyticsSnapshotRetentionDays: clampedEnvInt({
+      env,
+      // Reuses the env var the existing in-sync snapshot pruning honors
+      // (src/app/api/cron/sync/route.ts parseRetentionDays) so the two
+      // pruners can never disagree about the snapshot window.
+      key: "ANALYTICS_SNAPSHOT_RETENTION_DAYS",
+      defaultValue: ANALYTICS_SNAPSHOT_RETENTION_DEFAULT_DAYS,
+      floor: ANALYTICS_SNAPSHOT_RETENTION_FLOOR_DAYS,
+    }),
+    batchSize: clampedEnvInt({
+      env,
+      key: "DB_PRUNE_BATCH_SIZE",
+      defaultValue: BATCH_SIZE_DEFAULT,
+      floor: BATCH_SIZE_MIN,
+      ceiling: BATCH_SIZE_MAX,
+    }),
+    maxBatchesPerTable: clampedEnvInt({
+      env,
+      key: "DB_PRUNE_MAX_BATCHES_PER_TABLE",
+      defaultValue: MAX_BATCHES_PER_TABLE_DEFAULT,
+      floor: MAX_BATCHES_PER_TABLE_MIN,
+      ceiling: MAX_BATCHES_PER_TABLE_MAX,
+    }),
+    timeBudgetMs: clampedEnvInt({
+      env,
+      key: "DB_PRUNE_TIME_BUDGET_MS",
+      defaultValue: TIME_BUDGET_MS_DEFAULT,
+      floor: TIME_BUDGET_MS_MIN,
+      ceiling: TIME_BUDGET_MS_MAX,
+    }),
+    forceDryRun: env.DB_PRUNE_FORCE_DRY_RUN?.trim().toLowerCase() === "true",
+  };
+}
+
+/** Rows with every relevant timestamp strictly before this date are prunable. */
+export function cutoffForRetentionDays(now: Date, retentionDays: number): Date {
+  return new Date(now.getTime() - retentionDays * DAY_MS);
+}

--- a/src/lib/db-pruning/prune.test.ts
+++ b/src/lib/db-pruning/prune.test.ts
@@ -87,13 +87,18 @@ describe("runDbPrune dry run", () => {
     expect(result.dryRun).toBe(true);
     expect(result.ok).toBe(true);
     expect(result.totalRows).toBe(5 * 7);
-    expect(result.tables.map((table) => table.table)).toEqual([
-      "ImladrisRawSourceRecord",
-      "ImladrisSourceSyncRun",
-      "MetricHistory",
-      "SecurityAuditEvent",
-      "AnalyticsSnapshot",
-    ]);
+    // All five tables are always processed; order rotates by day (see the
+    // rotation test below), so assert the set rather than a fixed order.
+    expect(result.tables).toHaveLength(5);
+    expect(result.tables.map((table) => table.table).sort()).toEqual(
+      [
+        "AnalyticsSnapshot",
+        "ImladrisRawSourceRecord",
+        "ImladrisSourceSyncRun",
+        "MetricHistory",
+        "SecurityAuditEvent",
+      ].sort(),
+    );
   });
 
   it("is forced by policy.forceDryRun even when the caller asks for a real run", async () => {
@@ -297,15 +302,44 @@ describe("batching", () => {
       logger: noopLogger,
     });
 
-    const rawRecords = result.tables.find(
-      (table) => table.table === "ImladrisRawSourceRecord",
-    );
-    expect(rawRecords?.batches).toBe(2);
-    expect(rawRecords?.truncated).toBe(true);
-    // The budget spans the whole run: later tables get no batches.
-    const audit = result.tables.find((table) => table.table === "SecurityAuditEvent");
-    expect(audit?.batches).toBe(0);
-    expect(audit?.truncated).toBe(false);
+    // The budget spans the whole run and is consumed in processed order, so
+    // assert by position (rotation-agnostic): the first table absorbs the
+    // budget; the last gets nothing.
+    expect(result.tables[0].batches).toBe(2);
+    expect(result.tables[0].truncated).toBe(true);
+    expect(result.tables.at(-1)?.batches).toBe(0);
+    expect(result.tables.at(-1)?.truncated).toBe(false);
+    expect(result.truncated).toBe(true);
+  });
+});
+
+describe("daily order rotation (anti-starvation)", () => {
+  it("rotates the processed table order by calendar day", async () => {
+    const order = async (now: Date) => {
+      const { prisma } = buildMockPrisma();
+      const result = await runDbPrune({ prisma, now, policy: testPolicy(), logger: noopLogger });
+      return result.tables.map((table) => table.table);
+    };
+
+    const dayA = await order(new Date("2026-06-10T12:00:00.000Z"));
+    const dayB = await order(new Date("2026-06-11T12:00:00.000Z"));
+
+    // Same set every day, different lead — so no table is permanently first.
+    expect(dayA).not.toEqual(dayB);
+    expect([...dayA].sort()).toEqual([...dayB].sort());
+    expect(dayA[0]).not.toBe(dayB[0]);
+  });
+
+  it("rotateSpecsForDay cycles every table into the lead across N days", async () => {
+    const { rotateSpecsForDay } = await import("@/lib/db-pruning/prune");
+    const specs = ["a", "b", "c", "d", "e"];
+    const leads = new Set<string>();
+    for (let day = 0; day < specs.length; day += 1) {
+      const now = new Date(day * 24 * 60 * 60 * 1000 + 12 * 60 * 60 * 1000);
+      leads.add(rotateSpecsForDay(specs, now)[0]);
+    }
+    expect(leads).toEqual(new Set(specs));
+    expect(rotateSpecsForDay([], NOW)).toEqual([]);
   });
 });
 

--- a/src/lib/db-pruning/prune.test.ts
+++ b/src/lib/db-pruning/prune.test.ts
@@ -1,0 +1,370 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Prisma } from "@/generated/prisma/client";
+import { getImladrisHistoricalWindow } from "@/lib/imladris/ingestion";
+import type { DbPrunePolicy } from "@/lib/db-pruning/policy";
+import {
+  FINANCE_STANDING_OBJECT_TYPE_VARIANTS,
+  MONTHLY_HISTORY_SNAPSHOT_EXEMPTION,
+  runDbPrune,
+  type DbPrunePrismaClient,
+} from "@/lib/db-pruning/prune";
+
+vi.mock("@/lib/prisma", () => ({ prisma: {} }));
+
+const NOW = new Date("2026-06-10T12:00:00.000Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function testPolicy(overrides: Partial<DbPrunePolicy> = {}): DbPrunePolicy {
+  return {
+    rawRecordRetentionDays: 425,
+    syncRunRetentionDays: 90,
+    metricHistoryRetentionDays: 425,
+    securityAuditRetentionDays: 425,
+    analyticsSnapshotRetentionDays: 30,
+    batchSize: 1000,
+    maxBatchesPerTable: 200,
+    timeBudgetMs: 240_000,
+    forceDryRun: false,
+    ...overrides,
+  };
+}
+
+interface CapturedQuery {
+  text: string;
+  values: unknown[];
+}
+
+function capture(query: Prisma.Sql): CapturedQuery {
+  return { text: query.text, values: [...query.values] };
+}
+
+function buildMockPrisma(options?: {
+  executeImpl?: (query: Prisma.Sql) => Promise<number>;
+  counts?: number;
+}) {
+  const executed: CapturedQuery[] = [];
+  const queried: CapturedQuery[] = [];
+
+  const $executeRaw = vi.fn(async (query: Prisma.Sql) => {
+    executed.push(capture(query));
+    if (options?.executeImpl) return options.executeImpl(query);
+    return 0;
+  });
+  const $queryRaw = vi.fn(async (query: Prisma.Sql) => {
+    queried.push(capture(query));
+    return [{ count: options?.counts ?? 0 }];
+  });
+
+  const prisma: DbPrunePrismaClient = {
+    $executeRaw: $executeRaw as unknown as DbPrunePrismaClient["$executeRaw"],
+    $queryRaw: $queryRaw as unknown as DbPrunePrismaClient["$queryRaw"],
+  };
+
+  return { prisma, executed, queried, $executeRaw, $queryRaw };
+}
+
+const noopLogger = () => {};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("runDbPrune dry run", () => {
+  it("only counts — never issues a delete", async () => {
+    const { prisma, executed, queried } = buildMockPrisma({ counts: 7 });
+
+    const result = await runDbPrune({
+      prisma,
+      dryRun: true,
+      now: NOW,
+      policy: testPolicy(),
+      logger: noopLogger,
+    });
+
+    expect(executed).toHaveLength(0);
+    expect(queried).toHaveLength(5);
+    expect(queried.every((query) => /^\s*SELECT COUNT\(\*\)/.test(query.text))).toBe(true);
+    expect(result.dryRun).toBe(true);
+    expect(result.ok).toBe(true);
+    expect(result.totalRows).toBe(5 * 7);
+    expect(result.tables.map((table) => table.table)).toEqual([
+      "ImladrisRawSourceRecord",
+      "ImladrisSourceSyncRun",
+      "MetricHistory",
+      "SecurityAuditEvent",
+      "AnalyticsSnapshot",
+    ]);
+  });
+
+  it("is forced by policy.forceDryRun even when the caller asks for a real run", async () => {
+    const { prisma, executed } = buildMockPrisma({ counts: 3 });
+
+    const result = await runDbPrune({
+      prisma,
+      dryRun: false,
+      now: NOW,
+      policy: testPolicy({ forceDryRun: true }),
+      logger: noopLogger,
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(executed).toHaveLength(0);
+  });
+});
+
+describe("raw source record protection", () => {
+  async function rawRecordDeleteQuery(policy: DbPrunePolicy): Promise<CapturedQuery> {
+    const { prisma, executed } = buildMockPrisma();
+    await runDbPrune({ prisma, now: NOW, policy, logger: noopLogger });
+    const query = executed.find((entry) =>
+      entry.text.includes('DELETE FROM "ImladrisRawSourceRecord"'),
+    );
+    expect(query).toBeDefined();
+    return query as CapturedQuery;
+  }
+
+  it("requires EVERY timestamp on the row to be older than the cutoff", async () => {
+    const query = await rawRecordDeleteQuery(testPolicy());
+
+    for (const column of [
+      "createdAt",
+      "updatedAt",
+      "occurredAt",
+      "sourceCreatedAt",
+      "sourceUpdatedAt",
+    ]) {
+      expect(query.text).toContain(`"${column}"`);
+    }
+    // Nullable source timestamps treat NULL as old — the non-null
+    // createdAt/updatedAt guards still apply.
+    expect(query.text).toContain(`COALESCE(r."occurredAt", 'epoch'::timestamp)`);
+
+    const expectedCutoff = new Date(NOW.getTime() - 425 * DAY_MS);
+    const dateValues = query.values.filter((value): value is Date => value instanceof Date);
+    expect(dateValues).toHaveLength(5);
+    for (const value of dateValues) {
+      expect(value.getTime()).toBe(expectedCutoff.getTime());
+    }
+  });
+
+  it("never deletes inside the 13-month Imladris lookback window", async () => {
+    const query = await rawRecordDeleteQuery(testPolicy());
+    const { windowStart } = getImladrisHistoricalWindow(NOW);
+
+    const dateValues = query.values.filter((value): value is Date => value instanceof Date);
+    expect(dateValues.length).toBeGreaterThan(0);
+    for (const cutoff of dateValues) {
+      expect(cutoff.getTime()).toBeLessThan(windowStart.getTime());
+    }
+  });
+
+  it("never deletes lineage-referenced rows — the check lives inside the DELETE statement", async () => {
+    const query = await rawRecordDeleteQuery(testPolicy());
+
+    expect(query.text).toMatch(
+      /NOT EXISTS \(\s*SELECT 1\s*FROM "ImladrisMetricLineage" l\s*WHERE l\."rawRecordId" = r\."id"\s*\)/,
+    );
+  });
+
+  it("never deletes standing finance object types (read at any age)", async () => {
+    const query = await rawRecordDeleteQuery(testPolicy());
+
+    expect(query.text).toContain('"objectType" NOT IN');
+    expect(FINANCE_STANDING_OBJECT_TYPE_VARIANTS.length).toBeGreaterThan(0);
+    for (const variant of FINANCE_STANDING_OBJECT_TYPE_VARIANTS) {
+      expect(query.values).toContain(variant);
+    }
+    expect(FINANCE_STANDING_OBJECT_TYPE_VARIANTS).toEqual(
+      expect.arrayContaining(["subscription", "deals", "activeCustomerRef", "balance"]),
+    );
+  });
+});
+
+describe("sync run pruning", () => {
+  it("only deletes runs with no remaining raw records (cascade safety)", async () => {
+    const { prisma, executed } = buildMockPrisma();
+    await runDbPrune({ prisma, now: NOW, policy: testPolicy(), logger: noopLogger });
+
+    const query = executed.find((entry) =>
+      entry.text.includes('DELETE FROM "ImladrisSourceSyncRun"'),
+    );
+    expect(query).toBeDefined();
+    expect(query?.text).toMatch(
+      /NOT EXISTS \(\s*SELECT 1\s*FROM "ImladrisRawSourceRecord" r\s*WHERE r\."syncRunId" = s\."id"\s*\)/,
+    );
+  });
+});
+
+describe("analytics snapshot pruning", () => {
+  it("exempts the monthly P&L history context", async () => {
+    const { prisma, executed } = buildMockPrisma();
+    await runDbPrune({ prisma, now: NOW, policy: testPolicy(), logger: noopLogger });
+
+    const query = executed.find((entry) =>
+      entry.text.includes('DELETE FROM "AnalyticsSnapshot"'),
+    );
+    expect(query).toBeDefined();
+    expect(query?.text).toContain('NOT (');
+    expect(query?.values).toContain(MONTHLY_HISTORY_SNAPSHOT_EXEMPTION.contextKey);
+    expect(query?.values).toContain(MONTHLY_HISTORY_SNAPSHOT_EXEMPTION.rangePreset);
+  });
+
+  it("stays in lockstep with the canonical monthly history constants", async () => {
+    const { MONTHLY_HISTORY_CONTEXT_KEY, MONTHLY_HISTORY_RANGE_PRESET } = await import(
+      "@/lib/analytics/monthly-pnl-history"
+    );
+
+    expect(MONTHLY_HISTORY_SNAPSHOT_EXEMPTION.contextKey).toBe(MONTHLY_HISTORY_CONTEXT_KEY);
+    expect(MONTHLY_HISTORY_SNAPSHOT_EXEMPTION.rangePreset).toBe(MONTHLY_HISTORY_RANGE_PRESET);
+  });
+});
+
+describe("batching", () => {
+  it("loops until a batch comes back partial and sums deletions", async () => {
+    const batchSize = 100;
+    const perTableCalls = new Map<string, number>();
+    const { prisma, $executeRaw } = buildMockPrisma({
+      executeImpl: async (query) => {
+        const table = /DELETE FROM "([A-Za-z]+)"/.exec(query.text)?.[1] ?? "unknown";
+        const call = (perTableCalls.get(table) ?? 0) + 1;
+        perTableCalls.set(table, call);
+        if (table === "MetricHistory") {
+          // Two full batches, then a partial one.
+          return call <= 2 ? batchSize : 40;
+        }
+        return 0;
+      },
+    });
+
+    const result = await runDbPrune({
+      prisma,
+      now: NOW,
+      policy: testPolicy({ batchSize }),
+      logger: noopLogger,
+    });
+
+    const metricHistory = result.tables.find((table) => table.table === "MetricHistory");
+    expect(metricHistory?.rows).toBe(240);
+    expect(metricHistory?.batches).toBe(3);
+    expect(metricHistory?.truncated).toBe(false);
+    expect(result.ok).toBe(true);
+    // Every batch is a separate statement — no single long-running delete.
+    expect($executeRaw.mock.calls.length).toBeGreaterThanOrEqual(7);
+    const limits = $executeRaw.mock.calls.map(
+      (call) => (call[0] as Prisma.Sql).values.at(-1),
+    );
+    expect(limits.every((limit) => limit === batchSize)).toBe(true);
+  });
+
+  it("stops at the per-table batch cap and reports truncation", async () => {
+    const batchSize = 50;
+    const { prisma } = buildMockPrisma({
+      executeImpl: async (query) =>
+        query.text.includes('"SecurityAuditEvent"') ? batchSize : 0,
+    });
+
+    const result = await runDbPrune({
+      prisma,
+      now: NOW,
+      policy: testPolicy({ batchSize, maxBatchesPerTable: 4 }),
+      logger: noopLogger,
+    });
+
+    const audit = result.tables.find((table) => table.table === "SecurityAuditEvent");
+    expect(audit?.batches).toBe(4);
+    expect(audit?.rows).toBe(200);
+    expect(audit?.truncated).toBe(true);
+    expect(result.truncated).toBe(true);
+    // Truncation is not a failure — the next scheduled run resumes.
+    expect(result.ok).toBe(true);
+  });
+
+  it("stops when the wall-clock budget is exhausted", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const { prisma } = buildMockPrisma({
+      executeImpl: async () => {
+        vi.setSystemTime(new Date(Date.now() + 7_000));
+        return 1000;
+      },
+    });
+
+    const result = await runDbPrune({
+      prisma,
+      now: NOW,
+      policy: testPolicy({ batchSize: 1000, timeBudgetMs: 10_000 }),
+      logger: noopLogger,
+    });
+
+    const rawRecords = result.tables.find(
+      (table) => table.table === "ImladrisRawSourceRecord",
+    );
+    expect(rawRecords?.batches).toBe(2);
+    expect(rawRecords?.truncated).toBe(true);
+    // The budget spans the whole run: later tables get no batches.
+    const audit = result.tables.find((table) => table.table === "SecurityAuditEvent");
+    expect(audit?.batches).toBe(0);
+    expect(audit?.truncated).toBe(false);
+  });
+});
+
+describe("failure isolation", () => {
+  it("records a table error, keeps pruning the rest, and reports ok=false", async () => {
+    const { prisma, executed } = buildMockPrisma({
+      executeImpl: async (query) => {
+        if (query.text.includes('DELETE FROM "ImladrisRawSourceRecord"')) {
+          throw new Error("relation is busy");
+        }
+        return 0;
+      },
+    });
+
+    const result = await runDbPrune({
+      prisma,
+      now: NOW,
+      policy: testPolicy(),
+      logger: noopLogger,
+    });
+
+    expect(result.ok).toBe(false);
+    const rawRecords = result.tables.find(
+      (table) => table.table === "ImladrisRawSourceRecord",
+    );
+    expect(rawRecords?.error).toBe("relation is busy");
+    // The other four tables still ran their deletes.
+    const otherDeletes = executed.filter(
+      (entry) => !entry.text.includes('DELETE FROM "ImladrisRawSourceRecord"'),
+    );
+    expect(otherDeletes).toHaveLength(4);
+  });
+});
+
+describe("structured logging", () => {
+  it("emits parseable [db-prune] lines for batches and summaries", async () => {
+    const lines: string[] = [];
+    const { prisma } = buildMockPrisma({
+      executeImpl: async (query) =>
+        query.text.includes('"MetricHistory"') ? 10 : 0,
+    });
+
+    await runDbPrune({
+      prisma,
+      now: NOW,
+      policy: testPolicy({ batchSize: 100 }),
+      logger: (message) => lines.push(message),
+    });
+
+    expect(lines.length).toBeGreaterThan(0);
+    const events = lines.map((line) => {
+      expect(line.startsWith("[db-prune] ")).toBe(true);
+      return JSON.parse(line.slice("[db-prune] ".length)) as { event: string };
+    });
+    expect(events.some((event) => event.event === "run_start")).toBe(true);
+    expect(events.some((event) => event.event === "batch")).toBe(true);
+    expect(
+      events.filter((event) => event.event === "table_summary"),
+    ).toHaveLength(5);
+    expect(events.at(-1)?.event).toBe("run_summary");
+  });
+});

--- a/src/lib/db-pruning/prune.ts
+++ b/src/lib/db-pruning/prune.ts
@@ -1,0 +1,387 @@
+/**
+ * Database pruning engine.
+ *
+ * The ONLY code path that is allowed to delete retention-managed rows.
+ * Every delete is a bounded `DELETE … WHERE id IN (SELECT … LIMIT n)` batch
+ * in its own implicit transaction, so the job never holds long-running locks
+ * and can be interrupted at any point without leaving partial state — it
+ * simply resumes on the next scheduled run.
+ *
+ * Invariants enforced here (see docs/runbooks/db-pruning.md):
+ *  - Raw source records are only deleted when EVERY timestamp on the row
+ *    (occurredAt, sourceCreatedAt, sourceUpdatedAt, createdAt, updatedAt) is
+ *    older than the cutoff, which itself is floor-clamped to stay strictly
+ *    outside the 13-month Imladris lookback window.
+ *  - Raw source records referenced by ImladrisMetricLineage are never
+ *    deleted (the FK is SetNull, so the check must be explicit). The
+ *    NOT EXISTS is evaluated inside the DELETE statement itself, so a
+ *    concurrent materialization cannot race the check.
+ *  - Standing finance object types (read at any age by financeWindowWhere)
+ *    are never deleted.
+ *  - Sync runs are only deleted once they have no raw records left —
+ *    ImladrisRawSourceRecord.syncRunId cascades on delete.
+ *  - Monthly P&L history snapshots are exempt (same exemption as the
+ *    existing pruneAnalyticsSnapshots in src/lib/analytics/snapshots.ts).
+ */
+
+import { Prisma } from "@/generated/prisma/client";
+import {
+  IMLADRIS_FINANCE_STANDING_BASE_OBJECT_TYPES,
+  imladrisObjectTypeQueryVariants,
+} from "@/lib/imladris/object-types";
+import {
+  cutoffForRetentionDays,
+  resolveDbPrunePolicy,
+  type DbPrunePolicy,
+} from "@/lib/db-pruning/policy";
+
+/**
+ * Kept in lockstep with MONTHLY_HISTORY_CONTEXT_KEY / _RANGE_PRESET in
+ * src/lib/analytics/monthly-pnl-history.ts (asserted by a unit test).
+ * Redeclared locally so this module does not import the analytics stack.
+ */
+export const MONTHLY_HISTORY_SNAPSHOT_EXEMPTION = {
+  contextKey: "financial-planning",
+  rangePreset: "monthly",
+} as const;
+
+export const FINANCE_STANDING_OBJECT_TYPE_VARIANTS = imladrisObjectTypeQueryVariants(
+  ...IMLADRIS_FINANCE_STANDING_BASE_OBJECT_TYPES,
+);
+
+export interface DbPrunePrismaClient {
+  $executeRaw(query: Prisma.Sql): Promise<number>;
+  $queryRaw<T = unknown>(query: Prisma.Sql): Promise<T>;
+}
+
+export type DbPruneLogger = (message: string) => void;
+
+export interface PruneTableResult {
+  table: string;
+  dryRun: boolean;
+  retentionDays: number;
+  cutoff: string;
+  /** Rows deleted (real run) or rows currently matching the predicate (dry run). */
+  rows: number;
+  batches: number;
+  /** True when the run stopped at a batch/time cap with work remaining. */
+  truncated: boolean;
+  durationMs: number;
+  error?: string;
+}
+
+export interface DbPruneRunResult {
+  ok: boolean;
+  dryRun: boolean;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  totalRows: number;
+  truncated: boolean;
+  policy: Omit<DbPrunePolicy, "forceDryRun">;
+  tables: PruneTableResult[];
+}
+
+interface CountRow {
+  count: number;
+}
+
+interface PruneTableSpec {
+  table: string;
+  retentionDays: number;
+  cutoff: Date;
+  countSql: Prisma.Sql;
+  deleteSql: (batchSize: number) => Prisma.Sql;
+}
+
+function rawRecordPrunableWhere(cutoff: Date): Prisma.Sql {
+  return Prisma.sql`
+    r."createdAt" < ${cutoff}
+    AND r."updatedAt" < ${cutoff}
+    AND COALESCE(r."occurredAt", 'epoch'::timestamp) < ${cutoff}
+    AND COALESCE(r."sourceCreatedAt", 'epoch'::timestamp) < ${cutoff}
+    AND COALESCE(r."sourceUpdatedAt", 'epoch'::timestamp) < ${cutoff}
+    AND r."objectType" NOT IN (${Prisma.join(FINANCE_STANDING_OBJECT_TYPE_VARIANTS)})
+    AND NOT EXISTS (
+      SELECT 1
+      FROM "ImladrisMetricLineage" l
+      WHERE l."rawRecordId" = r."id"
+    )`;
+}
+
+function syncRunPrunableWhere(cutoff: Date): Prisma.Sql {
+  return Prisma.sql`
+    s."startedAt" < ${cutoff}
+    AND NOT EXISTS (
+      SELECT 1
+      FROM "ImladrisRawSourceRecord" r
+      WHERE r."syncRunId" = s."id"
+    )`;
+}
+
+function snapshotPrunableWhere(cutoff: Date): Prisma.Sql {
+  return Prisma.sql`
+    a."capturedAt" < ${cutoff}
+    AND NOT (
+      a."contextKey" = ${MONTHLY_HISTORY_SNAPSHOT_EXEMPTION.contextKey}
+      AND a."rangePreset" = ${MONTHLY_HISTORY_SNAPSHOT_EXEMPTION.rangePreset}
+    )`;
+}
+
+function buildPruneTableSpecs(policy: DbPrunePolicy, now: Date): PruneTableSpec[] {
+  const rawRecordCutoff = cutoffForRetentionDays(now, policy.rawRecordRetentionDays);
+  const syncRunCutoff = cutoffForRetentionDays(now, policy.syncRunRetentionDays);
+  const metricHistoryCutoff = cutoffForRetentionDays(now, policy.metricHistoryRetentionDays);
+  const securityAuditCutoff = cutoffForRetentionDays(now, policy.securityAuditRetentionDays);
+  const snapshotCutoff = cutoffForRetentionDays(now, policy.analyticsSnapshotRetentionDays);
+
+  return [
+    // Ordered by expected space recovered. Raw records run before sync runs
+    // so freshly-emptied runs qualify for deletion in the same pass.
+    {
+      table: "ImladrisRawSourceRecord",
+      retentionDays: policy.rawRecordRetentionDays,
+      cutoff: rawRecordCutoff,
+      countSql: Prisma.sql`
+        SELECT COUNT(*)::float8 AS count
+        FROM "ImladrisRawSourceRecord" r
+        WHERE ${rawRecordPrunableWhere(rawRecordCutoff)}`,
+      deleteSql: (batchSize) => Prisma.sql`
+        DELETE FROM "ImladrisRawSourceRecord"
+        WHERE "id" IN (
+          SELECT r."id"
+          FROM "ImladrisRawSourceRecord" r
+          WHERE ${rawRecordPrunableWhere(rawRecordCutoff)}
+          LIMIT ${batchSize}
+        )`,
+    },
+    {
+      table: "ImladrisSourceSyncRun",
+      retentionDays: policy.syncRunRetentionDays,
+      cutoff: syncRunCutoff,
+      countSql: Prisma.sql`
+        SELECT COUNT(*)::float8 AS count
+        FROM "ImladrisSourceSyncRun" s
+        WHERE ${syncRunPrunableWhere(syncRunCutoff)}`,
+      deleteSql: (batchSize) => Prisma.sql`
+        DELETE FROM "ImladrisSourceSyncRun"
+        WHERE "id" IN (
+          SELECT s."id"
+          FROM "ImladrisSourceSyncRun" s
+          WHERE ${syncRunPrunableWhere(syncRunCutoff)}
+          LIMIT ${batchSize}
+        )`,
+    },
+    {
+      table: "MetricHistory",
+      retentionDays: policy.metricHistoryRetentionDays,
+      cutoff: metricHistoryCutoff,
+      countSql: Prisma.sql`
+        SELECT COUNT(*)::float8 AS count
+        FROM "MetricHistory" m
+        WHERE m."capturedAt" < ${metricHistoryCutoff}`,
+      deleteSql: (batchSize) => Prisma.sql`
+        DELETE FROM "MetricHistory"
+        WHERE "id" IN (
+          SELECT m."id"
+          FROM "MetricHistory" m
+          WHERE m."capturedAt" < ${metricHistoryCutoff}
+          LIMIT ${batchSize}
+        )`,
+    },
+    {
+      table: "SecurityAuditEvent",
+      retentionDays: policy.securityAuditRetentionDays,
+      cutoff: securityAuditCutoff,
+      countSql: Prisma.sql`
+        SELECT COUNT(*)::float8 AS count
+        FROM "SecurityAuditEvent" e
+        WHERE e."createdAt" < ${securityAuditCutoff}`,
+      deleteSql: (batchSize) => Prisma.sql`
+        DELETE FROM "SecurityAuditEvent"
+        WHERE "id" IN (
+          SELECT e."id"
+          FROM "SecurityAuditEvent" e
+          WHERE e."createdAt" < ${securityAuditCutoff}
+          LIMIT ${batchSize}
+        )`,
+    },
+    {
+      table: "AnalyticsSnapshot",
+      retentionDays: policy.analyticsSnapshotRetentionDays,
+      cutoff: snapshotCutoff,
+      countSql: Prisma.sql`
+        SELECT COUNT(*)::float8 AS count
+        FROM "AnalyticsSnapshot" a
+        WHERE ${snapshotPrunableWhere(snapshotCutoff)}`,
+      deleteSql: (batchSize) => Prisma.sql`
+        DELETE FROM "AnalyticsSnapshot"
+        WHERE "id" IN (
+          SELECT a."id"
+          FROM "AnalyticsSnapshot" a
+          WHERE ${snapshotPrunableWhere(snapshotCutoff)}
+          LIMIT ${batchSize}
+        )`,
+    },
+  ];
+}
+
+function logStructured(logger: DbPruneLogger, payload: Record<string, unknown>): void {
+  logger(`[db-prune] ${JSON.stringify(payload)}`);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function pruneTable(input: {
+  prisma: DbPrunePrismaClient;
+  spec: PruneTableSpec;
+  dryRun: boolean;
+  batchSize: number;
+  maxBatches: number;
+  deadlineMs: number;
+  logger: DbPruneLogger;
+}): Promise<PruneTableResult> {
+  const { prisma, spec, dryRun, batchSize, maxBatches, deadlineMs, logger } = input;
+  const startedMs = Date.now();
+  const base = {
+    table: spec.table,
+    dryRun,
+    retentionDays: spec.retentionDays,
+    cutoff: spec.cutoff.toISOString(),
+  };
+
+  try {
+    if (dryRun) {
+      const rows = await prisma.$queryRaw<CountRow[]>(spec.countSql);
+      const count = Math.max(0, Math.round(rows[0]?.count ?? 0));
+      const result: PruneTableResult = {
+        ...base,
+        rows: count,
+        batches: 0,
+        truncated: false,
+        durationMs: Date.now() - startedMs,
+      };
+      logStructured(logger, { event: "table_summary", ...result });
+      return result;
+    }
+
+    let deleted = 0;
+    let batches = 0;
+    let lastBatchFull = false;
+
+    while (batches < maxBatches && Date.now() < deadlineMs) {
+      const affected = await prisma.$executeRaw(spec.deleteSql(batchSize));
+      batches += 1;
+      deleted += affected;
+      lastBatchFull = affected >= batchSize;
+      if (affected > 0) {
+        logStructured(logger, {
+          event: "batch",
+          table: spec.table,
+          batch: batches,
+          affected,
+          dryRun,
+        });
+      }
+      if (!lastBatchFull) break;
+    }
+
+    const result: PruneTableResult = {
+      ...base,
+      rows: deleted,
+      batches,
+      truncated: lastBatchFull,
+      durationMs: Date.now() - startedMs,
+    };
+    logStructured(logger, { event: "table_summary", ...result });
+    return result;
+  } catch (error) {
+    const result: PruneTableResult = {
+      ...base,
+      rows: 0,
+      batches: 0,
+      truncated: false,
+      durationMs: Date.now() - startedMs,
+      error: errorMessage(error),
+    };
+    logStructured(logger, { event: "table_error", ...result });
+    return result;
+  }
+}
+
+export async function runDbPrune(input: {
+  prisma: DbPrunePrismaClient;
+  dryRun?: boolean;
+  now?: Date;
+  policy?: DbPrunePolicy;
+  logger?: DbPruneLogger;
+}): Promise<DbPruneRunResult> {
+  const policy = input.policy ?? resolveDbPrunePolicy();
+  const now = input.now ?? new Date();
+  const dryRun = policy.forceDryRun || input.dryRun === true;
+  const logger = input.logger ?? ((message: string) => console.info(message));
+  const startedMs = Date.now();
+  const deadlineMs = startedMs + policy.timeBudgetMs;
+  const startedAt = new Date(startedMs).toISOString();
+
+  logStructured(logger, {
+    event: "run_start",
+    startedAt,
+    dryRun,
+    forcedDryRun: policy.forceDryRun,
+    batchSize: policy.batchSize,
+    maxBatchesPerTable: policy.maxBatchesPerTable,
+    timeBudgetMs: policy.timeBudgetMs,
+  });
+
+  const tables: PruneTableResult[] = [];
+  for (const spec of buildPruneTableSpecs(policy, now)) {
+    tables.push(
+      await pruneTable({
+        prisma: input.prisma,
+        spec,
+        dryRun,
+        batchSize: policy.batchSize,
+        maxBatches: policy.maxBatchesPerTable,
+        deadlineMs,
+        logger,
+      }),
+    );
+  }
+
+  const finishedMs = Date.now();
+  const reportedPolicy: Omit<DbPrunePolicy, "forceDryRun"> = {
+    rawRecordRetentionDays: policy.rawRecordRetentionDays,
+    syncRunRetentionDays: policy.syncRunRetentionDays,
+    metricHistoryRetentionDays: policy.metricHistoryRetentionDays,
+    securityAuditRetentionDays: policy.securityAuditRetentionDays,
+    analyticsSnapshotRetentionDays: policy.analyticsSnapshotRetentionDays,
+    batchSize: policy.batchSize,
+    maxBatchesPerTable: policy.maxBatchesPerTable,
+    timeBudgetMs: policy.timeBudgetMs,
+  };
+  const result: DbPruneRunResult = {
+    ok: tables.every((table) => !table.error),
+    dryRun,
+    startedAt,
+    finishedAt: new Date(finishedMs).toISOString(),
+    durationMs: finishedMs - startedMs,
+    totalRows: tables.reduce((sum, table) => sum + table.rows, 0),
+    truncated: tables.some((table) => table.truncated),
+    policy: reportedPolicy,
+    tables,
+  };
+
+  logStructured(logger, {
+    event: "run_summary",
+    ok: result.ok,
+    dryRun: result.dryRun,
+    totalRows: result.totalRows,
+    truncated: result.truncated,
+    durationMs: result.durationMs,
+  });
+
+  return result;
+}

--- a/src/lib/db-pruning/prune.ts
+++ b/src/lib/db-pruning/prune.ts
@@ -226,6 +226,32 @@ function buildPruneTableSpecs(policy: DbPrunePolicy, now: Date): PruneTableSpec[
   ];
 }
 
+const ROTATION_DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Rotate the per-table processing order by calendar day.
+ *
+ * The per-table batch cap (maxBatchesPerTable) already bounds how long any
+ * one table holds the run in the common case, so it yields to the next table
+ * long before the wall-clock budget matters. But if deletes are
+ * pathologically slow (a single table's capped batches exceed the whole time
+ * budget), a *fixed* order would let the first table starve every later table
+ * on every run — the same tables would never be reached. Rotating the start
+ * index by day guarantees that, across consecutive daily runs, every table
+ * eventually leads and gets pruned.
+ *
+ * Trade-off: on days where ImladrisSourceSyncRun is ordered before
+ * ImladrisRawSourceRecord, a sync run emptied in this run is only collected
+ * on the next run. That lag is harmless — pruning is idempotent and
+ * eventually consistent.
+ */
+export function rotateSpecsForDay<T>(specs: T[], now: Date): T[] {
+  if (specs.length === 0) return specs;
+  const dayIndex = Math.floor(now.getTime() / ROTATION_DAY_MS);
+  const offset = ((dayIndex % specs.length) + specs.length) % specs.length;
+  return [...specs.slice(offset), ...specs.slice(0, offset)];
+}
+
 function logStructured(logger: DbPruneLogger, payload: Record<string, unknown>): void {
   logger(`[db-prune] ${JSON.stringify(payload)}`);
 }
@@ -337,7 +363,7 @@ export async function runDbPrune(input: {
   });
 
   const tables: PruneTableResult[] = [];
-  for (const spec of buildPruneTableSpecs(policy, now)) {
+  for (const spec of rotateSpecsForDay(buildPruneTableSpecs(policy, now), now)) {
     tables.push(
       await pruneTable({
         prisma: input.prisma,

--- a/src/lib/imladris/materialization.ts
+++ b/src/lib/imladris/materialization.ts
@@ -4,6 +4,7 @@ import {
 } from "@/generated/prisma/client";
 import { parseImladrisNumber } from "@/lib/imladris/number-parsing";
 import {
+  IMLADRIS_FINANCE_STANDING_BASE_OBJECT_TYPES,
   imladrisObjectTypeQueryVariants,
   normalizeImladrisObjectType,
 } from "@/lib/imladris/object-types";
@@ -68,13 +69,7 @@ const PAID_AD_PROVIDERS = [
 const STRIPE_INVOICE_LINE_ITEM_KEY = "__imladrisStripeInvoiceLineItem";
 const INTEGRATION_PROVIDER_VALUES = new Set<string>(Object.values(IntegrationProvider));
 const FINANCE_STANDING_OBJECT_TYPES = imladrisObjectTypeQueryVariants(
-  "active_customer_ref",
-  "account_balance",
-  "balance",
-  "deal",
-  "snapshot",
-  "subscription",
-  "subscription_deal",
+  ...IMLADRIS_FINANCE_STANDING_BASE_OBJECT_TYPES,
 );
 
 interface ImladrisActorContext {

--- a/src/lib/imladris/object-types.ts
+++ b/src/lib/imladris/object-types.ts
@@ -52,6 +52,25 @@ function pluralizeImladrisObjectType(value: string): string {
   return `${value}s`;
 }
 
+/**
+ * Base object types whose raw records feed point-in-time ("standing")
+ * finance metrics regardless of age — `financeWindowWhere` in
+ * materialization.ts selects them with `timestamp <= periodEnd`, so rows
+ * arbitrarily older than the 13-month lookback window are still read.
+ *
+ * Shared between materialization (query side) and db-pruning (which must
+ * NEVER delete raw records of these types — see src/lib/db-pruning/).
+ */
+export const IMLADRIS_FINANCE_STANDING_BASE_OBJECT_TYPES = [
+  "active_customer_ref",
+  "account_balance",
+  "balance",
+  "deal",
+  "snapshot",
+  "subscription",
+  "subscription_deal",
+] as const;
+
 export function imladrisObjectTypeQueryVariants(...objectTypes: string[]): string[] {
   const variants = new Set<string>();
 


### PR DESCRIPTION
## Commits
- Reconcile with db-growth-controls (#584)
- Count WAL in /api/health/db; honest size split; rotate prune order
- Add timestamp indexes supporting the prune predicate
- Add /api/health/db database size probe
- Add scheduled DB retention pruning job
- Share Imladris standing finance object types via object-types

## Files changed
 .env.example                                       |  21 ++
 docs/runbooks/db-pruning.md                        | 203 ++++++++++
 .../migration.sql                                  |  21 ++
 prisma/schema.prisma                               |  12 +
 railway/cron-db-prune/Dockerfile                   |   8 +
 railway/cron-db-prune/railway.json                 |  11 +
 railway/cron-db-prune/run.sh                       |  27 ++
 src/app/api/cron/db-prune/route.test.ts            | 216 +++++++++++
 src/app/api/cron/db-prune/route.ts                 | 101 +++++
 src/app/api/health/db/route.test.ts                | 204 ++++++++++
 src/app/api/health/db/route.ts                     | 147 ++++++++
 src/lib/db-pruning/policy.test.ts                  | 131 +++++++
 src/lib/db-pruning/policy.ts                       | 146 ++++++++
 src/lib/db-pruning/prune.test.ts                   | 404 ++++++++++++++++++++
 src/lib/db-pruning/prune.ts                        | 413 +++++++++++++++++++++
 src/lib/imladris/materialization.ts                |   9 +-
 src/lib/imladris/object-types.ts                   |  19 +
 17 files changed, 2086 insertions(+), 7 deletions(-)
---
### Postgres-volume / Imladris-lineage incident cluster
This is one of **6 overlapping branches** from the same incident that could **not** be auto-consolidated (all have unique patches; 4 of 5 conflict on the lineage/pruning code). Pick the canonical approach for the shared pruning/growth-control logic, then rebase the rest in sequence. Suggested order:
1. `fix/db-connect-resilience` — connection resilience (I/O stalls; orthogonal, merges clean)
2. `feat/db-pruning` — scheduled retention pruning + `/api/health/db` probe + indexes
3. `claude/cool-greider-41cea8` — thin canonical metric values + DB growth controls
4. `claude/zen-meitner-16de46` — raw-source-record retention pruning
5. `claude/vigorous-cannon-e0c038` — lineage bloat reclaim (CTAS swap) + runbook
6. `claude/quizzical-banach-9da052` — lineage source handling + live-dashboard fixes

_Surfaced during repo cleanup; was unmerged with no PR._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
