### PR TITLE
fix(analytics): ingest PostHog via HogQL aggregation instead of raw events

### DIFF
--- a/src/lib/__tests__/analytics-fetchers-development.test.ts
+++ b/src/lib/__tests__/analytics-fetchers-development.test.ts
@@ -18,16 +18,25 @@ afterEach(() => {
 });
 
 describe("development analytics fetchers", () => {
-  it("follows PostHog event pagination so historical syncs do not stop at the first page", async () => {
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce(jsonResponse({
-        results: [{ uuid: "event_1", event: "Signup" }],
-        next: "https://app.posthog.com/api/projects/project_1/events?cursor=page_2",
-      }))
-      .mockResolvedValueOnce(jsonResponse({
-        results: [{ uuid: "event_2", event: "Activated" }],
-        next: null,
-      }));
+  // The PostHog fetcher issues two HogQL queries against /api/projects/:id/query/
+  // — an aggregate "GROUP BY event" count and a bounded recent-events sample.
+  function hogqlBody(req: RequestInit | undefined): string {
+    return typeof req?.body === "string" ? req.body : "";
+  }
+
+  it("aggregates PostHog event counts via the HogQL query API and keeps a bounded sample", async () => {
+    const fetchMock = vi.fn(async (_url: string | URL | Request, req?: RequestInit) => {
+      if (hogqlBody(req).includes("GROUP BY event")) {
+        return jsonResponse({
+          columns: ["event", "count"],
+          results: [["$pageview", 5], ["demo_booked", 2], ["feature_clicked", 9]],
+        });
+      }
+      return jsonResponse({
+        columns: ["uuid", "event", "timestamp", "distinct_id"],
+        results: [["evt-1", "$pageview", "2026-05-30 12:00:00", "person-1"]],
+      });
+    });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
     const data = await fetchPostHogData({
@@ -38,28 +47,42 @@ describe("development analytics fetchers", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/api/projects/project_1/query/"),
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer phx_token" }),
+      }),
+    );
+    // Aggregate totals are complete for the window (not bounded by the sample).
+    expect(data.eventCount).toBe(16);
     expect(data.events).toEqual([
-      { uuid: "event_1", event: "Signup" },
-      { uuid: "event_2", event: "Activated" },
+      { id: "evt-1", uuid: "evt-1", event: "$pageview", timestamp: "2026-05-30 12:00:00", distinct_id: "person-1" },
     ]);
-    expect(data.eventCount).toBe(2);
     expect(data._meta).toEqual(expect.objectContaining({
-      pageCount: 2,
+      queryMode: "hogql",
       truncated: false,
+      sampleSize: 1,
+      totalEvents: 16,
     }));
   });
 
-  it("summarizes fetched PostHog pageview and conversion events for downstream Imladris metrics", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({
-      results: [
-        { uuid: "event_pageview_1", event: "$pageview" },
-        { uuid: "event_pageview_2", event: "page_view" },
-        { uuid: "event_demo", event: "demo_booked" },
-        { uuid: "event_trial", event: "trial_started" },
-        { uuid: "event_other", event: "feature_clicked" },
-      ],
-      next: null,
-    }));
+  it("classifies aggregated pageview and conversion counts for downstream Imladris metrics", async () => {
+    const fetchMock = vi.fn(async (_url: string | URL | Request, req?: RequestInit) => {
+      if (hogqlBody(req).includes("GROUP BY event")) {
+        return jsonResponse({
+          columns: ["event", "count"],
+          results: [
+            ["$pageview", 3],
+            ["page_view", 1],
+            ["demo_booked", 2],
+            ["trial_started", 4],
+            ["feature_clicked", 7],
+          ],
+        });
+      }
+      return jsonResponse({ columns: ["uuid", "event", "timestamp", "distinct_id"], results: [] });
+    });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
     const data = await fetchPostHogData({
@@ -70,14 +93,14 @@ describe("development analytics fetchers", () => {
     });
 
     expect(data).toEqual(expect.objectContaining({
-      pageviewCount: 2,
-      conversionEventCount: 2,
+      pageviewCount: 4,
+      conversionEventCount: 6,
       eventNameCounts: {
-        "$pageview": 1,
+        "$pageview": 3,
         pageview: 1,
-        demobooked: 1,
-        trialstarted: 1,
-        featureclicked: 1,
+        demobooked: 2,
+        trialstarted: 4,
+        featureclicked: 7,
       },
     }));
   });

--- a/src/lib/__tests__/analytics-refresh-runner-monthly-history.test.ts
+++ b/src/lib/__tests__/analytics-refresh-runner-monthly-history.test.ts
@@ -879,19 +879,19 @@ describe("analytics monthly financial history refresh", () => {
       githubOwner: "example",
       githubRepo: "imladris",
     } as never);
-    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+    const fetchMock = vi.fn(async (url: string | URL | Request, req?: RequestInit) => {
       const href = String(url);
       if (href.includes("posthog.com")) {
+        const body = typeof req?.body === "string" ? req.body : "";
+        if (body.includes("GROUP BY event")) {
+          return new Response(JSON.stringify({
+            columns: ["event", "count"],
+            results: [["activation_completed", 1]],
+          }), { status: 200 });
+        }
         return new Response(JSON.stringify({
-          results: [
-            {
-              id: "evt_1",
-              event: "activation_completed",
-              distinct_id: "acct_1",
-              timestamp: "2025-03-14T10:00:00.000Z",
-              properties: { companyId: "acct_1" },
-            },
-          ],
+          columns: ["uuid", "event", "timestamp", "distinct_id"],
+          results: [["evt_1", "activation_completed", "2025-03-14 10:00:00", "acct_1"]],
         }), { status: 200 });
       }
       if (href.includes("linear.app")) {
@@ -943,8 +943,9 @@ describe("analytics monthly financial history refresh", () => {
 
     expect(result.failureCount).toBe(0);
     expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining("/api/projects/12345/events"),
+      expect.stringContaining("/api/projects/12345/query/"),
       expect.objectContaining({
+        method: "POST",
         headers: expect.objectContaining({
           Authorization: "Bearer phx_test",
         }),

--- a/src/lib/analytics/fetchers-development.ts
+++ b/src/lib/analytics/fetchers-development.ts
@@ -89,24 +89,42 @@ const POSTHOG_MARKETING_CONVERSION_EVENT_KEYS = new Set([
   "trialstarted",
 ]);
 
-function summarizePostHogEvents(events: unknown[]): {
-  pageviewCount: number;
-  conversionEventCount: number;
-  eventNameCounts: Record<string, number>;
-} {
-  const eventNameCounts: Record<string, number> = {};
-  let pageviewCount = 0;
-  let conversionEventCount = 0;
+// Default number of recent raw events to retain as a sample alongside the
+// aggregated counts. Bounded so a busy project cannot bloat a snapshot payload.
+const POSTHOG_EVENT_SAMPLE_LIMIT = 500;
 
-  for (const event of events) {
-    const key = normalizeEventKey(asRecord(event).event);
-    if (!key) continue;
-    eventNameCounts[key] = (eventNameCounts[key] ?? 0) + 1;
-    if (POSTHOG_PAGEVIEW_EVENT_KEYS.has(key)) pageviewCount += 1;
-    if (POSTHOG_MARKETING_CONVERSION_EVENT_KEYS.has(key)) conversionEventCount += 1;
-  }
+function postHogTimestampWindow(fromDate: Date, toDate: Date): string {
+  // toDateKey yields YYYY-MM-DD (ISO date slice), so these interpolations are
+  // not attacker-controlled. Mirrors the prior /events after/before semantics.
+  const after = toDateKey(fromDate);
+  const before = toDateKey(toDate);
+  return `timestamp >= toDateTime('${after} 00:00:00') AND timestamp < toDateTime('${before} 00:00:00')`;
+}
 
-  return { pageviewCount, conversionEventCount, eventNameCounts };
+async function runPostHogHogQLQuery(input: {
+  host: string;
+  apiKey: string;
+  projectId: string;
+  query: string;
+}): Promise<{ columns: string[]; rows: unknown[][] }> {
+  const url = `${input.host}/api/projects/${encodeURIComponent(input.projectId)}/query/`;
+  const response = await fetchJsonResponse(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${input.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query: { kind: "HogQLQuery", query: input.query } }),
+    cache: "no-store",
+  });
+  const payload = asRecord(await readJson(response));
+  const columns = asArray(payload.columns).map((column) => asString(column) ?? "");
+  const rows = asArray(payload.results).map((row) => asArray(row));
+  return { columns, rows };
+}
+
+function columnIndex(columns: string[], name: string): number {
+  return columns.indexOf(name);
 }
 
 function isoDate(value: unknown): string | null {
@@ -204,50 +222,95 @@ function normalizeLinearProject(project: unknown, issues: UnknownRecord[], recen
   };
 }
 
+/**
+ * Fetches PostHog product analytics for a project.
+ *
+ * Uses PostHog's HogQL query API to pull *aggregated* event counts (grouped by
+ * event name) in a single fast, small request, instead of paginating the raw
+ * `/events` endpoint. The old approach routinely blew the refresh job timeout
+ * and stored tens of MB of raw events per snapshot (a disk-pressure risk on a
+ * busy project). The aggregate counts (eventCount, pageviewCount, …) are
+ * complete and authoritative for the window; a small bounded sample of recent
+ * events is also returned so the Imladris materialization lineage — which keys
+ * product events by identity — keeps producing per-event records.
+ */
 export async function fetchPostHogData(input: {
   apiKey: string;
   projectId: string;
   host?: string | null;
   fromDate: Date;
   toDate: Date;
-  maxPages?: number;
+  sampleLimit?: number;
 }): Promise<UnknownRecord> {
   const host = normalizePostHogHost(input.host);
-  const params = new URLSearchParams({
-    after: toDateKey(input.fromDate),
-    before: toDateKey(input.toDate),
-    limit: "1000",
-  });
-  const events: unknown[] = [];
-  const maxPages = normalizeMaxPages(input.maxPages);
-  let pageCount = 0;
-  let nextUrl: string | null =
-    `${host}/api/projects/${encodeURIComponent(input.projectId)}/events?${params.toString()}`;
+  const window = postHogTimestampWindow(input.fromDate, input.toDate);
+  const sampleLimit =
+    typeof input.sampleLimit === "number" && Number.isFinite(input.sampleLimit)
+      ? Math.max(1, Math.floor(input.sampleLimit))
+      : POSTHOG_EVENT_SAMPLE_LIMIT;
 
-  while (nextUrl && pageCount < maxPages) {
-    pageCount += 1;
-    const response = await fetchJsonResponse(nextUrl, {
-      headers: {
-        Authorization: `Bearer ${input.apiKey}`,
-      },
-      cache: "no-store",
-    });
-    const payload = asRecord(await readJson(response));
-    events.push(...asArray(payload.results));
-    nextUrl = asString(payload.next);
+  // Aggregated counts by event name — complete for the entire window.
+  const aggregate = await runPostHogHogQLQuery({
+    host,
+    apiKey: input.apiKey,
+    projectId: input.projectId,
+    query: `SELECT event, count() AS count FROM events WHERE ${window} GROUP BY event ORDER BY count DESC LIMIT 10000`,
+  });
+  const aggEvent = columnIndex(aggregate.columns, "event");
+  const aggCount = columnIndex(aggregate.columns, "count");
+
+  const eventNameCounts: Record<string, number> = {};
+  let eventCount = 0;
+  let pageviewCount = 0;
+  let conversionEventCount = 0;
+  for (const row of aggregate.rows) {
+    const key = normalizeEventKey(aggEvent >= 0 ? row[aggEvent] : undefined);
+    const count = asNumber(aggCount >= 0 ? row[aggCount] : null) ?? 0;
+    if (!key || count <= 0) continue;
+    eventNameCounts[key] = (eventNameCounts[key] ?? 0) + count;
+    eventCount += count;
+    if (POSTHOG_PAGEVIEW_EVENT_KEYS.has(key)) pageviewCount += count;
+    if (POSTHOG_MARKETING_CONVERSION_EVENT_KEYS.has(key)) conversionEventCount += count;
   }
 
-  const eventSummary = summarizePostHogEvents(events);
+  // Bounded sample of the most recent events — keeps the materialization
+  // lineage working without persisting the full (potentially huge) stream.
+  const sample = await runPostHogHogQLQuery({
+    host,
+    apiKey: input.apiKey,
+    projectId: input.projectId,
+    query: `SELECT toString(uuid) AS uuid, event, toString(timestamp) AS timestamp, toString(distinct_id) AS distinct_id FROM events WHERE ${window} ORDER BY timestamp DESC LIMIT ${sampleLimit}`,
+  });
+  const sUuid = columnIndex(sample.columns, "uuid");
+  const sEvent = columnIndex(sample.columns, "event");
+  const sTimestamp = columnIndex(sample.columns, "timestamp");
+  const sDistinct = columnIndex(sample.columns, "distinct_id");
+  const events = sample.rows.map((row) => {
+    const uuid = sUuid >= 0 ? asString(row[sUuid]) : null;
+    return {
+      id: uuid,
+      uuid,
+      event: sEvent >= 0 ? asString(row[sEvent]) : null,
+      timestamp: sTimestamp >= 0 ? asString(row[sTimestamp]) : null,
+      distinct_id: sDistinct >= 0 ? asString(row[sDistinct]) : null,
+    };
+  });
 
   return {
     events,
-    eventCount: events.length,
-    ...eventSummary,
+    eventCount,
+    pageviewCount,
+    conversionEventCount,
+    eventNameCounts,
     _meta: {
       fetchedAt: new Date().toISOString(),
       source: "live",
-      pageCount,
-      truncated: Boolean(nextUrl),
+      queryMode: "hogql",
+      sampleSize: events.length,
+      totalEvents: eventCount,
+      // Aggregate counts are complete for the window; only the raw-event sample
+      // is intentionally bounded, so the payload is not considered truncated.
+      truncated: false,
     },
   };
 }

--- a/src/lib/analytics/refresh-runner.ts
+++ b/src/lib/analytics/refresh-runner.ts
@@ -69,6 +69,9 @@ function timeoutMsForRefreshJob(providerKey: string): number {
   // page sizes to fit the complexity cap, so it serially pages issues +
   // per-project issues and overran 10s ("Timed out after 10000ms").
   if (providerKey === "stripe" || providerKey === "linear") return 25_000;
+  // PostHog runs two HogQL queries against a high-volume events table, and
+  // "product" recomputes the full Imladris metric set; both can overrun 10s.
+  if (providerKey === "posthog" || providerKey === "product") return 25_000;
   return 10_000;
 }
 


### PR DESCRIPTION
## Why
PostHog product analytics were **never landing in the dashboards**. Investigation found two stacked bugs:

1. **Credential gate** — the refresh job runs only if `posthogApiKey && posthogProjectId`. Prod had the API key but was missing `POSTHOG_PROJECT_ID`, so the job was never queued (0 `posthog` snapshots ever). *Already fixed* by setting `POSTHOG_PROJECT_ID=160406` (project "Arda") in the prod Railway env.
2. **Fetcher timeout + payload bloat** — once queued, `fetchPostHogData` paginated the raw `/events` endpoint (`limit=1000`, up to 100 pages). Measured on the live project: **~1.5s and ~7.7 MB per page**, with far more than 1000 events in 7d. It blew the 10s job timeout (`Timed out after 10000ms`) and would have stored tens of MB of raw events per snapshot — the same disk-pressure shape as the earlier ENOSPC/OOM incident.

## What changed
- **`fetchPostHogData` → HogQL query API.** One `GROUP BY event` aggregation produces complete, authoritative counts (`eventCount`, `pageviewCount`, `conversionEventCount`, `eventNameCounts`), plus one bounded recent-events sample (default 500) so the Imladris materialization lineage (which keys product events by identity) keeps producing per-event records.
  - Measured: **~1.9s total, ~2.5 KB** vs. minutes and tens of MB.
  - Aggregate counts are complete for the window, so `_meta.truncated` stays `false` (won't trip `assertRefreshPayloadComplete`).
- **Refresh-job timeout** bumped to 25s for `posthog` (two HogQL round-trips) and `product` (recomputes the full Imladris metric set), matching the existing stripe/linear carve-out. Both were failing with the same 10s timeout.

## Test plan
- `analytics-fetchers-development.test.ts` rewritten for the HogQL request/response shape (aggregation + bounded sample).
- `analytics-refresh-runner-monthly-history.test.ts` PostHog mock updated to the `/query/` endpoint.
- ✅ `vitest run` (33 tests in the two files), ✅ `tsc --noEmit`, ✅ `eslint` all pass locally.

## Reviewer notes
- **Tradeoff:** `delivery_health.productEvents` (distinct posthog event records) is now bounded by the sample (≤500) instead of the full stream. Aggregate `eventCount` is exact. Previously it was effectively broken (0). Follow-up option: migrate `productEvents` to read the aggregate count directly and drop the raw sample entirely.
- **Date window** preserves the prior `after`/`before` semantics.

## Out of scope (related findings)
- **GitHub** ingestion is also dead: no connection row and no `GITHUB_TOKEN`/`GITHUB_OWNER`/`GITHUB_REPO` env vars in prod → its job is never queued. Needs a GitHub token to be configured. Together with PostHog this is why `development.delivery_health` (needs linear+github+posthog) can't compute.