### PR TITLE
fix(worker): guard sync cron with global advisory lock to stop OOM crash loop

### DIFF
--- a/docs/runbooks/oom-crash-loop.md
+++ b/docs/runbooks/oom-crash-loop.md
@@ -90,8 +90,13 @@ done
   (mirroring `pruneAnalyticsSnapshots`) **after** auditing all readers
   (`company-goals.ts`, `investor-dashboard-export.ts`, `expense-dashboard.ts`,
   monthly history back to 2025-01-01) so longer-range features don't lose data.
-- **Worker service** (`Dockerfile.worker`) also runs sync; if it is enabled,
+- ~~**Worker service** (`Dockerfile.worker`) also runs sync; if it is enabled,
   wrap its sync entrypoint in `withSyncAdvisoryLock` so it can't run a cycle
-  concurrently with the web cron.
+  concurrently with the web cron.~~ **Done** — `worker/sync-runner.ts` now runs
+  each cycle under `withSyncAdvisoryLock` (on the worker's own pool, see
+  `worker/prisma.ts` `getWorkerPool`). An overlapping cycle is skipped and
+  logged as `Sync cycle skipped — another sync cycle is already running`, so the
+  worker cron can no longer stack heavy cycles with the web cron or another
+  replica.
 - Consider `select`-projecting only the payload fields the calculators use, to
   cut per-row weight further (larger refactor — calculators read payloads deeply).

--- a/worker/__tests__/prisma.test.ts
+++ b/worker/__tests__/prisma.test.ts
@@ -83,6 +83,17 @@ describe('worker prisma', () => {
     expect(mockPoolEnd).toHaveBeenCalledOnce();
   });
 
+  it('getWorkerPool returns the pool backing the worker Prisma client', async () => {
+    const { getWorkerPrisma, getWorkerPool } = await import('../prisma');
+    getWorkerPrisma();
+    const pool = getWorkerPool();
+    expect(pool).toBeTruthy();
+    // Initializing the pool lazily must not create a second pool.
+    expect(mockPoolCtor).toHaveBeenCalledOnce();
+    // Calling again returns the same pinned pool (needed for the advisory lock).
+    expect(getWorkerPool()).toBe(pool);
+  });
+
   it('throws if no DATABASE_URL is set', async () => {
     delete process.env.DATABASE_URL;
     delete process.env.WORKER_DATABASE_URL;

--- a/worker/prisma.ts
+++ b/worker/prisma.ts
@@ -66,6 +66,24 @@ export function getWorkerPrisma(): PrismaClient {
   return workerPrisma;
 }
 
+/**
+ * Return the worker's underlying pg connection pool, initializing the worker
+ * Prisma client (and therefore the pool) on first use.
+ *
+ * Needed by the global sync advisory lock, which must pin a SINGLE physical
+ * connection for `pg_try_advisory_lock`/`pg_advisory_unlock`. The worker passes
+ * its OWN pool (not the web app's) so the lock is taken on the worker's
+ * connections while still coordinating with the web cron — Postgres advisory
+ * locks are shared across connections and processes.
+ */
+export function getWorkerPool(): Pool {
+  getWorkerPrisma();
+  if (!workerPool) {
+    throw new Error('Worker pg connection pool is not initialized');
+  }
+  return workerPool;
+}
+
 export async function disconnectWorkerPrisma(): Promise<void> {
   if (workerPrisma) {
     logger.info('Disconnecting worker Prisma client');

--- a/worker/sync-runner.ts
+++ b/worker/sync-runner.ts
@@ -24,11 +24,12 @@
 
 import { workerConfig } from './config';
 import { logger } from './logger';
-import { getWorkerPrisma, disconnectWorkerPrisma } from './prisma';
+import { getWorkerPrisma, getWorkerPool, disconnectWorkerPrisma } from './prisma';
 import { startHealthServer, updateSyncStatus, setReady } from './health';
 import { withTimeout } from './timeout';
 import { assertSyncResultsHealthy } from './sync-results';
 import { loadOrchestrator } from './orchestrator-loader';
+import { withSyncAdvisoryLock } from '@/lib/sync/sync-lock';
 
 // ─── Graceful Shutdown ───────────────────────────────────────────────────────
 
@@ -116,12 +117,35 @@ async function runSyncCycle(): Promise<void> {
 
   try {
     const orchestrator = await loadOrchestrator();
-    const syncResult = await withTimeout(
-      orchestrator.runSync(prisma, workerConfig.modules),
-      workerConfig.syncTimeoutMs,
-      `Sync cycle timed out after ${workerConfig.syncTimeoutMs}ms`
+    // Run under the global sync advisory lock so the worker can never run a
+    // heavy cycle concurrently with the web cron (/api/cron/sync) or another
+    // worker replica. Overlapping cycles each load large raw-record sets and
+    // drove the heap monotonically to the V8 limit — the OOM crash loop (see
+    // docs/runbooks/oom-crash-loop.md). The lock is taken on the worker's own
+    // pool, but Postgres advisory locks coordinate across processes.
+    const outcome = await withSyncAdvisoryLock(
+      () =>
+        withTimeout(
+          orchestrator.runSync(prisma, workerConfig.modules),
+          workerConfig.syncTimeoutMs,
+          `Sync cycle timed out after ${workerConfig.syncTimeoutMs}ms`
+        ),
+      { pool: getWorkerPool() }
     );
-    assertSyncResultsHealthy(syncResult);
+
+    if (!outcome.ran) {
+      // Another cycle holds the lock — skip rather than stack. This is the
+      // guard working, not an error, so report it as a successful no-op.
+      const durationMs = Date.now() - startTime;
+      updateSyncStatus('success', durationMs);
+      logger.info('Sync cycle skipped — another sync cycle is already running', {
+        reason: outcome.reason,
+        durationMs,
+      });
+      return;
+    }
+
+    assertSyncResultsHealthy(outcome.result);
 
     const durationMs = Date.now() - startTime;
     updateSyncStatus('success', durationMs);


### PR DESCRIPTION
## What

The worker sync cron (`worker/sync-runner.ts`) ran the same heavy sync cycle as the web cron (`/api/cron/sync`) but — unlike the web route — was **not** wrapped in `withSyncAdvisoryLock`. When the worker is enabled it could run a cycle concurrently with the web cron (or another worker replica). Because each cycle loads large raw-record sets into memory, stacked cycles drove the heap monotonically to the V8 limit — the **OOM crash loop** documented in `docs/runbooks/oom-crash-loop.md`, where it was listed as the outstanding follow-up:

> **Worker service** (`Dockerfile.worker`) also runs sync; if it is enabled, wrap its sync entrypoint in `withSyncAdvisoryLock` so it can't run a cycle concurrently with the web cron.

This PR closes that gap so the worker can no longer re-trigger the crash loop.

## How

- **`worker/sync-runner.ts`** — each cycle now runs under `withSyncAdvisoryLock`. The lock is the same global Postgres advisory lock (`WIPG`/`SYNC`) the web cron uses; Postgres advisory locks coordinate across connections and processes, so the worker serializes against the web cron and other replicas. An overlapping cycle is **skipped and logged** (`Sync cycle skipped — another sync cycle is already running`) and reported as a successful no-op — the guard working, not an error. Peak memory is bounded to a single cycle (sawtooth, not monotonic climb).
- **`worker/prisma.ts`** — adds `getWorkerPool()` so the lock can pin a single physical connection on the worker's *own* pool (advisory lock requires the `pg_try_advisory_lock`/`pg_advisory_unlock` pair on the same backend connection).
- **`worker/__tests__/prisma.test.ts`** — covers `getWorkerPool()` (returns the backing pool, lazily, without creating a second pool).
- **`docs/runbooks/oom-crash-loop.md`** — marks the worker follow-up as done.

## Testing

- `vitest run worker/` — 25 passed
- Full suite (`vitest run`) was green before the change (3148 passed); these changes are additive to the worker path.
- `eslint` clean on changed files; pre-commit staged typecheck passed.

Note: `npx tsc -p worker/tsconfig.json` reports `TS6059` (rootDir) for `../src/*` imports — this is **pre-existing** (the worker already imports `@/generated/prisma/client`) and not a real type error; the worker runs via `npx tsx` at runtime where `rootDir` is irrelevant, and CI builds only `src/` via `next build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8MshpgJNQ3c8sbARRTd7X)_