### PR TITLE
feat: add design interview workspace and owner fallback

### DIFF
--- a/src/app/(dashboard)/settings/page.test.tsx
+++ b/src/app/(dashboard)/settings/page.test.tsx
@@ -27,6 +27,10 @@ vi.mock("@/components/settings/priorities-tab", () => ({
   PrioritiesTab: () => <div>Priorities</div>,
 }));
 
+vi.mock("@/components/settings/design-interview-tab", () => ({
+  DesignInterviewTab: () => <div>Design Interview</div>,
+}));
+
 vi.mock("@/components/settings/team-tab", () => ({
   TeamTab: () => <div>Team</div>,
 }));
@@ -49,6 +53,7 @@ describe("SettingsPage", () => {
     const { queryByRole, getByText } = render(<SettingsPage />);
 
     expect(getByText("Board Settings")).toBeTruthy();
+    expect(queryByRole("tab", { name: "Design Interview" })).toBeTruthy();
     expect(queryByRole("tab", { name: "Integrations" })).toBeNull();
   });
 

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -11,6 +11,7 @@ import { PrioritiesTab } from "@/components/settings/priorities-tab";
 import { TeamTab } from "@/components/settings/team-tab";
 import { DepartmentsTab } from "@/components/settings/departments-tab";
 import { OperationsTab } from "@/components/settings/operations-tab";
+import { DesignInterviewTab } from "@/components/settings/design-interview-tab";
 
 const TABS = [
   { id: "board", label: "Board & WIP Limits" },
@@ -18,6 +19,7 @@ const TABS = [
   { id: "projects", label: "Projects" },
   { id: "departments", label: "Departments" },
   { id: "priorities", label: "Company Priorities" },
+  { id: "design-interview", label: "Design Interview" },
   { id: "team", label: "Team" },
   { id: "operations", label: "Operations" },
 ] as const;
@@ -122,6 +124,7 @@ export default function SettingsPage() {
         {activeTab === "projects" && <ProjectsTab />}
         {activeTab === "departments" && <DepartmentsTab />}
         {activeTab === "priorities" && <PrioritiesTab />}
+        {activeTab === "design-interview" && <DesignInterviewTab />}
         {activeTab === "team" && <TeamTab />}
         {activeTab === "operations" && <OperationsTab />}
       </div>

--- a/src/app/api/deals/route.test.ts
+++ b/src/app/api/deals/route.test.ts
@@ -1,70 +1,84 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
+const authMock = vi.hoisted(() => vi.fn());
+const enforcePermissionMock = vi.hoisted(() => vi.fn());
+const dealCreateMock = vi.hoisted(() => vi.fn());
+const dealStageHistoryCreateMock = vi.hoisted(() => vi.fn());
+
 vi.mock("@/lib/auth", () => ({
-  auth: vi.fn(),
+  auth: authMock,
 }));
 
 vi.mock("@/lib/permissions", () => ({
-  enforcePermission: vi.fn(async () => ({ deniedResponse: null })),
+  enforcePermission: enforcePermissionMock,
 }));
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     deal: {
-      create: vi.fn(),
+      create: dealCreateMock,
     },
     dealStageHistory: {
-      create: vi.fn(),
+      create: dealStageHistoryCreateMock,
     },
   },
 }));
 
-describe("POST /api/deals", () => {
-  beforeEach(async () => {
+describe("deals route", () => {
+  beforeEach(() => {
     vi.resetAllMocks();
-    vi.resetModules();
 
-    const { auth } = await import("@/lib/auth");
-    vi.mocked(auth).mockResolvedValue({
+    authMock.mockResolvedValue({
       user: {
         id: "user-1",
         email: "user@example.com",
         role: "member",
         organizationId: "org-1",
       },
-    } as never);
+    });
 
-    const { prisma } = await import("@/lib/prisma");
-    vi.mocked(prisma.deal.create).mockResolvedValue({
+    enforcePermissionMock.mockResolvedValue({ role: "member" });
+    dealCreateMock.mockResolvedValue({
       id: "deal-1",
-    } as never);
-    vi.mocked(prisma.dealStageHistory.create).mockResolvedValue({
+      name: "Acme Expansion",
+    });
+    dealStageHistoryCreateMock.mockResolvedValue({
       id: "history-1",
-    } as never);
+    });
   });
 
-  it("persists the session organization on newly created deals", async () => {
-    const { prisma } = await import("@/lib/prisma");
+  it("assigns the authenticated user's organization when creating a deal", async () => {
     const { POST } = await import("@/app/api/deals/route");
 
     const response = await POST(
       new NextRequest("http://localhost/api/deals", {
         method: "POST",
         body: JSON.stringify({
-          name: "Acme",
+          name: "Acme Expansion",
+          stage: "LEAD",
+          source: "OTHER",
         }),
-      })
+      }),
     );
 
     expect(response.status).toBe(201);
-    expect(prisma.deal.create).toHaveBeenCalledWith(
+    expect(dealCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
-          name: "Acme",
+          name: "Acme Expansion",
+          ownerId: "user-1",
           organizationId: "org-1",
         }),
-      })
+      }),
     );
+    expect(dealStageHistoryCreateMock).toHaveBeenCalledWith({
+      data: {
+        dealId: "deal-1",
+        fromStage: null,
+        toStage: "LEAD",
+        changedBy: "user-1",
+      },
+    });
   });
 });

--- a/src/components/settings/design-interview-tab.tsx
+++ b/src/components/settings/design-interview-tab.tsx
@@ -1,0 +1,584 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { clsx } from "clsx";
+import {
+  CheckCircle2,
+  ClipboardCopy,
+  Download,
+  FileText,
+  MessageSquareQuote,
+  Mic,
+  RotateCcw,
+  Sparkles,
+} from "lucide-react";
+import {
+  buildDesignInterviewPrompt,
+  DEFAULT_DESIGN_INTERVIEW_DRAFT,
+  DESIGN_INTERVIEW_CONTEXT,
+  DESIGN_INTERVIEW_PROMPTS,
+  DESIGN_INTERVIEW_STORAGE_KEY,
+  personalizeDesignInterviewTemplate,
+  type DesignInterviewDraft,
+} from "@/lib/design-interview";
+
+type WorkspaceTab = "run" | "capture";
+
+function readDraft(): DesignInterviewDraft {
+  if (typeof window === "undefined") return DEFAULT_DESIGN_INTERVIEW_DRAFT;
+
+  try {
+    const raw = window.localStorage.getItem(DESIGN_INTERVIEW_STORAGE_KEY);
+    if (!raw) return DEFAULT_DESIGN_INTERVIEW_DRAFT;
+
+    const parsed = JSON.parse(raw) as Partial<DesignInterviewDraft>;
+    return {
+      ...DEFAULT_DESIGN_INTERVIEW_DRAFT,
+      ...parsed,
+      structuredOutput:
+        typeof parsed.structuredOutput === "string" && parsed.structuredOutput.trim().length > 0
+          ? parsed.structuredOutput
+          : DEFAULT_DESIGN_INTERVIEW_DRAFT.structuredOutput,
+      promptNotes:
+        parsed.promptNotes && typeof parsed.promptNotes === "object"
+          ? parsed.promptNotes
+          : {},
+      completedPromptIds: Array.isArray(parsed.completedPromptIds)
+        ? parsed.completedPromptIds.filter((value): value is string => typeof value === "string")
+        : [],
+    };
+  } catch {
+    return DEFAULT_DESIGN_INTERVIEW_DRAFT;
+  }
+}
+
+async function copyToClipboard(value: string): Promise<boolean> {
+  if (typeof navigator === "undefined" || !navigator.clipboard) return false;
+
+  try {
+    await navigator.clipboard.writeText(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function DesignInterviewTab() {
+  const [draft, setDraft] = useState<DesignInterviewDraft>(() => readDraft());
+  const [activePromptId, setActivePromptId] = useState(DESIGN_INTERVIEW_PROMPTS[0]?.id ?? "");
+  const [activeWorkspaceTab, setActiveWorkspaceTab] = useState<WorkspaceTab>("run");
+  const [copyState, setCopyState] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(DESIGN_INTERVIEW_STORAGE_KEY, JSON.stringify(draft));
+    } catch {
+      // Ignore storage failures.
+    }
+  }, [draft]);
+
+  const activePrompt =
+    DESIGN_INTERVIEW_PROMPTS.find((prompt) => prompt.id === activePromptId) ??
+    DESIGN_INTERVIEW_PROMPTS[0];
+
+  const completedPromptIds = new Set(draft.completedPromptIds);
+  const progressPercent = Math.round(
+    (completedPromptIds.size / DESIGN_INTERVIEW_PROMPTS.length) * 100,
+  );
+
+  const outputTemplate = useMemo(
+    () =>
+      personalizeDesignInterviewTemplate(draft.intervieweeName, draft.intervieweeRole),
+    [draft.intervieweeName, draft.intervieweeRole],
+  );
+  const generatedPrompt = useMemo(
+    () =>
+      buildDesignInterviewPrompt({
+        intervieweeName: draft.intervieweeName,
+        intervieweeRole: draft.intervieweeRole,
+      }),
+    [draft.intervieweeName, draft.intervieweeRole],
+  );
+  const previousTemplateRef = useRef(outputTemplate);
+
+  useEffect(() => {
+    const previousTemplate = previousTemplateRef.current;
+
+    setDraft((current) => {
+      if (current.structuredOutput !== previousTemplate) {
+        return current;
+      }
+
+      if (current.structuredOutput === outputTemplate) {
+        return current;
+      }
+
+      return {
+        ...current,
+        structuredOutput: outputTemplate,
+      };
+    });
+
+    previousTemplateRef.current = outputTemplate;
+  }, [outputTemplate]);
+
+  async function handleCopy(label: string, value: string) {
+    const copied = await copyToClipboard(value);
+    setCopyState(copied ? label : `${label}-failed`);
+    window.setTimeout(() => setCopyState(null), 1600);
+  }
+
+  function updateDraft(patch: Partial<DesignInterviewDraft>) {
+    setDraft((current) => ({ ...current, ...patch }));
+  }
+
+  function updatePromptNote(promptId: string, value: string) {
+    setDraft((current) => ({
+      ...current,
+      promptNotes: {
+        ...current.promptNotes,
+        [promptId]: value,
+      },
+    }));
+  }
+
+  function togglePromptComplete(promptId: string) {
+    setDraft((current) => {
+      const next = new Set(current.completedPromptIds);
+      if (next.has(promptId)) next.delete(promptId);
+      else next.add(promptId);
+
+      return {
+        ...current,
+        completedPromptIds: Array.from(next),
+      };
+    });
+  }
+
+  function resetWorkspace() {
+    setDraft(DEFAULT_DESIGN_INTERVIEW_DRAFT);
+    setActivePromptId(DESIGN_INTERVIEW_PROMPTS[0]?.id ?? "");
+    setActiveWorkspaceTab("run");
+    try {
+      window.localStorage.removeItem(DESIGN_INTERVIEW_STORAGE_KEY);
+    } catch {
+      // Ignore storage failures.
+    }
+  }
+
+  return (
+    <div className="max-w-6xl space-y-6">
+      <section className="overflow-hidden rounded-2xl border border-border bg-card">
+        <div className="bg-[linear-gradient(125deg,#0a0a0a_0%,#151515_45%,rgba(252,90,41,0.96)_140%)] px-5 py-5 text-white">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="max-w-3xl space-y-3">
+              <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-white/80">
+                <MessageSquareQuote className="h-3.5 w-3.5" />
+                Design Research Ops
+              </span>
+              <div>
+                <h2 className="text-xl font-semibold">Arda Design Interview</h2>
+                <p className="mt-1 text-sm text-white/75">
+                  Run the self-interview as a repeatable workflow: prep the interviewer,
+                  copy the AI prompt, collect the raw transcript, and turn it into the
+                  structured markdown artifact used for design guidance.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => void handleCopy("prompt", generatedPrompt)}
+                className="inline-flex items-center gap-2 rounded-lg bg-white px-3 py-2 text-sm font-medium text-black transition-colors hover:bg-white/90"
+              >
+                <ClipboardCopy className="h-4 w-4" />
+                Copy Full AI Prompt
+              </button>
+              <button
+                onClick={() => void handleCopy("template", outputTemplate)}
+                className="inline-flex items-center gap-2 rounded-lg border border-white/20 bg-white/5 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-white/10"
+              >
+                <Download className="h-4 w-4" />
+                Copy Output Template
+              </button>
+              {copyState && (
+                <span
+                  className={clsx(
+                    "inline-flex items-center rounded-full px-2.5 py-1 text-[11px] font-medium",
+                    copyState.endsWith("failed")
+                      ? "bg-white/10 text-white"
+                      : "bg-emerald-500/20 text-emerald-100",
+                  )}
+                >
+                  {copyState.endsWith("failed") ? "Clipboard copy failed" : "Copied"}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div className="grid gap-4 xl:grid-cols-[280px_minmax(0,1fr)]">
+        <aside className="space-y-4">
+          <section className="rounded-lg border border-border bg-card p-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-foreground">Interview Progress</h3>
+              <span className="rounded-full bg-secondary px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                {completedPromptIds.size}/{DESIGN_INTERVIEW_PROMPTS.length}
+              </span>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Work prompt by prompt, then compile the final markdown artifact.
+            </p>
+
+            <div className="mt-4">
+              <div className="h-2 overflow-hidden rounded-full bg-secondary">
+                <div
+                  className="h-full rounded-full bg-[#FC5A29] transition-all"
+                  style={{ width: `${progressPercent}%` }}
+                />
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">{progressPercent}% complete</p>
+            </div>
+
+            <div className="mt-4 space-y-2">
+              {DESIGN_INTERVIEW_PROMPTS.map((prompt, index) => {
+                const isDone = completedPromptIds.has(prompt.id);
+                const isActive = activePromptId === prompt.id;
+
+                return (
+                  <button
+                    key={prompt.id}
+                    type="button"
+                    onClick={() => setActivePromptId(prompt.id)}
+                    className={clsx(
+                      "flex w-full items-start gap-3 rounded-lg border px-3 py-3 text-left transition-colors",
+                      isActive
+                        ? "border-[#FC5A29]/40 bg-[#FC5A29]/5"
+                        : "border-border bg-card hover:bg-secondary/60",
+                    )}
+                  >
+                    <span
+                      className={clsx(
+                        "mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-xs font-semibold",
+                        isDone
+                          ? "border-emerald-500 bg-emerald-500 text-white"
+                          : "border-border text-muted-foreground",
+                      )}
+                    >
+                      {isDone ? <CheckCircle2 className="h-3.5 w-3.5" /> : index + 1}
+                    </span>
+                    <span className="min-w-0">
+                      <span className="block text-sm font-medium text-foreground">
+                        {prompt.title}
+                      </span>
+                      <span className="mt-1 line-clamp-3 block text-xs text-muted-foreground">
+                        {prompt.prompt}
+                      </span>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="mt-4 rounded-lg border border-border bg-secondary/40 px-3 py-3">
+              <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                <Mic className="h-4 w-4 text-[#FC5A29]" />
+                Voice-first reminder
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Use dictation. The goal is to get a messy, high-volume transcript and
+                structure it later.
+              </p>
+            </div>
+          </section>
+        </aside>
+
+        <div className="space-y-4">
+          <section className="rounded-lg border border-border bg-card p-4">
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">Session Setup</h3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Set the interviewee once so the output template stays anchored to the
+                right person.
+              </p>
+            </div>
+
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              <label className="flex flex-col gap-1">
+                <span className="text-xs text-muted-foreground">Interviewee name</span>
+                <input
+                  type="text"
+                  value={draft.intervieweeName}
+                  onChange={(event) => updateDraft({ intervieweeName: event.target.value })}
+                  placeholder="Kyle Henson"
+                  className="rounded-md border border-border bg-secondary px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
+                />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="text-xs text-muted-foreground">Role</span>
+                <input
+                  type="text"
+                  value={draft.intervieweeRole}
+                  onChange={(event) => updateDraft({ intervieweeRole: event.target.value })}
+                  placeholder="Founder"
+                  className="rounded-md border border-border bg-secondary px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
+                />
+              </label>
+            </div>
+          </section>
+
+          <div className="flex border-b border-border">
+            {[
+              { id: "run", label: "Run Interview" },
+              { id: "capture", label: "Capture Output" },
+            ].map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => setActiveWorkspaceTab(tab.id as WorkspaceTab)}
+                className={clsx(
+                  "border-b-2 px-4 py-2.5 text-sm font-medium transition-colors",
+                  activeWorkspaceTab === tab.id
+                    ? "border-primary text-primary"
+                    : "border-transparent text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          {activeWorkspaceTab === "run" && (
+            <div className="space-y-4">
+              <section className="rounded-lg border border-border bg-card p-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h3 className="text-sm font-semibold text-foreground">Existing Context</h3>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Preload this context so the conversation stays on design intent, not implementation basics.
+                    </p>
+                  </div>
+                  <span className="rounded-full bg-secondary px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                    Pre-filled
+                  </span>
+                </div>
+
+                <div className="mt-4 space-y-2">
+                  {DESIGN_INTERVIEW_CONTEXT.map((line) => (
+                    <div
+                      key={line}
+                      className="rounded-lg border border-border bg-secondary/40 px-3 py-2 text-sm text-foreground"
+                    >
+                      {line}
+                    </div>
+                  ))}
+                </div>
+              </section>
+
+              {activePrompt && (
+                <section className="rounded-lg border border-border bg-card p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <h3 className="text-sm font-semibold text-foreground">{activePrompt.title}</h3>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Use this as the live interviewer brief for the current stage.
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => togglePromptComplete(activePrompt.id)}
+                      className={clsx(
+                        "inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-medium transition-colors",
+                        completedPromptIds.has(activePrompt.id)
+                          ? "bg-emerald-500 text-white"
+                          : "btn-ghost-muted border border-border",
+                      )}
+                    >
+                      <CheckCircle2 className="h-4 w-4" />
+                      {completedPromptIds.has(activePrompt.id) ? "Completed" : "Mark Complete"}
+                    </button>
+                  </div>
+
+                  <div className="mt-5 space-y-5">
+                    <div>
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                        Ask
+                      </p>
+                      <div className="mt-2 rounded-lg border border-[#FC5A29]/25 bg-[#FC5A29]/5 px-4 py-3 text-sm leading-6 text-foreground">
+                        {activePrompt.prompt}
+                      </div>
+                    </div>
+
+                    <div>
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                        Calibration Example
+                      </p>
+                      <div className="mt-2 rounded-lg border border-border bg-secondary/30 px-4 py-3 text-sm leading-6 text-muted-foreground">
+                        {activePrompt.example}
+                      </div>
+                    </div>
+
+                    <div>
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                        Follow-up Probes
+                      </p>
+                      <div className="mt-2 grid gap-2">
+                        {activePrompt.probes.map((probe) => (
+                          <div
+                            key={probe}
+                            className="rounded-lg border border-border px-3 py-2 text-sm text-foreground"
+                          >
+                            {probe}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+
+                    {activePrompt.followupPrompt && (
+                      <div className="space-y-5">
+                        <div>
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                            {activePrompt.followupTitle ?? "Follow-up"}
+                          </p>
+                          <div className="mt-2 rounded-lg border border-border bg-secondary/30 px-4 py-3 text-sm leading-6 text-foreground">
+                            {activePrompt.followupPrompt}
+                          </div>
+                        </div>
+
+                        {(activePrompt.followupProbes ?? []).length > 0 && (
+                          <div>
+                            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                              Additional Probes
+                            </p>
+                            <div className="mt-2 grid gap-2">
+                              {(activePrompt.followupProbes ?? []).map((probe) => (
+                                <div
+                                  key={probe}
+                                  className="rounded-lg border border-border px-3 py-2 text-sm text-foreground"
+                                >
+                                  {probe}
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    )}
+
+                    <label className="block">
+                      <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                        Operator Notes
+                      </span>
+                      <textarea
+                        value={draft.promptNotes[activePrompt.id] ?? ""}
+                        onChange={(event) =>
+                          updatePromptNote(activePrompt.id, event.target.value)
+                        }
+                        placeholder="Capture contradictions, strong phrasing, follow-up angles, or anything worth carrying into the final write-up."
+                        rows={6}
+                        className="mt-2 w-full rounded-lg border border-border bg-secondary px-3 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
+                      />
+                    </label>
+                  </div>
+                </section>
+              )}
+
+              <section className="rounded-lg border border-border bg-card p-4">
+                <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                  <Sparkles className="h-4 w-4 text-[#FC5A29]" />
+                  Prompt Launch Pad
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Keep the AI conversation outside WIPGuard, but use this as the source of truth
+                  for the prompt and workflow.
+                </p>
+
+                <textarea
+                  readOnly
+                  value={generatedPrompt}
+                  rows={14}
+                  className="mt-4 w-full rounded-lg border border-border bg-secondary px-3 py-3 font-mono text-xs leading-5 text-foreground focus:outline-none"
+                />
+
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button
+                    onClick={() => void handleCopy("prompt", generatedPrompt)}
+                    className="btn-primary-theme inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium"
+                  >
+                    <ClipboardCopy className="h-4 w-4" />
+                    Copy Full Prompt
+                  </button>
+                  <button
+                    onClick={resetWorkspace}
+                    className="btn-ghost-muted inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-sm"
+                  >
+                    <RotateCcw className="h-4 w-4" />
+                    Reset Local Draft
+                  </button>
+                </div>
+              </section>
+            </div>
+          )}
+
+          {activeWorkspaceTab === "capture" && (
+            <div className="space-y-4">
+              <section className="rounded-lg border border-border bg-card p-4">
+                <h3 className="text-sm font-semibold text-foreground">Transcript and Raw Notes</h3>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Paste the full AI conversation, dictation transcript, or rough notes here before you compress them into the structured artifact.
+                </p>
+
+                <textarea
+                  value={draft.transcript}
+                  onChange={(event) => updateDraft({ transcript: event.target.value })}
+                  placeholder="Paste the interview transcript, raw notes, or highlights here..."
+                  rows={12}
+                  className="mt-4 w-full rounded-lg border border-border bg-secondary px-3 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
+                />
+              </section>
+
+              <section className="rounded-lg border border-border bg-card p-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <h3 className="text-sm font-semibold text-foreground">Structured Output</h3>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Use the template below as the final handoff format for design-skill generation and review.
+                    </p>
+                  </div>
+                  <button
+                    onClick={() => void handleCopy("template", outputTemplate)}
+                    className="btn-ghost-muted inline-flex items-center gap-1.5 rounded-lg border border-border px-3 py-2 text-sm"
+                  >
+                    <FileText className="h-4 w-4" />
+                    Copy Template
+                  </button>
+                </div>
+
+                <textarea
+                  value={draft.structuredOutput}
+                  onChange={(event) => updateDraft({ structuredOutput: event.target.value })}
+                  rows={24}
+                  className="mt-4 w-full rounded-lg border border-border bg-secondary px-3 py-3 font-mono text-xs leading-5 text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none"
+                />
+
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button
+                    onClick={() => updateDraft({ structuredOutput: outputTemplate })}
+                    className="btn-ghost-muted inline-flex items-center gap-1.5 rounded-lg border border-border px-3 py-2 text-sm"
+                  >
+                    <Download className="h-4 w-4" />
+                    Reload Template
+                  </button>
+                </div>
+
+                <p className="mt-3 text-xs text-muted-foreground">
+                  Final QA question: &ldquo;Does this capture what you said? Anything I got wrong or missed?&rdquo;
+                </p>
+              </section>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/__tests__/analytics-credentials-owner-fallback.test.ts
+++ b/src/lib/__tests__/analytics-credentials-owner-fallback.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  IntegrationConnectionStatus,
+  IntegrationProvider,
+} from "@/generated/prisma/client";
+
+const {
+  mockIntegrationConnectionFindMany,
+  mockIntegrationConnectionUpdateMany,
+  mockIntegrationConnectionUpdate,
+  mockIntegrationConnectionUpsert,
+} = vi.hoisted(() => ({
+  mockIntegrationConnectionFindMany: vi.fn(),
+  mockIntegrationConnectionUpdateMany: vi.fn(),
+  mockIntegrationConnectionUpdate: vi.fn(),
+  mockIntegrationConnectionUpsert: vi.fn(),
+}));
+
+const { mockGetValidIntegrationAccessToken } = vi.hoisted(() => ({
+  mockGetValidIntegrationAccessToken: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    integrationConnection: {
+      findMany: mockIntegrationConnectionFindMany,
+      updateMany: mockIntegrationConnectionUpdateMany,
+      update: mockIntegrationConnectionUpdate,
+      upsert: mockIntegrationConnectionUpsert,
+    },
+  },
+}));
+
+vi.mock("@/lib/integrations/token-refresh", () => ({
+  getValidIntegrationAccessToken: mockGetValidIntegrationAccessToken,
+}));
+
+describe("analytics credentials owner fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.INTEGRATION_OWNER_USER_ID = "owner_1";
+  });
+
+  afterEach(() => {
+    delete process.env.INTEGRATION_OWNER_USER_ID;
+  });
+
+  it("fills a missing Stripe provider from another connected user when the owner has other rows", async () => {
+    mockIntegrationConnectionFindMany
+      .mockResolvedValueOnce([
+        {
+          userId: "owner_1",
+          provider: IntegrationProvider.SLACK,
+          status: IntegrationConnectionStatus.DISCONNECTED,
+          accessToken: null,
+          refreshToken: null,
+          tokenType: null,
+          expiresAt: null,
+          scopes: [],
+          metadata: null,
+          connectedAt: new Date("2026-03-01T00:00:00.000Z"),
+          lastSyncedAt: null,
+          lastError: null,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          userId: "member_2",
+          provider: IntegrationProvider.STRIPE,
+          status: IntegrationConnectionStatus.CONNECTED,
+          accessToken: "plainv1.stripe-access",
+          refreshToken: "plainv1.stripe-refresh",
+          tokenType: "Bearer",
+          expiresAt: null,
+          scopes: ["read_write"],
+          metadata: null,
+          connectedAt: new Date("2026-03-02T00:00:00.000Z"),
+          lastSyncedAt: new Date("2026-03-02T01:00:00.000Z"),
+          lastError: null,
+        },
+      ]);
+
+    mockGetValidIntegrationAccessToken.mockResolvedValue("sk_live_connected");
+
+    const { getCredentials } = await import("@/lib/analytics/credentials");
+    const creds = await getCredentials("owner_1");
+
+    expect(mockIntegrationConnectionFindMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: {
+          userId: { not: "owner_1" },
+          status: IntegrationConnectionStatus.CONNECTED,
+        },
+      })
+    );
+    expect(mockGetValidIntegrationAccessToken).toHaveBeenCalledWith({
+      userId: "member_2",
+      provider: IntegrationProvider.STRIPE,
+    });
+    expect(creds.stripeKey).toBe("sk_live_connected");
+    expect(creds.freshness[IntegrationProvider.STRIPE]).toEqual(
+      expect.objectContaining({
+        provider: IntegrationProvider.STRIPE,
+        source: "connection",
+        status: IntegrationConnectionStatus.CONNECTED,
+      })
+    );
+  });
+
+  it("prefers a connected Stripe fallback when the owner row exists but is disconnected", async () => {
+    mockIntegrationConnectionFindMany
+      .mockResolvedValueOnce([
+        {
+          userId: "owner_1",
+          provider: IntegrationProvider.STRIPE,
+          status: IntegrationConnectionStatus.DISCONNECTED,
+          accessToken: null,
+          refreshToken: null,
+          tokenType: null,
+          expiresAt: null,
+          scopes: [],
+          metadata: null,
+          connectedAt: new Date("2026-03-01T00:00:00.000Z"),
+          lastSyncedAt: null,
+          lastError: "stale owner row",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          userId: "member_2",
+          provider: IntegrationProvider.STRIPE,
+          status: IntegrationConnectionStatus.CONNECTED,
+          accessToken: "plainv1.stripe-access",
+          refreshToken: "plainv1.stripe-refresh",
+          tokenType: "Bearer",
+          expiresAt: null,
+          scopes: ["read_write"],
+          metadata: null,
+          connectedAt: new Date("2026-03-02T00:00:00.000Z"),
+          lastSyncedAt: new Date("2026-03-02T01:00:00.000Z"),
+          lastError: null,
+        },
+      ]);
+
+    mockGetValidIntegrationAccessToken.mockResolvedValue("sk_live_connected");
+
+    const { getCredentials } = await import("@/lib/analytics/credentials");
+    const creds = await getCredentials("owner_1");
+
+    expect(mockIntegrationConnectionFindMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: {
+          userId: { not: "owner_1" },
+          status: IntegrationConnectionStatus.CONNECTED,
+        },
+      })
+    );
+    expect(mockGetValidIntegrationAccessToken).toHaveBeenCalledWith({
+      userId: "member_2",
+      provider: IntegrationProvider.STRIPE,
+    });
+    expect(creds.stripeKey).toBe("sk_live_connected");
+    expect(creds.freshness[IntegrationProvider.STRIPE]).toEqual(
+      expect.objectContaining({
+        provider: IntegrationProvider.STRIPE,
+        source: "connection",
+        status: IntegrationConnectionStatus.CONNECTED,
+        lastError: null,
+      })
+    );
+  });
+});

--- a/src/lib/__tests__/design-interview.test.ts
+++ b/src/lib/__tests__/design-interview.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  DESIGN_INTERVIEW_OUTPUT_TEMPLATE,
+  DESIGN_INTERVIEW_PROMPTS,
+  buildDesignInterviewPrompt,
+  personalizeDesignInterviewTemplate,
+} from "@/lib/design-interview";
+
+describe("design interview prompt builder", () => {
+  it("includes every interview section in the generated prompt", () => {
+    const prompt = buildDesignInterviewPrompt();
+
+    expect(DESIGN_INTERVIEW_PROMPTS).toHaveLength(5);
+
+    for (const section of DESIGN_INTERVIEW_PROMPTS) {
+      expect(prompt).toContain(section.title);
+      expect(prompt).toContain(section.prompt);
+    }
+  });
+
+  it("includes the structured markdown template", () => {
+    const prompt = buildDesignInterviewPrompt();
+
+    expect(prompt).toContain("# Arda - Design Interview");
+    expect(prompt).toContain(DESIGN_INTERVIEW_OUTPUT_TEMPLATE);
+  });
+
+  it("personalizes the interviewee line when values are provided", () => {
+    const template = personalizeDesignInterviewTemplate("Kyle Henson", "Founder");
+    expect(template).toContain("**Interviewee:** Kyle Henson, Founder");
+  });
+
+  it("keeps visual aesthetics nested under identity in the generated prompt", () => {
+    const prompt = buildDesignInterviewPrompt();
+
+    expect(prompt).toContain("## Prompt 2: The Identity");
+    expect(prompt).toContain("Then ask specifically about Visual Aesthetics:");
+    expect(prompt).toContain("Now let's talk about how Arda should look");
+  });
+
+  it("personalizes the generated prompt with the session interviewee", () => {
+    const prompt = buildDesignInterviewPrompt({
+      intervieweeName: "Kyle Henson",
+      intervieweeRole: "Founder",
+    });
+
+    expect(prompt).toContain("This session is for: Kyle Henson, Founder");
+    expect(prompt).toContain("**Interviewee:** Kyle Henson, Founder");
+  });
+});

--- a/src/lib/analytics/credentials.ts
+++ b/src/lib/analytics/credentials.ts
@@ -507,54 +507,80 @@ export async function getCredentials(userId?: string): Promise<AnalyticsCredenti
   let byProvider = new Map<IntegrationProvider, ConnectionRecord>();
 
   if (userId) {
-    let connections = await prisma.integrationConnection.findMany({
+    const connectionSelect = {
+      userId: true,
+      provider: true,
+      status: true,
+      accessToken: true,
+      refreshToken: true,
+      tokenType: true,
+      expiresAt: true,
+      scopes: true,
+      metadata: true,
+      connectedAt: true,
+      lastSyncedAt: true,
+      lastError: true,
+    } as const;
+
+    const connections = await prisma.integrationConnection.findMany({
       where: { userId },
-      select: {
-        userId: true,
-        provider: true,
-        status: true,
-        accessToken: true,
-        refreshToken: true,
-        tokenType: true,
-        expiresAt: true,
-        scopes: true,
-        metadata: true,
-        connectedAt: true,
-        lastSyncedAt: true,
-        lastError: true,
-      },
+      select: connectionSelect,
     });
 
-    // Owner fallback: when the configured owner has no connections yet
-    // (migration hasn't run), fetch from any connected user.  We order by
-    // connectedAt desc and deduplicate in JS to avoid a Prisma/PostgreSQL
-    // DISTINCT ON + ORDER BY constraint conflict.
-    if (connections.length === 0 && isConfiguredIntegrationOwner(userId)) {
-      const allConnected = await prisma.integrationConnection.findMany({
-        where: { status: IntegrationConnectionStatus.CONNECTED },
+    // Owner fallback: when the configured owner is missing one or more providers
+    // (migration hasn't run or only partially completed), fill providers that
+    // are absent or only have stale non-connected owner rows from the most
+    // recently connected non-owner rows.
+    if (isConfiguredIntegrationOwner(userId)) {
+      const ownerConnectionByProvider = new Map(
+        connections.map((connection) => [connection.provider, connection])
+      );
+      const fallbackProviders = Array.from(
+        new Set(
+          Object.values(IntegrationProvider).filter((provider) => {
+            const ownerConnection = ownerConnectionByProvider.get(provider);
+            return !ownerConnection || ownerConnection.status !== IntegrationConnectionStatus.CONNECTED;
+          })
+        )
+      );
+
+      const fallbackWhere =
+        fallbackProviders.length === Object.values(IntegrationProvider).length
+          ? {
+              status: IntegrationConnectionStatus.CONNECTED,
+              userId: { not: userId },
+            }
+          : {
+              status: IntegrationConnectionStatus.CONNECTED,
+              userId: { not: userId },
+              provider: { in: fallbackProviders },
+            };
+
+      const fallbackConnections = await prisma.integrationConnection.findMany({
+        where: fallbackWhere,
         orderBy: { connectedAt: "desc" },
-        select: {
-          userId: true,
-          provider: true,
-          status: true,
-          accessToken: true,
-          refreshToken: true,
-          tokenType: true,
-          expiresAt: true,
-          scopes: true,
-          metadata: true,
-          connectedAt: true,
-          lastSyncedAt: true,
-          lastError: true,
-        },
+        select: connectionSelect,
       });
-      // Keep only the most recently connected row per provider.
-      const seen = new Set<IntegrationProvider>();
-      connections = allConnected.filter((c) => {
-        if (seen.has(c.provider)) return false;
-        seen.add(c.provider);
-        return true;
-      });
+
+      const fallbackProvidersResolved = new Set<IntegrationProvider>();
+      for (const connection of fallbackConnections) {
+        if (fallbackProvidersResolved.has(connection.provider)) {
+          continue;
+        }
+        fallbackProvidersResolved.add(connection.provider);
+
+        const ownerIndex = connections.findIndex(
+          (ownerConnection) => ownerConnection.provider === connection.provider
+        );
+        if (ownerIndex === -1) {
+          connections.push(connection);
+          continue;
+        }
+
+        if (connections[ownerIndex].status !== IntegrationConnectionStatus.CONNECTED) {
+          connections[ownerIndex] = connection;
+        }
+      }
     }
 
     byProvider = new Map(

--- a/src/lib/design-interview.ts
+++ b/src/lib/design-interview.ts
@@ -1,0 +1,290 @@
+export interface DesignInterviewPrompt {
+  id: string;
+  title: string;
+  prompt: string;
+  example: string;
+  probes: string[];
+  followupTitle?: string;
+  followupPrompt?: string;
+  followupProbes?: string[];
+}
+
+export interface DesignInterviewDraft {
+  intervieweeName: string;
+  intervieweeRole: string;
+  transcript: string;
+  structuredOutput: string;
+  promptNotes: Record<string, string>;
+  completedPromptIds: string[];
+}
+
+export const DESIGN_INTERVIEW_STORAGE_KEY = "wipguard:design-interview:draft";
+
+export const DESIGN_INTERVIEW_CONTEXT = [
+  "Stack: React 19, TypeScript, Tailwind CSS v4, shadcn/ui, AG Grid, Storybook 10",
+  "Brand color: #FC5A29 (orange), dark sidebar (#0A0A0A), Geist font",
+  "Two user types: shop floor workers (scan QR codes, wear gloves, safety glasses) and operations managers (configure items/suppliers/thresholds)",
+  "Physical-digital bridge: printed kanban cards with QR codes placed in inventory bins",
+];
+
+export const DESIGN_INTERVIEW_RULES = [
+  "Ask one prompt at a time and wait for the answer before moving on.",
+  "After each answer, ask 1-2 follow-up probes based on what they actually said.",
+  "Dig into vague adjectives until they become concrete examples.",
+  "Follow the energy when they care deeply about something.",
+  "Capture contradictions instead of resolving them.",
+  "Keep pushing from abstract to specific.",
+  "Show the example answer to calibrate the depth expected.",
+  "Allow skip on anything and note the skip in the final output.",
+  "Optimize for depth over coverage in a 15-20 minute conversation.",
+  "After all prompts, compile the output into the structured format at the bottom.",
+];
+
+export const DESIGN_INTERVIEW_PROMPTS: DesignInterviewPrompt[] = [
+  {
+    id: "problem",
+    title: "The Problem",
+    prompt: "What's the core problem Arda is solving, and how do you want people to feel after using it?",
+    example:
+      "We're solving the morning chaos. Developers start their day scattered across Slack, email, and todos. After using Dawn, they should feel oriented and calm. Like they know exactly what matters today.",
+    probes: [
+      "What does the world look like if Arda works perfectly five years from now?",
+      "What's the one thing users must be able to do effortlessly?",
+      "The shop floor worker scanning a card versus the manager setting things up: whose experience matters more?",
+      "What were people doing before Arda? What's the old way you're replacing?",
+    ],
+  },
+  {
+    id: "identity",
+    title: "The Identity",
+    prompt:
+      "Describe Arda's personality like you'd describe a person. What products or objects do you admire that capture what you're going for? What do you explicitly reject?",
+    example:
+      "Dawn is like a thoughtful friend who's annoyingly well organized but never judgmental. I admire Linear's speed and Apple Notes' invisibility. I reject anything that feels corporate, cluttered, or like a generic AI chat.",
+    probes: [
+      "Give me three words for how it should feel to use Arda.",
+      "What should Arda never feel like? What would make you cringe?",
+      "The products you admire: what specifically? Speed? Aesthetics? Philosophy?",
+      "Are there physical objects, spaces, or non-digital things that capture the feeling?",
+    ],
+    followupTitle: "Visual Aesthetics",
+    followupPrompt:
+      "Now let's talk about how Arda should look, not just feel, but actually look. Think about colors, density, whitespace, typography. Is it bold and industrial? Clean and airy? Dense and information rich like a Bloomberg terminal? Dark mode or light? When you imagine the ideal Arda screen, what do you see?",
+    followupProbes: [
+      "Show me a website, app, or physical dashboard that looks like what you imagine.",
+      "Is it more Apple clean or more McMaster-Carr dense? Or something else entirely?",
+      "Does the current orange with a dark sidebar feel right? What would you change?",
+      "How much whitespace should there be: calm and spacious, or packed and efficient?",
+      "Are there specific visual trends you want to avoid?",
+    ],
+  },
+  {
+    id: "reality",
+    title: "The Reality",
+    prompt:
+      "What's working today and what's broken? What do users or people who've seen Arda actually say, both the compliments and the complaints?",
+    example:
+      "People love the morning briefing. They say it's the first thing that actually made their mornings feel structured. But the chat feels generic, like every other AI interface. And people can't tell if it's thinking or stuck.",
+    probes: [
+      "What's the most common complaint or friction point?",
+      "What do people love that you didn't expect them to love?",
+      "If you could fix one UX problem tomorrow, what would it be?",
+      "Are there things users do that surprise you, using Arda in ways you didn't intend?",
+    ],
+  },
+  {
+    id: "user",
+    title: "The User",
+    prompt:
+      "Tell me about the people using Arda. Walk me through their day. What's their environment like? What frustrates them about their current tools?",
+    example:
+      "Our users are engineering managers at mid-size companies. They're in meetings half the day, context switching constantly. They're frustrated by Jira's complexity. They just want to know what their team shipped this week.",
+    probes: [
+      "How tech-savvy are they? Would they be comfortable with a complex UI or does it need to be dead simple?",
+      "What's the physical environment like where they use Arda? Desk? Shop floor? Both?",
+      "Are there accessibility constraints you think about? Screen size, lighting, gloves, noise?",
+      "What other tools do they use daily? What does Arda need to play nicely with?",
+    ],
+  },
+  {
+    id: "voice",
+    title: "The Voice",
+    prompt:
+      "Show me how Arda talks. If Arda had to send a message for each of these situations, what would it say: a welcome message, an error, a confirmation that something worked, and an empty screen with no data yet?",
+    example:
+      "Good morning. You've got 3 things on deck today. We say check in, not session. We never say syncing or processing. We say what's actually happening.",
+    probes: [
+      "How formal or casual? Would Arda use contractions, emoji, or exclamation marks?",
+      "When something goes wrong, what's the tone? Clinical, reassuring, apologetic?",
+      "Are there words Arda should never use?",
+      "Is the voice the same everywhere, management UI and scan flow, or does it change?",
+    ],
+  },
+];
+
+export const DESIGN_INTERVIEW_OUTPUT_TEMPLATE = `# Arda - Design Interview
+
+**Date:** [today's date]
+**Interviewee:** [name, role]
+
+---
+
+## Product
+
+- **One-liner:** [one sentence describing Arda]
+- **Core job:** [the one thing users must do effortlessly]
+- **Intended feeling:** [how users should feel]
+- **If Arda works perfectly:** [their vision]
+
+---
+
+## Design values
+
+**Three words:** [word], [word], [word]
+
+**Admired products/things:**
+- [product] - [what specifically they admire]
+
+**Rejections:**
+- [what Arda should never feel like]
+
+## Visual aesthetics
+
+**Overall vibe:** [their description]
+**Density:** [spacious / balanced / dense / very dense]
+**Color direction:** [how they feel about the current orange + dark sidebar, any changes they'd make]
+**Reference visuals:** [websites, apps, physical things they pointed to as looking right]
+**Visual trends to avoid:** [specific aesthetic choices they reject]
+
+---
+
+## User reality
+
+**What's working:**
+- [strength]
+
+**What's broken:**
+- [pain point]
+
+**Top priority fix:** [the one thing they'd fix tomorrow]
+
+**Surprising user behavior:** [anything unexpected]
+
+---
+
+## Users
+
+**Who they are:** [description]
+**Their environment:** [physical context, constraints]
+**Their tech level:** [low / medium / high]
+**Their frustrations with current tools:** [list]
+**Other tools they use:** [list]
+
+---
+
+## Voice
+
+**Formality:** [formal / casual / between]
+
+**Example messages:**
+- Welcome: "[their example]"
+- Error: "[their example]"
+- Confirmation: "[their example]"
+- Empty state: "[their example]"
+
+**Words to use:** [list]
+**Words to avoid:** [list]
+
+---
+
+## Notes
+
+[Anything that didn't fit above. Contradictions, things they emphasized, things they skipped. What they talked about longest vs. shortest.]`;
+
+export const DEFAULT_DESIGN_INTERVIEW_DRAFT: DesignInterviewDraft = {
+  intervieweeName: "",
+  intervieweeRole: "",
+  transcript: "",
+  structuredOutput: DESIGN_INTERVIEW_OUTPUT_TEMPLATE,
+  promptNotes: {},
+  completedPromptIds: [],
+};
+
+export function buildDesignInterviewPrompt(input?: {
+  intervieweeName?: string;
+  intervieweeRole?: string;
+}): string {
+  const intervieweeName = input?.intervieweeName?.trim() ?? "";
+  const intervieweeRole = input?.intervieweeRole?.trim() ?? "";
+  const interviewee = [intervieweeName, intervieweeRole].filter(Boolean).join(", ");
+  const outputTemplate = personalizeDesignInterviewTemplate(intervieweeName, intervieweeRole);
+  const promptSections = DESIGN_INTERVIEW_PROMPTS.map((section, index) => {
+    const sectionLines = [
+      `## Prompt ${index + 1}: ${section.title}`,
+      "",
+      "Ask:",
+      `> ${section.prompt}`,
+      "",
+      `Example to share: "${section.example}"`,
+      "",
+      "Follow-up probes:",
+      ...section.probes.map((probe) => `- ${probe}`),
+    ];
+
+    if (section.followupPrompt) {
+      sectionLines.push(
+        "",
+        `Then ask specifically about ${section.followupTitle ?? "this area"}:`,
+        `> ${section.followupPrompt}`,
+        "",
+        "Follow-up probes:",
+        ...(section.followupProbes ?? []).map((probe) => `- ${probe}`),
+      );
+    }
+
+    return sectionLines.join("\n");
+  });
+
+  return [
+    "You are running a design interview for Arda, a lean manufacturing tool that helps small manufacturers manage inventory through physical kanban cards, QR scanning, and automated reordering. The interview captures design intent to generate a company design skill that AI agents will use when building Arda's UI.",
+    "",
+    ...(interviewee
+      ? [`This session is for: ${interviewee}`, ""]
+      : []),
+    "Here's what we already know from the codebase:",
+    ...DESIGN_INTERVIEW_CONTEXT.map((line) => `- ${line}`),
+    "",
+    "You don't need to re-ask about the stack or technical details. Focus on product vision, design values, visual aesthetics, user reality, and voice.",
+    "",
+    "IMPORTANT: This person may have very different opinions than what's been captured so far. Don't lead them toward the existing answers. Ask open-ended questions and let them express their own perspective. If their answer contradicts the pre-filled context, that's valuable. Capture it. Each team member's unique point of view matters.",
+    "",
+    "## Rules",
+    ...DESIGN_INTERVIEW_RULES.map((rule, index) => `${index + 1}. ${rule}`),
+    "",
+    "## Voice dictation note",
+    "The person will likely be dictating their answers. Their responses may be long, rambly, have filler words, go on tangents, or circle back. This is great. It means they're thinking out loud. Don't ask them to be more concise. Your job is to pull the signal out of the noise when you compile the output at the end. During the conversation, just keep them talking.",
+    "",
+    "## Start by introducing yourself:",
+    "",
+    "\"Hi! I'm going to ask you 5 questions about Arda - how it should feel, who it's for, what's working, what's broken, and how it talks. There are no wrong answers. Just tell me what comes to mind. I'll organize everything afterward.\n\nLet's start. What's your name and role at Arda?\"",
+    "",
+    "[Wait for answer, then proceed with prompts in order.]",
+    "",
+    ...promptSections,
+    "",
+    "## After all prompts, compile into this format:",
+    "",
+    "```markdown",
+    outputTemplate,
+    "```",
+    "",
+    "Present the compiled output and ask: \"Does this capture what you said? Anything I got wrong or missed?\" Let them correct before finalizing.",
+  ].join("\n");
+}
+
+export function personalizeDesignInterviewTemplate(name: string, role: string): string {
+  const interviewee = [name.trim(), role.trim()].filter(Boolean).join(", ");
+  if (!interviewee) return DESIGN_INTERVIEW_OUTPUT_TEMPLATE;
+
+  return DESIGN_INTERVIEW_OUTPUT_TEMPLATE.replace("[name, role]", interviewee);
+}

--- a/tests/e2e/deals.spec.ts
+++ b/tests/e2e/deals.spec.ts
@@ -91,7 +91,7 @@ test.describe('Deal Pipeline', () => {
     );
 
     await page.getByLabel(/deal stage/i).selectOption({ label: targetStage });
-    await page.getByRole('button', { name: /save.*changes/i }).click();
+    await page.getByTestId('save-deal-changes').click();
     await saveResponse;
 
     await dealsPage.goto();


### PR DESCRIPTION
## Commits
- feat: add design interview workspace and owner fallback

## Files changed
 src/app/(dashboard)/settings/page.test.tsx         |   5 +
 src/app/(dashboard)/settings/page.tsx              |   3 +
 src/app/api/deals/route.test.ts                    |  58 +-
 src/components/settings/design-interview-tab.tsx   | 584 +++++++++++++++++++++
 .../analytics-credentials-owner-fallback.test.ts   | 174 ++++++
 src/lib/__tests__/design-interview.test.ts         |  50 ++
 src/lib/analytics/credentials.ts                   | 112 ++--
 src/lib/design-interview.ts                        | 290 ++++++++++
 tests/e2e/deals.spec.ts                            |   2 +-
 9 files changed, 1212 insertions(+), 66 deletions(-)

_Surfaced during repo cleanup; was unmerged with no PR. Larger/older branch — likely needs a rebase on current `main` before merge._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
