### PR TITLE
Add retention pruning for ImladrisRawSourceRecord

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,3 +130,10 @@ IMLADRIS_METRIC_VALUE_PRUNE_BUDGET_MS=15000
 OUTBOX_DISPATCHED_RETENTION_DAYS=14
 OUTBOX_DEAD_LETTER_RETENTION_DAYS=30
 OUTBOX_PRUNE_BUDGET_MS=15000
+# Raw provider snapshots (ImladrisRawSourceRecord): a record is deleted once its
+# updatedAt is older than this AND no metric value's lineage still references it.
+# Default 365 — comfortably beyond the 180-day longest reader window (expense +
+# investor dashboards). Pruned on updatedAt (refreshes on every re-sync), never
+# createdAt, so re-synced rows that are still reader-visible are kept.
+IMLADRIS_RAW_SOURCE_RETENTION_DAYS=365
+IMLADRIS_RAW_SOURCE_PRUNE_BUDGET_MS=15000

--- a/docs/db-growth-controls.md
+++ b/docs/db-growth-controls.md
@@ -7,6 +7,7 @@ database crash-looped for ~17h. Two tables grew without bound:
 | ----------------------- | -------------- | ----------- | ----- |
 | `ImladrisMetricLineage` | 8,164MB (91% of DB) | 21,983,741 | Every 10-minute sync materializes canonical metric values with `periodEnd = now`, minting NEW `ImladrisCanonicalMetricValue` rows each cycle; `replaceLineage` writes one lineage row per contributing raw record per value, and lineage of superseded values was never aged out (~273 retained generations per raw record). |
 | `OutboxEvent`           | 664MB          | 906,352     | No cleanup anywhere; events accumulated since 2026-02-16. |
+| `ImladrisRawSourceRecord` | not the acute driver | grows forever | Every 10-minute sync upserts raw provider snapshots; the table grows by NEW distinct objects (events, PRs, issues, balance/charge snapshots) and was never pruned. PR #594 fixed the acute OOM crash loop (materialization reads are 30-day-bounded) and deferred this prune to its own reader-audited control — section 5. |
 
 ## Controls
 
@@ -14,10 +15,10 @@ All controls run continuously inside the shared sync cycle
 (`runAnalyticsSync` in `src/lib/sync/analytics.ts`), which both the worker
 orchestrator (`worker/sync-runner.ts` → `src/lib/sync/orchestrator.ts`) and
 the legacy cron route (`/api/cron/sync`) call. Results appear in the sync
-output as `lineagePruning` / `metricValuePruning` / `outboxPruning` (the name
-`retention` was already taken by customer-retention materialization), and
-pruning errors surface as partial failures so a silently regrowing table
-stays visible.
+output as `lineagePruning` / `metricValuePruning` / `outboxPruning` /
+`rawSourceRecordPruning` (the name `retention` was already taken by
+customer-retention materialization), and pruning errors surface as partial
+failures so a silently regrowing table stays visible.
 
 ### 1. Lineage retention — `src/lib/imladris/lineage-retention.ts`
 
@@ -85,17 +86,92 @@ behind the lineage pruner — the overall-latest value per group and anything
 inside the lineage window still carry lineage and are untouchable. If lineage
 pruning breaks, thinning fail-safes to a no-op for those rows.
 
-## Why no schema migration
+### 5. Raw source record retention — `src/lib/imladris/raw-source-retention.ts`
 
-Deliberate: on a ~9GB table, the safest migration is none. Both pruners use
-LIMIT-bounded, autocommitted `DELETE` statements driven by existing indexes
+`ImladrisRawSourceRecord` stores raw provider snapshots. Ingestion
+(`src/lib/imladris/ingestion.ts`) UPSERTs on
+`@@unique([provider, objectType, externalId, scopeKey])`, so a re-synced object
+updates its row in place; the table grows by NEW distinct objects — PostHog
+events, GitHub PRs, Linear issues, Mercury/Stripe balance & charge snapshots —
+which arrive forever. Deletes rows that are BOTH older than
+`IMLADRIS_RAW_SOURCE_RETENTION_DAYS` (default **365**) AND no longer referenced
+by any metric value's lineage.
+
+**Reader audit (the cutoff must be ≥ the longest window any reader needs):**
+
+| Reader | Window |
+| --- | --- |
+| `materialization.ts` | 30 days (`providerWindowWhere`); `financeWindowWhere` also pulls *standing* objects — balances, subscriptions, deals — with no lower bound (wants the latest as-of `periodEnd`). |
+| `expense-dashboard.ts` (`buildExpenseDashboard`) | presets 30d/90d/**180d**; Mercury balances unbounded. Monthly burn history. |
+| `investor-dashboard-export.ts` (`buildInvestorDashboardExport`) | presets 30d/90d/**180d** via `recordWithinExportWindow`. |
+| `company-goals.ts` (`buildCompanyGoalsDashboard`) | no date window — top 200 Linear projects by `sourceUpdatedAt`. |
+
+The longest **bounded** reader window is **180 days**. `monthly-pnl-history.ts`
+and `refresh-runner.ts` read back to `MONTHLY_HISTORY_START_DATE` (2025-01-01,
+~18 months) but from `AnalyticsSnapshot`, a **different** table — no
+`ImladrisRawSourceRecord` reader needs that horizon, so retention here does not
+have to match it. The 365-day default is 2× the 180-day window, leaving margin
+for dormant-but-live objects (a Linear project untouched for months but still
+tracked; a standing balance from a provider that stopped syncing).
+
+**Why `updatedAt`, not `createdAt`:** because ingestion upserts in place,
+`createdAt` is fixed at first insert while `updatedAt` (`@updatedAt`) and the
+source timestamps refresh on every re-sync. A row first seen a year ago but
+re-synced yesterday has an old `createdAt` yet is fully reader-visible —
+pruning on `createdAt` would delete live data. Ingestion clamps every persisted
+source timestamp to ≤ the sync start time (`observableDate`) and `@updatedAt`
+is stamped at write time, so `max(occurredAt, sourceCreatedAt, sourceUpdatedAt)
+≤ updatedAt` always holds; therefore `updatedAt < cutoff` guarantees every
+source timestamp on the row is older than the cutoff and no bounded-window
+reader can select it.
+
+**The `NOT EXISTS` lineage guard** (mirroring §4) is load-bearing twice over:
+`ImladrisMetricLineage.rawRecordId` references this table with
+`onDelete: SetNull`, so deleting only lineage-free rows means that FK action
+never fires and each `DELETE` stays exactly LIMIT-bounded (no UPDATE storm on
+the multi-GB lineage table); and it protects any raw record whose provenance a
+current metric value still points at — including an old-but-still-latest
+standing finance record — until its metric value is superseded and aged out by
+the lineage pruner (§1). This sequences the pass strictly behind lineage
+pruning; if lineage pruning is broken, this pass fail-safes to a no-op for
+those rows.
+
+## Why one schema migration (the raw-source index)
+
+Sections 1, 3 and 4 add **no** migration: on a ~9GB table the safest migration
+is none, and those pruners ride existing indexes
 (`ImladrisMetricLineage.metricValueId`; `ImladrisCanonicalMetricValue` and the
-post-cleanup `OutboxEvent` table are small), so no statement's locks or WAL
-grow with the backlog and no long transactions are held. Each pass is also
-time-budgeted (`IMLADRIS_LINEAGE_PRUNE_BUDGET_MS` default 60s,
-`OUTBOX_PRUNE_BUDGET_MS` default 15s); an interrupted pass reports
-`completed: false` and resumes on the next sync cycle. Raw SQL is used because
-Prisma's `deleteMany` cannot bound rows per statement.
+post-cleanup `OutboxEvent` table are small). Section 5 needs one — its candidate
+scan filters on `updatedAt`, which had no index — so it adds
+`@@index([updatedAt])` on `ImladrisRawSourceRecord`
+(`20260615120000_add_imladris_raw_source_record_retention_index`). The
+`NOT EXISTS` probe rides the existing `ImladrisMetricLineage.rawRecordId` index.
+
+Production applies migrations via `migrate.cjs` at container startup, which runs
+each migration **inside a transaction** (and refuses any migration containing the
+`CONCURRENTLY` keyword). An in-transaction `CREATE INDEX` on this large,
+continuously-written table would hold an `ACCESS EXCLUSIVE` lock for the whole
+build, so the index is built lock-free out-of-band instead: the migration uses
+`CREATE INDEX IF NOT EXISTS`, and the operator runs the companion script against
+production **before** the migration deploys (i.e. before merging to `main`, since
+deploys auto-run on push):
+
+```
+psql "$DATABASE_URL" -f scripts/ops/20260615120000_imladris_raw_source_record_updatedat_index.lockfree.sql
+```
+
+That script issues `CREATE INDEX CONCURRENTLY IF NOT EXISTS` (psql autocommits, so
+no transaction); the migration's `IF NOT EXISTS` then no-ops. If the script is
+skipped the migration still succeeds — it just builds the index in-transaction
+with the brief lock, which is fine on fresh/small databases (CI, new envs).
+
+All pruners use LIMIT-bounded, autocommitted `DELETE` statements, so no
+statement's locks or WAL grow with the backlog and no long transactions are
+held. Each pass is also time-budgeted (`IMLADRIS_LINEAGE_PRUNE_BUDGET_MS`
+default 60s; `IMLADRIS_METRIC_VALUE_PRUNE_BUDGET_MS`, `OUTBOX_PRUNE_BUDGET_MS`
+and `IMLADRIS_RAW_SOURCE_PRUNE_BUDGET_MS` default 15s); an interrupted pass
+reports `completed: false` and resumes on the next sync cycle. Raw SQL is used
+because Prisma's `deleteMany` cannot bound rows per statement.
 
 ## Draining the existing backlog
 
@@ -105,11 +181,11 @@ sync cycles, and the outbox backlog in a few cycles. Watch the sync output's
 `lineagePruning.deletedRows` / `completed` fields (worker logs or
 `/api/cron/sync?wait=1` response).
 
-During the drain the analytics module runs up to ~90s longer per cycle (the
-sum of the three `*_PRUNE_BUDGET_MS` budgets). The worker's
-whole-cycle timeout is `WORKER_SYNC_TIMEOUT` (default 300s); if cycles already
-run near that ceiling, either raise it temporarily or lower the prune budgets
-— an interrupted pass is harmless and resumes next cycle.
+During the drain the analytics module runs up to ~105s longer per cycle (the
+sum of the four `*_PRUNE_BUDGET_MS` budgets: 60s + 15s + 15s + 15s). The
+worker's whole-cycle timeout is `WORKER_SYNC_TIMEOUT` (default 300s); if cycles
+already run near that ceiling, either raise it temporarily or lower the prune
+budgets — an interrupted pass is harmless and resumes next cycle.
 
 ## Reclaiming disk after the drain
 
@@ -139,3 +215,5 @@ writes reuse freed pages — but does not shrink files on disk. After
 | `OUTBOX_DISPATCHED_RETENTION_DAYS` | 14 | Window for terminal-success events. |
 | `OUTBOX_DEAD_LETTER_RETENTION_DAYS` | 30 | Window for inspectable/replayable dead letters. |
 | `OUTBOX_PRUNE_BUDGET_MS` | 15000 | Per-cycle pruning time budget. |
+| `IMLADRIS_RAW_SOURCE_RETENTION_DAYS` | 365 | Raw provider snapshots are deleted once `updatedAt` is older than this AND no metric value's lineage references them. Keep ≥ the longest reader window (180d for the expense/investor dashboards). |
+| `IMLADRIS_RAW_SOURCE_PRUNE_BUDGET_MS` | 15000 | Per-cycle pruning time budget. |

--- a/prisma/migrations/20260615120000_add_imladris_raw_source_record_retention_index/migration.sql
+++ b/prisma/migrations/20260615120000_add_imladris_raw_source_record_retention_index/migration.sql
@@ -1,0 +1,12 @@
+-- Index that drives the ImladrisRawSourceRecord retention prune scan
+-- (updatedAt < cutoff) in src/lib/imladris/raw-source-retention.ts.
+--
+-- IF NOT EXISTS is intentional. On the large production table this index should
+-- be pre-built WITHOUT an exclusive lock BEFORE this migration runs, because the
+-- deploy runner (migrate.cjs) applies every migration inside a transaction and
+-- an in-transaction CREATE INDEX holds an ACCESS EXCLUSIVE lock for the whole
+-- build. Pre-build it with the companion ops script, after which this statement
+-- no-ops; on fresh/small databases it simply builds the index directly:
+--   scripts/ops/20260615120000_imladris_raw_source_record_updatedat_index.lockfree.sql
+-- See docs/db-growth-controls.md ("schema migration").
+CREATE INDEX IF NOT EXISTS "ImladrisRawSourceRecord_updatedAt_idx" ON "ImladrisRawSourceRecord"("updatedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2452,6 +2452,9 @@ model ImladrisRawSourceRecord {
   @@index([provider, objectType, occurredAt])
   @@index([scopeKey, provider, objectType])
   @@index([organizationId, provider, objectType])
+  // Drives the retention prune scan (updatedAt < cutoff) in
+  // src/lib/imladris/raw-source-retention.ts.
+  @@index([updatedAt])
 }
 
 model ImladrisCanonicalMetricValue {

--- a/scripts/ops/20260615120000_imladris_raw_source_record_updatedat_index.lockfree.sql
+++ b/scripts/ops/20260615120000_imladris_raw_source_record_updatedat_index.lockfree.sql
@@ -1,0 +1,23 @@
+-- Pre-build the ImladrisRawSourceRecord.updatedAt retention index WITHOUT
+-- blocking sync writes.
+--
+-- WHY: production deploys auto-run migrate.cjs on push to main, which applies
+-- Prisma migrations inside a transaction. An in-transaction `CREATE INDEX` on
+-- this large, continuously-written table takes an ACCESS EXCLUSIVE lock for the
+-- entire build, and migrate.cjs additionally refuses any migration containing
+-- the CONCURRENTLY keyword. So build the index here first; the migration
+-- 20260615120000_add_imladris_raw_source_record_retention_index uses
+-- `CREATE INDEX IF NOT EXISTS`, so it then no-ops instead of taking the lock.
+--
+-- HOW: run against the production database BEFORE that migration deploys
+-- (i.e. before merging to main). CONCURRENTLY cannot run inside a transaction,
+-- so run it via psql, which autocommits each statement:
+--
+--   psql "$DATABASE_URL" -f scripts/ops/20260615120000_imladris_raw_source_record_updatedat_index.lockfree.sql
+--
+-- If the build is interrupted, Postgres can leave an INVALID index behind.
+-- Drop it and re-run:
+--   DROP INDEX IF EXISTS "ImladrisRawSourceRecord_updatedAt_idx";
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "ImladrisRawSourceRecord_updatedAt_idx"
+  ON "ImladrisRawSourceRecord" ("updatedAt");

--- a/src/app/api/cron/sync/route.ts
+++ b/src/app/api/cron/sync/route.ts
@@ -155,6 +155,7 @@ function collectAnalyticsPartialFailures(value: unknown): string[] {
     ["lineagePruning", "lineage_pruning"],
     ["metricValuePruning", "metric_value_pruning"],
     ["outboxPruning", "outbox_pruning"],
+    ["rawSourceRecordPruning", "raw_source_record_pruning"],
   ] as const) {
     const outcome = asRecord(record[field]);
     if (typeof outcome?.error === "string" && outcome.error.trim().length > 0) {
@@ -404,6 +405,7 @@ async function executeCronSync(input: {
       lineagePruning: null as unknown,
       metricValuePruning: null as unknown,
       outboxPruning: null as unknown,
+      rawSourceRecordPruning: null as unknown,
     };
 
     if (analyticsSyncResult.status === "fulfilled") {
@@ -417,6 +419,7 @@ async function executeCronSync(input: {
       settled.lineagePruning = analyticsSyncResult.value.lineagePruning;
       settled.metricValuePruning = analyticsSyncResult.value.metricValuePruning;
       settled.outboxPruning = analyticsSyncResult.value.outboxPruning;
+      settled.rawSourceRecordPruning = analyticsSyncResult.value.rawSourceRecordPruning;
       failures.push(...collectAnalyticsPartialFailures(analyticsSyncResult.value));
     } else {
       const msg = analyticsSyncResult.reason instanceof Error ? analyticsSyncResult.reason.message : String(analyticsSyncResult.reason);

--- a/src/lib/imladris/raw-source-retention.test.ts
+++ b/src/lib/imladris/raw-source-retention.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { pruneImladrisRawSourceRecords } from "@/lib/imladris/raw-source-retention";
+
+const NOW = new Date("2026-06-15T12:00:00.000Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_RETENTION_DAYS = 365;
+
+/**
+ * prisma.$executeRaw`...` invokes the mock as a tagged template:
+ * (strings, ...boundValues).
+ */
+type SqlCall = [TemplateStringsArray, ...unknown[]];
+
+function sqlTextOf(call: SqlCall): string {
+  return call[0].join(" ¶ ");
+}
+
+function boundValuesOf(call: SqlCall): unknown[] {
+  return call.slice(1);
+}
+
+function createPrismaMock(deleteCounts: number[]) {
+  const counts = [...deleteCounts];
+  return {
+    $executeRaw: vi.fn(async () => counts.shift() ?? 0),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("pruneImladrisRawSourceRecords", () => {
+  it("completes immediately when nothing is left to prune", async () => {
+    const prisma = createPrismaMock([0]);
+
+    const result = await pruneImladrisRawSourceRecords({
+      prisma: prisma as never,
+      now: NOW,
+    });
+
+    expect(result).toEqual({
+      deletedRows: 0,
+      batches: 1,
+      cutoff: new Date(NOW.getTime() - DEFAULT_RETENTION_DAYS * DAY_MS).toISOString(),
+      completed: true,
+      durationMs: expect.any(Number),
+    });
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("only deletes old, lineage-free raw records (updatedAt, not createdAt)", async () => {
+    const prisma = createPrismaMock([0]);
+
+    await pruneImladrisRawSourceRecords({ prisma: prisma as never, now: NOW });
+
+    const call = prisma.$executeRaw.mock.calls[0] as unknown as SqlCall;
+    const sql = sqlTextOf(call);
+    expect(sql).toContain('DELETE FROM "ImladrisRawSourceRecord"');
+    // Prune column is updatedAt: it refreshes on every in-place upsert, so it is
+    // always >= the row's source timestamps. createdAt is fixed at first insert
+    // and would wrongly delete re-synced, reader-visible rows.
+    expect(sql).toContain('r."updatedAt" <');
+    expect(sql).not.toContain('"createdAt"');
+    // Rows still referenced by metric-value lineage are untouchable: keeps the
+    // SetNull FK action from firing (DELETEs stay LIMIT-bounded) and protects
+    // raw records whose provenance a current metric still points at.
+    expect(sql).toContain("NOT EXISTS");
+    expect(sql).toContain(
+      'FROM "ImladrisMetricLineage" l WHERE l."rawRecordId" = r."id"',
+    );
+    expect(sql).toContain("LIMIT");
+    // Bound values, in order: cutoff, batch size.
+    expect(boundValuesOf(call)).toEqual([
+      new Date(NOW.getTime() - DEFAULT_RETENTION_DAYS * DAY_MS),
+      10_000,
+    ]);
+  });
+
+  it("loops in bounded batches until the backlog drains", async () => {
+    const prisma = createPrismaMock([2, 2, 1]);
+
+    const result = await pruneImladrisRawSourceRecords({
+      prisma: prisma as never,
+      now: NOW,
+      batchSize: 2,
+    });
+
+    expect(result.deletedRows).toBe(5);
+    expect(result.batches).toBe(3);
+    expect(result.completed).toBe(true);
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops at the time budget and reports an incomplete pass", async () => {
+    const ticks = [0, 10, 200, 250];
+    const clock = vi.fn(() => (ticks.length > 1 ? (ticks.shift() as number) : ticks[0]));
+    // A full batch means more rows remain when the budget expires.
+    const prisma = createPrismaMock([2]);
+
+    const result = await pruneImladrisRawSourceRecords({
+      prisma: prisma as never,
+      now: NOW,
+      batchSize: 2,
+      budgetMs: 100,
+      clock,
+    });
+
+    expect(result.completed).toBe(false);
+    expect(result.deletedRows).toBe(2);
+    expect(result.batches).toBe(1);
+    expect(result.durationMs).toBe(250);
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults the retention window to 365 days (>= the 180d longest reader window)", async () => {
+    const prisma = createPrismaMock([0]);
+
+    const result = await pruneImladrisRawSourceRecords({
+      prisma: prisma as never,
+      now: NOW,
+    });
+
+    expect(result.cutoff).toBe(
+      new Date(NOW.getTime() - 365 * DAY_MS).toISOString(),
+    );
+  });
+
+  it("honors an explicit retentionDays override", async () => {
+    const prisma = createPrismaMock([0]);
+
+    const result = await pruneImladrisRawSourceRecords({
+      prisma: prisma as never,
+      now: NOW,
+      retentionDays: 200,
+    });
+
+    expect(result.cutoff).toBe(new Date(NOW.getTime() - 200 * DAY_MS).toISOString());
+  });
+
+  it("reads IMLADRIS_RAW_SOURCE_RETENTION_DAYS when no override is provided", async () => {
+    vi.stubEnv("IMLADRIS_RAW_SOURCE_RETENTION_DAYS", "400");
+    const prisma = createPrismaMock([0]);
+
+    const result = await pruneImladrisRawSourceRecords({
+      prisma: prisma as never,
+      now: NOW,
+    });
+
+    expect(result.cutoff).toBe(new Date(NOW.getTime() - 400 * DAY_MS).toISOString());
+    const call = prisma.$executeRaw.mock.calls[0] as unknown as SqlCall;
+    expect(boundValuesOf(call)).toContainEqual(new Date(NOW.getTime() - 400 * DAY_MS));
+  });
+});

--- a/src/lib/imladris/raw-source-retention.ts
+++ b/src/lib/imladris/raw-source-retention.ts
@@ -1,0 +1,184 @@
+/**
+ * Imladris raw source record retention.
+ *
+ * Companion to the other growth controls in docs/db-growth-controls.md. The
+ * cron sync ingests raw provider snapshots every ~10 minutes
+ * (src/lib/imladris/ingestion.ts). Ingestion UPSERTs on
+ * `@@unique([provider, objectType, externalId, scopeKey])`, so a re-synced
+ * object updates its row in place; the table grows by NEW distinct objects —
+ * PostHog events, GitHub PRs, Linear issues, Mercury/Stripe balance & charge
+ * snapshots — which arrive forever and are never pruned. This is the third
+ * unbounded table behind the 2026-06-10 disk-full class of outage. PR #594
+ * fixed the acute OOM crash loop (the materialization read is 30-day-bounded,
+ * so unbounded table growth was not the acute driver) and explicitly deferred
+ * pruning to here because it needs careful reader-auditing.
+ *
+ * READER AUDIT (every reader of ImladrisRawSourceRecord — the cutoff must be
+ * >= the longest window any of them needs):
+ *   - materialization.ts: 30-day window (providerWindowWhere). financeWindowWhere
+ *     additionally pulls "standing" objects (balances, subscriptions, deals,
+ *     active_customer_ref) with NO lower bound — it wants the LATEST such record
+ *     as-of periodEnd.
+ *   - expense-dashboard.ts (buildExpenseDashboard): range presets 30d/90d/180d
+ *     (max 180d), plus Mercury balances with no lower bound. Builds monthly
+ *     burn history.
+ *   - investor-dashboard-export.ts (buildInvestorDashboardExport): range presets
+ *     30d/90d/180d (max 180d) via recordWithinExportWindow.
+ *   - company-goals.ts (buildCompanyGoalsDashboard): no date window — reads the
+ *     200 most-recently-updated Linear project records (orderBy sourceUpdatedAt).
+ * The longest BOUNDED reader window is therefore 180 days. (monthly-pnl-history.ts
+ * and refresh-runner.ts read AnalyticsSnapshot back to MONTHLY_HISTORY_START_DATE
+ * = 2025-01-01 — a DIFFERENT table; no ImladrisRawSourceRecord reader needs that
+ * ~18-month horizon, so retention here does not have to match it.)
+ *
+ * WHY `updatedAt`, NOT `createdAt`, IS THE PRUNE COLUMN: because ingestion
+ * upserts in place, `createdAt` is fixed at first insert while `updatedAt`
+ * (@updatedAt) and the source timestamps refresh on every re-sync. A row first
+ * seen a year ago but re-synced yesterday has an OLD createdAt and is fully
+ * reader-visible — pruning on createdAt would delete live data. ingestion.ts
+ * clamps every persisted source timestamp to <= the sync start time
+ * (`observableDate`), and @updatedAt is stamped at write time, so the invariant
+ *   max(occurredAt, sourceCreatedAt, sourceUpdatedAt) <= updatedAt
+ * always holds. Hence `updatedAt < now - retentionDays` GUARANTEES every source
+ * timestamp on the row is also older than the cutoff, so no bounded-window
+ * reader (window <= retentionDays) can select it. The default of 365 days is
+ * 2x the 180-day max window, leaving comfortable margin for dormant-but-live
+ * objects (e.g. a Linear project not edited in months but still tracked, or a
+ * standing balance from a provider that stopped syncing).
+ *
+ * THE `NOT EXISTS` LINEAGE GUARD is load-bearing twice over, exactly mirroring
+ * the metric-value thinner (src/lib/imladris/metric-value-retention.ts):
+ *   - ImladrisMetricLineage.rawRecordId references this table with
+ *     `onDelete: SetNull`. Deleting only lineage-free rows means that FK action
+ *     can never fire, so each DELETE stays exactly LIMIT-bounded and never
+ *     amplifies into an UPDATE storm on the multi-GB lineage table.
+ *   - It protects any raw record whose provenance a current metric value still
+ *     points at — including an old-but-still-latest standing finance record that
+ *     a fresh finance metric references. Such a record keeps lineage until its
+ *     metric value is superseded AND aged out by the lineage pruner
+ *     (IMLADRIS_LINEAGE_RETENTION_DAYS, default 14), only then becoming prunable.
+ *     This sequences the pass strictly behind lineage pruning; if lineage pruning
+ *     is broken or backlogged, this pass fail-safes to a no-op for those rows.
+ *
+ * Operational shape matches the other growth pruners: LIMIT-bounded,
+ * autocommitted raw `DELETE` statements (Prisma's deleteMany cannot bound rows
+ * per statement) driven by indexes — the new ImladrisRawSourceRecord.updatedAt
+ * index for the outer scan and the existing ImladrisMetricLineage.rawRecordId
+ * index for the NOT EXISTS probe — and a per-cycle time budget so a large
+ * initial backlog drains incrementally across cycles instead of stalling a sync.
+ * Deleted space is reclaimed by autovacuum; returning it to the OS needs
+ * VACUUM FULL / pg_repack — see docs/db-growth-controls.md.
+ */
+
+import type { PrismaClientType } from "@/lib/prisma";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_RETENTION_DAYS = 365;
+const DEFAULT_BUDGET_MS = 15_000;
+const DEFAULT_BATCH_SIZE = 10_000;
+
+export interface PruneImladrisRawSourceRecordsInput {
+  prisma: PrismaClientType;
+  /**
+   * Raw records whose `updatedAt` is older than this many days AND which no
+   * longer back any metric value's lineage are deleted. Defaults to
+   * IMLADRIS_RAW_SOURCE_RETENTION_DAYS (env) or 365 — comfortably beyond the
+   * 180-day longest bounded reader window (expense + investor dashboards).
+   */
+  retentionDays?: number;
+  /**
+   * Soft time budget for one pruning pass. Defaults to
+   * IMLADRIS_RAW_SOURCE_PRUNE_BUDGET_MS (env) or 15s. The pass stops at the
+   * budget and resumes on the next sync cycle.
+   */
+  budgetMs?: number;
+  /** Max raw records deleted per DELETE statement. */
+  batchSize?: number;
+  /** Test seam: reference time for the cutoff. Defaults to now. */
+  now?: Date;
+  /** Test seam: monotonic clock for the time budget. Defaults to Date.now. */
+  clock?: () => number;
+}
+
+export interface PruneImladrisRawSourceRecordsResult {
+  deletedRows: number;
+  /** DELETE statements issued. */
+  batches: number;
+  cutoff: string;
+  /**
+   * False when the time budget expired before the backlog fully drained.
+   * The next sync cycle picks up where this one stopped.
+   */
+  completed: boolean;
+  durationMs: number;
+}
+
+function positiveIntFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  const parsed = raw ? Number(raw) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
+  return fallback;
+}
+
+export async function pruneImladrisRawSourceRecords(
+  input: PruneImladrisRawSourceRecordsInput,
+): Promise<PruneImladrisRawSourceRecordsResult> {
+  const retentionDays = Math.max(
+    1,
+    Math.floor(
+      input.retentionDays ??
+        positiveIntFromEnv("IMLADRIS_RAW_SOURCE_RETENTION_DAYS", DEFAULT_RETENTION_DAYS),
+    ),
+  );
+  const budgetMs = Math.max(
+    1,
+    Math.floor(
+      input.budgetMs ?? positiveIntFromEnv("IMLADRIS_RAW_SOURCE_PRUNE_BUDGET_MS", DEFAULT_BUDGET_MS),
+    ),
+  );
+  const batchSize = Math.max(1, Math.floor(input.batchSize ?? DEFAULT_BATCH_SIZE));
+  const now = input.now ?? new Date();
+  const clock = input.clock ?? (() => Date.now());
+  const cutoff = new Date(now.getTime() - retentionDays * DAY_MS);
+
+  const startedAt = clock();
+  const deadline = startedAt + budgetMs;
+
+  let deletedRows = 0;
+  let batches = 0;
+  let completed = false;
+
+  // Each DELETE is a single bounded, autocommitted statement. The candidate
+  // scan rides the ImladrisRawSourceRecord.updatedAt index; the NOT EXISTS
+  // probe rides the ImladrisMetricLineage.rawRecordId index, keeping rows still
+  // referenced by live lineage untouchable (so the SetNull FK action never
+  // fires and each statement stays exactly LIMIT-bounded).
+  while (clock() < deadline) {
+    const deleted = await input.prisma.$executeRaw`
+      DELETE FROM "ImladrisRawSourceRecord"
+      WHERE "id" IN (
+        SELECT r."id"
+        FROM "ImladrisRawSourceRecord" r
+        WHERE r."updatedAt" < ${cutoff}
+          AND NOT EXISTS (
+            SELECT 1 FROM "ImladrisMetricLineage" l WHERE l."rawRecordId" = r."id"
+          )
+        LIMIT ${batchSize}
+      )
+    `;
+    batches += 1;
+    deletedRows += deleted;
+    if (deleted < batchSize) {
+      completed = true;
+      break;
+    }
+  }
+
+  return {
+    deletedRows,
+    batches,
+    cutoff: cutoff.toISOString(),
+    completed,
+    durationMs: clock() - startedAt,
+  };
+}

--- a/src/lib/sync/analytics.test.ts
+++ b/src/lib/sync/analytics.test.ts
@@ -4,6 +4,7 @@ import { pruneAnalyticsSnapshots } from "@/lib/analytics/snapshots";
 import { pruneOutboxEvents } from "@/lib/events/outbox-retention";
 import { pruneImladrisMetricLineage } from "@/lib/imladris/lineage-retention";
 import { pruneImladrisMetricValues } from "@/lib/imladris/metric-value-retention";
+import { pruneImladrisRawSourceRecords } from "@/lib/imladris/raw-source-retention";
 import { materializeImladrisCanonicalMetrics } from "@/lib/imladris/materialization";
 import { runAnalyticsSync } from "@/lib/sync/analytics";
 import { discoverConnectedUserIds } from "@/lib/sync/users";
@@ -26,6 +27,10 @@ vi.mock("@/lib/imladris/lineage-retention", () => ({
 
 vi.mock("@/lib/imladris/metric-value-retention", () => ({
   pruneImladrisMetricValues: vi.fn(),
+}));
+
+vi.mock("@/lib/imladris/raw-source-retention", () => ({
+  pruneImladrisRawSourceRecords: vi.fn(),
 }));
 
 vi.mock("@/lib/imladris/materialization", () => ({
@@ -78,6 +83,13 @@ describe("runAnalyticsSync", () => {
       batches: 0,
       dispatchedCutoff: "2026-05-18T12:00:00.000Z",
       deadLetterCutoff: "2026-05-02T12:00:00.000Z",
+      completed: true,
+      durationMs: 1,
+    } as never);
+    vi.mocked(pruneImladrisRawSourceRecords).mockResolvedValue({
+      deletedRows: 0,
+      batches: 0,
+      cutoff: "2025-06-01T12:00:00.000Z",
       completed: true,
       durationMs: 1,
     } as never);
@@ -398,9 +410,17 @@ describe("runAnalyticsSync", () => {
       completed: false,
       durationMs: 3,
     };
+    const rawSourceResult = {
+      deletedRows: 9000,
+      batches: 1,
+      cutoff: "2025-06-01T12:00:00.000Z",
+      completed: false,
+      durationMs: 4,
+    };
     vi.mocked(pruneImladrisMetricLineage).mockResolvedValueOnce(lineageResult as never);
     vi.mocked(pruneImladrisMetricValues).mockResolvedValueOnce(metricValueResult as never);
     vi.mocked(pruneOutboxEvents).mockResolvedValueOnce(outboxResult as never);
+    vi.mocked(pruneImladrisRawSourceRecords).mockResolvedValueOnce(rawSourceResult as never);
 
     const result = await runAnalyticsSync({
       prisma: prisma as never,
@@ -409,6 +429,7 @@ describe("runAnalyticsSync", () => {
     expect(result.lineagePruning).toEqual(lineageResult);
     expect(result.metricValuePruning).toEqual(metricValueResult);
     expect(result.outboxPruning).toEqual(outboxResult);
+    expect(result.rawSourceRecordPruning).toEqual(rawSourceResult);
     expect(pruneImladrisMetricLineage).toHaveBeenCalledWith({
       prisma,
       now: new Date("2026-06-01T12:00:00.000Z"),
@@ -421,18 +442,26 @@ describe("runAnalyticsSync", () => {
       prisma,
       now: new Date("2026-06-01T12:00:00.000Z"),
     });
+    expect(pruneImladrisRawSourceRecords).toHaveBeenCalledWith({
+      prisma,
+      now: new Date("2026-06-01T12:00:00.000Z"),
+    });
 
     // Pruning must run after materialization so it never contends with the
     // cycle's own lineage writes, and metric value thinning must run after
-    // lineage pruning (it only deletes lineage-free rows).
+    // lineage pruning (it only deletes lineage-free rows). Raw source pruning
+    // also runs after lineage pruning — it only deletes raw records whose
+    // lineage has already been aged out (the NOT EXISTS guard).
     const lastMaterializeOrder = vi
       .mocked(materializeImladrisCanonicalMetrics)
       .mock.invocationCallOrder.at(-1);
     const lineageOrder = vi.mocked(pruneImladrisMetricLineage).mock.invocationCallOrder[0];
     const metricValueOrder = vi.mocked(pruneImladrisMetricValues).mock.invocationCallOrder[0];
+    const rawSourceOrder = vi.mocked(pruneImladrisRawSourceRecords).mock.invocationCallOrder[0];
     expect(lastMaterializeOrder).toBeDefined();
     expect(lineageOrder).toBeGreaterThan(lastMaterializeOrder as number);
     expect(metricValueOrder).toBeGreaterThan(lineageOrder);
+    expect(rawSourceOrder).toBeGreaterThan(lineageOrder);
   });
 
   it("captures growth-control pruning failures without failing the sync", async () => {
@@ -445,6 +474,9 @@ describe("runAnalyticsSync", () => {
       new Error("metric value prune exploded"),
     );
     vi.mocked(pruneOutboxEvents).mockRejectedValueOnce(new Error("outbox prune exploded"));
+    vi.mocked(pruneImladrisRawSourceRecords).mockRejectedValueOnce(
+      new Error("raw source prune exploded"),
+    );
 
     const result = await runAnalyticsSync({
       prisma: prisma as never,
@@ -453,6 +485,7 @@ describe("runAnalyticsSync", () => {
     expect(result.lineagePruning).toEqual({ error: "lineage prune exploded" });
     expect(result.metricValuePruning).toEqual({ error: "metric value prune exploded" });
     expect(result.outboxPruning).toEqual({ error: "outbox prune exploded" });
+    expect(result.rawSourceRecordPruning).toEqual({ error: "raw source prune exploded" });
     // The sync itself still succeeds end-to-end.
     expect(result.refresh).toEqual({ refreshed: true });
     expect(result.imladris).toHaveLength(2);
@@ -464,6 +497,9 @@ describe("runAnalyticsSync", () => {
     });
     expect(consoleError).toHaveBeenCalledWith("analytics_sync.outbox_pruning_failed", {
       error: "outbox prune exploded",
+    });
+    expect(consoleError).toHaveBeenCalledWith("analytics_sync.raw_source_record_pruning_failed", {
+      error: "raw source prune exploded",
     });
     consoleError.mockRestore();
   });

--- a/src/lib/sync/analytics.ts
+++ b/src/lib/sync/analytics.ts
@@ -37,6 +37,10 @@ import {
   type PruneImladrisMetricValuesResult,
 } from '@/lib/imladris/metric-value-retention';
 import {
+  pruneImladrisRawSourceRecords,
+  type PruneImladrisRawSourceRecordsResult,
+} from '@/lib/imladris/raw-source-retention';
+import {
   materializeImladrisCanonicalMetrics,
   type MaterializedImladrisMetricResult,
 } from '@/lib/imladris/materialization';
@@ -79,6 +83,7 @@ export interface AnalyticsSyncResult {
   lineagePruning: GrowthPruneOutcome<PruneImladrisMetricLineageResult>;
   metricValuePruning: GrowthPruneOutcome<PruneImladrisMetricValuesResult>;
   outboxPruning: GrowthPruneOutcome<PruneOutboxEventsResult>;
+  rawSourceRecordPruning: GrowthPruneOutcome<PruneImladrisRawSourceRecordsResult>;
 }
 
 const DEFAULT_RANGE_PRESETS: RollingRangePreset[] = ['7d', '30d'];
@@ -299,6 +304,27 @@ export async function runAnalyticsSync(
     console.error('analytics_sync.outbox_pruning_failed', { error: message });
     return { error: message };
   });
+  // Raw provider snapshots: the third unbounded table. Runs after lineage
+  // pruning by design — it only deletes raw records no metric value's lineage
+  // still references (the NOT EXISTS guard), so the lineage pass aging out
+  // superseded values clears the way and this pass can never fire the
+  // ImladrisMetricLineage.rawRecordId SetNull FK action.
+  const rawSourceRecordPruning = await pruneImladrisRawSourceRecords({
+    prisma: input.prisma,
+    now,
+  }).catch((error: unknown): GrowthPruneOutcome<PruneImladrisRawSourceRecordsResult> => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('analytics_sync.raw_source_record_pruning_failed', { error: message });
+    return { error: message };
+  });
 
-  return { refresh, pruning, imladris, lineagePruning, metricValuePruning, outboxPruning };
+  return {
+    refresh,
+    pruning,
+    imladris,
+    lineagePruning,
+    metricValuePruning,
+    outboxPruning,
+    rawSourceRecordPruning,
+  };
 }

--- a/src/lib/sync/orchestrator.ts
+++ b/src/lib/sync/orchestrator.ts
@@ -111,6 +111,7 @@ function collectAnalyticsPartialFailures(value: unknown): string[] {
     ['lineagePruning', 'lineage_pruning'],
     ['metricValuePruning', 'metric_value_pruning'],
     ['outboxPruning', 'outbox_pruning'],
+    ['rawSourceRecordPruning', 'raw_source_record_pruning'],
   ] as const) {
     const outcome = asRecord(record[field]);
     if (typeof outcome?.error === 'string' && outcome.error.trim().length > 0) {


### PR DESCRIPTION
## Commits
- Add retention pruning for ImladrisRawSourceRecord

## Files changed
 .env.example                                       |   7 +
 docs/db-growth-controls.md                         | 116 ++++++++++---
 .../migration.sql                                  |  12 ++
 prisma/schema.prisma                               |   3 +
 ..._raw_source_record_updatedat_index.lockfree.sql |  23 +++
 src/app/api/cron/sync/route.ts                     |   3 +
 src/lib/imladris/raw-source-retention.test.ts      | 154 +++++++++++++++++
 src/lib/imladris/raw-source-retention.ts           | 184 +++++++++++++++++++++
 src/lib/sync/analytics.test.ts                     |  38 ++++-
 src/lib/sync/analytics.ts                          |  28 +++-
 src/lib/sync/orchestrator.ts                       |   1 +
 11 files changed, 548 insertions(+), 21 deletions(-)
---
### Postgres-volume / Imladris-lineage incident cluster
This is one of **6 overlapping branches** from the same incident that could **not** be auto-consolidated (all have unique patches; 4 of 5 conflict on the lineage/pruning code). Pick the canonical approach for the shared pruning/growth-control logic, then rebase the rest in sequence. Suggested order:
1. `fix/db-connect-resilience` — connection resilience (I/O stalls; orthogonal, merges clean)
2. `feat/db-pruning` — scheduled retention pruning + `/api/health/db` probe + indexes
3. `claude/cool-greider-41cea8` — thin canonical metric values + DB growth controls
4. `claude/zen-meitner-16de46` — raw-source-record retention pruning
5. `claude/vigorous-cannon-e0c038` — lineage bloat reclaim (CTAS swap) + runbook
6. `claude/quizzical-banach-9da052` — lineage source handling + live-dashboard fixes

_Surfaced during repo cleanup; was unmerged with no PR._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
