### PR TITLE
Add Free Kanban Generator bounce-rate comparison to ads-traffic analytics

### DIFF
--- a/src/app/dev/kanban-bounce-preview/page.tsx
+++ b/src/app/dev/kanban-bounce-preview/page.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+/**
+ * Dev-only visual preview for the Kanban bounce-rate comparison UI.
+ *
+ * Renders both the overview "spotlight" tile (as seen on
+ * /analytics/website-traffic) and the full benchmark card (as seen on
+ * /analytics/ads-coda-kanban) using a hardcoded fixture, so the new
+ * components can be visually QA'd without GA credentials or a database.
+ *
+ * Mounted outside the (dashboard) route group so it does not require auth.
+ * Safe to delete after the feature ships.
+ */
+
+import { KanbanBounceBenchmark } from "@/components/analytics/kanban-bounce-benchmark";
+import type {
+  KanbanBounceComparison,
+  AnalyticsDashboardData,
+} from "@/lib/analytics/types";
+
+// Fixture modeled on the May 6 doc-association data:
+// /kanban-template: 1,760 sessions, 42% bounce (slightly worse than site).
+// Site-wide bounce: 50%.
+const FIXTURE_COMPARISON: KanbanBounceComparison = {
+  matchedPaths: ["/kanban-template"],
+  kanbanBounceRate: 0.42,
+  kanbanSessions: 1760,
+  siteBounceRate: 0.5,
+  deltaVsSitePts: -8,
+  periodDeltaPts: -3.2,
+  rankAmongPeers: 2,
+  peerCount: 5,
+  peerPages: [
+    { path: "/product", bounceRate: 0.35, sessions: 5120 },
+    { path: "/blog/wp-limits", bounceRate: 0.48, sessions: 1390 },
+    { path: "/pricing", bounceRate: 0.55, sessions: 1820 },
+    { path: "/about", bounceRate: 0.62, sessions: 480 },
+    { path: "/blog/kanban-101", bounceRate: 0.71, sessions: 320 },
+  ],
+  verdict: "better",
+};
+
+const FIXTURE_DATA = {
+  googleAnalytics: { kanbanBounceComparison: FIXTURE_COMPARISON },
+} as unknown as AnalyticsDashboardData;
+
+export default function KanbanBouncePreviewPage() {
+  const comparison = FIXTURE_DATA.googleAnalytics?.kanbanBounceComparison;
+  if (!comparison) return null;
+
+  return (
+    <div className="min-h-screen bg-background p-8">
+      <div className="mx-auto max-w-6xl space-y-10">
+        <header>
+          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Dev preview
+          </p>
+          <h1 className="text-2xl font-bold text-foreground">
+            Kanban Generator bounce-rate comparison
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Hardcoded fixture (no GA call). Top: overview spotlight tile.
+            Bottom: full benchmark card from the Coda Kanban tab.
+          </p>
+        </header>
+
+        <section className="space-y-3">
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+            Overview spotlight (/analytics/website-traffic)
+          </h2>
+          <PreviewSpotlight comparison={comparison} />
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+            Full benchmark card (/analytics/ads-coda-kanban)
+          </h2>
+          <KanbanBounceBenchmark comparison={comparison} />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+/* Inline duplicate of KanbanBounceSpotlight so the preview doesn't need the
+   full MarketingTabNew shell. Kept narrowly in sync with marketing-tab-new.tsx. */
+import Link from "next/link";
+import { ArrowRight, TrendingDown, TrendingUp, Minus } from "lucide-react";
+
+function PreviewSpotlight({ comparison }: { comparison: KanbanBounceComparison }) {
+  const {
+    kanbanBounceRate,
+    siteBounceRate,
+    deltaVsSitePts,
+    periodDeltaPts,
+    verdict,
+    matchedPaths,
+    kanbanSessions,
+  } = comparison;
+
+  const fmtPctFrac = (frac: number) => `${(frac * 100).toFixed(1)}%`;
+  const fmtPts = (pts: number) =>
+    `${pts >= 0 ? "+" : ""}${pts.toFixed(1)}pt${Math.abs(pts) === 1 ? "" : "s"}`;
+
+  const Icon =
+    verdict === "better" ? TrendingDown : verdict === "worse" ? TrendingUp : Minus;
+  const accentClass =
+    verdict === "better"
+      ? "border-emerald-500/40 bg-emerald-500/5"
+      : verdict === "worse"
+        ? "border-red-500/40 bg-red-500/5"
+        : "border-border bg-card";
+  const iconClass =
+    verdict === "better"
+      ? "text-emerald-500"
+      : verdict === "worse"
+        ? "text-red-500"
+        : "text-muted-foreground";
+  const headline =
+    verdict === "better"
+      ? "Kanban whitepaper outperforming site"
+      : verdict === "worse"
+        ? "Kanban whitepaper bouncing harder than site"
+        : "Kanban whitepaper on par with site";
+  const matchedSummary =
+    matchedPaths.length === 1 ? matchedPaths[0] : `${matchedPaths.length} Kanban paths`;
+
+  return (
+    <Link
+      href="/analytics/ads-coda-kanban"
+      className={`flex flex-wrap items-center gap-4 rounded-xl border p-4 transition-colors hover:bg-secondary/30 ${accentClass}`}
+    >
+      <div className={`rounded-lg bg-background/60 p-2 ${iconClass}`}>
+        <Icon className="h-5 w-5" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-foreground">{headline}</p>
+        <p className="text-xs text-muted-foreground">
+          {matchedSummary} • {kanbanSessions.toLocaleString()} sessions
+        </p>
+      </div>
+      <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1">
+        <div className="text-right">
+          <p className="text-[10px] uppercase tracking-wider text-muted-foreground">
+            Bounce
+          </p>
+          <p className="text-xl font-bold tabular-nums text-foreground">
+            {fmtPctFrac(kanbanBounceRate)}
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-[10px] uppercase tracking-wider text-muted-foreground">
+            vs Site ({fmtPctFrac(siteBounceRate)})
+          </p>
+          <p
+            className={`text-sm font-semibold tabular-nums ${
+              deltaVsSitePts < 0
+                ? "text-emerald-500"
+                : deltaVsSitePts > 0
+                  ? "text-red-500"
+                  : "text-muted-foreground"
+            }`}
+          >
+            {fmtPts(deltaVsSitePts)}
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-[10px] uppercase tracking-wider text-muted-foreground">
+            vs Prior 30d
+          </p>
+          <p
+            className={`text-sm font-semibold tabular-nums ${
+              typeof periodDeltaPts !== "number"
+                ? "text-muted-foreground"
+                : periodDeltaPts < 0
+                  ? "text-emerald-500"
+                  : periodDeltaPts > 0
+                    ? "text-red-500"
+                    : "text-muted-foreground"
+            }`}
+          >
+            {typeof periodDeltaPts === "number" ? fmtPts(periodDeltaPts) : "—"}
+          </p>
+        </div>
+      </div>
+      <ArrowRight className="h-4 w-4 text-muted-foreground" />
+    </Link>
+  );
+}

--- a/src/components/analytics/ads-coda-kanban-tab.tsx
+++ b/src/components/analytics/ads-coda-kanban-tab.tsx
@@ -9,6 +9,7 @@ import { FinanceDataEmptyState } from "@/components/analytics/finance-empty-stat
 import { RingStat } from "@/components/analytics/bar-display";
 import { StatCard } from "@/components/analytics/stat-card";
 import { AreaTrend } from "@/components/charts";
+import { KanbanBounceBenchmark } from "@/components/analytics/kanban-bounce-benchmark";
 import {
   fmt$, fmtN, timeAgo,
   AlertBanner, DataTable, InsightCard,
@@ -21,6 +22,9 @@ interface AdsCodaKanbanTabProps {
 
 export function AdsCodaKanbanTab({ data }: AdsCodaKanbanTabProps) {
   const coda = data?.coda ?? data?.codaKanban;
+  // GA-derived bounce-rate benchmark is independent of Coda — render it even
+  // when Coda is missing so we don't blank the whole tab on a Coda outage.
+  const kanbanBounce = data?.googleAnalytics?.kanbanBounceComparison ?? null;
   const reasons = [
     ...(data?.errors ?? [])
       .filter((entry) => entry.source === "coda" || entry.source === "codaKanban")
@@ -31,12 +35,15 @@ export function AdsCodaKanbanTab({ data }: AdsCodaKanbanTabProps) {
 
   if (!coda) {
     return (
-      <FinanceDataEmptyState
-        title="Coda campaign data is unavailable"
-        message="We could not load Coda campaign records for this range."
-        reasons={reasons}
-        reconnectHref="/settings?tab=integrations"
-      />
+      <div className="space-y-6">
+        {kanbanBounce && <KanbanBounceBenchmark comparison={kanbanBounce} />}
+        <FinanceDataEmptyState
+          title="Coda campaign data is unavailable"
+          message="We could not load Coda campaign records for this range."
+          reasons={reasons}
+          reconnectHref="/settings?tab=integrations"
+        />
+      </div>
     );
   }
 
@@ -322,6 +329,11 @@ export function AdsCodaKanbanTab({ data }: AdsCodaKanbanTabProps) {
           <StatCard label="Unknown-email downloads" value={fmtN(unknownEmailCards)} icon={AlertCircle} />
         </div>
       </SectionCard>
+
+      {/* Bounce Rate Benchmark — GA4-derived, frames the whitepaper landing
+          page against the rest of the site so the operator sees whether
+          downloader engagement is healthy before drilling into Coda counts. */}
+      {kanbanBounce && <KanbanBounceBenchmark comparison={kanbanBounce} />}
 
       {/* Trend */}
       {coda.trends?.downloadsDaily?.length ? (

--- a/src/components/analytics/kanban-bounce-benchmark.test.tsx
+++ b/src/components/analytics/kanban-bounce-benchmark.test.tsx
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { KanbanBounceBenchmark } from "@/components/analytics/kanban-bounce-benchmark";
+import type { KanbanBounceComparison } from "@/lib/analytics/types";
+
+function makeComparison(
+  overrides: Partial<KanbanBounceComparison> = {}
+): KanbanBounceComparison {
+  return {
+    matchedPaths: ["/kanban-template"],
+    kanbanBounceRate: 0.42,
+    kanbanSessions: 1760,
+    siteBounceRate: 0.5,
+    deltaVsSitePts: -8,
+    periodDeltaPts: -3,
+    rankAmongPeers: 2,
+    peerCount: 9,
+    peerPages: [
+      { path: "/product", bounceRate: 0.35, sessions: 5120 },
+      { path: "/pricing", bounceRate: 0.55, sessions: 1820 },
+    ],
+    verdict: "better",
+    ...overrides,
+  };
+}
+
+describe("KanbanBounceBenchmark", () => {
+  it("renders nothing when no comparison data is provided", () => {
+    const { container } = render(<KanbanBounceBenchmark comparison={null} />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders the Kanban bounce-rate value formatted as percent", () => {
+    render(<KanbanBounceBenchmark comparison={makeComparison()} />);
+    // 42.0% appears both in the stat tile AND in the peer-row entry —
+    // assert it shows up at least once in either location.
+    const occurrences = screen.getAllByText("42.0%");
+    expect(occurrences.length).toBeGreaterThan(0);
+  });
+
+  it("renders site bounce + delta vs site with correct sign", () => {
+    render(
+      <KanbanBounceBenchmark
+        comparison={makeComparison({ deltaVsSitePts: -8 })}
+      />
+    );
+    expect(screen.getByText("50.0%")).toBeTruthy(); // site
+    expect(screen.getByText("-8.0pts")).toBeTruthy();
+  });
+
+  it("renders 'Improving' when periodDeltaPts is negative", () => {
+    render(
+      <KanbanBounceBenchmark
+        comparison={makeComparison({ periodDeltaPts: -3 })}
+      />
+    );
+    expect(screen.getByText("Improving")).toBeTruthy();
+  });
+
+  it("renders '—' and 'No prior data' when periodDeltaPts is null", () => {
+    render(
+      <KanbanBounceBenchmark
+        comparison={makeComparison({ periodDeltaPts: null })}
+      />
+    );
+    expect(screen.getByText("—")).toBeTruthy();
+    expect(screen.getByText("No prior data")).toBeTruthy();
+  });
+
+  it("highlights the Kanban row in the peer ranking", () => {
+    render(<KanbanBounceBenchmark comparison={makeComparison()} />);
+    const list = screen.getByTestId("kanban-bounce-peer-list");
+    const kanbanRow = within(list).getByText(/\/kanban-template/);
+    expect(kanbanRow.textContent).toContain("/kanban-template");
+    // Outer row carries the highlight data attribute
+    const rowEl = kanbanRow.closest('[data-kanban-row="true"]');
+    expect(rowEl).not.toBeNull();
+  });
+
+  it("sorts peer ranking by ascending bounce rate", () => {
+    render(<KanbanBounceBenchmark comparison={makeComparison()} />);
+    const list = screen.getByTestId("kanban-bounce-peer-list");
+    // peers: /product 35%, /kanban-template 42%, /pricing 55%
+    // Expect that visual order: product first, kanban-template second, pricing third
+    const rows = list.querySelectorAll("[data-kanban-row]");
+    const paths = Array.from(rows).map((r) =>
+      (r.textContent || "").split("★")[0].trim()
+    );
+    const idxProduct = paths.findIndex((p) => p.startsWith("/product"));
+    const idxKanban = paths.findIndex((p) => p.startsWith("/kanban-template"));
+    const idxPricing = paths.findIndex((p) => p.startsWith("/pricing"));
+    expect(idxProduct).toBeLessThan(idxKanban);
+    expect(idxKanban).toBeLessThan(idxPricing);
+  });
+});

--- a/src/components/analytics/kanban-bounce-benchmark.tsx
+++ b/src/components/analytics/kanban-bounce-benchmark.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { TrendingDown, TrendingUp, Minus, Target } from "lucide-react";
+import type { KanbanBounceComparison } from "@/lib/analytics/types";
+import { StatCard } from "@/components/analytics/stat-card";
+import { SectionCard } from "./dashboard-primitives";
+
+interface KanbanBounceBenchmarkProps {
+  comparison: KanbanBounceComparison | null | undefined;
+}
+
+/**
+ * Renders the Free Kanban Generator bounce-rate benchmark:
+ *   - 4 stat tiles: Kanban page bounce / Site avg / Δ vs site / Period delta
+ *   - Peer-page ranking with the Kanban path highlighted
+ *
+ * Returns null when no comparison data is available — the parent decides
+ * whether to render an empty state.
+ */
+export function KanbanBounceBenchmark({ comparison }: KanbanBounceBenchmarkProps) {
+  if (!comparison) return null;
+
+  const {
+    matchedPaths,
+    kanbanBounceRate,
+    kanbanSessions,
+    siteBounceRate,
+    deltaVsSitePts,
+    periodDeltaPts,
+    rankAmongPeers,
+    peerCount,
+    peerPages,
+    verdict,
+  } = comparison;
+
+  // ── Format helpers ──
+  const fmtPct = (frac: number) => `${(frac * 100).toFixed(1)}%`;
+  const fmtPts = (pts: number, opts: { sign?: boolean } = {}) => {
+    const sign = opts.sign && pts >= 0 ? "+" : "";
+    return `${sign}${pts.toFixed(1)}pt${Math.abs(pts) === 1 ? "" : "s"}`;
+  };
+
+  // For bounce rate, LOWER is better — so a NEGATIVE delta is a POSITIVE outcome.
+  const deltaIsImprovement = deltaVsSitePts < 0;
+  const deltaChangeType = deltaIsImprovement ? "positive" : deltaVsSitePts > 0 ? "negative" : "neutral";
+
+  const periodIsImprovement = typeof periodDeltaPts === "number" && periodDeltaPts < 0;
+  const periodChangeType =
+    typeof periodDeltaPts !== "number"
+      ? "neutral"
+      : periodIsImprovement
+        ? "positive"
+        : periodDeltaPts > 0
+          ? "negative"
+          : "neutral";
+
+  const verdictLabel =
+    verdict === "better" ? "Beating site avg" : verdict === "worse" ? "Below site avg" : "On par with site avg";
+  const verdictIcon = verdict === "better" ? TrendingDown : verdict === "worse" ? TrendingUp : Minus;
+  const verdictColor =
+    verdict === "better" ? "text-emerald-500" : verdict === "worse" ? "text-red-500" : "text-muted-foreground";
+
+  // Peer ranking copy.
+  const rankCopy =
+    rankAmongPeers === null
+      ? "—"
+      : `#${rankAmongPeers} of ${peerCount + 1}`;
+  const rankSubtitle =
+    rankAmongPeers === null
+      ? "No peer pages with sessions"
+      : rankAmongPeers === 1
+        ? "Best engagement on site"
+        : rankAmongPeers <= 3
+          ? "Top-3 engagement"
+          : rankAmongPeers > peerCount / 2
+            ? "Below median engagement"
+            : "Above median engagement";
+
+  // Bar chart bounds — pad min/max so bars don't bunch at the edges.
+  const allBounces = [kanbanBounceRate, ...peerPages.map((p) => p.bounceRate)];
+  const minBounce = Math.min(...allBounces);
+  const maxBounce = Math.max(...allBounces);
+  const range = Math.max(maxBounce - minBounce, 0.05);
+
+  // Combined ranked list (Kanban + peers) sorted by bounce ascending
+  // for the visualization.
+  const ranked = [
+    {
+      path: matchedPaths[0] ?? "/kanban-template",
+      bounceRate: kanbanBounceRate,
+      sessions: kanbanSessions,
+      isKanban: true,
+    },
+    ...peerPages.map((p) => ({ ...p, isKanban: false })),
+  ].sort((a, b) => a.bounceRate - b.bounceRate);
+
+  const subtitleParts: string[] = [];
+  if (matchedPaths.length === 1) {
+    subtitleParts.push(`Matched ${matchedPaths[0]}`);
+  } else if (matchedPaths.length > 1) {
+    subtitleParts.push(`Matched ${matchedPaths.length} Kanban variants`);
+  }
+  subtitleParts.push(`${kanbanSessions.toLocaleString()} sessions in window`);
+
+  return (
+    <SectionCard
+      title="Bounce Rate vs. Site & Peer Pages"
+      subtitle={subtitleParts.join(" • ")}
+    >
+      {/* Stat tiles */}
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatCard
+          label="Kanban Page Bounce"
+          value={fmtPct(kanbanBounceRate)}
+          subtitle={verdictLabel}
+          icon={verdictIcon}
+          iconColor={verdictColor}
+        />
+        <StatCard
+          label="Site Avg Bounce"
+          value={fmtPct(siteBounceRate)}
+          subtitle="All pages, all channels"
+          icon={Target}
+        />
+        <StatCard
+          label="Δ vs Site"
+          value={fmtPts(deltaVsSitePts, { sign: true })}
+          change={deltaIsImprovement ? "Better than site" : deltaVsSitePts > 0 ? "Worse than site" : "Even with site"}
+          changeType={deltaChangeType}
+        />
+        <StatCard
+          label="vs Prior 30d"
+          value={typeof periodDeltaPts === "number" ? fmtPts(periodDeltaPts, { sign: true }) : "—"}
+          change={
+            typeof periodDeltaPts === "number"
+              ? periodIsImprovement
+                ? "Improving"
+                : periodDeltaPts > 0
+                  ? "Worsening"
+                  : "Flat"
+              : "No prior data"
+          }
+          changeType={periodChangeType}
+        />
+      </div>
+
+      {/* Peer rank + ranked bar list */}
+      <div className="mt-5 space-y-4">
+        <div className="flex items-baseline justify-between border-b border-border pb-2">
+          <span className="text-sm font-medium text-foreground">
+            Peer ranking by bounce rate
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {rankCopy} <span className="text-[11px]">({rankSubtitle})</span>
+          </span>
+        </div>
+
+        <div className="space-y-1.5" data-testid="kanban-bounce-peer-list">
+          {ranked.map((row, i) => {
+            const widthPct =
+              range === 0
+                ? 50
+                : Math.max(8, ((row.bounceRate - minBounce) / range) * 100);
+            const barColor = row.isKanban
+              ? "#fc5a29"
+              : row.bounceRate <= siteBounceRate
+                ? "#22c55e"
+                : "#94a3b8";
+            return (
+              <div
+                key={`${row.path}-${i}`}
+                className={`flex items-center gap-3 rounded-md px-2 py-1 ${
+                  row.isKanban ? "bg-primary/10 ring-1 ring-primary/30" : ""
+                }`}
+                data-kanban-row={row.isKanban ? "true" : "false"}
+              >
+                <span
+                  className={`w-44 truncate text-xs ${
+                    row.isKanban
+                      ? "font-semibold text-foreground"
+                      : "text-muted-foreground"
+                  }`}
+                  title={row.path}
+                >
+                  {row.path}
+                  {row.isKanban ? " ★" : ""}
+                </span>
+                <div className="flex-1">
+                  <div className="relative h-5 overflow-hidden rounded-md bg-secondary/40">
+                    <div
+                      className="h-full rounded-md transition-all"
+                      style={{
+                        width: `${widthPct}%`,
+                        backgroundColor: barColor,
+                        minWidth: "32px",
+                      }}
+                    />
+                  </div>
+                </div>
+                <span className="w-16 text-right text-xs tabular-nums text-foreground">
+                  {fmtPct(row.bounceRate)}
+                </span>
+                <span className="w-20 text-right text-[11px] tabular-nums text-muted-foreground">
+                  {row.sessions.toLocaleString()} sess
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/components/analytics/marketing-tab-new.tsx
+++ b/src/components/analytics/marketing-tab-new.tsx
@@ -22,11 +22,130 @@ import {
   Award,
   Link2,
   Instagram,
+  ArrowRight,
+  TrendingDown,
+  Minus,
 } from 'lucide-react';
 
 interface MarketingTabNewProps {
   data: AnalyticsDashboardData | null;
   variant?: 'website-traffic' | 'social-media';
+}
+
+/**
+ * Single click-through KPI tile that highlights how the Free Kanban Generator
+ * whitepaper landing page is performing on bounce rate vs. the site average.
+ *
+ * Sits at the top of the website-traffic overview so the operator catches
+ * engagement issues on the highest-volume marketing asset before drilling
+ * into channel-by-channel detail.
+ */
+function KanbanBounceSpotlight({
+  comparison,
+}: {
+  comparison: NonNullable<AnalyticsDashboardData['googleAnalytics']>['kanbanBounceComparison'];
+}) {
+  if (!comparison) return null;
+  const {
+    kanbanBounceRate,
+    siteBounceRate,
+    deltaVsSitePts,
+    periodDeltaPts,
+    verdict,
+    matchedPaths,
+    kanbanSessions,
+  } = comparison;
+
+  const fmtPctFrac = (frac: number) => `${(frac * 100).toFixed(1)}%`;
+  const fmtPts = (pts: number) =>
+    `${pts >= 0 ? '+' : ''}${pts.toFixed(1)}pt${Math.abs(pts) === 1 ? '' : 's'}`;
+
+  const Icon = verdict === 'better' ? TrendingDown : verdict === 'worse' ? TrendingUp : Minus;
+  const accentClass =
+    verdict === 'better'
+      ? 'border-emerald-500/40 bg-emerald-500/5'
+      : verdict === 'worse'
+        ? 'border-red-500/40 bg-red-500/5'
+        : 'border-border bg-card';
+  const iconClass =
+    verdict === 'better'
+      ? 'text-emerald-500'
+      : verdict === 'worse'
+        ? 'text-red-500'
+        : 'text-muted-foreground';
+  const headline =
+    verdict === 'better'
+      ? 'Kanban whitepaper outperforming site'
+      : verdict === 'worse'
+        ? 'Kanban whitepaper bouncing harder than site'
+        : 'Kanban whitepaper on par with site';
+  const matchedSummary =
+    matchedPaths.length === 1
+      ? matchedPaths[0]
+      : `${matchedPaths.length} Kanban paths`;
+
+  return (
+    <Link
+      href="/analytics/ads-coda-kanban"
+      className={`flex flex-wrap items-center gap-4 rounded-xl border p-4 transition-colors hover:bg-secondary/30 ${accentClass}`}
+      data-testid="kanban-bounce-spotlight"
+    >
+      <div className={`rounded-lg bg-background/60 p-2 ${iconClass}`}>
+        <Icon className="h-5 w-5" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-foreground">{headline}</p>
+        <p className="text-xs text-muted-foreground">
+          {matchedSummary} • {kanbanSessions.toLocaleString()} sessions
+        </p>
+      </div>
+      <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1">
+        <div className="text-right">
+          <p className="text-[10px] uppercase tracking-wider text-muted-foreground">
+            Bounce
+          </p>
+          <p className="text-xl font-bold tabular-nums text-foreground">
+            {fmtPctFrac(kanbanBounceRate)}
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-[10px] uppercase tracking-wider text-muted-foreground">
+            vs Site ({fmtPctFrac(siteBounceRate)})
+          </p>
+          <p
+            className={`text-sm font-semibold tabular-nums ${
+              deltaVsSitePts < 0
+                ? 'text-emerald-500'
+                : deltaVsSitePts > 0
+                  ? 'text-red-500'
+                  : 'text-muted-foreground'
+            }`}
+          >
+            {fmtPts(deltaVsSitePts)}
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-[10px] uppercase tracking-wider text-muted-foreground">
+            vs Prior 30d
+          </p>
+          <p
+            className={`text-sm font-semibold tabular-nums ${
+              typeof periodDeltaPts !== 'number'
+                ? 'text-muted-foreground'
+                : periodDeltaPts < 0
+                  ? 'text-emerald-500'
+                  : periodDeltaPts > 0
+                    ? 'text-red-500'
+                    : 'text-muted-foreground'
+            }`}
+          >
+            {typeof periodDeltaPts === 'number' ? fmtPts(periodDeltaPts) : '—'}
+          </p>
+        </div>
+      </div>
+      <ArrowRight className="h-4 w-4 text-muted-foreground" />
+    </Link>
+  );
 }
 
 // Helper functions
@@ -400,6 +519,14 @@ export function MarketingTabNew({ data, variant = 'website-traffic' }: Marketing
       </div>
 
       <AiInsightsPanel bundle={data.aiInsights || null} defaultFilter={insightFilter} />
+
+      {/* Kanban Generator bounce-rate spotlight (website-traffic only).
+          Single click-through tile so the operator immediately sees whether
+          the whitepaper landing page is over- or under-performing site avg,
+          then can drill into /analytics/ads-coda-kanban for the full breakdown. */}
+      {isWebsiteTraffic && data.googleAnalytics?.kanbanBounceComparison ? (
+        <KanbanBounceSpotlight comparison={data.googleAnalytics.kanbanBounceComparison} />
+      ) : null}
 
       {/* Top KPI Row */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">

--- a/src/lib/__tests__/kanban-bounce-comparison.test.ts
+++ b/src/lib/__tests__/kanban-bounce-comparison.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+import type { GATopPage } from "@/lib/analytics/types";
+import {
+  computeKanbanBounceComparison,
+  findKanbanPages,
+  isKanbanLandingPage,
+} from "@/lib/analytics/kanban-bounce-comparison";
+
+function page(
+  path: string,
+  bounceRate: number,
+  sessions: number,
+  pageviews = sessions
+): GATopPage {
+  return { path, bounceRate, sessions, pageviews, avgDuration: 0 };
+}
+
+describe("isKanbanLandingPage", () => {
+  it("matches the canonical Kanban landing-page slugs", () => {
+    expect(isKanbanLandingPage("/kanban-template")).toBe(true);
+    expect(isKanbanLandingPage("/free-kanban-generator")).toBe(true);
+    expect(isKanbanLandingPage("/free-kanban")).toBe(true);
+    expect(isKanbanLandingPage("/kanban")).toBe(true);
+  });
+
+  it("matches sub-paths up to depth 2", () => {
+    expect(isKanbanLandingPage("/kanban-template/print")).toBe(true);
+    expect(isKanbanLandingPage("/kanban-template/")).toBe(true);
+  });
+
+  it("strips query strings and trailing slashes before matching", () => {
+    expect(isKanbanLandingPage("/kanban-template?utm_source=reddit")).toBe(true);
+    expect(isKanbanLandingPage("/kanban-template/#hero")).toBe(true);
+  });
+
+  it("rejects internal app routes that share the /kanban prefix", () => {
+    expect(isKanbanLandingPage("/kanban-board")).toBe(false);
+    expect(isKanbanLandingPage("/kanban-card/abc-123")).toBe(false);
+    expect(isKanbanLandingPage("/kanban-loop")).toBe(false);
+  });
+
+  it("rejects deep nested paths beyond depth 2", () => {
+    expect(isKanbanLandingPage("/kanban-template/preview/abc/edit")).toBe(false);
+  });
+
+  it("rejects unrelated paths", () => {
+    expect(isKanbanLandingPage("/product")).toBe(false);
+    expect(isKanbanLandingPage("/pricing")).toBe(false);
+    expect(isKanbanLandingPage("/")).toBe(false);
+    expect(isKanbanLandingPage("")).toBe(false);
+  });
+
+  it("is case-insensitive on the path prefix", () => {
+    expect(isKanbanLandingPage("/Kanban-Template")).toBe(true);
+    expect(isKanbanLandingPage("/FREE-KANBAN-GENERATOR")).toBe(true);
+  });
+});
+
+describe("findKanbanPages", () => {
+  it("returns only matched landing pages, preserving order", () => {
+    const pages: GATopPage[] = [
+      page("/product", 0.4, 1000),
+      page("/kanban-template", 0.42, 800),
+      page("/pricing", 0.5, 600),
+      page("/free-kanban-generator", 0.38, 400),
+      page("/kanban-board", 0.7, 100),
+    ];
+    expect(findKanbanPages(pages).map((p) => p.path)).toEqual([
+      "/kanban-template",
+      "/free-kanban-generator",
+    ]);
+  });
+});
+
+describe("computeKanbanBounceComparison", () => {
+  it("returns null when no Kanban pages are matched", () => {
+    const result = computeKanbanBounceComparison({
+      siteBounceRate: 0.5,
+      topPages: [page("/product", 0.4, 1000), page("/pricing", 0.55, 500)],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when matched Kanban pages have zero sessions", () => {
+    const result = computeKanbanBounceComparison({
+      siteBounceRate: 0.5,
+      topPages: [page("/kanban-template", 0.42, 0)],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("normalizes GA4 percentage-format bounce rates (0–100) to fractions (0–1)", () => {
+    const result = computeKanbanBounceComparison({
+      siteBounceRate: 50, // percentage form
+      topPages: [page("/kanban-template", 42, 1000)], // percentage form
+    });
+    expect(result).not.toBeNull();
+    expect(result!.kanbanBounceRate).toBeCloseTo(0.42, 5);
+    expect(result!.siteBounceRate).toBeCloseTo(0.5, 5);
+    expect(result!.deltaVsSitePts).toBeCloseTo(-8, 5);
+  });
+
+  it("weights bounce rate by sessions when multiple Kanban variants match", () => {
+    // /kanban-template: 50% bounce on 100 sessions = 50 bounces
+    // /free-kanban:     20% bounce on 900 sessions = 180 bounces
+    // Total: 230 bounces / 1000 sessions = 23%
+    const result = computeKanbanBounceComparison({
+      siteBounceRate: 0.4,
+      topPages: [
+        page("/kanban-template", 0.5, 100),
+        page("/free-kanban", 0.2, 900),
+      ],
+    });
+    expect(result).not.toBeNull();
+    expect(result!.kanbanBounceRate).toBeCloseTo(0.23, 5);
+    expect(result!.kanbanSessions).toBe(1000);
+    expect(result!.matchedPaths).toEqual(["/kanban-template", "/free-kanban"]);
+  });
+
+  it("computes deltaVsSitePts with correct sign (positive = Kanban worse)", () => {
+    const worse = computeKanbanBounceComparison({
+      siteBounceRate: 0.4,
+      topPages: [page("/kanban-template", 0.5, 500)],
+    });
+    expect(worse!.deltaVsSitePts).toBeCloseTo(10, 5);
+    expect(worse!.verdict).toBe("worse");
+
+    const better = computeKanbanBounceComparison({
+      siteBounceRate: 0.5,
+      topPages: [page("/kanban-template", 0.35, 500)],
+    });
+    expect(better!.deltaVsSitePts).toBeCloseTo(-15, 5);
+    expect(better!.verdict).toBe("better");
+  });
+
+  it("labels small deltas (< 2 pts) as comparable", () => {
+    const result = computeKanbanBounceComparison({
+      siteBounceRate: 0.5,
+      topPages: [page("/kanban-template", 0.51, 500)],
+    });
+    expect(result!.verdict).toBe("comparable");
+    expect(Math.abs(result!.deltaVsSitePts)).toBeLessThan(2);
+  });
+
+  it("returns null periodDeltaPts when no prior-period data is provided", () => {
+    const result = computeKanbanBounceComparison({
+      siteBounceRate: 0.5,
+      topPages: [page("/kanban-template", 0.42, 500)],
+    });
+    expect(result!.periodDeltaPts).toBeNull();
+  });
+
+  it("returns null periodDeltaPts when prior-period top pages contained no Kanban match", () => {
+    const result = computeKanbanBounceComparison({
+      siteBounceRate: 0.5,
+      topPages: [page("/kanban-template", 0.42, 500)],
+      topPagesPrev: [page("/product", 0.4, 1000)],
+    });
+    expect(result!.periodDeltaPts).toBeNull();
+  });
+
+  it("computes period-over-period bounce delta when prior-period Kanban data exists", () => {
+    // Current: 30% bounce; Prior: 50% bounce. Delta = -20pts (improving).
+    const result = computeKanbanBounceComparison({
+      siteBounceRate: 0.5,
+      topPages: [page("/kanban-template", 0.3, 500)],
+      topPagesPrev: [page("/kanban-template", 0.5, 400)],
+    });
+    expect(result!.periodDeltaPts).toBeCloseTo(-20, 5);
+  });
+
+  it("ranks the Kanban page against peer pages by bounce ascending", () => {
+    const result = computeKanbanBounceComparison({
+      siteBounceRate: 0.5,
+      topPages: [
+        page("/product", 0.3, 1000), // best
+        page("/pricing", 0.55, 500),
+        page("/kanban-template", 0.42, 800), // should rank #2
+        page("/blog/post", 0.6, 300),
+      ],
+    });
+    expect(result!.rankAmongPeers).toBe(2); // one peer (/product) is better
+    expect(result!.peerCount).toBe(3);
+    expect(result!.peerPages.map((p) => p.path)).toEqual([
+      "/product",
+      "/pricing",
+      "/blog/post",
+    ]);
+  });
+
+  it("excludes the Kanban page itself from the peer list", () => {
+    const result = computeKanbanBounceComparison({
+      siteBounceRate: 0.5,
+      topPages: [
+        page("/kanban-template", 0.42, 500),
+        page("/product", 0.4, 1000),
+      ],
+    });
+    expect(result!.peerPages.map((p) => p.path)).not.toContain(
+      "/kanban-template"
+    );
+  });
+
+  it("excludes peer pages with zero sessions from the ranking", () => {
+    const result = computeKanbanBounceComparison({
+      siteBounceRate: 0.5,
+      topPages: [
+        page("/kanban-template", 0.42, 500),
+        page("/product", 0.4, 0), // no sessions — exclude
+        page("/pricing", 0.55, 100),
+      ],
+    });
+    expect(result!.peerCount).toBe(1);
+    expect(result!.peerPages.map((p) => p.path)).toEqual(["/pricing"]);
+  });
+
+  it("limits the peer list to peerLimit entries (default 10)", () => {
+    const manyPeers = Array.from({ length: 20 }, (_, i) =>
+      page(`/page-${i}`, 0.3 + i * 0.01, 100 + i)
+    );
+    const result = computeKanbanBounceComparison({
+      siteBounceRate: 0.5,
+      topPages: [page("/kanban-template", 0.42, 500), ...manyPeers],
+    });
+    expect(result!.peerPages.length).toBe(10);
+    // peerCount still reflects ALL eligible peers
+    expect(result!.peerCount).toBe(20);
+  });
+});

--- a/src/lib/analytics/fetchers-ga-webflow.ts
+++ b/src/lib/analytics/fetchers-ga-webflow.ts
@@ -13,6 +13,7 @@ import {
   WebflowContentFreshness,
   AnalyticsTimestamp,
 } from "./types";
+import { computeKanbanBounceComparison } from "./kanban-bounce-comparison";
 
 type GAReportValue = { value?: string };
 type GAReportRow = { dimensionValues?: GAReportValue[]; metricValues?: GAReportValue[] };
@@ -181,7 +182,13 @@ export async function fetchGAData(
     : [{ startDate: "60daysAgo", endDate: "31daysAgo" }];
 
   // Run all requests in parallel
-  const [current30d, previous30d, trafficAndTrend, topPagesRaw] = await Promise.all([
+  const [
+    current30d,
+    previous30d,
+    trafficAndTrend,
+    topPagesRaw,
+    topPagesPrevRaw,
+  ] = await Promise.all([
     // Request 1: Current 30d metrics
     fetch(apiUrl, {
       method: "POST",
@@ -241,7 +248,9 @@ export async function fetchGAData(
       return await safeJson<GAReportResponse>(r, "GA report (traffic)");
     }),
 
-    // Request 4: Top pages
+    // Request 4: Top pages (current 30d) — now includes sessions + bounceRate
+    // so we can compute per-page engagement and benchmark specific landing
+    // pages (e.g. the Free Kanban Generator whitepaper) against the site.
     fetch(apiUrl, {
       method: "POST",
       headers,
@@ -251,8 +260,10 @@ export async function fetchGAData(
         metrics: [
           { name: "screenPageViews" },
           { name: "averageSessionDuration" },
+          { name: "sessions" },
+          { name: "bounceRate" },
         ],
-        limit: 10,
+        limit: 25,
         orderBys: [
           {
             metric: { metricName: "screenPageViews" },
@@ -263,6 +274,33 @@ export async function fetchGAData(
     }).then(async (r) => {
       if (!r.ok) throw new Error(`GA4 report (top pages) failed (${r.status})`);
       return await safeJson<GAReportResponse>(r, "GA report (top pages)");
+    }),
+
+    // Request 5: Top pages (previous 30d) — enables period-over-period
+    // bounce-rate deltas for individual landing pages.
+    fetch(apiUrl, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        dateRanges: previousRange,
+        dimensions: [{ name: "pagePath" }],
+        metrics: [
+          { name: "screenPageViews" },
+          { name: "averageSessionDuration" },
+          { name: "sessions" },
+          { name: "bounceRate" },
+        ],
+        limit: 25,
+        orderBys: [
+          {
+            metric: { metricName: "screenPageViews" },
+            desc: true,
+          },
+        ],
+      }),
+    }).then(async (r) => {
+      if (!r.ok) throw new Error(`GA4 report (top pages prev) failed (${r.status})`);
+      return await safeJson<GAReportResponse>(r, "GA report (top pages prev)");
     }),
   ]);
 
@@ -279,6 +317,7 @@ export async function fetchGAData(
   const sessionsPrev30d = parseInt(previous30dRow[0]?.value || "0");
   const usersPrev30d = parseInt(previous30dRow[1]?.value || "0");
   const pageviewsPrev30d = parseInt(previous30dRow[2]?.value || "0");
+  const bounceRatePrev30d = parseFloat(previous30dRow[3]?.value || "0");
 
   // Parse traffic by channel
   const trafficByChannelMap: Record<string, GATrafficChannel> = {};
@@ -319,15 +358,31 @@ export async function fetchGAData(
     sessions,
   }));
 
-  // Parse top pages
-  const topPages: GATopPage[] = (topPagesRaw.rows || []).map((row: GAReportRow) => {
+  // Parse top pages (current 30d)
+  // Metric order matches Request 4: [screenPageViews, averageSessionDuration, sessions, bounceRate]
+  const parseTopPagesRow = (row: GAReportRow): GATopPage => {
     const dimensionValues = row.dimensionValues ?? [];
     const metricValues = row.metricValues ?? [];
     return {
       path: dimensionValues[0]?.value || "/",
       pageviews: parseInt(metricValues[0]?.value || "0"),
       avgDuration: parseFloat(metricValues[1]?.value || "0"),
+      sessions: parseInt(metricValues[2]?.value || "0"),
+      bounceRate: parseFloat(metricValues[3]?.value || "0"),
     };
+  };
+
+  const topPages: GATopPage[] = (topPagesRaw.rows || []).map(parseTopPagesRow);
+  const topPagesPrev30d: GATopPage[] = (topPagesPrevRaw.rows || []).map(parseTopPagesRow);
+
+  // Compute the Kanban whitepaper bounce-rate benchmark up-front so consumers
+  // (overview KPI tile, Kanban dashboard tab) get a stable shape and don't
+  // recompute it on every render.
+  const kanbanBounceComparison = computeKanbanBounceComparison({
+    siteBounceRate: bounceRate,
+    siteBounceRatePrev: bounceRatePrev30d,
+    topPages,
+    topPagesPrev: topPagesPrev30d,
   });
 
   return {
@@ -338,10 +393,13 @@ export async function fetchGAData(
     pageviews30d,
     pageviewsPrev30d,
     bounceRate,
+    bounceRatePrev30d,
     avgSessionDuration,
     trafficByChannel,
     topPages,
+    topPagesPrev30d,
     dailyTrend,
+    kanbanBounceComparison,
     _meta: makeMeta("live"),
   };
 }

--- a/src/lib/analytics/kanban-bounce-comparison.ts
+++ b/src/lib/analytics/kanban-bounce-comparison.ts
@@ -1,0 +1,194 @@
+/**
+ * Bounce-rate benchmark for the Free Kanban Generator whitepaper landing page.
+ *
+ * Compares the matched Kanban landing-page(s) against:
+ *  1. Site-wide bounce rate
+ *  2. Peer top-N pages (sessions-weighted ranking)
+ *  3. Period-over-period delta (current 30d vs prior 30d)
+ *
+ * GA4 returns `bounceRate` either as a fraction (0–1) or a percentage (0–100);
+ * inputs are normalized to a 0–1 fraction before any math, so all outputs are
+ * in 0–1 fraction form too. Percentage-point deltas in the output are in
+ * "percentage points" (e.g. 42% – 50% = -8 pts).
+ */
+
+import type { GATopPage, KanbanBounceComparison } from "./types";
+
+/** Path prefixes that identify the Free Kanban Generator landing pages. */
+const KANBAN_PATH_PREFIXES = [
+  "/kanban-template",
+  "/free-kanban-generator",
+  "/free-kanban",
+  "/kanban",
+] as const;
+
+/**
+ * Internal app routes that share the `/kanban` prefix but are NOT public
+ * landing pages. We exclude these from matches.
+ */
+const KANBAN_PATH_EXCLUDES = [
+  "/kanban-board",
+  "/kanban-card",
+  "/kanban-loop",
+] as const;
+
+/** Max path depth (segment count) for a public landing page. Filters out
+ * deep internal routes like `/kanban-template/preview/abc/edit`. */
+const MAX_LANDING_PAGE_DEPTH = 2;
+
+/**
+ * True if `path` looks like a public Kanban Generator landing page.
+ * Strips query strings + trailing slashes before matching.
+ */
+export function isKanbanLandingPage(path: string): boolean {
+  if (!path) return false;
+  const cleaned = path.split(/[?#]/)[0].replace(/\/+$/, "") || "/";
+  const lower = cleaned.toLowerCase();
+
+  for (const exclude of KANBAN_PATH_EXCLUDES) {
+    if (lower === exclude || lower.startsWith(`${exclude}/`)) return false;
+  }
+  // Depth = number of non-empty segments
+  const segments = lower.split("/").filter(Boolean);
+  if (segments.length > MAX_LANDING_PAGE_DEPTH) return false;
+
+  return KANBAN_PATH_PREFIXES.some(
+    (prefix) => lower === prefix || lower.startsWith(`${prefix}/`)
+  );
+}
+
+/**
+ * Return only the Kanban landing pages in `topPages`.
+ */
+export function findKanbanPages(topPages: GATopPage[]): GATopPage[] {
+  return topPages.filter((p) => isKanbanLandingPage(p.path));
+}
+
+/**
+ * Normalize a GA4 bounce-rate value to a 0–1 fraction.
+ * GA4 sometimes returns 0–1 fractions, sometimes 0–100 percentages.
+ */
+function normalizeBounce(raw: number): number {
+  if (!Number.isFinite(raw) || raw < 0) return 0;
+  return raw > 1 ? raw / 100 : raw;
+}
+
+/**
+ * Sessions-weighted bounce rate across a list of pages.
+ * GA4 aggregates bounce that way, so weighted-by-sessions is the right
+ * fold when combining multiple variant URLs of the same content.
+ */
+function weightedBounce(pages: GATopPage[]): { bounce: number; sessions: number } {
+  let totalSessions = 0;
+  let weightedSum = 0;
+  for (const page of pages) {
+    const sessions = Math.max(0, page.sessions ?? 0);
+    if (sessions === 0) continue;
+    const bounce = normalizeBounce(page.bounceRate ?? 0);
+    weightedSum += bounce * sessions;
+    totalSessions += sessions;
+  }
+  if (totalSessions === 0) return { bounce: 0, sessions: 0 };
+  return { bounce: weightedSum / totalSessions, sessions: totalSessions };
+}
+
+/**
+ * Threshold (in percentage points) below which Kanban bounce is considered
+ * "comparable" to the site average rather than "better" or "worse". Keeps
+ * tiny statistical noise from triggering misleading verdicts.
+ */
+const COMPARABLE_THRESHOLD_PTS = 2;
+
+interface ComputeArgs {
+  /** Site-wide current 30d bounce rate (0–1 fraction or 0–100 percent — auto-normalized). */
+  siteBounceRate: number;
+  /** Site-wide previous 30d bounce rate. Pass 0 or undefined when unavailable. */
+  siteBounceRatePrev?: number;
+  /** Top pages for the current 30d window. */
+  topPages: GATopPage[];
+  /** Top pages for the prior 30d window. Optional — without it the period delta is null. */
+  topPagesPrev?: GATopPage[];
+  /** Maximum number of peer pages to surface in the ranking. Defaults to 10. */
+  peerLimit?: number;
+}
+
+/**
+ * Compute the Kanban whitepaper bounce-rate comparison.
+ *
+ * Returns `null` when no Kanban pages were matched in `topPages` (e.g. the
+ * landing page didn't appear in the top-N list for the period). The dashboard
+ * UI uses the null signal to render an empty state instead of a misleading
+ * comparison built from zeros.
+ */
+export function computeKanbanBounceComparison(
+  args: ComputeArgs
+): KanbanBounceComparison | null {
+  const peerLimit = args.peerLimit ?? 10;
+
+  const matched = findKanbanPages(args.topPages);
+  if (matched.length === 0) return null;
+
+  const { bounce: kanbanBounce, sessions: kanbanSessions } = weightedBounce(matched);
+  // If matched pages had zero sessions in the period, the bounce signal is
+  // not meaningful — treat the same as no match.
+  if (kanbanSessions === 0) return null;
+
+  const siteBounce = normalizeBounce(args.siteBounceRate);
+  const deltaVsSitePts = (kanbanBounce - siteBounce) * 100;
+
+  // Period-over-period delta — weighted bounce across previously-matched
+  // Kanban paths in the prior window. Falls back to null if we have no prior
+  // data or zero prior Kanban sessions.
+  let periodDeltaPts: number | null = null;
+  if (args.topPagesPrev && args.topPagesPrev.length > 0) {
+    const matchedPrev = findKanbanPages(args.topPagesPrev);
+    if (matchedPrev.length > 0) {
+      const { bounce: prevKanbanBounce, sessions: prevSessions } =
+        weightedBounce(matchedPrev);
+      if (prevSessions > 0) {
+        periodDeltaPts = (kanbanBounce - prevKanbanBounce) * 100;
+      }
+    }
+  }
+
+  // Peer ranking: every non-Kanban top page that had real sessions, sorted
+  // ascending by bounce (lower = better). Kanban gets ranked into the same
+  // list to find its position.
+  const peers = args.topPages
+    .filter((p) => !isKanbanLandingPage(p.path))
+    .filter((p) => (p.sessions ?? 0) > 0)
+    .map((p) => ({
+      path: p.path,
+      bounceRate: normalizeBounce(p.bounceRate ?? 0),
+      sessions: p.sessions ?? 0,
+    }))
+    .sort((a, b) => a.bounceRate - b.bounceRate);
+
+  let rankAmongPeers: number | null = null;
+  if (peers.length > 0) {
+    // Find how many peers have a strictly LOWER (better) bounce than Kanban.
+    // Rank = that count + 1 (1-indexed where 1 = best). Ties go to Kanban.
+    const better = peers.filter((p) => p.bounceRate < kanbanBounce).length;
+    rankAmongPeers = better + 1;
+  }
+
+  const verdict: KanbanBounceComparison["verdict"] =
+    Math.abs(deltaVsSitePts) < COMPARABLE_THRESHOLD_PTS
+      ? "comparable"
+      : deltaVsSitePts < 0
+        ? "better"
+        : "worse";
+
+  return {
+    matchedPaths: matched.map((p) => p.path),
+    kanbanBounceRate: kanbanBounce,
+    kanbanSessions,
+    siteBounceRate: siteBounce,
+    deltaVsSitePts,
+    periodDeltaPts,
+    rankAmongPeers,
+    peerCount: peers.length,
+    peerPages: peers.slice(0, peerLimit),
+    verdict,
+  };
+}

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -29,6 +29,7 @@ export type IntegrationProviderKey =
   | "googleAds"
   | "metaAds"
   | "metaPage"
+  | "instagram"
   | "semrush"
   | "pylon"
   | "product"
@@ -445,6 +446,38 @@ export interface GATopPage {
   path: string;
   pageviews: number;
   avgDuration: number;
+  /** GA4 bounce rate for this page as a fraction (0–1). 0 when unavailable. */
+  bounceRate: number;
+  /** Sessions for this page in the current range. 0 when unavailable. */
+  sessions: number;
+}
+
+/**
+ * Result of comparing the Free Kanban Generator landing page(s) against
+ * peer pages and the site-wide bounce rate. All bounce values are
+ * normalized to a 0–1 fraction.
+ */
+export interface KanbanBounceComparison {
+  /** Matched Kanban landing-page paths (e.g. /kanban-template). */
+  matchedPaths: string[];
+  /** Sessions-weighted bounce rate across all matched Kanban pages, 0–1. */
+  kanbanBounceRate: number;
+  /** Total sessions across the matched Kanban pages. */
+  kanbanSessions: number;
+  /** Site-wide bounce rate, 0–1. */
+  siteBounceRate: number;
+  /** Kanban bounce minus site bounce, in percentage points (positive = Kanban is worse). */
+  deltaVsSitePts: number;
+  /** Period-over-period delta in percentage points (current 30d minus prior 30d). null when unavailable. */
+  periodDeltaPts: number | null;
+  /** Rank of the matched Kanban page among the top-N pages by bounce, 1-indexed (1 = best/lowest bounce). */
+  rankAmongPeers: number | null;
+  /** Total peer pages considered in the ranking. */
+  peerCount: number;
+  /** Top-N peer pages sorted ascending by bounce rate (excludes matched Kanban paths). */
+  peerPages: Array<{ path: string; bounceRate: number; sessions: number }>;
+  /** Plain-English verdict: "better", "worse", or "comparable" vs site average. */
+  verdict: "better" | "worse" | "comparable";
 }
 
 export interface GAData {
@@ -455,10 +488,16 @@ export interface GAData {
   pageviews30d: number;
   pageviewsPrev30d: number;
   bounceRate: number;
+  /** Site-wide bounce rate for the previous 30-day window, 0–1. 0 when unavailable. */
+  bounceRatePrev30d?: number;
   avgSessionDuration: number;
   trafficByChannel: GATrafficChannel[];
   topPages: GATopPage[];
+  /** Per-page bounce/sessions for the previous 30-day window. Used for period-over-period deltas. */
+  topPagesPrev30d?: GATopPage[];
   dailyTrend: { date: string; sessions: number }[];
+  /** Pre-computed Kanban whitepaper bounce-rate comparison. null when no Kanban pages match. */
+  kanbanBounceComparison?: KanbanBounceComparison | null;
   _meta: AnalyticsTimestamp;
 }
 


### PR DESCRIPTION
## Commits
- Add Free Kanban Generator bounce-rate comparison to ads-traffic analytics

## Files changed
 src/app/dev/kanban-bounce-preview/page.tsx         | 189 +++++++++++++++++
 src/components/analytics/ads-coda-kanban-tab.tsx   |  24 ++-
 .../analytics/kanban-bounce-benchmark.test.tsx     |  95 +++++++++
 .../analytics/kanban-bounce-benchmark.tsx          | 213 +++++++++++++++++++
 src/components/analytics/marketing-tab-new.tsx     | 127 ++++++++++++
 src/lib/__tests__/kanban-bounce-comparison.test.ts | 229 +++++++++++++++++++++
 src/lib/analytics/fetchers-ga-webflow.ts           |  68 +++++-
 src/lib/analytics/kanban-bounce-comparison.ts      | 194 +++++++++++++++++
 src/lib/analytics/types.ts                         |  39 ++++
 9 files changed, 1167 insertions(+), 11 deletions(-)

_Surfaced during repo cleanup; was unmerged with no PR. Larger/older branch — likely needs a rebase on current `main` before merge._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
