### PR TITLE
Salvage board dashboard context

### DIFF
--- a/src/components/workspaces/customer-health-dashboard.test.tsx
+++ b/src/components/workspaces/customer-health-dashboard.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { CustomerHealthDashboard } from "./customer-health-dashboard";
 import type { CustomerHealthDashboardData } from "@/lib/retention/customer-health-dashboard";
@@ -115,6 +116,101 @@ const DATA: CustomerHealthDashboardData = {
       },
       lastMaterializedAt: "2026-03-15T00:00:00.000Z",
     },
+    {
+      accountId: "cust_2",
+      name: "Tenant Two",
+      status: "At Risk",
+      lifecyclePhase: "MATURE",
+      primaryLirPassed: false,
+      primaryLirLabel: "Active weeks trailing 8",
+      primaryLirValue: 2,
+      primaryLirThreshold: 5,
+      currentMonthActivity: 3,
+      trendVsPriorPct: -42,
+      supportRisk: true,
+      billingRisk: false,
+      onboardingRisk: false,
+      ownerName: "CS Owner",
+      segment: "SMB",
+      plan: "Starter",
+      ageBucket: "180d+",
+      reasonCodes: [
+        {
+          code: "usage_collapse",
+          label: "Current-month usage collapse",
+          detail: "Recent activity is materially below baseline.",
+          severity: "critical",
+          dimension: "usage",
+        },
+      ],
+      coverage: {
+        arda: true,
+        coda: false,
+        stripe: false,
+        hubspot: true,
+        pylon: true,
+        missingSources: ["coda", "stripe"],
+      },
+      lastMaterializedAt: "2026-03-15T00:00:00.000Z",
+    },
+    {
+      accountId: "cust_3",
+      name: "Tenant Three",
+      status: "Onboarding Risk",
+      lifecyclePhase: "ONBOARDING",
+      primaryLirPassed: false,
+      primaryLirLabel: "First order",
+      primaryLirValue: 0,
+      primaryLirThreshold: 1,
+      currentMonthActivity: 1,
+      trendVsPriorPct: -10,
+      supportRisk: false,
+      billingRisk: false,
+      onboardingRisk: true,
+      ownerName: "CS Owner",
+      segment: "SMB",
+      plan: "Starter",
+      ageBucket: "0-30d",
+      reasonCodes: [],
+      coverage: {
+        arda: false,
+        coda: true,
+        stripe: true,
+        hubspot: true,
+        pylon: true,
+        missingSources: ["arda"],
+      },
+      lastMaterializedAt: "2026-03-15T00:00:00.000Z",
+    },
+    {
+      accountId: "cust_4",
+      name: "Tenant Four",
+      status: "Billing Risk",
+      lifecyclePhase: "MATURE",
+      primaryLirPassed: false,
+      primaryLirLabel: "Payment current",
+      primaryLirValue: 0,
+      primaryLirThreshold: 1,
+      currentMonthActivity: 4,
+      trendVsPriorPct: -5,
+      supportRisk: false,
+      billingRisk: true,
+      onboardingRisk: false,
+      ownerName: "CS Owner",
+      segment: "Mid-market",
+      plan: "Growth",
+      ageBucket: "180d+",
+      reasonCodes: [],
+      coverage: {
+        arda: true,
+        coda: true,
+        stripe: true,
+        hubspot: false,
+        pylon: true,
+        missingSources: ["hubspot"],
+      },
+      lastMaterializedAt: "2026-03-15T00:00:00.000Z",
+    },
   ],
 };
 
@@ -134,9 +230,49 @@ describe("CustomerHealthDashboard", () => {
     expect(codaCoverage).toBeTruthy();
     expect(within(codaCoverage as HTMLElement).getByText("50.0%")).toBeTruthy();
     expect(screen.getByText("Needs Attention")).toBeTruthy();
-    expect(screen.getByText("Tenant Two")).toBeTruthy();
+    expect(screen.getAllByText("Tenant Two").length).toBeGreaterThan(0);
     expect(screen.getByText("Current-month usage collapse")).toBeTruthy();
     expect(screen.getByText("Tenant One")).toBeTruthy();
+  });
+
+  it("filters the board risk table by customer status and missing source", async () => {
+    const user = userEvent.setup();
+    render(<CustomerHealthDashboard data={DATA} />);
+
+    expect(screen.getByText("Board Customer Risk")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "At Risk" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Onboarding Risk" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Billing Risk" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Missing ARDA" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Missing Coda" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Missing HubSpot" })).toBeTruthy();
+    const accountTable = screen.getByRole("table");
+
+    await user.click(screen.getByRole("button", { name: "At Risk" }));
+    expect(within(accountTable).getByText("Tenant Two")).toBeTruthy();
+    expect(within(accountTable).queryByText("Tenant One")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Missing Coda" }));
+    expect(within(accountTable).getByText("Tenant Two")).toBeTruthy();
+    expect(within(accountTable).queryByText("Tenant One")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "All Sources" }));
+    await user.click(screen.getByRole("button", { name: "Onboarding Risk" }));
+    expect(within(accountTable).getByText("Tenant Three")).toBeTruthy();
+    expect(within(accountTable).queryByText("Tenant Two")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Missing ARDA" }));
+    expect(within(accountTable).getByText("Tenant Three")).toBeTruthy();
+    expect(within(accountTable).queryByText("Tenant Four")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "All Sources" }));
+    await user.click(screen.getByRole("button", { name: "Billing Risk" }));
+    expect(within(accountTable).getByText("Tenant Four")).toBeTruthy();
+    expect(within(accountTable).queryByText("Tenant Three")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Missing HubSpot" }));
+    expect(within(accountTable).getByText("Tenant Four")).toBeTruthy();
+    expect(within(accountTable).queryByText("Tenant Three")).toBeNull();
   });
 
   it("renders an empty state when no accounts have materialized health", () => {

--- a/src/components/workspaces/customer-health-dashboard.tsx
+++ b/src/components/workspaces/customer-health-dashboard.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import {
   Activity,
   AlertTriangle,
@@ -14,6 +17,25 @@ import type {
   CustomerHealthSourceCoverage,
 } from "@/lib/retention/customer-health-dashboard";
 import { parseImladrisNumber } from "@/lib/imladris/number-parsing";
+
+const HEALTH_STATUS_FILTERS = [
+  "At Risk",
+  "Onboarding Risk",
+  "Billing Risk",
+  "Watch",
+  "Healthy",
+] satisfies CustomerHealthAccountRow["status"][];
+
+const MISSING_SOURCE_FILTERS = [
+  { id: "arda", label: "Missing ARDA" },
+  { id: "coda", label: "Missing Coda" },
+  { id: "stripe", label: "Missing Stripe" },
+  { id: "hubspot", label: "Missing HubSpot" },
+  { id: "pylon", label: "Missing Pylon" },
+] as const;
+
+type HealthStatusFilter = "all" | CustomerHealthAccountRow["status"];
+type MissingSourceFilter = "all" | (typeof MISSING_SOURCE_FILTERS)[number]["id"];
 
 function scalarValue(value: unknown, seen = new WeakSet<object>()): unknown {
   if (value === null || value === undefined) return value;
@@ -223,7 +245,33 @@ function AccountRow({ account }: { account: CustomerHealthAccountRow }) {
   );
 }
 
+function FilterButton({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={
+        active
+          ? "rounded-md bg-primary px-2.5 py-1.5 text-xs font-medium text-primary-foreground"
+          : "rounded-md border border-border bg-card px-2.5 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
+      }
+    >
+      {label}
+    </button>
+  );
+}
+
 export function CustomerHealthDashboard({ data }: { data: CustomerHealthDashboardData }) {
+  const [statusFilter, setStatusFilter] = useState<HealthStatusFilter>("all");
+  const [missingSourceFilter, setMissingSourceFilter] = useState<MissingSourceFilter>("all");
   const lirPct =
     data.totals.totalAccounts > 0
       ? (data.totals.lirPassingAccounts / data.totals.totalAccounts) * 100
@@ -233,6 +281,13 @@ export function CustomerHealthDashboard({ data }: { data: CustomerHealthDashboar
     ...data.riskQueues.onboardingRisk,
     ...data.riskQueues.billingRisk,
   ].slice(0, 6);
+  const filteredAccounts = data.accounts.filter((account) => {
+    const statusMatches = statusFilter === "all" || account.status === statusFilter;
+    const sourceMatches =
+      missingSourceFilter === "all" ||
+      account.coverage.missingSources.includes(missingSourceFilter);
+    return statusMatches && sourceMatches;
+  });
 
   return (
     <div className="h-full overflow-y-auto p-4">
@@ -371,7 +426,40 @@ export function CustomerHealthDashboard({ data }: { data: CustomerHealthDashboar
 
         <section className="space-y-3">
           <div className="flex flex-wrap items-center justify-between gap-3">
-            <h2 className="text-sm font-semibold text-foreground">Account Health</h2>
+            <div>
+              <h2 className="text-sm font-semibold text-foreground">Board Customer Risk</h2>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Filter the account table to isolate investor-visible risk by status or missing evidence.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <FilterButton
+                active={statusFilter === "all"}
+                label="All Statuses"
+                onClick={() => setStatusFilter("all")}
+              />
+              {HEALTH_STATUS_FILTERS.map((status) => (
+                <FilterButton
+                  key={status}
+                  active={statusFilter === status}
+                  label={status}
+                  onClick={() => setStatusFilter(status)}
+                />
+              ))}
+              <FilterButton
+                active={missingSourceFilter === "all"}
+                label="All Sources"
+                onClick={() => setMissingSourceFilter("all")}
+              />
+              {MISSING_SOURCE_FILTERS.map((source) => (
+                <FilterButton
+                  key={source.id}
+                  active={missingSourceFilter === source.id}
+                  label={source.label}
+                  onClick={() => setMissingSourceFilter(source.id)}
+                />
+              ))}
+            </div>
             <div className="flex flex-wrap gap-2 text-xs">
               {data.healthStatusBreakdown.map((entry) => (
                 <span
@@ -397,11 +485,16 @@ export function CustomerHealthDashboard({ data }: { data: CustomerHealthDashboar
                   </tr>
                 </thead>
                 <tbody>
-                  {data.accounts.map((account) => (
+                  {filteredAccounts.map((account) => (
                     <AccountRow key={account.accountId} account={account} />
                   ))}
                 </tbody>
               </table>
+              {filteredAccounts.length === 0 ? (
+                <div className="border-t border-border p-4 text-sm text-muted-foreground">
+                  No accounts match the selected board risk filters.
+                </div>
+              ) : null}
             </div>
           ) : (
             <div className="rounded-lg border border-dashed border-border bg-card p-6 text-sm text-muted-foreground">

--- a/src/components/workspaces/expense-dashboard.test.tsx
+++ b/src/components/workspaces/expense-dashboard.test.tsx
@@ -92,11 +92,34 @@ describe("ExpenseDashboard", () => {
     expect(screen.getByRole("heading", { name: "Arda Financial Dashboard" })).toBeTruthy();
     expect(screen.getByText(/Mercury Data \(Cash Basis\)/)).toBeTruthy();
     expect(screen.getByRole("button", { name: "Refresh data" })).toBeTruthy();
+    expect(screen.getByText("Board Burn Context")).toBeTruthy();
+    expect(screen.getByText("Primary burn driver")).toBeTruthy();
+    expect(screen.getByText("Payroll")).toBeTruthy();
+    expect(screen.getByText("Vendor concentration")).toBeTruthy();
     ["Overview", "Category x Month", "Categories", "Vendors", "Runway", "Recommendations"].forEach((label) => {
       expect(screen.getByRole("button", { name: label })).toBeTruthy();
     });
     expect(screen.getByText("Monthly Operating Cash Flows")).toBeTruthy();
     expect(screen.getByText("Spend by Category (6 Months)")).toBeTruthy();
+  });
+
+  it("uses watch coloring for sub-target board runway", () => {
+    render(
+      <ExpenseDashboard
+        initialData={{
+          ...DATA,
+          chartSeries: {
+            ...DATA.chartSeries,
+            netBurn: [160_000, 165_000, 170_000],
+            runwayCash: 200_000,
+          },
+        }}
+      />,
+    );
+
+    const runwayValue = screen.getByText("1.2 mo");
+    expect(runwayValue.className).toContain("expense-yellow");
+    expect(runwayValue.className).not.toContain("expense-green");
   });
 
   it("switches tabs and expands category drilldowns", async () => {

--- a/src/components/workspaces/expense-dashboard.tsx
+++ b/src/components/workspaces/expense-dashboard.tsx
@@ -174,6 +174,65 @@ function KpiCards({ data }: { data: ExpenseDashboardData }) {
   );
 }
 
+function titleCase(value: string): string {
+  return value
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function BoardBurnContext({ data }: { data: ExpenseDashboardData }) {
+  const total = totalSpend(data);
+  const categories = sortedCategories(data);
+  const vendors = sortedVendors(data);
+  const primaryCategory = categories[0] ?? null;
+  const topVendor = vendors[0] ?? null;
+  const recentNet = data.chartSeries.netBurn.map(numericValue).slice(-3);
+  const avgNet = recentNet.length ? recentNet.reduce((sum, value) => sum + value, 0) / recentNet.length : 0;
+  const cash = numericValue(data.chartSeries.runwayCash ?? 0);
+  const runway = avgNet > 0 ? cash / avgNet : 0;
+  const runwayHealthy = runway >= 9;
+
+  return (
+    <section className="expense-board-context expense-section" aria-label="Board burn context">
+      <div className="expense-section-title">Board Burn Context</div>
+      <div className="expense-grid expense-g4">
+        <div className="expense-card">
+          <div className="expense-card-label">Primary burn driver</div>
+          <div className="expense-card-value expense-yellow">
+            {primaryCategory ? titleCase(primaryCategory) : "Missing"}
+          </div>
+          <div className="expense-card-sub">
+            {primaryCategory
+              ? `${fmt(data.categoryTotals[primaryCategory])} · ${pct(data.categoryTotals[primaryCategory], total)}`
+              : "No category spend"}
+          </div>
+        </div>
+        <div className="expense-card">
+          <div className="expense-card-label">Vendor concentration</div>
+          <div className="expense-card-value expense-yellow">
+            {topVendor ? pct(data.vendorTotals[topVendor], total) : "0%"}
+          </div>
+          <div className="expense-card-sub">{topVendor ?? "No vendor spend"}</div>
+        </div>
+        <div className="expense-card">
+          <div className="expense-card-label">Recent net burn</div>
+          <div className="expense-card-value expense-yellow">{fmt(avgNet)}/mo</div>
+          <div className="expense-card-sub">3-month average from Mercury cashflow.</div>
+        </div>
+        <div className="expense-card">
+          <div className="expense-card-label">Runway bridge</div>
+          <div className={`expense-card-value ${runwayHealthy ? "expense-green" : "expense-yellow"}`}>
+            {runway > 0 ? `${runway.toFixed(1)} mo` : "Missing"}
+          </div>
+          <div className="expense-card-sub">Cash {fmt(cash)} at recent burn.</div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function DetailTable({
   title,
   transactions,
@@ -856,6 +915,8 @@ export function ExpenseDashboard({ initialData }: { initialData: ExpenseDashboar
             <div className="expense-alert-detail">April net burn was $295,306, driven by $174K Pillsbury Winthrop legal fees (financing close). 3-mo avg burn rose to $176,465/mo (was $113,807). Runway at 3-mo avg: 14.5 months. Determine if April legal cost is one-time before treating this as the new baseline.</div>
           </div>
         </div>
+
+        <BoardBurnContext data={data} />
 
         <KpiCards data={data} />
 


### PR DESCRIPTION
## Summary
- Salvage the still-current customer-health board risk filters from stale dashboard PR work (#652/#645 overlap)
- Add the expense dashboard board burn context cards from #652
- Leave the stale company tracker workspace component and trendSeries backend changes out because current main now uses /operating/company via ImladrisCompanyShell/CompanyDashboardView

## Verification
- npm test -- src/components/workspaces/customer-health-dashboard.test.tsx src/components/workspaces/expense-dashboard.test.tsx
- npm test -- src/app/api/imladris/imladris-routes.test.ts
- npx eslint src/components/workspaces/customer-health-dashboard.tsx src/components/workspaces/customer-health-dashboard.test.tsx src/components/workspaces/expense-dashboard.tsx src/components/workspaces/expense-dashboard.test.tsx