### PR TITLE
Add activation journey actor drilldowns

### DIFF
--- a/src/app/(dashboard)/operating/activation-journey/page.tsx
+++ b/src/app/(dashboard)/operating/activation-journey/page.tsx
@@ -1,0 +1,32 @@
+import { redirect } from "next/navigation";
+import { ActivationJourneyDashboard } from "@/components/imladris/activation-journey-dashboard";
+import { auth } from "@/lib/auth";
+import { buildActivationJourneyDashboard } from "@/lib/imladris/activation-journey";
+import { prisma } from "@/lib/prisma";
+import { getAuthenticatedUser } from "@/lib/session-user";
+
+export const dynamic = "force-dynamic";
+
+export default async function ActivationJourneyPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ days?: string }>;
+}) {
+  const session = await auth();
+  const user = getAuthenticatedUser(session);
+  if (!user) redirect("/login");
+
+  const params = await searchParams;
+  const days = params.days ? Math.max(1, Math.min(365, Number(params.days) || 30)) : 30;
+
+  const dashboard = await buildActivationJourneyDashboard({
+    prisma,
+    context: {
+      userId: user.id,
+      organizationId: user.organizationId ?? null,
+    },
+    days,
+  });
+
+  return <ActivationJourneyDashboard initialData={dashboard} />;
+}

--- a/src/app/api/imladris/dashboards/activation-journey/route.ts
+++ b/src/app/api/imladris/dashboards/activation-journey/route.ts
@@ -1,0 +1,45 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { getImladrisApiContext } from "@/app/api/imladris/_context";
+import { buildActivationJourneyDashboard } from "@/lib/imladris/activation-journey";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const apiContext = await getImladrisApiContext();
+  if (!apiContext.ok) return apiContext.response;
+
+  const sp = request.nextUrl.searchParams;
+  const daysParam = Number(sp.get("days"));
+  const days = Number.isFinite(daysParam) && daysParam > 0 ? daysParam : undefined;
+  const all = sp.get("all") === "1" || sp.get("range") === "all";
+
+  // Custom window: ?from=YYYY-MM-DD&to=YYYY-MM-DD (to is inclusive of the whole day).
+  const fromRaw = sp.get("from");
+  const toRaw = sp.get("to");
+  const fromDate = fromRaw ? new Date(fromRaw) : null;
+  const from = fromDate && !Number.isNaN(fromDate.getTime()) ? fromDate : undefined;
+  let to: Date | undefined;
+  if (toRaw) {
+    const toDate = new Date(toRaw);
+    if (!Number.isNaN(toDate.getTime())) {
+      toDate.setUTCHours(23, 59, 59, 999);
+      to = toDate;
+    }
+  }
+
+  const dashboard = await buildActivationJourneyDashboard({
+    prisma,
+    context: apiContext.context,
+    days,
+    from,
+    to,
+    all,
+  });
+
+  return NextResponse.json({
+    product: "Imladris",
+    generatedAt: new Date().toISOString(),
+    ...dashboard,
+  });
+}

--- a/src/components/imladris/activation-journey-dashboard.module.css
+++ b/src/components/imladris/activation-journey-dashboard.module.css
@@ -1,0 +1,1588 @@
+/* ═══════════════════════════════════════════════════════════════════════
+   Activation Journey Dashboard — CSS Module
+   Three-view tabbed dashboard: Journey Flow · Diagnostics · Segments
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* ── Design tokens ─────────────────────────────────────────────────────── */
+
+.root {
+  --accent: #fc5a29;
+  --bg: #ffffff;
+  --bg-subtle: #f6f7f9;
+  --border: #e7e9ee;
+  --border-strong: #d9dce3;
+  --fg: #16181d;
+  --muted: #6b7280;
+  --muted-2: #9aa1ac;
+  --font-mono: ui-monospace, "SF Mono", "SFMono-Regular", "Cascadia Mono",
+    "Roboto Mono", Menlo, Consolas, monospace;
+  --success-bg: #dcfce7;
+  --success-text: #166534;
+  --warning-bg: #fef3c7;
+  --warning-text: #92400e;
+  --danger-bg: #fee2e2;
+  --danger-text: #991b1b;
+  --info-bg: #dbeafe;
+  --info-text: #1e40af;
+  height: 100%;
+  min-width: 0;
+  overflow: hidden;
+  background: var(--bg-subtle);
+  color: var(--fg);
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Shell: topbar ─────────────────────────────────────────────────────── */
+
+.topbar {
+  height: 52px;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+}
+
+.titleBlock {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.eyebrow {
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.titleBlock h1 {
+  margin: 1px 0 0;
+  font-size: 16px;
+  line-height: 1.15;
+  letter-spacing: 0;
+}
+
+.topbarSpacer {
+  flex: 1 1 auto;
+}
+
+/* ── Shared: segmented control ─────────────────────────────────────────── */
+
+.seg {
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  border-radius: 9px;
+}
+
+.seg button {
+  height: 28px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  padding: 0 10px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--muted);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  white-space: nowrap;
+}
+
+.seg button:hover {
+  background: #f3f4f6;
+  color: var(--fg);
+}
+
+.segActive {
+  background: #111827 !important;
+  color: #fff !important;
+}
+
+.segLight {
+  border-color: transparent;
+  background: var(--bg-subtle);
+}
+
+/* ── Shared: badge ─────────────────────────────────────────────────────── */
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border-radius: 999px;
+  padding: 3px 8px;
+  font-size: 11px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.badgeSuccess {
+  color: var(--success-text);
+  background: var(--success-bg);
+}
+
+.badgeWarning {
+  color: var(--warning-text);
+  background: var(--warning-bg);
+}
+
+.badgeDanger {
+  color: var(--danger-text);
+  background: var(--danger-bg);
+}
+
+/* ── Shared: mono ──────────────────────────────────────────────────────── */
+
+.mono {
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+}
+
+/* ── Shell: scroll + view ──────────────────────────────────────────────── */
+
+.scroll {
+  flex: 1 1 auto;
+  overflow: auto;
+}
+
+.viewPane {
+  animation: viewIn 0.18s ease-out;
+}
+
+@keyframes viewIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.canvas {
+  max-width: 1320px;
+  margin: 0 auto;
+  padding: 22px 24px 64px;
+}
+
+/* ── Shared: panel ─────────────────────────────────────────────────────── */
+
+.panel {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  overflow: hidden;
+}
+
+.panelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.panelTitle {
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
+.panelSub {
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+.panelTag {
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+  color: var(--muted-2);
+  letter-spacing: 0.04em;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Journey Flow view
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* KPI strip */
+
+.kpiGrid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.kpiCard {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.kpiLabel {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.kpiValue {
+  font-size: 26px;
+  line-height: 1;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+}
+
+.kpiAccent {
+  color: var(--accent);
+}
+
+.kpiSub {
+  color: var(--muted);
+  font-size: 11px;
+  margin-top: 2px;
+}
+
+/* Activation definition bar */
+
+.actBar {
+  margin-top: 14px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  font-size: 12px;
+  color: var(--fg);
+}
+
+.actBarLabel {
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.actSelect {
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-subtle);
+  padding: 0 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--fg);
+  cursor: pointer;
+}
+
+.actBarMeta {
+  font-size: 11px;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+/* Observation chips */
+
+.obsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.obsCard {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  padding: 12px;
+  display: grid;
+  gap: 6px;
+}
+
+.obsTitle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.obsIconInfo {
+  color: var(--info-text);
+  display: flex;
+}
+
+.obsIconWarn {
+  color: var(--warning-text);
+  display: flex;
+}
+
+.obsBadge {
+  margin-left: auto;
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 999px;
+}
+
+.obsBadgeInfo {
+  color: var(--info-text);
+  background: var(--info-bg);
+}
+
+.obsBadgeWarn {
+  color: var(--warning-text);
+  background: var(--warning-bg);
+}
+
+.obsDetail {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+/* Sankey panel */
+
+.sankeyPanel {
+  margin-top: 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  overflow: hidden;
+}
+
+.sankeyHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.sankeyTitle {
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.sankeySub {
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+.sankeyControls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sourceToggleOn,
+.sourceToggleOff {
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0 10px;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.sourceToggleOn {
+  background: #111827;
+  color: #fff;
+  border-color: #111827;
+}
+
+.sourceToggleOff {
+  background: var(--bg);
+  color: var(--muted);
+}
+
+.sourceToggleOff:hover {
+  background: #f3f4f6;
+  color: var(--fg);
+}
+
+.sankeyBody {
+  position: relative;
+  padding: 8px 14px 14px;
+  min-height: 120px;
+}
+
+.tracePill {
+  position: absolute;
+  top: 10px;
+  right: 14px;
+  z-index: 2;
+  height: 26px;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  background: var(--bg);
+  padding: 0 10px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--fg);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.traceX {
+  font-size: 14px;
+  color: var(--muted);
+  line-height: 1;
+}
+
+.sankeyLegend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.legendItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.legendSwatch {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+}
+
+/* Sankey tooltip */
+
+.sankeyTip {
+  position: absolute;
+  z-index: 10;
+  pointer-events: none;
+  padding: 8px 10px;
+  background: #111827;
+  color: #fff;
+  border-radius: 8px;
+  font-size: 11px;
+  min-width: 110px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+.tipTitle {
+  font-weight: 800;
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+
+.tipRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 1px 0;
+  color: #cbd5e1;
+}
+
+.tipVal {
+  font-weight: 700;
+  color: #fff;
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+}
+
+/* Flow bottom — sequential funnel + friction (2-column) */
+
+.flowBottom {
+  margin-top: 14px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(300px, 0.85fr);
+  gap: 12px;
+}
+
+/* Sequential funnel */
+
+.funnelBody {
+  padding: 12px 14px;
+  display: grid;
+  gap: 12px;
+}
+
+.funnelRowTop {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.funnelLabel {
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.funnelCount {
+  font-size: 12px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+}
+
+.funnelPct {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.funnelBarRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 3px;
+}
+
+.funnelTrack {
+  flex: 1;
+  position: relative;
+  height: 10px;
+  border-radius: 999px;
+  background: #f3f4f6;
+  overflow: hidden;
+}
+
+.funnelGhost {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 3px,
+    rgba(0, 0, 0, 0.05) 3px,
+    rgba(0, 0, 0, 0.05) 6px
+  );
+  border-radius: inherit;
+}
+
+.funnelFill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  border-radius: inherit;
+  transition: width 0.2s ease;
+}
+
+.funnelNote {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--muted);
+  white-space: nowrap;
+  min-width: 60px;
+  text-align: right;
+}
+
+/* Friction by stage */
+
+.frictionBody {
+  padding: 10px 14px;
+  display: grid;
+  gap: 6px;
+}
+
+.frictionRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 6px;
+}
+
+.frictionLabel {
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.frictionTags {
+  display: flex;
+  gap: 5px;
+}
+
+.frictionTagRage {
+  font-size: 10px;
+  font-weight: 800;
+  color: var(--danger-text);
+  background: var(--danger-bg);
+  border-radius: 999px;
+  padding: 2px 7px;
+  white-space: nowrap;
+}
+
+.frictionTagDead {
+  font-size: 10px;
+  font-weight: 800;
+  color: var(--warning-text);
+  background: var(--warning-bg);
+  border-radius: 999px;
+  padding: 2px 7px;
+  white-space: nowrap;
+}
+
+.frictionTagOff {
+  font-size: 10px;
+  font-weight: 800;
+  color: var(--muted-2);
+  background: #f3f4f6;
+  border-radius: 999px;
+  padding: 2px 7px;
+  white-space: nowrap;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Diagnostics view
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* Health strip */
+
+.healthGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.healthCard {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.healthLabel {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.healthValue {
+  font-size: 22px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+}
+
+.healthSub {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+/* Diagnostic panel */
+
+.diagPanel {
+  margin-top: 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  overflow: hidden;
+}
+
+.diagHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.diagControls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Diagnostic rows (funnel mode) */
+
+.diagRows {
+  padding: 8px 0;
+}
+
+.diagRow {
+  border-bottom: 1px solid var(--border);
+}
+
+.diagRow:last-child {
+  border-bottom: 0;
+}
+
+.diagRowHead {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1.3fr) minmax(120px, 1fr) 60px 54px minmax(80px, auto) 20px;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.diagRowHead:hover {
+  background: var(--bg-subtle);
+}
+
+.diagIndex {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  background: #111827;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+}
+
+.diagInfo {
+  min-width: 0;
+}
+
+.diagLabel {
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.diagEv {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--muted);
+  margin-top: 1px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Diagnostic bar */
+
+.diagBar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.diagBarTrack {
+  flex: 1;
+  height: 8px;
+  border-radius: 999px;
+  background: #f3f4f6;
+  overflow: hidden;
+}
+
+.diagBarFill {
+  height: 100%;
+  border-radius: inherit;
+  transition: width 0.2s ease;
+}
+
+.diagActors {
+  font-size: 11px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+  min-width: 28px;
+  text-align: right;
+}
+
+.diagConv {
+  font-size: 12px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+  text-align: right;
+}
+
+.diagT2c {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.diagFriction {
+  display: flex;
+  gap: 4px;
+  justify-content: flex-end;
+}
+
+.diagChevron {
+  font-size: 10px;
+  color: var(--muted-2);
+  transition: transform 0.15s;
+  text-align: center;
+}
+
+/* Diagnostic sub-stages */
+
+.diagSubs {
+  padding: 6px 14px 14px 62px;
+  display: grid;
+  gap: 4px;
+}
+
+.diagSubRow {
+  display: grid;
+  grid-template-columns: 12px minmax(0, 1.4fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.diagSubDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+}
+
+.diagSubLabel {
+  font-weight: 700;
+}
+
+.diagSubKind {
+  text-transform: uppercase;
+  font-size: 10px;
+  font-weight: 800;
+  color: var(--info-text);
+  background: var(--info-bg);
+  border-radius: 999px;
+  padding: 2px 7px;
+  white-space: nowrap;
+}
+
+.diagSubMetric {
+  justify-self: end;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+/* Diag bottom — taxonomy + where it leaks */
+
+.diagBottom {
+  margin-top: 14px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(280px, 0.85fr);
+  gap: 12px;
+}
+
+/* Event taxonomy table */
+
+.taxScroll {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 440px;
+}
+
+.table th,
+.table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.table th {
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0;
+  font-weight: 800;
+  background: #fafafa;
+}
+
+.table tr:last-child td {
+  border-bottom: 0;
+}
+
+.eventName {
+  font-family: var(--font-mono);
+  font-weight: 800;
+  color: #111827;
+  font-size: 11.5px;
+}
+
+.taxMapMs {
+  font-size: 10px;
+  font-weight: 800;
+  color: var(--success-text);
+  background: var(--success-bg);
+  border-radius: 999px;
+  padding: 2px 7px;
+  white-space: nowrap;
+  text-transform: capitalize;
+}
+
+.taxMapSub {
+  font-size: 10px;
+  font-weight: 800;
+  color: var(--info-text);
+  background: var(--info-bg);
+  border-radius: 999px;
+  padding: 2px 7px;
+  white-space: nowrap;
+  text-transform: capitalize;
+}
+
+.taxMapNone {
+  font-size: 10px;
+  font-weight: 800;
+  color: var(--muted-2);
+  background: #f3f4f6;
+  border-radius: 999px;
+  padding: 2px 7px;
+  white-space: nowrap;
+}
+
+/* Where it leaks */
+
+.leakBody {
+  padding: 12px 14px;
+  display: grid;
+  gap: 12px;
+}
+
+.leakRow {
+  display: grid;
+  gap: 4px;
+}
+
+.leakTop {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.leakLabel {
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.leakLost {
+  font-size: 13px;
+  font-weight: 800;
+  color: var(--danger-text);
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+}
+
+.leakBar {
+  height: 6px;
+  border-radius: 999px;
+  background: #f3f4f6;
+  overflow: hidden;
+}
+
+.leakFill {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--danger-text);
+  opacity: 0.6;
+  transition: width 0.2s ease;
+}
+
+.leakPct {
+  font-size: 11px;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Segments view
+   ═══════════════════════════════════════════════════════════════════════ */
+
+.segLayout {
+  max-width: 1320px;
+  margin: 0 auto;
+  padding: 22px 24px 64px;
+  display: grid;
+  grid-template-columns: 200px minmax(0, 1fr);
+  gap: 16px;
+}
+
+/* Filter rail (sidebar) */
+
+.filterRail {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding-top: 4px;
+}
+
+.filterLabel {
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+
+.filterButtons {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.filterBtn,
+.filterBtnActive {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 7px 10px;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  background: var(--bg);
+  color: var(--muted);
+}
+
+.filterBtn:hover {
+  background: var(--bg-subtle);
+  color: var(--fg);
+}
+
+.filterBtnActive {
+  background: #111827;
+  color: #fff;
+  border-color: #111827;
+}
+
+.filterSelect {
+  width: 100%;
+  height: 32px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  padding: 0 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--fg);
+  cursor: pointer;
+}
+
+.filterHelp {
+  font-size: 11px;
+  color: var(--muted-2);
+  line-height: 1.45;
+}
+
+/* Segment main */
+
+.segMain {
+  display: grid;
+  gap: 14px;
+}
+
+/* Segment comparison table */
+
+.segTableWrap {
+  padding: 0;
+}
+
+.segTableHead {
+  display: grid;
+  grid-template-columns: minmax(100px, 1.2fr) minmax(80px, 1fr) minmax(100px, 1.1fr) 54px 54px;
+  gap: 8px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+  background: #fafafa;
+}
+
+.segTableRow {
+  display: grid;
+  grid-template-columns: minmax(100px, 1.2fr) minmax(80px, 1fr) minmax(100px, 1.1fr) 54px 54px;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  align-items: center;
+}
+
+.segTableRow:last-child {
+  border-bottom: 0;
+}
+
+.segName {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.segDot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  flex: 0 0 auto;
+}
+
+.segNameText {
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.segActors {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.segActorBar {
+  flex: 1;
+  height: 6px;
+  background: #f3f4f6;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.segActorFill {
+  height: 100%;
+  background: var(--fg);
+  opacity: 0.25;
+  border-radius: inherit;
+}
+
+.segMiniFunnel {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 28px;
+}
+
+.segMiniBar {
+  width: 10px;
+  border-radius: 2px 2px 0 0;
+  min-height: 2px;
+}
+
+.segRate {
+  font-size: 12px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+  text-align: right;
+}
+
+.segMedian {
+  font-size: 11px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+  text-align: right;
+}
+
+/* Segment bottom */
+
+.segBottom {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 12px;
+}
+
+/* Time to convert */
+
+.t2cBody {
+  padding: 12px 14px;
+  display: grid;
+  gap: 12px;
+}
+
+.t2cRow {
+  display: grid;
+  gap: 4px;
+}
+
+.t2cTop {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.t2cLabel {
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.t2cVal {
+  font-size: 12px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+}
+
+.t2cBar {
+  height: 5px;
+  border-radius: 999px;
+  background: #f3f4f6;
+  overflow: hidden;
+}
+
+.t2cFill {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent);
+  opacity: 0.55;
+  transition: width 0.2s ease;
+}
+
+/* Actor journey cards */
+
+.actorList {
+  padding: 10px 14px;
+  display: grid;
+  gap: 6px;
+  max-height: 480px;
+  overflow-y: auto;
+}
+
+.actorCard {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  cursor: pointer;
+  transition: border-color 0.1s, background 0.1s;
+}
+
+.actorCard:hover {
+  border-color: var(--border-strong);
+}
+
+.actorTop {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 12px;
+}
+
+.actorId {
+  font-family: var(--font-mono);
+  font-weight: 800;
+  font-size: 11px;
+  color: var(--fg);
+}
+
+.actorSource {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.actorSrcDot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+}
+
+.actorFurthest {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.actorChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  margin-top: 6px;
+}
+
+.actorChip {
+  font-size: 10px;
+  font-weight: 800;
+  color: #fff;
+  border-radius: 4px;
+  padding: 2px 6px;
+  white-space: nowrap;
+}
+
+.actorActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 7px;
+}
+
+.actorAction {
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--bg);
+  color: var(--fg);
+  text-decoration: none;
+  font-size: 10px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.actorAction:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Responsive
+   ═══════════════════════════════════════════════════════════════════════ */
+
+@media (max-width: 1180px) {
+  .kpiGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .healthGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .flowBottom,
+  .diagBottom {
+    grid-template-columns: 1fr;
+  }
+
+  .segBottom {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .topbar {
+    height: auto;
+    align-items: flex-start;
+    padding: 12px 16px;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .titleBlock h1 {
+    font-size: 14px;
+  }
+
+  .topbarSpacer {
+    display: none;
+  }
+
+  .seg button {
+    padding: 0 7px;
+    font-size: 11px;
+  }
+
+  .canvas {
+    padding: 16px 12px 42px;
+  }
+
+  .kpiGrid,
+  .healthGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .kpiValue {
+    font-size: 20px;
+  }
+
+  .healthValue {
+    font-size: 18px;
+  }
+
+  .actBar {
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 8px 10px;
+  }
+
+  .obsGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .sankeyBody {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 8px 0 14px;
+  }
+
+  .sankeyHeader {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .segLayout {
+    grid-template-columns: 1fr;
+    padding: 16px 12px 42px;
+  }
+
+  .filterRail {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .filterButtons {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .filterBtn,
+  .filterBtnActive {
+    width: auto;
+  }
+
+  .diagRowHead {
+    grid-template-columns: 30px minmax(0, 1fr) auto;
+    gap: 6px;
+    padding: 10px 10px;
+    font-size: 11px;
+  }
+
+  .diagSubs {
+    padding: 6px 10px 14px 44px;
+  }
+
+  .diagSubRow {
+    grid-template-columns: 10px minmax(0, 1fr) auto;
+    gap: 6px;
+    font-size: 11px;
+  }
+
+  .diagSubKind {
+    display: none;
+  }
+
+  .diagBottom {
+    grid-template-columns: 1fr;
+  }
+
+  .segTableHead,
+  .segTableRow {
+    grid-template-columns: minmax(80px, 1fr) 54px 54px;
+  }
+
+  .segActors,
+  .segMiniFunnel {
+    display: none;
+  }
+
+  .segBottom {
+    grid-template-columns: 1fr;
+  }
+
+  .actorList {
+    max-height: none;
+  }
+
+  .badge {
+    font-size: 10px;
+    padding: 2px 6px;
+  }
+}
+
+@media (max-width: 480px) {
+  .topbar {
+    padding: 10px 12px;
+  }
+
+  .kpiGrid,
+  .healthGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .kpiCard,
+  .healthCard {
+    padding: 10px;
+  }
+
+  .kpiValue {
+    font-size: 22px;
+  }
+
+  .canvas {
+    padding: 12px 10px 42px;
+  }
+
+  .segLayout {
+    padding: 12px 10px 42px;
+  }
+
+  .diagRowHead {
+    grid-template-columns: 26px minmax(0, 1fr);
+  }
+
+  .diagBar,
+  .diagConv,
+  .diagT2c,
+  .diagFriction {
+    display: none;
+  }
+
+  .diagSubs {
+    padding-left: 36px;
+  }
+}

--- a/src/components/imladris/activation-journey-dashboard.tsx
+++ b/src/components/imladris/activation-journey-dashboard.tsx
@@ -1,0 +1,411 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
+import { Database } from "lucide-react";
+import type {
+  ActivationJourneyDashboardPayload,
+  ActivationJourneyMilestoneKey,
+} from "@/lib/imladris/activation-journey";
+import { readSessionCache, writeSessionCache } from "@/lib/client/session-cache";
+import { JourneyFlowView } from "./journey-flow-view";
+import { DiagnosticsView } from "./diagnostics-view";
+import { SegmentsView } from "./segments-view";
+import styles from "./activation-journey-dashboard.module.css";
+
+// ── Constants ───────────────────────────────────────────────────────────
+
+const MILESTONE_OPTIONS: Array<{ value: ActivationJourneyMilestoneKey; label: string }> = [
+  { value: "site_visited", label: "Site visited" },
+  { value: "kanban_submitted", label: "Free kanban submitted" },
+  { value: "cta_clicked", label: "CTA clicked" },
+  { value: "demo", label: "Demo booked" },
+  { value: "trial", label: "Trial started" },
+  { value: "paid", label: "Became paid" },
+  { value: "signup", label: "Signed up" },
+  { value: "tour_started", label: "Tour started" },
+  { value: "video_completed", label: "Video completed" },
+  { value: "item_created", label: "Item created" },
+  { value: "card_printed", label: "Card printed" },
+  { value: "queue_added", label: "Added to order queue" },
+  { value: "order_placed", label: "Order placed" },
+  { value: "activation_completed", label: "Activation completed" },
+];
+
+const DATE_RANGES = ["7d", "30d", "90d", "365d", "All"] as const;
+type DateRange = (typeof DATE_RANGES)[number];
+
+const VIEW_TABS = [
+  { id: "flow" as const, label: "Journey flow" },
+  { id: "funnel" as const, label: "Diagnostics" },
+  { id: "explorer" as const, label: "Segments" },
+];
+
+// ── State ───────────────────────────────────────────────────────────────
+
+type View = "flow" | "funnel" | "explorer";
+type Segmentation = "flow" | "cohort" | "source" | "furthest";
+type TaxFilter = "all" | "mapped" | "unmapped";
+type SegDimension = "source" | "cohort";
+type DiagSubView = "funnel" | "flow";
+
+interface ActivationJourneyState {
+  view: View;
+  range: DateRange;
+  customFrom: string;
+  customTo: string;
+  customActive: boolean;
+  actKey: ActivationJourneyMilestoneKey;
+  seg: Segmentation;
+  showSource: boolean;
+  focusA: string | null;
+  focusB: string | null;
+  expanded: string | null;
+  taxFilter: TaxFilter;
+  segDim: SegDimension;
+  selActor: number | null;
+  bViz: DiagSubView;
+}
+
+type Action =
+  | { type: "SET_VIEW"; view: View }
+  | { type: "SET_RANGE"; range: DateRange }
+  | { type: "SET_CUSTOM_RANGE"; from: string; to: string }
+  | { type: "SET_ACT_KEY"; actKey: ActivationJourneyMilestoneKey }
+  | { type: "SET_SEG"; seg: Segmentation }
+  | { type: "TOGGLE_SOURCE" }
+  | { type: "SET_FOCUS_A"; nodeId: string | null }
+  | { type: "SET_FOCUS_B"; nodeId: string | null }
+  | { type: "SET_EXPANDED"; key: string | null }
+  | { type: "SET_TAX_FILTER"; filter: TaxFilter }
+  | { type: "SET_SEG_DIM"; dim: SegDimension }
+  | { type: "SET_SEL_ACTOR"; index: number | null }
+  | { type: "SET_BVIZ"; mode: DiagSubView };
+
+const initialState: ActivationJourneyState = {
+  view: "flow",
+  range: "30d",
+  customFrom: "",
+  customTo: "",
+  customActive: false,
+  actKey: "order_placed",
+  seg: "flow",
+  showSource: true,
+  focusA: null,
+  focusB: null,
+  expanded: null,
+  taxFilter: "all",
+  segDim: "source",
+  selActor: null,
+  bViz: "funnel",
+};
+
+function reducer(state: ActivationJourneyState, action: Action): ActivationJourneyState {
+  switch (action.type) {
+    case "SET_VIEW":
+      return { ...state, view: action.view };
+    case "SET_RANGE":
+      return { ...state, range: action.range, customActive: false };
+    case "SET_CUSTOM_RANGE":
+      return { ...state, customFrom: action.from, customTo: action.to, customActive: true };
+    case "SET_ACT_KEY":
+      return { ...state, actKey: action.actKey };
+    case "SET_SEG":
+      return { ...state, seg: action.seg, focusA: null };
+    case "TOGGLE_SOURCE":
+      return { ...state, showSource: !state.showSource, focusA: null };
+    case "SET_FOCUS_A":
+      return { ...state, focusA: action.nodeId };
+    case "SET_FOCUS_B":
+      return { ...state, focusB: action.nodeId };
+    case "SET_EXPANDED":
+      return { ...state, expanded: state.expanded === action.key ? null : action.key };
+    case "SET_TAX_FILTER":
+      return { ...state, taxFilter: action.filter };
+    case "SET_SEG_DIM":
+      return { ...state, segDim: action.dim };
+    case "SET_SEL_ACTOR":
+      return { ...state, selActor: state.selActor === action.index ? null : action.index };
+    case "SET_BVIZ":
+      return { ...state, bViz: action.mode };
+    default:
+      return state;
+  }
+}
+
+// ── Formatting helpers ──────────────────────────────────────────────────
+
+export function formatNumber(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+export function formatCompact(n: number): string {
+  const rounded = Math.round(n);
+  if (rounded >= 1000) {
+    const k = rounded / 1000;
+    return (k >= 100 ? Math.round(k) : Math.round(k * 10) / 10) + "k";
+  }
+  return "" + rounded;
+}
+
+export function formatPercent(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "n/a";
+  return `${value.toFixed(value % 1 === 0 ? 0 : 1)}%`;
+}
+
+export function formatRate(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "n/a";
+  const pct = value * 100;
+  return `${pct.toFixed(pct > 0 && pct < 10 ? 1 : 0)}%`;
+}
+
+export function formatHours(value: number | null): string {
+  if (value === null) return "n/a";
+  if (value < 1) return `${Math.round(value * 60)}m`;
+  if (value < 48) return `${value % 1 === 0 ? value : value.toFixed(1)}h`;
+  return `${(value / 24).toFixed(1)}d`;
+}
+
+export function formatDateTime(value: string | null): string {
+  if (!value) return "No events";
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+// ── Cache key ───────────────────────────────────────────────────────────
+
+type Selection = { range: DateRange; customActive: boolean; customFrom: string; customTo: string };
+
+function selectionKey(s: Selection): string {
+  return s.customActive ? `custom:${s.customFrom}:${s.customTo}` : s.range;
+}
+
+function cacheKey(key: string): string {
+  return `imladris:aj:${key}`;
+}
+
+const PRESET_DAYS: Record<string, number> = { "7d": 7, "30d": 30, "90d": 90, "365d": 365 };
+
+function selectionUrl(s: Selection): string {
+  const base = "/api/imladris/dashboards/activation-journey";
+  if (s.customActive && s.customFrom && s.customTo) {
+    return `${base}?from=${s.customFrom}&to=${s.customTo}`;
+  }
+  if (s.range === "All") return `${base}?all=1`;
+  const d = PRESET_DAYS[s.range];
+  return d ? `${base}?days=${d}` : base;
+}
+
+function daysToRange(days: number): DateRange {
+  if (days <= 7) return "7d";
+  if (days <= 30) return "30d";
+  if (days <= 90) return "90d";
+  if (days <= 365) return "365d";
+  return "All";
+}
+
+// ── Main component ──────────────────────────────────────────────────────
+
+interface ActivationJourneyDashboardProps {
+  initialData: ActivationJourneyDashboardPayload;
+}
+
+export function ActivationJourneyDashboard({ initialData }: ActivationJourneyDashboardProps) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const [data, setData] = useReducer(
+    (_prev: ActivationJourneyDashboardPayload, next: ActivationJourneyDashboardPayload) => next,
+    initialData,
+  );
+  const fetchingRef = useRef(false);
+  const lastKeyRef = useRef<string>(daysToRange(initialData.window.days));
+  const [draftFrom, setDraftFrom] = useState("");
+  const [draftTo, setDraftTo] = useState("");
+
+  // Fetch data when the selected window (preset / All / custom) changes
+  const fetchData = useCallback(async (sel: Selection) => {
+    if (fetchingRef.current) return;
+    const key = selectionKey(sel);
+
+    // Check session cache first
+    const cached = readSessionCache<ActivationJourneyDashboardPayload>(cacheKey(key));
+    if (cached) {
+      setData(cached);
+      return;
+    }
+
+    fetchingRef.current = true;
+    try {
+      const res = await fetch(selectionUrl(sel));
+      if (!res.ok) return;
+      const json = await res.json();
+      writeSessionCache(cacheKey(key), json);
+      setData(json);
+    } finally {
+      fetchingRef.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    const sel: Selection = {
+      range: state.range,
+      customActive: state.customActive,
+      customFrom: state.customFrom,
+      customTo: state.customTo,
+    };
+    const key = selectionKey(sel);
+    if (key !== lastKeyRef.current) {
+      lastKeyRef.current = key;
+      fetchData(sel);
+    }
+  }, [state.range, state.customActive, state.customFrom, state.customTo, fetchData]);
+
+  // Cache the initial data under its initial range key
+  useEffect(() => {
+    writeSessionCache(cacheKey(daysToRange(initialData.window.days)), initialData);
+  }, [initialData]);
+
+  const sourceStatusClass =
+    data.source.status === "ready"
+      ? styles.badgeSuccess
+      : data.source.status === "partial"
+        ? styles.badgeWarning
+        : styles.badgeDanger;
+
+  const activationLabel = useMemo(
+    () => MILESTONE_OPTIONS.find((o) => o.value === state.actKey)?.label ?? "Order placed",
+    [state.actKey],
+  );
+
+  return (
+    <div className={styles.root}>
+      {/* ── Topbar ── */}
+      <header className={styles.topbar}>
+        <div className={styles.titleBlock}>
+          <span className={styles.eyebrow}>Imladris · Product analytics</span>
+          <h1>Activation Journey</h1>
+        </div>
+        <div className={styles.topbarSpacer} />
+
+        {/* View toggle */}
+        <div className={styles.seg}>
+          {VIEW_TABS.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              className={state.view === tab.id ? styles.segActive : undefined}
+              onClick={() => dispatch({ type: "SET_VIEW", view: tab.id })}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Date range presets */}
+        <div className={`${styles.seg} ${styles.segLight}`}>
+          {DATE_RANGES.map((r) => (
+            <button
+              key={r}
+              type="button"
+              className={!state.customActive && state.range === r ? styles.segActive : undefined}
+              onClick={() => dispatch({ type: "SET_RANGE", range: r })}
+            >
+              {r}
+            </button>
+          ))}
+        </div>
+
+        {/* Custom date range — back to whenever data starts */}
+        <div className={`${styles.seg} ${styles.segLight}`} style={{ gap: 4, alignItems: "center" }}>
+          <input
+            type="date"
+            aria-label="From date"
+            value={draftFrom}
+            max={draftTo || undefined}
+            onChange={(e) => setDraftFrom(e.target.value)}
+            style={{ fontSize: 12, padding: "2px 4px", border: "none", background: "transparent", color: "inherit" }}
+          />
+          <span style={{ color: "#9ca3af", fontSize: 12 }}>→</span>
+          <input
+            type="date"
+            aria-label="To date"
+            value={draftTo}
+            min={draftFrom || undefined}
+            onChange={(e) => setDraftTo(e.target.value)}
+            style={{ fontSize: 12, padding: "2px 4px", border: "none", background: "transparent", color: "inherit" }}
+          />
+          <button
+            type="button"
+            className={state.customActive ? styles.segActive : undefined}
+            disabled={!draftFrom || !draftTo}
+            onClick={() => dispatch({ type: "SET_CUSTOM_RANGE", from: draftFrom, to: draftTo })}
+          >
+            Apply
+          </button>
+        </div>
+
+        {/* Source badge */}
+        <span className={`${styles.badge} ${sourceStatusClass}`}>
+          <Database size={12} />
+          PostHog {data.source.status}
+        </span>
+      </header>
+
+      {/* ── View content ── */}
+      <div className={styles.scroll}>
+        {state.view === "flow" && (
+          <div className={styles.viewPane}>
+            <JourneyFlowView
+              data={data}
+              actKey={state.actKey}
+              activationLabel={activationLabel}
+              seg={state.seg}
+              showSource={state.showSource}
+              focusNode={state.focusA}
+              onActKeyChange={(k) => dispatch({ type: "SET_ACT_KEY", actKey: k })}
+              onSegChange={(s) => dispatch({ type: "SET_SEG", seg: s })}
+              onToggleSource={() => dispatch({ type: "TOGGLE_SOURCE" })}
+              onFocusChange={(id) => dispatch({ type: "SET_FOCUS_A", nodeId: id })}
+            />
+          </div>
+        )}
+        {state.view === "funnel" && (
+          <div className={styles.viewPane}>
+            <DiagnosticsView
+              data={data}
+              actKey={state.actKey}
+              activationLabel={activationLabel}
+              expanded={state.expanded}
+              taxFilter={state.taxFilter}
+              bViz={state.bViz}
+              showSource={state.showSource}
+              seg={state.seg}
+              focusNode={state.focusB}
+              onActKeyChange={(k) => dispatch({ type: "SET_ACT_KEY", actKey: k })}
+              onExpand={(k) => dispatch({ type: "SET_EXPANDED", key: k })}
+              onTaxFilter={(f) => dispatch({ type: "SET_TAX_FILTER", filter: f })}
+              onBViz={(m) => dispatch({ type: "SET_BVIZ", mode: m })}
+              onFocusChange={(id) => dispatch({ type: "SET_FOCUS_B", nodeId: id })}
+            />
+          </div>
+        )}
+        {state.view === "explorer" && (
+          <div className={styles.viewPane}>
+            <SegmentsView
+              data={data}
+              actKey={state.actKey}
+              activationLabel={activationLabel}
+              segDim={state.segDim}
+              selActor={state.selActor}
+              onActKeyChange={(k) => dispatch({ type: "SET_ACT_KEY", actKey: k })}
+              onSegDim={(d) => dispatch({ type: "SET_SEG_DIM", dim: d })}
+              onSelActor={(i) => dispatch({ type: "SET_SEL_ACTOR", index: i })}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/imladris/diagnostics-view.tsx
+++ b/src/components/imladris/diagnostics-view.tsx
@@ -1,0 +1,448 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type {
+  ActivationJourneyDashboardPayload,
+  ActivationJourneyMilestoneKey,
+} from "@/lib/imladris/activation-journey";
+import { SankeyChart, type SankeyTooltip } from "./sankey-chart";
+import {
+  formatCompact,
+  formatHours,
+  formatNumber,
+  formatRate,
+} from "./activation-journey-dashboard";
+import styles from "./activation-journey-dashboard.module.css";
+
+// ── Constants ───────────────────────────────────────────────────────────
+
+const MILESTONE_OPTIONS: Array<{ value: ActivationJourneyMilestoneKey; label: string }> = [
+  { value: "site_visited", label: "Site visited" },
+  { value: "kanban_submitted", label: "Free kanban submitted" },
+  { value: "cta_clicked", label: "CTA clicked" },
+  { value: "demo", label: "Demo booked" },
+  { value: "trial", label: "Trial started" },
+  { value: "paid", label: "Became paid" },
+  { value: "signup", label: "Signed up" },
+  { value: "tour_started", label: "Tour started" },
+  { value: "video_completed", label: "Video completed" },
+  { value: "item_created", label: "Item created" },
+  { value: "card_printed", label: "Card printed" },
+  { value: "queue_added", label: "Added to order queue" },
+  { value: "order_placed", label: "Order placed" },
+  { value: "activation_completed", label: "Activation completed" },
+];
+
+const MILESTONE_COLORS: Record<ActivationJourneyMilestoneKey, string> = {
+  site_visited: "#3aa392",
+  kanban_submitted: "#2f8c7a",
+  cta_clicked: "#2a806e",
+  demo: "#257562",
+  trial: "#1f6a57",
+  paid: "#18a558",
+  signup: "#7d8cc0",
+  tour_started: "#9aa6b8",
+  video_completed: "#8693ac",
+  item_created: "#6f86b0",
+  card_printed: "#5f86a8",
+  queue_added: "#4f8f93",
+  order_placed: "#d98a3a",
+  activation_completed: "#FC5A29",
+};
+
+type TaxFilter = "all" | "mapped" | "unmapped";
+type DiagSubView = "funnel" | "flow";
+type Segmentation = "flow" | "cohort" | "source" | "furthest";
+
+interface DiagnosticsViewProps {
+  data: ActivationJourneyDashboardPayload;
+  actKey: ActivationJourneyMilestoneKey;
+  activationLabel: string;
+  expanded: string | null;
+  taxFilter: TaxFilter;
+  bViz: DiagSubView;
+  showSource: boolean;
+  seg: Segmentation;
+  focusNode: string | null;
+  onActKeyChange: (key: ActivationJourneyMilestoneKey) => void;
+  onExpand: (key: string | null) => void;
+  onTaxFilter: (filter: TaxFilter) => void;
+  onBViz: (mode: DiagSubView) => void;
+  onFocusChange: (nodeId: string | null) => void;
+}
+
+export function DiagnosticsView({
+  data,
+  actKey,
+  expanded,
+  taxFilter,
+  bViz,
+  showSource,
+  seg,
+  focusNode,
+  onActKeyChange,
+  onExpand,
+  onTaxFilter,
+  onBViz,
+  onFocusChange,
+}: DiagnosticsViewProps) {
+  const [tooltip, setTooltip] = useState<SankeyTooltip | null>(null);
+  const [mousePos, setMousePos] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+
+  // Health strip
+  const totalEvents = data.summary.totalEvents;
+  const unmapped = data.source.unmappedEvents;
+  const mapped = totalEvents - unmapped;
+  const liveMs = data.milestones.filter((m) => m.actors > 0).length;
+
+  // Filtered taxonomy
+  const taxRows = useMemo(() => {
+    return data.eventTaxonomy.filter((row) => {
+      const isMapped = Boolean(row.mappedMilestone) || row.mappedSubStages.length > 0;
+      if (taxFilter === "mapped") return isMapped;
+      if (taxFilter === "unmapped") return !isMapped;
+      return true;
+    });
+  }, [data.eventTaxonomy, taxFilter]);
+
+  // Drop-off ranking (where it leaks)
+  const dropRank = useMemo(() => {
+    const ms = data.milestones;
+    const lost: Array<{ from: string; to: string; lost: number; pct: number }> = [];
+    for (let i = 1; i < ms.length; i++) {
+      const diff = Math.max(0, ms[i - 1].actors - ms[i].actors);
+      lost.push({
+        from: ms[i - 1].label,
+        to: ms[i].label,
+        lost: diff,
+        pct: ms[i - 1].actors > 0 ? diff / ms[i - 1].actors : 0,
+      });
+    }
+    lost.sort((a, b) => b.lost - a.lost);
+    return lost.slice(0, 4);
+  }, [data.milestones]);
+  const maxLost = Math.max(1, ...dropRank.map((d) => d.lost));
+
+  const firstMsActors = data.milestones[0]?.actors ?? 1;
+
+  // Transition times indexed by toKey
+  const t2cByTo = useMemo(() => {
+    const map = new Map<string, number | null>();
+    for (const t of data.transitionTimes ?? []) {
+      map.set(t.to, t.medianHours);
+    }
+    return map;
+  }, [data.transitionTimes]);
+
+  return (
+    <div className={styles.canvas}>
+      {/* Health strip */}
+      <div className={styles.healthGrid}>
+        <div className={styles.healthCard}>
+          <div className={styles.healthLabel}>Mapped events</div>
+          <div className={styles.healthValue} style={{ color: "#166534" }}>{formatCompact(mapped)}</div>
+          <div className={styles.healthSub}>
+            {totalEvents > 0 ? formatRate(mapped / totalEvents) : "n/a"} of volume
+          </div>
+        </div>
+        <div className={styles.healthCard}>
+          <div className={styles.healthLabel}>Unmapped events</div>
+          <div className={styles.healthValue} style={{ color: "#DC2626" }}>{formatCompact(unmapped)}</div>
+          <div className={styles.healthSub}>no milestone or sub-stage</div>
+        </div>
+        <div className={styles.healthCard}>
+          <div className={styles.healthLabel}>Live milestones</div>
+          <div className={styles.healthValue}>{liveMs}/10</div>
+          <div className={styles.healthSub}>firing in this window</div>
+        </div>
+        <div className={styles.healthCard}>
+          <div className={styles.healthLabel}>$pageleave</div>
+          <div className={styles.healthValue} style={{ color: "#737373" }}>off</div>
+          <div className={styles.healthSub}>drop-off sub-stages empty</div>
+        </div>
+      </div>
+
+      {/* Milestone diagnostics panel */}
+      <div className={styles.diagPanel}>
+        <div className={styles.diagHeader}>
+          <div>
+            <div className={styles.panelTitle}>Milestone diagnostics</div>
+            <div className={styles.panelSub}>
+              Per-stage conversion, time-to-convert, and live friction. Click a stage for sub-stages.
+            </div>
+          </div>
+          <div className={styles.diagControls}>
+            <select
+              className={styles.actSelect}
+              value={actKey}
+              onChange={(e) => onActKeyChange(e.target.value as ActivationJourneyMilestoneKey)}
+            >
+              {MILESTONE_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+            <div className={styles.seg}>
+              {(["funnel", "flow"] as const).map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  className={bViz === m ? styles.segActive : undefined}
+                  onClick={() => onBViz(m)}
+                >
+                  {m === "funnel" ? "Funnel" : "Flow"}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {bViz === "funnel" ? (
+          <div className={styles.diagRows}>
+            {data.milestones.map((ms, i) => {
+              // Use the data layer's PER-FUNNEL conversion (null at each funnel's first
+              // milestone) so we never divide signup by paid across the funnel boundary.
+              const conv = ms.conversionFromPrevious === null ? null : ms.conversionFromPrevious / 100;
+              const isGoal = ms.key === actKey;
+              const isExpanded = expanded === ms.key;
+              const frictionData = data.friction?.find((f) => f.milestoneKey === ms.key);
+              const t2c = t2cByTo.get(ms.key);
+
+              return (
+                <div key={ms.key} className={styles.diagRow}>
+                  <div
+                    className={styles.diagRowHead}
+                    style={{ background: isGoal ? "#FEF7F5" : undefined }}
+                    onClick={() => onExpand(ms.key)}
+                  >
+                    <span className={styles.diagIndex}>{i + 1}</span>
+                    <div className={styles.diagInfo}>
+                      <div
+                        className={styles.diagLabel}
+                        style={{ color: isGoal ? "#B83B17" : undefined }}
+                      >
+                        {ms.label}
+                      </div>
+                      <div className={styles.diagEv}>{milestoneEventName(ms.key)}</div>
+                    </div>
+                    <div className={styles.diagBar}>
+                      <div className={styles.diagBarTrack}>
+                        <div
+                          className={styles.diagBarFill}
+                          style={{
+                            width: `${Math.max(1, (ms.actors / Math.max(1, firstMsActors)) * 100)}%`,
+                            background: MILESTONE_COLORS[ms.key],
+                          }}
+                        />
+                      </div>
+                      <span className={styles.diagActors}>{formatCompact(ms.actors)}</span>
+                    </div>
+                    <span
+                      className={styles.diagConv}
+                      style={{
+                        color:
+                          conv !== null && conv < 0.5
+                            ? "#DC2626"
+                            : conv === null
+                              ? "#737373"
+                              : "#166534",
+                      }}
+                    >
+                      {conv === null ? "entry" : formatRate(conv)}
+                    </span>
+                    <span className={styles.diagT2c}>{t2c !== undefined ? formatHours(t2c) : "—"}</span>
+                    <div className={styles.diagFriction}>
+                      {frictionData && frictionData.rageClicks > 0 && (
+                        <span className={styles.frictionTagRage}>{frictionData.rageClicks} rage</span>
+                      )}
+                      {frictionData && frictionData.deadClicks > 0 && (
+                        <span className={styles.frictionTagDead}>{frictionData.deadClicks} dead</span>
+                      )}
+                    </div>
+                    <span
+                      className={styles.diagChevron}
+                      style={{ transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)" }}
+                    >
+                      &#9662;
+                    </span>
+                  </div>
+                  {isExpanded && ms.subStages.length > 0 && (
+                    <div className={styles.diagSubs}>
+                      {ms.subStages.map((sub) => (
+                        <div key={sub.key} className={styles.diagSubRow}>
+                          <span
+                            className={styles.diagSubDot}
+                            style={{ background: sub.eventCount > 0 ? "#16a34a" : "#cbd1da" }}
+                          />
+                          <span
+                            className={styles.diagSubLabel}
+                            style={{ color: sub.eventCount === 0 ? "#737373" : undefined }}
+                          >
+                            {sub.label}
+                          </span>
+                          <span className={styles.diagSubKind}>{sub.kind.replace("_", " ")}</span>
+                          <span className={styles.diagSubMetric}>
+                            {sub.eventCount > 0
+                              ? `${formatCompact(sub.eventCount)} ev · ${formatCompact(sub.actors)} actors`
+                              : "no events yet"}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          /* Flow mode — reuses the Sankey chart */
+          <div
+            className={styles.sankeyBody}
+            onMouseMove={(e) => {
+              const rect = e.currentTarget.getBoundingClientRect();
+              setMousePos({ x: e.clientX - rect.left, y: e.clientY - rect.top });
+            }}
+            onMouseLeave={() => setTooltip(null)}
+          >
+            {data.actorJourneys && (
+              <SankeyChart
+                actorJourneys={data.actorJourneys}
+                showSource={showSource}
+                segmentation={seg}
+                focusNode={focusNode}
+                onFocusChange={onFocusChange}
+                onTooltip={setTooltip}
+              />
+            )}
+            {tooltip && (
+              <div
+                className={styles.sankeyTip}
+                style={{ left: mousePos.x + 14, top: mousePos.y + 14 }}
+              >
+                <div className={styles.tipTitle}>{tooltip.title}</div>
+                {tooltip.rows.map((r) => (
+                  <div key={r.label} className={styles.tipRow}>
+                    <span>{r.label}</span>
+                    <span className={styles.tipVal}>{r.value}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Event taxonomy + Where it leaks */}
+      <div className={styles.diagBottom}>
+        {/* Event taxonomy table */}
+        <div className={styles.panel}>
+          <div className={styles.panelHeader}>
+            <div className={styles.panelTitle}>Event taxonomy</div>
+            <div className={styles.seg}>
+              {(["all", "mapped", "unmapped"] as const).map((f) => (
+                <button
+                  key={f}
+                  type="button"
+                  className={taxFilter === f ? styles.segActive : undefined}
+                  onClick={() => onTaxFilter(f)}
+                >
+                  {f.charAt(0).toUpperCase() + f.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className={styles.taxScroll}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th>Event</th>
+                  <th>Mapping</th>
+                  <th style={{ textAlign: "right" }}>Events</th>
+                  <th style={{ textAlign: "right" }}>Actors</th>
+                </tr>
+              </thead>
+              <tbody>
+                {taxRows.map((row) => {
+                  const isMilestone = Boolean(row.mappedMilestone);
+                  const isSub = row.mappedSubStages.length > 0;
+                  let mapLabel: string;
+                  let mapClass: string;
+                  if (isMilestone) {
+                    mapLabel = row.mappedMilestone!.replace(/_/g, " ");
+                    mapClass = styles.taxMapMs;
+                  } else if (isSub) {
+                    mapLabel = row.mappedSubStages[0].replace(/_/g, " ");
+                    mapClass = styles.taxMapSub;
+                  } else {
+                    mapLabel = "Unmapped";
+                    mapClass = styles.taxMapNone;
+                  }
+                  return (
+                    <tr key={row.event}>
+                      <td className={styles.eventName}>{row.event}</td>
+                      <td>
+                        <span className={mapClass}>{mapLabel}</span>
+                      </td>
+                      <td style={{ textAlign: "right" }} className={styles.mono}>
+                        {formatNumber(row.count)}
+                      </td>
+                      <td style={{ textAlign: "right", color: "#737373" }} className={styles.mono}>
+                        {formatNumber(row.actors)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Where it leaks */}
+        <div className={styles.panel}>
+          <div className={styles.panelHeader}>
+            <div className={styles.panelTitle}>Where it leaks</div>
+          </div>
+          <div className={styles.leakBody}>
+            {dropRank.map((d) => (
+              <div key={`${d.from}-${d.to}`} className={styles.leakRow}>
+                <div className={styles.leakTop}>
+                  <span className={styles.leakLabel}>{d.from} &rarr; {d.to}</span>
+                  <span className={styles.leakLost}>{formatCompact(d.lost)}</span>
+                </div>
+                <div className={styles.leakBar}>
+                  <div
+                    className={styles.leakFill}
+                    style={{ width: `${(d.lost / maxLost) * 100}%` }}
+                  />
+                </div>
+                <div className={styles.leakPct}>{formatRate(d.pct)} drop-off</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+const EVENT_NAMES: Record<ActivationJourneyMilestoneKey, string> = {
+  site_visited: "marketing_site_visited",
+  kanban_submitted: "$autocapture (submit on /create-free-kanban-cards)",
+  cta_clicked: "marketing_cta_clicked",
+  demo: "marketing_demo_requested",
+  trial: "trial_started (awaiting product-app instrumentation)",
+  paid: "subscription_paid (awaiting product-app instrumentation)",
+  signup: "user_signed_up",
+  tour_started: "onboarding_tour_started",
+  video_completed: "walkthrough_video_completed",
+  item_created: "item_created",
+  card_printed: "card_printed",
+  queue_added: "card_added_to_order_queue",
+  order_placed: "order_placed",
+  activation_completed: "cards_received",
+};
+
+function milestoneEventName(key: ActivationJourneyMilestoneKey): string {
+  return EVENT_NAMES[key] ?? key;
+}

--- a/src/components/imladris/journey-flow-view.tsx
+++ b/src/components/imladris/journey-flow-view.tsx
@@ -1,0 +1,558 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { AlertTriangle, Info } from "lucide-react";
+import type {
+  ActivationJourneyDashboardPayload,
+  ActivationJourneyMilestoneKey,
+} from "@/lib/imladris/activation-journey";
+import { SankeyChart, type SankeyTooltip } from "./sankey-chart";
+import {
+  formatCompact,
+  formatDateTime,
+  formatHours,
+  formatRate,
+} from "./activation-journey-dashboard";
+import styles from "./activation-journey-dashboard.module.css";
+
+// ── Constants ───────────────────────────────────────────────────────────
+
+const MILESTONE_OPTIONS: Array<{ value: ActivationJourneyMilestoneKey; label: string }> = [
+  { value: "site_visited", label: "Site visited" },
+  { value: "kanban_submitted", label: "Free kanban submitted" },
+  { value: "cta_clicked", label: "CTA clicked" },
+  { value: "demo", label: "Demo booked" },
+  { value: "trial", label: "Trial started" },
+  { value: "paid", label: "Became paid" },
+  { value: "signup", label: "Signed up" },
+  { value: "tour_started", label: "Tour started" },
+  { value: "video_completed", label: "Video completed" },
+  { value: "item_created", label: "Item created" },
+  { value: "card_printed", label: "Card printed" },
+  { value: "queue_added", label: "Added to order queue" },
+  { value: "order_placed", label: "Order placed" },
+  { value: "activation_completed", label: "Activation completed" },
+];
+
+const MILESTONE_COLORS: Record<ActivationJourneyMilestoneKey, string> = {
+  site_visited: "#3aa392",
+  kanban_submitted: "#2f8c7a",
+  cta_clicked: "#2a806e",
+  demo: "#257562",
+  trial: "#1f6a57",
+  paid: "#18a558",
+  signup: "#7d8cc0",
+  tour_started: "#9aa6b8",
+  video_completed: "#8693ac",
+  item_created: "#6f86b0",
+  card_printed: "#5f86a8",
+  queue_added: "#4f8f93",
+  order_placed: "#d98a3a",
+  activation_completed: "#FC5A29",
+};
+
+const SEG_OPTIONS: Array<{ id: Segmentation; label: string }> = [
+  { id: "flow", label: "Flow" },
+  { id: "cohort", label: "Cohort" },
+  { id: "source", label: "Source" },
+  { id: "furthest", label: "Furthest" },
+];
+
+type Segmentation = "flow" | "cohort" | "source" | "furthest";
+
+interface JourneyFlowViewProps {
+  data: ActivationJourneyDashboardPayload;
+  actKey: ActivationJourneyMilestoneKey;
+  activationLabel: string;
+  seg: Segmentation;
+  showSource: boolean;
+  focusNode: string | null;
+  onActKeyChange: (key: ActivationJourneyMilestoneKey) => void;
+  onSegChange: (seg: Segmentation) => void;
+  onToggleSource: () => void;
+  onFocusChange: (nodeId: string | null) => void;
+}
+
+// ── Sankey legend ───────────────────────────────────────────────────────
+
+const SOURCE_COLORS = [
+  { label: "Direct", color: "#5b6b7f" },
+  { label: "Google organic", color: "#2f8f5b" },
+  { label: "Google Ads", color: "#d08a1e" },
+  { label: "Facebook", color: "#1877F2" },
+  { label: "Instagram", color: "#E4405F" },
+  { label: "LinkedIn", color: "#2f86c9" },
+  { label: "Referral", color: "#1aa39a" },
+  { label: "Email", color: "#8a6d3b" },
+];
+
+const COHORT_COLORS = [
+  { label: "Tour completed", color: "#2f8f5b" },
+  { label: "Started, not completed", color: "#d08a1e" },
+  { label: "No tour observed", color: "#9aa1ac" },
+];
+
+function legendFor(seg: Segmentation): Array<{ label: string; color: string }> {
+  switch (seg) {
+    case "flow":
+      return [
+        { label: "Advancing", color: "#8aa0b8" },
+        { label: "Drop-off", color: "#DC2626" },
+      ];
+    case "cohort":
+      return [...COHORT_COLORS, { label: "Drop-off", color: "#DC2626" }];
+    case "source":
+      return [...SOURCE_COLORS, { label: "Drop-off", color: "#DC2626" }];
+    case "furthest":
+      return [
+        ...MILESTONE_OPTIONS.map((m) => ({ label: m.label, color: MILESTONE_COLORS[m.value] })),
+        { label: "Drop-off", color: "#DC2626" },
+      ];
+  }
+}
+
+// ── Component ───────────────────────────────────────────────────────────
+
+export function JourneyFlowView({
+  data,
+  actKey,
+  activationLabel,
+  seg,
+  showSource,
+  focusNode,
+  onActKeyChange,
+  onSegChange,
+  onToggleSource,
+  onFocusChange,
+}: JourneyFlowViewProps) {
+  const [tooltip, setTooltip] = useState<SankeyTooltip | null>(null);
+  const [mousePos, setMousePos] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+
+  // Compute KPIs based on selected activation milestone
+  const kpis = useMemo(() => {
+    const ms = data.milestones.find((m) => m.key === actKey);
+    const activated = ms?.actors ?? 0;
+    const rate = data.summary.identifiedActors > 0 ? activated / data.summary.identifiedActors : null;
+    return {
+      totalEvents: data.summary.totalEvents,
+      identifiedActors: data.summary.identifiedActors,
+      rate,
+      activated,
+      medianHours: ms?.medianHoursFromFirstEvent ?? null,
+    };
+  }, [data, actKey]);
+
+  // Sequential funnel rows — split into the two funnels. Conversion and bar scaling
+  // are computed WITHIN each funnel (the marketing→activation hop is the bridge, not
+  // a step), so each funnel reads as its own funnel starting at 100%.
+  const funnelRows = useMemo(() => {
+    if (!data.sequentialFunnel) return [];
+    const funnelByKey = new Map(data.milestones.map((m) => [m.key, m.funnel]));
+    const funnelFirsts = new Map<string, { seq: number; any: number }>();
+    for (const entry of data.sequentialFunnel) {
+      const funnel = funnelByKey.get(entry.milestoneKey) ?? "activation";
+      if (!funnelFirsts.has(funnel)) {
+        funnelFirsts.set(funnel, {
+          seq: entry.sequentialActors || 1,
+          any: entry.anyOrderActors || 1,
+        });
+      }
+    }
+    return data.sequentialFunnel.map((entry, i) => {
+      const funnel = funnelByKey.get(entry.milestoneKey) ?? "activation";
+      const prev = i === 0 ? null : data.sequentialFunnel[i - 1];
+      const prevFunnel = prev ? funnelByKey.get(prev.milestoneKey) : null;
+      const isFunnelStart = !prev || prevFunnel !== funnel;
+      const conv =
+        isFunnelStart || !prev
+          ? null
+          : prev.sequentialActors > 0
+            ? entry.sequentialActors / prev.sequentialActors
+            : 0;
+      const first = funnelFirsts.get(funnel) ?? { seq: 1, any: 1 };
+      const skip = entry.anyOrderActors - entry.sequentialActors;
+      const pctOfStart = first.seq > 0 ? entry.sequentialActors / first.seq : 0;
+      const ghostPct = first.any > 0 ? entry.anyOrderActors / first.any : 0;
+      const isGoal = entry.milestoneKey === actKey;
+      return {
+        ...entry,
+        funnel,
+        isFunnelStart,
+        conv,
+        skip,
+        pctOfStart,
+        ghostPct,
+        isGoal,
+        barColor: isGoal ? "#FC5A29" : MILESTONE_COLORS[entry.milestoneKey],
+      };
+    });
+  }, [data.sequentialFunnel, data.milestones, actKey]);
+
+  // Friction rows
+  const frictionRows = useMemo(() => {
+    if (!data.friction) return [];
+    return data.friction;
+  }, [data.friction]);
+
+  const legend = legendFor(seg);
+  const traceName = focusNode ? nodeName(focusNode) : null;
+
+  return (
+    <div className={styles.canvas}>
+      {/* KPI strip */}
+      <div className={styles.kpiGrid}>
+        <div className={styles.kpiCard}>
+          <span className={styles.kpiLabel}>PostHog events</span>
+          <span className={styles.kpiValue}>{formatCompact(kpis.totalEvents)}</span>
+          <span className={styles.kpiSub}>Last seen {formatDateTime(data.summary.lastEventAt)}</span>
+        </div>
+        <div className={styles.kpiCard}>
+          <span className={styles.kpiLabel}>Identified actors</span>
+          <span className={styles.kpiValue}>{formatCompact(kpis.identifiedActors)}</span>
+          <span className={styles.kpiSub}>
+            {formatCompact(data.source.subStageMappedEvents)} sub-stage · {formatCompact(data.source.unmappedEvents)} unmapped
+          </span>
+        </div>
+        <div className={styles.kpiCard}>
+          <span className={styles.kpiLabel}>Activation rate</span>
+          <span className={`${styles.kpiValue} ${styles.kpiAccent}`}>{formatRate(kpis.rate)}</span>
+          <span className={styles.kpiSub}>at &ldquo;{activationLabel}&rdquo;</span>
+        </div>
+        <div className={styles.kpiCard}>
+          <span className={styles.kpiLabel}>Activated actors</span>
+          <span className={styles.kpiValue}>{formatCompact(kpis.activated)}</span>
+          <span className={styles.kpiSub}>reached {activationLabel.toLowerCase()}</span>
+        </div>
+        <div className={styles.kpiCard}>
+          <span className={styles.kpiLabel}>Median time</span>
+          <span className={styles.kpiValue}>{formatHours(kpis.medianHours)}</span>
+          <span className={styles.kpiSub}>first event &rarr; {activationLabel.toLowerCase()}</span>
+        </div>
+      </div>
+
+      {/* Activation definition bar */}
+      <div className={styles.actBar}>
+        <span className={styles.actBarLabel}>Count an actor as activated when they reach</span>
+        <select
+          className={styles.actSelect}
+          value={actKey}
+          onChange={(e) => onActKeyChange(e.target.value as ActivationJourneyMilestoneKey)}
+        >
+          {MILESTONE_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
+        <div className={styles.topbarSpacer} />
+        <span className={styles.actBarMeta}>
+          Source: PostHog <span className={styles.mono}>distinct_id</span> · {data.window.days}d window
+        </span>
+      </div>
+
+      {/* Observation chips */}
+      {data.observations.length > 0 && (
+        <div className={styles.obsGrid}>
+          {data.observations.map((obs) => (
+            <div className={styles.obsCard} key={`${obs.severity}-${obs.title}`}>
+              <div className={styles.obsTitle}>
+                <span className={obs.severity === "info" ? styles.obsIconInfo : styles.obsIconWarn}>
+                  {obs.severity === "info" ? <Info size={14} /> : <AlertTriangle size={14} />}
+                </span>
+                <span>{obs.title}</span>
+                <span
+                  className={`${styles.obsBadge} ${obs.severity === "info" ? styles.obsBadgeInfo : styles.obsBadgeWarn}`}
+                >
+                  {obs.severity}
+                </span>
+              </div>
+              <p className={styles.obsDetail}>{obs.detail}</p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Sankey chart */}
+      <div className={styles.sankeyPanel}>
+        <div className={styles.sankeyHeader}>
+          <div>
+            <div className={styles.sankeyTitle}>Acquisition &rarr; activation flow</div>
+            <div className={styles.sankeySub}>
+              Bands are actors. Ribbons that leap a column skipped that milestone. Red exits are drop-off.
+            </div>
+          </div>
+          <div className={styles.sankeyControls}>
+            <button
+              type="button"
+              className={showSource ? styles.sourceToggleOn : styles.sourceToggleOff}
+              onClick={onToggleSource}
+            >
+              Acquisition source
+            </button>
+            <div className={styles.seg}>
+              {SEG_OPTIONS.map((s) => (
+                <button
+                  key={s.id}
+                  type="button"
+                  className={seg === s.id ? styles.segActive : undefined}
+                  onClick={() => onSegChange(s.id)}
+                >
+                  {s.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+        <div
+          className={styles.sankeyBody}
+          onMouseMove={(e) => {
+            const rect = e.currentTarget.getBoundingClientRect();
+            setMousePos({ x: e.clientX - rect.left, y: e.clientY - rect.top });
+          }}
+          onMouseLeave={() => setTooltip(null)}
+        >
+          {traceName && (
+            <button
+              type="button"
+              className={styles.tracePill}
+              onClick={() => onFocusChange(null)}
+            >
+              Tracing: {traceName} <span className={styles.traceX}>&times;</span>
+            </button>
+          )}
+          {data.actorJourneys && (
+            <SankeyChart
+              actorJourneys={data.actorJourneys}
+              showSource={showSource}
+              segmentation={seg}
+              focusNode={focusNode}
+              onFocusChange={onFocusChange}
+              onTooltip={setTooltip}
+            />
+          )}
+          {/* Legend */}
+          <div className={styles.sankeyLegend}>
+            {legend.map((l) => (
+              <span key={l.label} className={styles.legendItem}>
+                <span className={styles.legendSwatch} style={{ background: l.color }} />
+                {l.label}
+              </span>
+            ))}
+          </div>
+          {/* Tooltip */}
+          {tooltip && (
+            <div
+              className={styles.sankeyTip}
+              style={{ left: mousePos.x + 14, top: mousePos.y + 14 }}
+            >
+              <div className={styles.tipTitle}>{tooltip.title}</div>
+              {tooltip.rows.map((r) => (
+                <div key={r.label} className={styles.tipRow}>
+                  <span>{r.label}</span>
+                  <span className={styles.tipVal}>{r.value}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Sequential funnel + Friction (2-column grid) */}
+      <div className={styles.flowBottom}>
+        {/* Sequential funnel */}
+        <div className={styles.panel}>
+          <div className={styles.panelHeader}>
+            <div>
+              <div className={styles.panelTitle}>Sequential funnel</div>
+              <div className={styles.panelSub}>
+                Two funnels, strict order within each. Ghost bar = out-of-order reach.
+              </div>
+            </div>
+          </div>
+          <div className={styles.funnelBody}>
+            {funnelRows.map((row) => (
+              <div key={row.milestoneKey}>
+                {row.isFunnelStart && (
+                  <>
+                    {/* Non-linear bridge between the two funnels (renders above the activation funnel). */}
+                    {row.funnel === "activation" && (
+                      <div
+                        style={{
+                          margin: "10px 0",
+                          padding: "8px 10px",
+                          borderRadius: "8px",
+                          border: "1px dashed #c7cdd6",
+                          background: "#f8fafc",
+                          fontSize: "11px",
+                          color: "#475569",
+                        }}
+                      >
+                        <div style={{ fontWeight: 700, color: "#334155", marginBottom: "2px" }}>
+                          &#8618; Bridge · trial &cup; paid &rarr; signup
+                        </div>
+                        {data.bridge.commercialActors > 0 ? (
+                          <div>
+                            {formatCompact(data.bridge.signedUpActors)} of{" "}
+                            {formatCompact(data.bridge.commercialActors)} trial/paid actors signed up
+                            {data.bridge.conversionRate !== null
+                              ? ` (${data.bridge.conversionRate}%)`
+                              : ""}{" "}
+                            · {data.bridge.signupAttribution.postPaid} post-paid ·{" "}
+                            {data.bridge.signupAttribution.postTrial} post-trial ·{" "}
+                            {data.bridge.signupAttribution.direct} direct
+                          </div>
+                        ) : (
+                          <div>
+                            No trial/paid events yet — <span className={styles.mono}>trial_started</span>{" "}
+                            &amp; <span className={styles.mono}>subscription_paid</span> await product-app
+                            instrumentation. All {formatCompact(data.bridge.signupAttribution.total)}{" "}
+                            signups currently attributed as direct.
+                          </div>
+                        )}
+                      </div>
+                    )}
+                    <div
+                      style={{
+                        marginTop: row.funnel === "marketing" ? 0 : "6px",
+                        marginBottom: "6px",
+                        paddingBottom: "4px",
+                        borderBottom: "1px solid #e5e7eb",
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "baseline",
+                        fontSize: "11px",
+                        fontWeight: 700,
+                        textTransform: "uppercase",
+                        letterSpacing: "0.04em",
+                        color: "#374151",
+                      }}
+                    >
+                      <span>
+                        {row.funnel === "marketing"
+                          ? "Marketing website funnel"
+                          : "Activation funnel"}
+                      </span>
+                      <span
+                        style={{
+                          fontWeight: 500,
+                          textTransform: "none",
+                          letterSpacing: 0,
+                          color: "#9ca3af",
+                        }}
+                      >
+                        {row.funnel === "marketing"
+                          ? "www.arda.cards · ends at paid"
+                          : "live.app.arda.cards · begins at signup"}
+                      </span>
+                    </div>
+                  </>
+                )}
+                <div className={styles.funnelRowTop}>
+                  <span
+                    className={styles.funnelLabel}
+                    style={{ color: row.isGoal ? "#B83B17" : undefined }}
+                  >
+                    {row.label}
+                  </span>
+                  <span className={styles.funnelCount}>
+                    {formatCompact(row.sequentialActors)}{" "}
+                    <span className={styles.funnelPct}>· {formatRate(row.pctOfStart)}</span>
+                  </span>
+                </div>
+                <div className={styles.funnelBarRow}>
+                  <div className={styles.funnelTrack}>
+                    {/* Ghost bar (any-order reach, scaled within this funnel) */}
+                    <div
+                      className={styles.funnelGhost}
+                      style={{ width: `${Math.max(0.5, row.ghostPct * 100)}%` }}
+                    />
+                    {/* Solid bar (sequential reach, scaled within this funnel) */}
+                    <div
+                      className={styles.funnelFill}
+                      style={{
+                        width: `${Math.max(0.5, row.pctOfStart * 100)}%`,
+                        background: row.barColor,
+                      }}
+                    />
+                  </div>
+                  <span
+                    className={styles.funnelNote}
+                    style={{ color: row.conv !== null && row.conv < 0.5 ? "#DC2626" : undefined }}
+                  >
+                    {row.isFunnelStart
+                      ? `${formatCompact(row.anyOrderActors)} total`
+                      : `${formatRate(row.conv)}${row.skip > 0 ? ` · +${formatCompact(row.skip)} skip` : ""}`}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Friction by stage */}
+        <div className={styles.panel}>
+          <div className={styles.panelHeader}>
+            <div className={styles.panelTitle}>Friction by stage</div>
+            <span className={`${styles.badge} ${styles.badgeWarning}`}>live signal</span>
+          </div>
+          <div className={styles.frictionBody}>
+            {frictionRows.map((row) => (
+              <div
+                key={row.milestoneKey}
+                className={styles.frictionRow}
+                style={{ background: row.rageClicks > 30 ? "#FFFAF2" : undefined }}
+              >
+                <span className={styles.frictionLabel}>{row.label}</span>
+                <div className={styles.frictionTags}>
+                  {row.rageClicks > 0 && (
+                    <span className={styles.frictionTagRage}>{row.rageClicks} rage</span>
+                  )}
+                  {row.deadClicks > 0 && (
+                    <span className={styles.frictionTagDead}>{row.deadClicks} dead</span>
+                  )}
+                  <span className={styles.frictionTagOff}>pageleave off</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+const LONG_LABELS: Record<string, string> = {
+  site_visited: "Site visited",
+  kanban_submitted: "Free kanban submitted",
+  cta_clicked: "CTA clicked",
+  demo: "Demo booked",
+  trial: "Trial started",
+  paid: "Became paid",
+  signup: "Signed up",
+  tour_started: "Tour started",
+  video_completed: "Video completed",
+  item_created: "Item created",
+  card_printed: "Card printed",
+  queue_added: "Added to order queue",
+  order_placed: "Order placed",
+  activation_completed: "Activation completed",
+};
+
+const SOURCE_LABELS: Record<string, string> = {
+  direct: "Direct",
+  google_organic: "Google organic",
+  google_ads: "Google Ads",
+  facebook: "Facebook",
+  instagram: "Instagram",
+  linkedin: "LinkedIn",
+  referral: "Referral",
+  email: "Email",
+};
+
+function nodeName(id: string): string {
+  if (id.startsWith("src:")) return SOURCE_LABELS[id.slice(4)] ?? id;
+  if (id === "drop:no_tour") return "Never started tour";
+  if (id.startsWith("drop:")) return "Dropped after " + (LONG_LABELS[id.slice(5)] ?? id.slice(5));
+  if (id.startsWith("m:")) return LONG_LABELS[id.slice(2)] ?? id.slice(2);
+  return id;
+}

--- a/src/components/imladris/sankey-chart.tsx
+++ b/src/components/imladris/sankey-chart.tsx
@@ -1,0 +1,809 @@
+"use client";
+
+import { useMemo, useCallback } from "react";
+import type {
+  ActorJourneySummary,
+  ActivationJourneyMilestoneKey,
+  AcquisitionSourceKey,
+  ActorCohortKey,
+} from "@/lib/imladris/activation-journey";
+
+// ── Public types ────────────────────────────────────────────────────────
+
+export interface SankeyTooltip {
+  title: string;
+  rows: Array<{ label: string; value: string }>;
+}
+
+export interface SankeyChartProps {
+  actorJourneys: ActorJourneySummary[];
+  showSource: boolean;
+  segmentation: "flow" | "cohort" | "source" | "furthest";
+  focusNode: string | null;
+  onFocusChange: (nodeId: string | null) => void;
+  onTooltip: (tip: SankeyTooltip | null) => void;
+}
+
+// ── Constants ───────────────────────────────────────────────────────────
+
+const MILESTONE_ORDER: ActivationJourneyMilestoneKey[] = [
+  // Marketing website funnel (ends at paid)
+  "site_visited",
+  "kanban_submitted",
+  "cta_clicked",
+  "demo",
+  "trial",
+  "paid",
+  // Activation funnel (begins at signup)
+  "signup",
+  "tour_started",
+  "video_completed",
+  "item_created",
+  "card_printed",
+  "queue_added",
+  "order_placed",
+  "activation_completed",
+];
+
+const MILESTONE_SHORT_LABELS: Record<ActivationJourneyMilestoneKey, string> = {
+  site_visited: "Site",
+  kanban_submitted: "Kanban",
+  cta_clicked: "CTA",
+  demo: "Demo",
+  trial: "Trial",
+  paid: "Paid",
+  signup: "Signup",
+  tour_started: "Tour",
+  video_completed: "Video",
+  item_created: "Item",
+  card_printed: "Card",
+  queue_added: "Queue",
+  order_placed: "Order",
+  activation_completed: "Activated",
+};
+
+const MILESTONE_LONG_LABELS: Record<ActivationJourneyMilestoneKey, string> = {
+  site_visited: "Site visited",
+  kanban_submitted: "Free kanban submitted",
+  cta_clicked: "CTA clicked",
+  demo: "Demo booked",
+  trial: "Trial started",
+  paid: "Became paid",
+  signup: "Signed up",
+  tour_started: "Tour started",
+  video_completed: "Video completed",
+  item_created: "Item created",
+  card_printed: "Card printed",
+  queue_added: "Added to order queue",
+  order_placed: "Order placed",
+  activation_completed: "Activation completed",
+};
+
+const SOURCE_LABELS: Record<AcquisitionSourceKey, string> = {
+  direct: "Direct",
+  google_organic: "Google organic",
+  google_ads: "Google Ads",
+  facebook: "Facebook",
+  instagram: "Instagram",
+  linkedin: "LinkedIn",
+  referral: "Referral",
+  email: "Email",
+};
+
+// Derived from MILESTONE_ORDER so the columns can never drift out of sync.
+const COLUMN_HEADERS = ["Source", ...MILESTONE_ORDER.map((key) => MILESTONE_SHORT_LABELS[key])];
+
+const MILESTONE_COLORS: Record<ActivationJourneyMilestoneKey, string> = {
+  site_visited: "#3aa392",
+  kanban_submitted: "#2f8c7a",
+  cta_clicked: "#2a806e",
+  demo: "#257562",
+  trial: "#1f6a57",
+  paid: "#18a558",
+  signup: "#7d8cc0",
+  tour_started: "#9aa6b8",
+  video_completed: "#8693ac",
+  item_created: "#6f86b0",
+  card_printed: "#5f86a8",
+  queue_added: "#4f8f93",
+  order_placed: "#d98a3a",
+  activation_completed: "#FC5A29",
+};
+
+const SOURCE_COLORS: Record<AcquisitionSourceKey, string> = {
+  direct: "#5b6b7f",
+  google_organic: "#2f8f5b",
+  google_ads: "#d08a1e",
+  facebook: "#1877F2",
+  instagram: "#E4405F",
+  linkedin: "#2f86c9",
+  referral: "#1aa39a",
+  email: "#8a6d3b",
+};
+
+const COHORT_COLORS: Record<ActorCohortKey, string> = {
+  tour_completed: "#2f8f5b",
+  started_not_completed: "#d08a1e",
+  no_tour: "#9aa1ac",
+};
+
+const DROP_COLOR = "#DC2626";
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function formatCount(n: number): string {
+  if (n >= 1000) {
+    const k = n / 1000;
+    return (k >= 100 ? Math.round(k) : Math.round(k * 10) / 10) + "k";
+  }
+  return "" + n;
+}
+
+// ── Internal model ──────────────────────────────────────────────────────
+
+interface SankeyNode {
+  id: string;
+  column: number;
+  label: string;
+  longLabel: string;
+  color: string;
+  isDrop: boolean;
+  count: number;
+  // layout
+  x: number;
+  y: number;
+  height: number;
+}
+
+interface SankeyLink {
+  sourceId: string;
+  targetId: string;
+  segment: string;
+  count: number;
+  isDrop: boolean;
+  // layout
+  sy0: number;
+  sy1: number;
+  ty0: number;
+  ty1: number;
+  sx: number;
+  tx: number;
+}
+
+type Segmentation = SankeyChartProps["segmentation"];
+
+// ── Build graph ─────────────────────────────────────────────────────────
+
+function getSegmentKey(
+  segmentation: Segmentation,
+  actor: ActorJourneySummary,
+  isDrop: boolean,
+): string {
+  switch (segmentation) {
+    case "flow":
+      return isDrop ? "drop" : "adv";
+    case "cohort":
+      return "co:" + actor.cohort;
+    case "source":
+      return actor.source;
+    case "furthest":
+      return "fu:" + (actor.furthest ?? "none");
+  }
+}
+
+function segmentColor(segment: string, segmentation: Segmentation): string {
+  switch (segmentation) {
+    case "flow":
+      return segment === "drop" ? DROP_COLOR : "#8aa0b8";
+    case "cohort": {
+      const cohortKey = segment.slice(3) as ActorCohortKey;
+      return COHORT_COLORS[cohortKey] ?? "#9aa1ac";
+    }
+    case "source":
+      return SOURCE_COLORS[segment as AcquisitionSourceKey] ?? "#5b6b7f";
+    case "furthest": {
+      const furthestKey = segment.slice(3);
+      if (furthestKey === "none") return "#9aa1ac";
+      return MILESTONE_COLORS[furthestKey as ActivationJourneyMilestoneKey] ?? "#9aa6b8";
+    }
+  }
+}
+
+interface BuiltSankey {
+  nodes: SankeyNode[];
+  links: SankeyLink[];
+  viewBoxHeight: number;
+}
+
+function buildSankey(
+  actorJourneys: ActorJourneySummary[],
+  showSource: boolean,
+  segmentation: Segmentation,
+): BuiltSankey {
+  const WIDTH = 1100;
+  const viewBoxHeight = showSource ? 440 : 420;
+  const NODE_WIDTH = 10;
+  const PAD_TOP = 32;
+  const PAD_BOTTOM = 16;
+  const availableHeight = viewBoxHeight - PAD_TOP - PAD_BOTTOM;
+
+  // ── Determine columns ──────────────────────────────────────────────
+  const startCol = showSource ? 0 : 1;
+  const totalCols = COLUMN_HEADERS.length - startCol;
+  const colX = (col: number): number => {
+    const idx = col - startCol;
+    const gap = (WIDTH - 80) / (totalCols - 1);
+    return 40 + idx * gap;
+  };
+
+  // ── Count links ────────────────────────────────────────────────────
+  // linkKey: "sourceId|targetId|segment" -> count
+  const linkMap = new Map<string, { sourceId: string; targetId: string; segment: string; count: number; isDrop: boolean }>();
+  const nodeCountMap = new Map<string, number>();
+
+  function addLink(sourceId: string, targetId: string, segment: string, isDrop: boolean): void {
+    const key = `${sourceId}|${targetId}|${segment}`;
+    const existing = linkMap.get(key);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      linkMap.set(key, { sourceId, targetId, segment, count: 1, isDrop });
+    }
+    nodeCountMap.set(sourceId, (nodeCountMap.get(sourceId) ?? 0) + 1);
+    nodeCountMap.set(targetId, (nodeCountMap.get(targetId) ?? 0) + 1);
+  }
+
+  for (const actor of actorJourneys) {
+    const srcId = "src:" + actor.source;
+    const reachedMilestones = MILESTONE_ORDER.filter((m) => actor.milestones.includes(m));
+    const isDrop = (specific: boolean) => getSegmentKey(segmentation, actor, specific);
+
+    if (reachedMilestones.length === 0) {
+      // Actor didn't reach any milestone
+      if (showSource) {
+        addLink(srcId, "drop:none", isDrop(true), true);
+      }
+      continue;
+    }
+
+    // Build chain: source -> m1 -> m2 -> ... -> drop:furthest
+    const chain: string[] = [];
+    if (showSource) chain.push(srcId);
+    for (const m of reachedMilestones) {
+      chain.push("m:" + m);
+    }
+    // Add drop-off node if not fully activated
+    if (!actor.milestones.includes("activation_completed")) {
+      const furthest = reachedMilestones[reachedMilestones.length - 1];
+      chain.push("drop:" + furthest);
+    }
+
+    for (let i = 0; i < chain.length - 1; i++) {
+      const isDropLink = chain[i + 1].startsWith("drop:");
+      addLink(chain[i], chain[i + 1], getSegmentKey(segmentation, actor, isDropLink), isDropLink);
+    }
+  }
+
+  // ── Build node set ─────────────────────────────────────────────────
+  const ALL_SOURCES: AcquisitionSourceKey[] = ["direct", "google_organic", "google_ads", "facebook", "instagram", "linkedin", "referral", "email"];
+
+  // Determine which nodes actually have traffic
+  const nodesById = new Map<string, SankeyNode>();
+
+  // Source nodes (column 0)
+  if (showSource) {
+    for (const src of ALL_SOURCES) {
+      const id = "src:" + src;
+      const count = nodeCountMap.get(id) ?? 0;
+      if (count > 0) {
+        nodesById.set(id, {
+          id,
+          column: 0,
+          label: SOURCE_LABELS[src],
+          longLabel: SOURCE_LABELS[src],
+          color: SOURCE_COLORS[src],
+          isDrop: false,
+          count: count / 2, // each actor counted in both source and target, normalize
+          x: 0, y: 0, height: 0,
+        });
+      }
+    }
+  }
+
+  // Milestone nodes (columns 1-7)
+  for (let i = 0; i < MILESTONE_ORDER.length; i++) {
+    const key = MILESTONE_ORDER[i];
+    const id = "m:" + key;
+    // Count = sum of outgoing + incoming (but actually we want actor count entering)
+    // Better: count unique actors at this node
+    const count = actorJourneys.filter((a) => a.milestones.includes(key)).length;
+    if (count > 0) {
+      nodesById.set(id, {
+        id,
+        column: i + 1,
+        label: MILESTONE_SHORT_LABELS[key],
+        longLabel: MILESTONE_LONG_LABELS[key],
+        color: MILESTONE_COLORS[key],
+        isDrop: false,
+        count,
+        x: 0, y: 0, height: 0,
+      });
+    }
+  }
+
+  // Drop-off nodes
+  const dropMilestones: Array<{ dropId: string; column: number; afterKey: ActivationJourneyMilestoneKey | null }> = [
+    { dropId: "drop:none", column: 1, afterKey: null },
+    ...MILESTONE_ORDER.map((key, i) => ({
+      dropId: "drop:" + key,
+      column: i + 2, // drop at the NEXT column position
+      afterKey: key,
+    })),
+  ];
+
+  // Fix drop column positions: drop:no_tour is in column 1, drop:tour_started in col 2, etc.
+  // But drop:tour_started means they stopped AT tour, so the drop is between tour (col 1) and video (col 2)
+  // Actually, drop nodes sit in the column AFTER the milestone they stopped at.
+  // drop:no_tour -> column 1 (same column as tour, below it)
+  // drop:tour_started -> column 2 (same column as video, below it)
+  // etc.
+
+  for (const { dropId, column } of dropMilestones) {
+    const count = nodeCountMap.get(dropId);
+    if (count && count > 0) {
+      const afterKey = dropId === "drop:none" ? null : dropId.slice(5) as ActivationJourneyMilestoneKey;
+      const label = dropId === "drop:none"
+        ? "No milestone"
+        : "Dropped at " + (MILESTONE_SHORT_LABELS[afterKey!] ?? afterKey);
+      nodesById.set(dropId, {
+        id: dropId,
+        column: Math.min(column, 10), // clamp
+        label: formatCount(count), // drop labels just show count
+        longLabel: label,
+        color: DROP_COLOR,
+        isDrop: true,
+        count,
+        x: 0, y: 0, height: 0,
+      });
+    }
+  }
+
+  // Recompute node counts properly using link flows
+  // For source nodes: count = total outgoing links
+  // For milestone/drop nodes: count = total incoming links
+  for (const node of nodesById.values()) {
+    if (node.id.startsWith("src:")) {
+      let total = 0;
+      for (const link of linkMap.values()) {
+        if (link.sourceId === node.id) total += link.count;
+      }
+      node.count = total;
+    } else {
+      let total = 0;
+      for (const link of linkMap.values()) {
+        if (link.targetId === node.id) total += link.count;
+      }
+      // For milestone nodes that also act as sources, use the max of in/out
+      if (!node.isDrop) {
+        let outTotal = 0;
+        for (const link of linkMap.values()) {
+          if (link.sourceId === node.id) outTotal += link.count;
+        }
+        total = Math.max(total, outTotal);
+      }
+      if (total > 0) node.count = total;
+    }
+  }
+
+  // ── Layout: compute heights ────────────────────────────────────────
+  // Group nodes by column
+  const columns = new Map<number, SankeyNode[]>();
+  for (const node of nodesById.values()) {
+    const col = columns.get(node.column) ?? [];
+    col.push(node);
+    columns.set(node.column, col);
+  }
+
+  // Sort within columns: milestone nodes first, then drop nodes
+  for (const col of columns.values()) {
+    col.sort((a, b) => {
+      if (a.isDrop !== b.isDrop) return a.isDrop ? 1 : -1;
+      return 0;
+    });
+  }
+
+  // Find max column total for proportional scaling
+  let maxColTotal = 0;
+  for (const col of columns.values()) {
+    const total = col.reduce((sum, n) => sum + n.count, 0);
+    if (total > maxColTotal) maxColTotal = total;
+  }
+  if (maxColTotal === 0) maxColTotal = 1;
+
+  const NODE_GAP = 8;
+
+  for (const [colIdx, col] of columns.entries()) {
+    const colTotal = col.reduce((sum, n) => sum + n.count, 0);
+    const totalGap = (col.length - 1) * NODE_GAP;
+    const scaleHeight = availableHeight - totalGap;
+    const scaleFactor = colTotal > 0 ? scaleHeight / maxColTotal : 0;
+
+    let currentY = PAD_TOP;
+    // Center vertically
+    const usedHeight = col.reduce((sum, n) => sum + n.count * scaleFactor, 0) + totalGap;
+    currentY = PAD_TOP + (availableHeight - usedHeight) / 2;
+
+    for (const node of col) {
+      node.x = colX(colIdx);
+      node.height = Math.max(3, node.count * scaleFactor);
+      node.y = currentY;
+      currentY += node.height + NODE_GAP;
+    }
+  }
+
+  // ── Layout: compute link positions ─────────────────────────────────
+  // Track port offsets for each node
+  const sourcePortOffset = new Map<string, number>();
+  const targetPortOffset = new Map<string, number>();
+
+  const links: SankeyLink[] = [];
+
+  // Sort links for consistent ordering: group by source, then by target column
+  const sortedLinks = [...linkMap.values()].sort((a, b) => {
+    const na = nodesById.get(a.sourceId);
+    const nb = nodesById.get(b.sourceId);
+    if (!na || !nb) return 0;
+    if (na.column !== nb.column) return na.column - nb.column;
+    if (na.y !== nb.y) return na.y - nb.y;
+    const ta = nodesById.get(a.targetId);
+    const tb = nodesById.get(b.targetId);
+    if (!ta || !tb) return 0;
+    if (ta.column !== tb.column) return ta.column - tb.column;
+    return ta.y - tb.y;
+  });
+
+  for (const linkData of sortedLinks) {
+    const sourceNode = nodesById.get(linkData.sourceId);
+    const targetNode = nodesById.get(linkData.targetId);
+    if (!sourceNode || !targetNode) continue;
+
+    const sOffset = sourcePortOffset.get(linkData.sourceId) ?? 0;
+    const tOffset = targetPortOffset.get(linkData.targetId) ?? 0;
+
+    const linkHeight = sourceNode.count > 0
+      ? (linkData.count / sourceNode.count) * sourceNode.height
+      : 0;
+    const targetLinkHeight = targetNode.count > 0
+      ? (linkData.count / targetNode.count) * targetNode.height
+      : 0;
+
+    links.push({
+      sourceId: linkData.sourceId,
+      targetId: linkData.targetId,
+      segment: linkData.segment,
+      count: linkData.count,
+      isDrop: linkData.isDrop,
+      sx: sourceNode.x + NODE_WIDTH,
+      sy0: sourceNode.y + sOffset,
+      sy1: sourceNode.y + sOffset + linkHeight,
+      tx: targetNode.x,
+      ty0: targetNode.y + tOffset,
+      ty1: targetNode.y + tOffset + targetLinkHeight,
+    });
+
+    sourcePortOffset.set(linkData.sourceId, sOffset + linkHeight);
+    targetPortOffset.set(linkData.targetId, tOffset + targetLinkHeight);
+  }
+
+  return {
+    nodes: [...nodesById.values()],
+    links,
+    viewBoxHeight,
+  };
+}
+
+// ── BFS trace for focus ─────────────────────────────────────────────────
+
+function traceFocus(
+  focusNode: string,
+  links: SankeyLink[],
+): { nodes: Set<string>; linkKeys: Set<string> } {
+  const tracedNodes = new Set<string>([focusNode]);
+  const tracedLinks = new Set<string>();
+
+  // BFS forward
+  const forwardQueue = [focusNode];
+  while (forwardQueue.length > 0) {
+    const current = forwardQueue.shift()!;
+    for (const link of links) {
+      if (link.sourceId === current) {
+        const key = `${link.sourceId}|${link.targetId}|${link.segment}`;
+        if (!tracedLinks.has(key)) {
+          tracedLinks.add(key);
+          if (!tracedNodes.has(link.targetId)) {
+            tracedNodes.add(link.targetId);
+            forwardQueue.push(link.targetId);
+          }
+        }
+      }
+    }
+  }
+
+  // BFS backward
+  const backwardQueue = [focusNode];
+  while (backwardQueue.length > 0) {
+    const current = backwardQueue.shift()!;
+    for (const link of links) {
+      if (link.targetId === current) {
+        const key = `${link.sourceId}|${link.targetId}|${link.segment}`;
+        if (!tracedLinks.has(key)) {
+          tracedLinks.add(key);
+          if (!tracedNodes.has(link.sourceId)) {
+            tracedNodes.add(link.sourceId);
+            backwardQueue.push(link.sourceId);
+          }
+        }
+      }
+    }
+  }
+
+  return { nodes: tracedNodes, linkKeys: tracedLinks };
+}
+
+// ── Component ───────────────────────────────────────────────────────────
+
+export function SankeyChart({
+  actorJourneys,
+  showSource,
+  segmentation,
+  focusNode,
+  onFocusChange,
+  onTooltip,
+}: SankeyChartProps) {
+  const sankey = useMemo(
+    () => buildSankey(actorJourneys, showSource, segmentation),
+    [actorJourneys, showSource, segmentation],
+  );
+
+  const trace = useMemo(() => {
+    if (!focusNode) return null;
+    return traceFocus(focusNode, sankey.links);
+  }, [focusNode, sankey.links]);
+
+  const totalActors = actorJourneys.length;
+
+  const handleNodeClick = useCallback(
+    (nodeId: string, isDrop: boolean) => {
+      if (isDrop) return; // don't focus drop nodes
+      onFocusChange(focusNode === nodeId ? null : nodeId);
+    },
+    [focusNode, onFocusChange],
+  );
+
+  const handleNodeHover = useCallback(
+    (node: SankeyNode) => {
+      onTooltip({
+        title: node.longLabel,
+        rows: [
+          { label: "Actors", value: formatCount(node.count) },
+          ...(totalActors > 0
+            ? [{ label: "of total", value: ((node.count / totalActors) * 100).toFixed(1) + "%" }]
+            : []),
+        ],
+      });
+    },
+    [onTooltip, totalActors],
+  );
+
+  const handleLinkHover = useCallback(
+    (link: SankeyLink) => {
+      const sourceNode = sankey.nodes.find((n) => n.id === link.sourceId);
+      const targetNode = sankey.nodes.find((n) => n.id === link.targetId);
+      if (!sourceNode || !targetNode) return;
+      onTooltip({
+        title: `${sourceNode.longLabel} → ${targetNode.longLabel}`,
+        rows: [
+          { label: "Actors", value: formatCount(link.count) },
+          ...(totalActors > 0
+            ? [{ label: "of total", value: ((link.count / totalActors) * 100).toFixed(1) + "%" }]
+            : []),
+        ],
+      });
+    },
+    [onTooltip, sankey.nodes, totalActors],
+  );
+
+  const handleMouseLeave = useCallback(() => {
+    onTooltip(null);
+  }, [onTooltip]);
+
+  const startCol = showSource ? 0 : 1;
+
+  return (
+    <svg
+      viewBox={`0 0 1100 ${sankey.viewBoxHeight}`}
+      style={{ width: "100%", height: "auto", display: "block", userSelect: "none" }}
+    >
+      {/* Column headers */}
+      {COLUMN_HEADERS.map((header, i) => {
+        if (i < startCol) return null;
+        const totalCols = COLUMN_HEADERS.length - startCol;
+        const idx = i - startCol;
+        const gap = (1100 - 80) / (totalCols - 1);
+        const x = 40 + idx * gap + 5; // center on node
+        return (
+          <text
+            key={header}
+            x={x}
+            y={16}
+            textAnchor="middle"
+            style={{
+              fontSize: "9px",
+              fontWeight: 700,
+              textTransform: "uppercase" as const,
+              fill: "#94a3b8",
+              letterSpacing: "0.05em",
+            }}
+          >
+            {header}
+          </text>
+        );
+      })}
+
+      {/* Links (ribbons) */}
+      {sankey.links.map((link) => {
+        const key = `${link.sourceId}|${link.targetId}|${link.segment}`;
+        const color = segmentColor(link.segment, segmentation);
+        const isTracing = trace !== null;
+        const isTraced = trace?.linkKeys.has(key) ?? false;
+
+        let opacity: number;
+        if (isTracing) {
+          if (isTraced) {
+            opacity = link.isDrop ? 0.50 : 0.46;
+          } else {
+            opacity = 0.05;
+          }
+        } else {
+          opacity = link.isDrop ? 0.26 : 0.20;
+        }
+
+        const mx = (link.sx + link.tx) / 2;
+        const d = [
+          `M ${link.sx},${link.sy0}`,
+          `C ${mx},${link.sy0} ${mx},${link.ty0} ${link.tx},${link.ty0}`,
+          `L ${link.tx},${link.ty1}`,
+          `C ${mx},${link.ty1} ${mx},${link.sy1} ${link.sx},${link.sy1}`,
+          "Z",
+        ].join(" ");
+
+        return (
+          <path
+            key={key}
+            d={d}
+            fill={color}
+            opacity={opacity}
+            style={{ transition: "opacity 0.12s" }}
+            onMouseEnter={() => handleLinkHover(link)}
+            onMouseLeave={handleMouseLeave}
+          />
+        );
+      })}
+
+      {/* Nodes */}
+      {sankey.nodes.map((node) => {
+        const isTracing = trace !== null;
+        const isTraced = trace?.nodes.has(node.id) ?? false;
+        const nodeOpacity = isTracing && !isTraced ? 0.25 : 1;
+
+        return (
+          <g
+            key={node.id}
+            style={{ transition: "opacity 0.12s", opacity: nodeOpacity, cursor: node.isDrop ? "default" : "pointer" }}
+            onClick={() => handleNodeClick(node.id, node.isDrop)}
+            onMouseEnter={() => handleNodeHover(node)}
+            onMouseLeave={handleMouseLeave}
+          >
+            {/* Node bar */}
+            <rect
+              x={node.x}
+              y={node.y}
+              width={10}
+              height={node.height}
+              rx={2}
+              ry={2}
+              fill={node.color}
+            />
+
+            {/* Labels */}
+            {node.id.startsWith("src:") ? (
+              <>
+                {/* Source label: left of node */}
+                <text
+                  x={node.x - 6}
+                  y={node.y + node.height / 2 - (node.height > 26 ? 4 : 0)}
+                  textAnchor="end"
+                  dominantBaseline="central"
+                  style={{
+                    fontSize: "10.5px",
+                    fontWeight: 600,
+                    fill: "#475569",
+                  }}
+                >
+                  {node.label}
+                </text>
+                {node.height > 26 && (
+                  <text
+                    x={node.x - 6}
+                    y={node.y + node.height / 2 + 10}
+                    textAnchor="end"
+                    dominantBaseline="central"
+                    style={{
+                      fontSize: "9px",
+                      fontFamily: "monospace",
+                      fill: "#94a3b8",
+                    }}
+                  >
+                    {formatCount(node.count)}
+                  </text>
+                )}
+              </>
+            ) : node.isDrop ? (
+              <>
+                {/* Drop label: right of node, red */}
+                {node.height > 13 && (
+                  <text
+                    x={node.x + 16}
+                    y={node.y + node.height / 2}
+                    dominantBaseline="central"
+                    style={{
+                      fontSize: "10px",
+                      fontWeight: 700,
+                      fill: DROP_COLOR,
+                    }}
+                  >
+                    {formatCount(node.count)}
+                  </text>
+                )}
+              </>
+            ) : (
+              <>
+                {/* Milestone label: right of node */}
+                {node.height > 13 && (
+                  <>
+                    <text
+                      x={node.x + 16}
+                      y={node.y + node.height / 2 - (node.height > 26 ? 4 : 0)}
+                      dominantBaseline="central"
+                      style={{
+                        fontSize: "10px",
+                        fontWeight: 700,
+                        fill: node.color,
+                      }}
+                    >
+                      {node.label}
+                    </text>
+                    {node.height > 26 && (
+                      <text
+                        x={node.x + 16}
+                        y={node.y + node.height / 2 + 10}
+                        dominantBaseline="central"
+                        style={{
+                          fontSize: "9px",
+                          fontFamily: "monospace",
+                          fill: "#94a3b8",
+                        }}
+                      >
+                        {formatCount(node.count)}
+                      </text>
+                    )}
+                  </>
+                )}
+              </>
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/src/components/imladris/segments-view.tsx
+++ b/src/components/imladris/segments-view.tsx
@@ -1,0 +1,396 @@
+"use client";
+
+import { useMemo } from "react";
+import type {
+  ActivationJourneyDashboardPayload,
+  ActivationJourneyMilestoneKey,
+  ActorJourneySummary,
+  AcquisitionSourceKey,
+  ActorCohortKey,
+} from "@/lib/imladris/activation-journey";
+import {
+  formatCompact,
+  formatHours,
+  formatRate,
+} from "./activation-journey-dashboard";
+import styles from "./activation-journey-dashboard.module.css";
+
+// ── Constants ───────────────────────────────────────────────────────────
+
+const MILESTONE_OPTIONS: Array<{ value: ActivationJourneyMilestoneKey; label: string }> = [
+  { value: "site_visited", label: "Site visited" },
+  { value: "kanban_submitted", label: "Free kanban submitted" },
+  { value: "cta_clicked", label: "CTA clicked" },
+  { value: "demo", label: "Demo booked" },
+  { value: "trial", label: "Trial started" },
+  { value: "paid", label: "Became paid" },
+  { value: "signup", label: "Signed up" },
+  { value: "tour_started", label: "Tour started" },
+  { value: "video_completed", label: "Video completed" },
+  { value: "item_created", label: "Item created" },
+  { value: "card_printed", label: "Card printed" },
+  { value: "queue_added", label: "Added to order queue" },
+  { value: "order_placed", label: "Order placed" },
+  { value: "activation_completed", label: "Activation completed" },
+];
+
+const MILESTONE_KEYS: ActivationJourneyMilestoneKey[] = MILESTONE_OPTIONS.map((o) => o.value);
+
+const MILESTONE_COLORS: Record<ActivationJourneyMilestoneKey, string> = {
+  site_visited: "#3aa392",
+  kanban_submitted: "#2f8c7a",
+  cta_clicked: "#2a806e",
+  demo: "#257562",
+  trial: "#1f6a57",
+  paid: "#18a558",
+  signup: "#7d8cc0",
+  tour_started: "#9aa6b8",
+  video_completed: "#8693ac",
+  item_created: "#6f86b0",
+  card_printed: "#5f86a8",
+  queue_added: "#4f8f93",
+  order_placed: "#d98a3a",
+  activation_completed: "#FC5A29",
+};
+
+const SHORT_LABELS: Record<ActivationJourneyMilestoneKey, string> = {
+  site_visited: "Site",
+  kanban_submitted: "Kanban",
+  cta_clicked: "CTA",
+  demo: "Demo",
+  trial: "Trial",
+  paid: "Paid",
+  signup: "Signup",
+  tour_started: "Tour",
+  video_completed: "Video",
+  item_created: "Item",
+  card_printed: "Card",
+  queue_added: "Queue",
+  order_placed: "Order",
+  activation_completed: "Active",
+};
+
+const LONG_LABELS: Record<string, string> = {
+  site_visited: "Site visited",
+  kanban_submitted: "Free kanban submitted",
+  cta_clicked: "CTA clicked",
+  demo: "Demo booked",
+  trial: "Trial started",
+  paid: "Became paid",
+  signup: "Signed up",
+  tour_started: "Tour started",
+  video_completed: "Video completed",
+  item_created: "Item created",
+  card_printed: "Card printed",
+  queue_added: "Added to order queue",
+  order_placed: "Order placed",
+  activation_completed: "Activation completed",
+};
+
+const SOURCE_DEFS: Array<{ key: AcquisitionSourceKey; label: string; color: string }> = [
+  { key: "direct", label: "Direct", color: "#5b6b7f" },
+  { key: "google_organic", label: "Google organic", color: "#2f8f5b" },
+  { key: "google_ads", label: "Google Ads", color: "#d08a1e" },
+  { key: "facebook", label: "Facebook", color: "#1877F2" },
+  { key: "instagram", label: "Instagram", color: "#E4405F" },
+  { key: "linkedin", label: "LinkedIn", color: "#2f86c9" },
+  { key: "referral", label: "Referral", color: "#1aa39a" },
+  { key: "email", label: "Email", color: "#8a6d3b" },
+];
+
+const COHORT_DEFS: Array<{ key: ActorCohortKey; label: string; color: string }> = [
+  { key: "tour_completed", label: "Tour completed", color: "#2f8f5b" },
+  { key: "started_not_completed", label: "Started, not completed", color: "#d08a1e" },
+  { key: "no_tour", label: "No tour observed", color: "#9aa1ac" },
+];
+
+type SegDimension = "source" | "cohort";
+
+interface SegmentsViewProps {
+  data: ActivationJourneyDashboardPayload;
+  actKey: ActivationJourneyMilestoneKey;
+  activationLabel: string;
+  segDim: SegDimension;
+  selActor: number | null;
+  onActKeyChange: (key: ActivationJourneyMilestoneKey) => void;
+  onSegDim: (dim: SegDimension) => void;
+  onSelActor: (index: number | null) => void;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+interface SegmentRow {
+  key: string;
+  label: string;
+  color: string;
+  n: number;
+  stages: Array<{ key: ActivationJourneyMilestoneKey; count: number; pct: number }>;
+  actRate: number | null;
+  medianHours: number | null;
+}
+
+function buildSegmentRows(
+  actorJourneys: ActorJourneySummary[],
+  dim: SegDimension,
+  actKey: ActivationJourneyMilestoneKey,
+): SegmentRow[] {
+  const groups =
+    dim === "source"
+      ? SOURCE_DEFS.map((s) => ({
+          key: s.key,
+          label: s.label,
+          color: s.color,
+          test: (a: ActorJourneySummary) => a.source === s.key,
+        }))
+      : COHORT_DEFS.map((c) => ({
+          key: c.key,
+          label: c.label,
+          color: c.color,
+          test: (a: ActorJourneySummary) => a.cohort === c.key,
+        }));
+
+  return groups.map((g) => {
+    const sub = actorJourneys.filter(g.test);
+    const n = sub.length;
+    const stages = MILESTONE_KEYS.map((k) => {
+      const count = sub.filter((a) => a.milestones.includes(k)).length;
+      return { key: k, count, pct: n > 0 ? count / n : 0 };
+    });
+    const actStage = stages.find((s) => s.key === actKey);
+    const actRate = actStage && n > 0 ? actStage.count / n : null;
+
+    // Median hours — not available from actor summaries (they don't carry timestamps),
+    // so we use null here. The transition times panel handles this.
+    return {
+      key: g.key,
+      label: g.label,
+      color: g.color,
+      n,
+      stages,
+      actRate,
+      medianHours: null,
+    };
+  });
+}
+
+// ── Component ───────────────────────────────────────────────────────────
+
+export function SegmentsView({
+  data,
+  actKey,
+  activationLabel,
+  segDim,
+  selActor,
+  onActKeyChange,
+  onSegDim,
+  onSelActor,
+}: SegmentsViewProps) {
+  const segRows = useMemo(() => {
+    if (!data.actorJourneys) return [];
+    return buildSegmentRows(data.actorJourneys, segDim, actKey);
+  }, [data.actorJourneys, segDim, actKey]);
+
+  const maxN = Math.max(1, ...segRows.map((r) => r.n));
+
+  // Transition times
+  const t2cRows = data.transitionTimes ?? [];
+  const maxT2c = Math.max(1, ...t2cRows.map((t) => t.medianHours ?? 0));
+
+  // Actor samples
+  const samples = data.actorSamples ?? [];
+
+  return (
+    <div className={styles.segLayout}>
+      {/* Filter rail */}
+      <div className={styles.filterRail}>
+        <div>
+          <div className={styles.filterLabel}>Compare by</div>
+          <div className={styles.filterButtons}>
+            {(["source", "cohort"] as const).map((d) => (
+              <button
+                key={d}
+                type="button"
+                className={segDim === d ? styles.filterBtnActive : styles.filterBtn}
+                onClick={() => onSegDim(d)}
+              >
+                {d === "source" ? "Acquisition source" : "Cohort"}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div>
+          <div className={styles.filterLabel}>Activated when reaching</div>
+          <select
+            className={styles.filterSelect}
+            value={actKey}
+            onChange={(e) => onActKeyChange(e.target.value as ActivationJourneyMilestoneKey)}
+          >
+            {MILESTONE_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+        </div>
+        <div className={styles.filterHelp}>
+          Mini-funnel bars show stage reach rate per segment. Source from PostHog initial UTM / referrer.
+        </div>
+      </div>
+
+      {/* Main content */}
+      <div className={styles.segMain}>
+        {/* Segment comparison table */}
+        <div className={styles.panel}>
+          <div className={styles.panelHeader}>
+            <div className={styles.panelTitle}>
+              Activation by {segDim === "source" ? "acquisition source" : "cohort"}
+            </div>
+            <div className={styles.panelSub}>
+              rate at &ldquo;{activationLabel}&rdquo;
+            </div>
+          </div>
+          <div className={styles.segTableWrap}>
+            {/* Header */}
+            <div className={styles.segTableHead}>
+              <span>Segment</span>
+              <span>Actors</span>
+              <span>Tour &rarr; Active</span>
+              <span style={{ textAlign: "right" }}>Rate</span>
+              <span style={{ textAlign: "right" }}>Median</span>
+            </div>
+            {/* Rows */}
+            {segRows.map((row) => (
+              <div key={row.key} className={styles.segTableRow}>
+                <span className={styles.segName}>
+                  <span className={styles.segDot} style={{ background: row.color }} />
+                  <span className={styles.segNameText}>{row.label}</span>
+                </span>
+                <div className={styles.segActors}>
+                  <div className={styles.segActorBar}>
+                    <div
+                      className={styles.segActorFill}
+                      style={{ width: `${(row.n / maxN) * 100}%` }}
+                    />
+                  </div>
+                  <span className={styles.mono}>{formatCompact(row.n)}</span>
+                </div>
+                <div className={styles.segMiniFunnel}>
+                  {row.stages.map((s) => (
+                    <div
+                      key={s.key}
+                      className={styles.segMiniBar}
+                      style={{
+                        height: `${Math.max(2, s.pct * 28)}px`,
+                        background: MILESTONE_COLORS[s.key],
+                      }}
+                      title={`${SHORT_LABELS[s.key]}: ${formatRate(s.pct)}`}
+                    />
+                  ))}
+                </div>
+                <span className={styles.segRate}>{formatRate(row.actRate)}</span>
+                <span className={styles.segMedian}>{formatHours(row.medianHours)}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Time-to-convert + Actor journeys */}
+        <div className={styles.segBottom}>
+          {/* Time to convert */}
+          <div className={styles.panel}>
+            <div className={styles.panelHeader}>
+              <div className={styles.panelTitle}>Time to convert</div>
+            </div>
+            <div className={styles.t2cBody}>
+              {t2cRows.map((t) => (
+                <div key={`${t.from}-${t.to}`} className={styles.t2cRow}>
+                  <div className={styles.t2cTop}>
+                    <span className={styles.t2cLabel}>
+                      {LONG_LABELS[t.from] ?? t.from} &rarr; {LONG_LABELS[t.to] ?? t.to}
+                    </span>
+                    <span className={styles.t2cVal}>{formatHours(t.medianHours)}</span>
+                  </div>
+                  <div className={styles.t2cBar}>
+                    <div
+                      className={styles.t2cFill}
+                      style={{ width: `${Math.max(1, ((t.medianHours ?? 0) / maxT2c) * 100)}%` }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Actor journeys */}
+          <div className={styles.panel}>
+            <div className={styles.panelHeader}>
+              <span className={styles.panelTitle}>Actor journeys</span>
+              <span className={styles.panelTag}>sample</span>
+            </div>
+            <div className={styles.actorList}>
+              {samples.map((actor, i) => {
+                const isSelected = selActor === i;
+                const sourceDef = SOURCE_DEFS.find((s) => s.key === actor.source);
+                const actorLinks = [
+                  { label: "Replay", href: actor.sessionReplayUrl },
+                  { label: "Identity", href: actor.identityUrl },
+                  { label: "Analytics", href: actor.analyticsUrl },
+                ].filter((link): link is { label: string; href: string } => Boolean(link.href));
+                return (
+                  <div
+                    key={actor.actorId}
+                    className={styles.actorCard}
+                    style={{
+                      background: isSelected ? "#FEF7F5" : undefined,
+                      borderColor: isSelected ? "#FD9C80" : undefined,
+                    }}
+                    onClick={() => onSelActor(i)}
+                  >
+                    <div className={styles.actorTop}>
+                      <span className={styles.actorId}>{actor.actorId.slice(0, 8)}</span>
+                      <span className={styles.actorSource}>
+                        <span
+                          className={styles.actorSrcDot}
+                          style={{ background: sourceDef?.color ?? "#888" }}
+                        />
+                        {sourceDef?.label ?? actor.source}
+                      </span>
+                      <span className={styles.actorFurthest}>
+                        &rarr; {actor.furthestMilestone ? LONG_LABELS[actor.furthestMilestone] ?? actor.furthestMilestone : "No milestone"}
+                      </span>
+                    </div>
+                    <div className={styles.actorChips}>
+                      {actor.milestones.map((mk) => (
+                        <span
+                          key={mk}
+                          className={styles.actorChip}
+                          style={{ background: MILESTONE_COLORS[mk] }}
+                        >
+                          {SHORT_LABELS[mk]}
+                        </span>
+                      ))}
+                    </div>
+                    {actorLinks.length > 0 ? (
+                      <div className={styles.actorActions}>
+                        {actorLinks.map((link) => (
+                          <a
+                            key={link.label}
+                            className={styles.actorAction}
+                            href={link.href}
+                            target="_blank"
+                            rel="noreferrer"
+                            onClick={(event) => event.stopPropagation()}
+                          >
+                            {link.label}
+                          </a>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/imladris/activation-journey.test.ts
+++ b/src/lib/imladris/activation-journey.test.ts
@@ -1,0 +1,525 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { IntegrationProvider } from "@/generated/prisma/client";
+import { buildActivationJourneyDashboard } from "@/lib/imladris/activation-journey";
+import type { PrismaClientType } from "@/lib/prisma";
+
+function posthogEvent(input: {
+  id: string;
+  event: string;
+  distinctId?: string | null;
+  properties?: Record<string, unknown>;
+  occurredAt: string;
+  provider?: string;
+  objectType?: string;
+}) {
+  return {
+    id: input.id,
+    provider: input.provider ?? IntegrationProvider.POSTHOG,
+    objectType: input.objectType ?? "event",
+    externalId: input.id,
+    scopeKey: "global",
+    payload: {
+      uuid: input.id,
+      event: input.event,
+      distinct_id: input.distinctId,
+      timestamp: input.occurredAt,
+      properties: input.properties ?? {},
+    },
+    occurredAt: new Date(input.occurredAt),
+    sourceCreatedAt: new Date(input.occurredAt),
+    sourceUpdatedAt: new Date(input.occurredAt),
+    userId: null,
+    organizationId: "org_1",
+  };
+}
+
+function prismaWithPostHogRows(rows: unknown[]): PrismaClientType {
+  return {
+    imladrisRawSourceRecord: {
+      findMany: vi.fn().mockResolvedValue(rows),
+    },
+  } as unknown as PrismaClientType;
+}
+
+describe("buildActivationJourneyDashboard", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("summarizes PostHog events into activation milestones and cohorts", async () => {
+    vi.stubEnv("POSTHOG_PROJECT_ID", "12345");
+    vi.stubEnv("POSTHOG_HOST", "https://us.i.posthog.com");
+
+    const prisma = prismaWithPostHogRows([
+      posthogEvent({
+        id: "evt-1",
+        event: "onboarding_tour_started",
+        distinctId: "user-1",
+        properties: { $session_id: "session-1" },
+        occurredAt: "2026-06-20T10:00:00.000Z",
+      }),
+      posthogEvent({
+        id: "evt-2",
+        event: "walkthrough_video_completed",
+        distinctId: "user-1",
+        properties: { placement: "onboarding-tour" },
+        occurredAt: "2026-06-20T10:05:00.000Z",
+      }),
+      posthogEvent({
+        id: "evt-3",
+        event: "item_created",
+        distinctId: "user-1",
+        occurredAt: "2026-06-20T10:30:00.000Z",
+      }),
+      posthogEvent({
+        id: "evt-4",
+        event: "card_printed",
+        distinctId: "user-1",
+        properties: { print_type: "card" },
+        occurredAt: "2026-06-20T10:45:00.000Z",
+      }),
+      posthogEvent({
+        id: "evt-5",
+        event: "card_added_to_order_queue",
+        distinctId: "user-1",
+        occurredAt: "2026-06-20T11:00:00.000Z",
+      }),
+      posthogEvent({
+        id: "evt-6",
+        event: "card_fulfilled",
+        distinctId: "user-1",
+        occurredAt: "2026-06-20T11:45:00.000Z",
+      }),
+      posthogEvent({
+        id: "evt-7",
+        event: "cards_received",
+        distinctId: "user-1",
+        occurredAt: "2026-06-20T12:00:00.000Z",
+      }),
+      posthogEvent({
+        id: "evt-8",
+        event: "onboarding_tour_started",
+        distinctId: "user-2",
+        occurredAt: "2026-06-21T09:00:00.000Z",
+      }),
+      posthogEvent({
+        id: "evt-9",
+        event: "item_created",
+        distinctId: "user-2",
+        occurredAt: "2026-06-21T09:30:00.000Z",
+      }),
+      posthogEvent({
+        id: "evt-10",
+        event: "card_printed",
+        distinctId: "user-2",
+        properties: { print_type: "label" },
+        occurredAt: "2026-06-21T10:00:00.000Z",
+      }),
+    ]);
+
+    const dashboard = await buildActivationJourneyDashboard({
+      prisma,
+      context: { userId: "user_1", organizationId: "org_1" },
+      now: new Date("2026-06-22T00:00:00.000Z"),
+      days: 14,
+    });
+
+    expect(dashboard.summary).toMatchObject({
+      totalEvents: 10,
+      identifiedActors: 2,
+      activatedActors: 1,
+      activationRate: 50,
+    });
+    expect(dashboard.summary.medianHoursToActivation).toBe(2);
+
+    const milestoneUsers = Object.fromEntries(
+      dashboard.milestones.map((milestone) => [milestone.key, milestone.actors]),
+    );
+    expect(milestoneUsers).toMatchObject({
+      tour_started: 2,
+      video_completed: 1,
+      item_created: 2,
+      card_printed: 2,
+      queue_added: 1,
+      order_placed: 1,
+      activation_completed: 1,
+    });
+
+    const queueAdded = dashboard.milestones.find((milestone) => milestone.key === "queue_added");
+    expect(queueAdded?.conversionFromPrevious).toBe(50);
+    expect(queueAdded?.dropoffFromPrevious).toBe(50);
+
+    expect(dashboard.cohorts).toContainEqual({
+      key: "tour_completed",
+      label: "Tour completed",
+      actors: 1,
+      activatedActors: 1,
+      activationRate: 100,
+    });
+    expect(dashboard.cohorts).toContainEqual({
+      key: "tour_started_not_completed",
+      label: "Tour started, not completed",
+      actors: 1,
+      activatedActors: 0,
+      activationRate: 0,
+    });
+
+    expect(dashboard.paths[0]).toMatchObject({
+      sequence: [
+        "tour_started",
+        "video_completed",
+        "item_created",
+        "card_printed",
+        "queue_added",
+        "order_placed",
+        "activation_completed",
+      ],
+      actors: 1,
+      activatedActors: 1,
+      activationRate: 100,
+    });
+
+    expect(dashboard.actorSamples[0]).toMatchObject({
+      actorId: "user-1",
+      sessionReplayUrl: "https://us.posthog.com/project/12345/replay/session-1",
+      identityUrl: "https://us.posthog.com/project/12345/person/user-1",
+      analyticsUrl: "https://us.posthog.com/project/12345/events?distinct_id=user-1",
+    });
+  });
+
+  it("maps previously-unmapped events into milestone sub-stages", async () => {
+    const prisma = prismaWithPostHogRows([
+      // Auth / onboarding sub-stages under tour_started.
+      posthogEvent({
+        id: "pv-1",
+        event: "$pageview",
+        distinctId: "user-1",
+        properties: { $pathname: "/signup/" },
+        occurredAt: "2026-06-20T09:00:00.000Z",
+      }),
+      posthogEvent({
+        id: "su-1",
+        event: "user_signed_up",
+        distinctId: "user-1",
+        occurredAt: "2026-06-20T09:01:00.000Z",
+      }),
+      posthogEvent({
+        id: "rc-1",
+        event: "$rageclick",
+        distinctId: "user-1",
+        properties: { $current_url: "https://app.arda.cards/create-free-kanban-cards?ref=x" },
+        occurredAt: "2026-06-20T09:02:00.000Z",
+      }),
+      // Item-creation sub-stages under item_created.
+      posthogEvent({
+        id: "pv-2",
+        event: "$pageview",
+        distinctId: "user-1",
+        properties: { $pathname: "/items" },
+        occurredAt: "2026-06-20T09:10:00.000Z",
+      }),
+      posthogEvent({
+        id: "fu-1",
+        event: "item_file_uploaded",
+        distinctId: "user-1",
+        occurredAt: "2026-06-20T09:11:00.000Z",
+      }),
+      // A pageview on a page that belongs to no stage stays genuinely unmapped.
+      posthogEvent({
+        id: "pv-3",
+        event: "$pageview",
+        distinctId: "user-1",
+        properties: { $pathname: "/pricing" },
+        occurredAt: "2026-06-20T09:12:00.000Z",
+      }),
+    ]);
+
+    const dashboard = await buildActivationJourneyDashboard({
+      prisma,
+      context: { userId: "user_1", organizationId: "org_1" },
+      now: new Date("2026-06-22T00:00:00.000Z"),
+      days: 14,
+    });
+
+    // 4 events found a sub-stage home; user_signed_up is now the `signup` MILESTONE's
+    // primary event (no longer a sub-stage), and only the /pricing pageview is unmapped.
+    expect(dashboard.source.subStageMappedEvents).toBe(4);
+    expect(dashboard.source.unmappedEvents).toBe(1);
+
+    // `signup` is now a first-class activation milestone (promoted from a tour_started sub-stage).
+    const signup = dashboard.milestones.find((m) => m.key === "signup");
+    expect(signup?.funnel).toBe("activation");
+    expect(signup?.actors).toBe(1);
+    expect(signup?.events).toBe(1);
+
+    // The auth sub-stages moved from tour_started onto signup; tour_started now has none.
+    const tourStarted = dashboard.milestones.find((m) => m.key === "tour_started");
+    expect(tourStarted?.subStages).toHaveLength(0);
+    const subStageCounts = Object.fromEntries(
+      (signup?.subStages ?? []).map((sub) => [sub.key, sub.eventCount]),
+    );
+    expect(subStageCounts.auth_landing_pageview).toBe(1);
+    // The sign_up sub-stage is gone — user_signed_up is the signup milestone's primary event now.
+    expect(signup?.subStages.some((sub) => sub.key === "sign_up")).toBe(false);
+    // Auth-only rageclick sub-stage — the fixture rageclick is on /create-free-kanban-cards
+    // which routes to kanban_submitted's sub-stage, not signup's.
+    expect(subStageCounts.onboarding_rageclick).toBe(0);
+    // No $pageleave event in this fixture, so its drop-off sub-stage stays missing here.
+    const pageleave = signup?.subStages.find((sub) => sub.key === "onboarding_pageleave");
+    expect(pageleave?.status).toBe("missing");
+    expect(pageleave?.eventCount).toBe(0);
+
+    // The kanban-page rageclick is now attributed to the kanban_submitted milestone.
+    const kanbanSubmitted = dashboard.milestones.find((m) => m.key === "kanban_submitted");
+    const kanbanSubStageCounts = Object.fromEntries(
+      (kanbanSubmitted?.subStages ?? []).map((sub) => [sub.key, sub.eventCount]),
+    );
+    expect(kanbanSubStageCounts.kanban_rageclick).toBe(1);
+
+    const itemCreated = dashboard.milestones.find((m) => m.key === "item_created");
+    const itemSubStages = Object.fromEntries(
+      (itemCreated?.subStages ?? []).map((sub) => [sub.key, sub.eventCount]),
+    );
+    expect(itemSubStages.items_pageview).toBe(1);
+    expect(itemSubStages.item_file_uploaded).toBe(1);
+
+    // The shared $pageview event name feeds multiple sub-stages depending on page.
+    const pageviewRow = dashboard.eventTaxonomy.find((row) => row.event === "$pageview");
+    expect(pageviewRow?.mappedMilestone).toBeNull();
+    expect(pageviewRow?.mappedSubStages).toEqual(
+      expect.arrayContaining(["auth_landing_pageview", "items_pageview"]),
+    );
+    expect(pageviewRow?.mappedSubStages).not.toContain("receiving_pageview");
+  });
+
+  it("attributes engagement, experience, friction, and session events to stage sub-stages and excludes system events", async () => {
+    const prisma = prismaWithPostHogRows([
+      // Engagement: autocapture interactions on /items -> item_created.items_interactions
+      posthogEvent({
+        id: "ac-1",
+        event: "$autocapture",
+        distinctId: "user-1",
+        properties: { $pathname: "/items" },
+        occurredAt: "2026-06-20T09:00:00.000Z",
+      }),
+      // Experience: web vitals on /print-viewer -> card_printed.print_web_vitals
+      posthogEvent({
+        id: "wv-1",
+        event: "$web_vitals",
+        distinctId: "user-1",
+        properties: { $current_url: "https://app.arda.cards/print-viewer" },
+        occurredAt: "2026-06-20T09:01:00.000Z",
+      }),
+      // Friction: exception on /order-queue -> queue_added.order_queue_exceptions
+      posthogEvent({
+        id: "ex-1",
+        event: "$exception",
+        distinctId: "user-1",
+        properties: { $pathname: "/order-queue" },
+        occurredAt: "2026-06-20T09:02:00.000Z",
+      }),
+      // Friction: dead click on /receiving -> activation_completed.receiving_deadclick
+      posthogEvent({
+        id: "dc-1",
+        event: "$dead_click",
+        distinctId: "user-1",
+        properties: { $pathname: "/receiving" },
+        occurredAt: "2026-06-20T09:03:00.000Z",
+      }),
+      // Session: sign-out (page-agnostic) -> signup.sign_out
+      posthogEvent({
+        id: "so-1",
+        event: "user_signed_out",
+        distinctId: "user-1",
+        occurredAt: "2026-06-20T09:04:00.000Z",
+      }),
+      // System events: excluded from attribution, counted separately.
+      posthogEvent({
+        id: "id-1",
+        event: "$identify",
+        distinctId: "user-1",
+        occurredAt: "2026-06-20T09:05:00.000Z",
+      }),
+      posthogEvent({
+        id: "set-1",
+        event: "$set",
+        distinctId: "user-1",
+        occurredAt: "2026-06-20T09:06:00.000Z",
+      }),
+    ]);
+
+    const dashboard = await buildActivationJourneyDashboard({
+      prisma,
+      context: { userId: "user_1", organizationId: "org_1" },
+      now: new Date("2026-06-22T00:00:00.000Z"),
+      days: 14,
+    });
+
+    // 5 events found a sub-stage home; the 2 system events are excluded, none unmapped.
+    expect(dashboard.source.subStageMappedEvents).toBe(5);
+    expect(dashboard.source.systemEvents).toBe(2);
+    expect(dashboard.source.unmappedEvents).toBe(0);
+
+    const countFor = (milestoneKey: string, subKey: string) =>
+      dashboard.milestones
+        .find((m) => m.key === milestoneKey)
+        ?.subStages.find((sub) => sub.key === subKey)?.eventCount;
+
+    expect(countFor("item_created", "items_interactions")).toBe(1);
+    expect(countFor("card_printed", "print_web_vitals")).toBe(1);
+    expect(countFor("queue_added", "order_queue_exceptions")).toBe(1);
+    expect(countFor("activation_completed", "receiving_deadclick")).toBe(1);
+    expect(countFor("signup", "sign_out")).toBe(1);
+
+    // $autocapture is page-scoped: it feeds /items but not the receiving sub-stage.
+    const autocaptureRow = dashboard.eventTaxonomy.find((row) => row.event === "$autocapture");
+    expect(autocaptureRow?.mappedSubStages).toEqual(["items_interactions"]);
+  });
+
+  it("splits milestones into two funnels and computes the trial∪paid→signup bridge", async () => {
+    const prisma = prismaWithPostHogRows([
+      // userA: demo → trial → paid → signup (signup AFTER paid → post_paid)
+      posthogEvent({ id: "a-demo", event: "marketing_demo_requested", distinctId: "userA", occurredAt: "2026-06-20T08:00:00.000Z" }),
+      posthogEvent({ id: "a-trial", event: "trial_started", distinctId: "userA", occurredAt: "2026-06-20T09:00:00.000Z" }),
+      posthogEvent({ id: "a-paid", event: "subscription_paid", distinctId: "userA", occurredAt: "2026-06-20T10:00:00.000Z" }),
+      posthogEvent({ id: "a-signup", event: "user_signed_up", distinctId: "userA", occurredAt: "2026-06-20T11:00:00.000Z" }),
+      // userB: trial → signup (signup AFTER trial, never paid → post_trial)
+      posthogEvent({ id: "b-trial", event: "trial_started", distinctId: "userB", occurredAt: "2026-06-20T08:00:00.000Z" }),
+      posthogEvent({ id: "b-signup", event: "user_signed_up", distinctId: "userB", occurredAt: "2026-06-20T09:00:00.000Z" }),
+      // userC: signup only (no trial/paid → direct/free signup)
+      posthogEvent({ id: "c-signup", event: "user_signed_up", distinctId: "userC", occurredAt: "2026-06-20T08:00:00.000Z" }),
+      // userD: trial → paid, never signs up (commercial but does not enter the activation funnel)
+      posthogEvent({ id: "d-trial", event: "trial_started", distinctId: "userD", occurredAt: "2026-06-20T08:00:00.000Z" }),
+      posthogEvent({ id: "d-paid", event: "subscription_paid", distinctId: "userD", occurredAt: "2026-06-20T09:00:00.000Z" }),
+    ]);
+
+    const dashboard = await buildActivationJourneyDashboard({
+      prisma,
+      context: { userId: "user_1", organizationId: "org_1" },
+      now: new Date("2026-06-22T00:00:00.000Z"),
+      days: 14,
+    });
+
+    // Two funnels, each carrying its own ordered milestones.
+    expect(dashboard.marketingFunnel.map((m) => m.key)).toEqual([
+      "site_visited",
+      "kanban_submitted",
+      "cta_clicked",
+      "demo",
+      "trial",
+      "paid",
+    ]);
+    expect(dashboard.activationFunnel.map((m) => m.key)).toEqual([
+      "signup",
+      "tour_started",
+      "video_completed",
+      "item_created",
+      "card_printed",
+      "queue_added",
+      "order_placed",
+      "activation_completed",
+    ]);
+    expect(dashboard.marketingFunnel.every((m) => m.funnel === "marketing")).toBe(true);
+    expect(dashboard.activationFunnel.every((m) => m.funnel === "activation")).toBe(true);
+    // `paid` is the terminal marketing milestone.
+    expect(dashboard.marketingFunnel.at(-1)?.key).toBe("paid");
+
+    // THE KEY INVARIANT: signup is the first activation milestone and must NOT be
+    // divided by `paid` across the funnel boundary — its conversion is null (entry).
+    const signup = dashboard.activationFunnel[0];
+    expect(signup.key).toBe("signup");
+    expect(signup.conversionFromPrevious).toBeNull();
+    // site_visited (first marketing milestone) is likewise an entry point.
+    expect(dashboard.marketingFunnel[0].conversionFromPrevious).toBeNull();
+
+    // Bridge: trial ∪ paid → signup, with timestamp-based attribution.
+    expect(dashboard.bridge.commercialActors).toBe(3); // A, B, D have trial or paid
+    expect(dashboard.bridge.signedUpActors).toBe(2); // A, B are commercial AND signed up
+    expect(dashboard.bridge.conversionRate).toBe(66.67); // 2 / 3
+    expect(dashboard.bridge.signupAttribution).toEqual({
+      postPaid: 1, // A
+      postTrial: 1, // B
+      direct: 1, // C
+      total: 3, // A, B, C
+    });
+  });
+
+  it("queries the PostHog raw-event window in the caller scope", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const prisma = {
+      imladrisRawSourceRecord: { findMany },
+    } as unknown as PrismaClientType;
+
+    await buildActivationJourneyDashboard({
+      prisma,
+      context: { userId: "user_1", organizationId: "org_1" },
+      now: new Date("2026-06-22T00:00:00.000Z"),
+      days: 7,
+    });
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          provider: IntegrationProvider.POSTHOG,
+          objectType: "event",
+          occurredAt: {
+            gte: new Date("2026-06-15T00:00:00.000Z"),
+            lte: new Date("2026-06-22T00:00:00.000Z"),
+          },
+        }),
+        orderBy: [{ occurredAt: "asc" }, { sourceUpdatedAt: "asc" }],
+      }),
+    );
+  });
+
+  it("supports an explicit from/to custom window (overrides days)", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const prisma = { imladrisRawSourceRecord: { findMany } } as unknown as PrismaClientType;
+    await buildActivationJourneyDashboard({
+      prisma,
+      context: { userId: "user_1", organizationId: "org_1" },
+      now: new Date("2026-06-22T00:00:00.000Z"),
+      days: 7, // should be ignored when from/to are given
+      from: new Date("2026-01-01T00:00:00.000Z"),
+      to: new Date("2026-03-31T23:59:59.999Z"),
+    });
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          occurredAt: {
+            gte: new Date("2026-01-01T00:00:00.000Z"),
+            lte: new Date("2026-03-31T23:59:59.999Z"),
+          },
+        }),
+      }),
+    );
+  });
+
+  it("all=true queries from epoch and reports the earliest event as window.from", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const prisma = { imladrisRawSourceRecord: { findMany } } as unknown as PrismaClientType;
+    await buildActivationJourneyDashboard({
+      prisma,
+      context: { userId: "user_1", organizationId: "org_1" },
+      now: new Date("2026-06-22T00:00:00.000Z"),
+      all: true,
+    });
+    const call = findMany.mock.calls[0][0];
+    expect(call.where.occurredAt.gte).toEqual(new Date(0));
+    expect(call.where.occurredAt.lte).toEqual(new Date("2026-06-22T00:00:00.000Z"));
+
+    // With real events, window.from reflects the earliest event (not epoch 0).
+    const prisma2 = prismaWithPostHogRows([
+      posthogEvent({ id: "e1", event: "user_signed_up", distinctId: "u1", occurredAt: "2025-09-15T10:00:00.000Z" }),
+      posthogEvent({ id: "e2", event: "user_signed_up", distinctId: "u2", occurredAt: "2026-05-01T10:00:00.000Z" }),
+    ]);
+    const dash = await buildActivationJourneyDashboard({
+      prisma: prisma2,
+      context: { userId: "user_1", organizationId: "org_1" },
+      now: new Date("2026-06-22T00:00:00.000Z"),
+      all: true,
+    });
+    expect(dash.window.from).toBe("2025-09-15T10:00:00.000Z");
+  });
+});

--- a/src/lib/imladris/activation-journey.ts
+++ b/src/lib/imladris/activation-journey.ts
@@ -1,0 +1,1676 @@
+import { IntegrationProvider } from "@/generated/prisma/client";
+import type { PrismaClientType } from "@/lib/prisma";
+
+export type ActivationJourneyMilestoneKey =
+  // ── Marketing website funnel (www.arda.cards) — terminates at `paid` ──
+  | "site_visited"
+  | "kanban_submitted"
+  | "cta_clicked"
+  | "demo"
+  | "trial"
+  | "paid"
+  // ── Activation funnel (live.app.arda.cards) — begins at `signup` ──────
+  | "signup"
+  | "tour_started"
+  | "video_completed"
+  | "item_created"
+  | "card_printed"
+  | "queue_added"
+  | "order_placed"
+  | "activation_completed";
+
+/**
+ * Which of the two funnels a milestone belongs to. The marketing (commercial)
+ * funnel and the activation (product-usage) funnel are independent: each computes
+ * its own conversions, and `signup` — the first activation milestone — can follow
+ * `trial` OR `paid`, or be a direct/free signup. See `ActivationJourneyBridge`.
+ */
+export type ActivationFunnelKey = "marketing" | "activation";
+
+export type AcquisitionSourceKey =
+  | "direct"
+  | "google_organic"
+  | "google_ads"
+  | "facebook"
+  | "instagram"
+  | "linkedin"
+  | "referral"
+  | "email";
+
+export type ActorCohortKey = "tour_completed" | "started_not_completed" | "no_tour";
+
+/**
+ * Sub-stage "kinds" describe the supporting signal a sub-stage tracks. Sub-stages
+ * are diagnostic detail layered *under* a milestone (page views, drop-off,
+ * frustration, supporting conversions, etc.) and give the previously-unmapped
+ * PostHog events a home. They do NOT advance the milestone funnel — only a
+ * milestone's primary events do that.
+ */
+export type ActivationJourneySubStageKind =
+  | "pageview"
+  | "pageleave"
+  | "sign_up"
+  | "sign_in"
+  | "sign_out"
+  | "password_reset"
+  | "file_upload"
+  | "rage_click"
+  | "dead_click"
+  | "interaction"
+  | "web_vitals"
+  | "exception"
+  | "video"
+  | "fulfillment"
+  | "invite";
+
+type SourceStatus = "ready" | "partial" | "missing";
+type ObservationSeverity = "info" | "warning" | "critical";
+
+export interface ActivationJourneySummary {
+  totalEvents: number;
+  identifiedActors: number;
+  activatedActors: number;
+  activationRate: number | null;
+  medianHoursToActivation: number | null;
+  lastEventAt: string | null;
+}
+
+export interface ActivationJourneySubStage {
+  key: string;
+  label: string;
+  kind: ActivationJourneySubStageKind;
+  description: string;
+  /** PostHog event name(s) this sub-stage listens for. */
+  events: string[];
+  /** "instrumented" once events were observed in the window; "missing" otherwise (e.g. not yet captured). */
+  status: "instrumented" | "missing";
+  eventCount: number;
+  actors: number;
+}
+
+export interface ActivationJourneyMilestone {
+  key: ActivationJourneyMilestoneKey;
+  funnel: ActivationFunnelKey;
+  label: string;
+  description: string;
+  status: "instrumented" | "missing";
+  actors: number;
+  events: number;
+  /** Conversion from the PREVIOUS milestone WITHIN THE SAME FUNNEL. Null for the first milestone of each funnel — never computed across the marketing→activation boundary. */
+  conversionFromPrevious: number | null;
+  dropoffFromPrevious: number | null;
+  medianHoursFromFirstEvent: number | null;
+  subStages: ActivationJourneySubStage[];
+}
+
+/**
+ * The non-linear join between the marketing (commercial) funnel and the
+ * activation funnel. `signup` has no single upstream parent — it can follow
+ * `trial` OR `paid`, or be a direct/free signup — so this is modeled as a
+ * set-union bridge, NOT a funnel step.
+ */
+export interface ActivationJourneyBridge {
+  /** Actors who reached trial OR paid (the commercial-outcome set, the union denominator). */
+  commercialActors: number;
+  /** Of the commercial set, how many also signed up (entered the activation funnel). */
+  signedUpActors: number;
+  /** signedUpActors / commercialActors. */
+  conversionRate: number | null;
+  /** Every signup attributed to its inbound path by timestamp; buckets sum to `total`. */
+  signupAttribution: {
+    /** Signed up after becoming paid. */
+    postPaid: number;
+    /** Signed up after a trial (and not paid-first). */
+    postTrial: number;
+    /** Signed up with no preceding trial/paid — free/direct. */
+    direct: number;
+    /** All signups (== activation funnel entrants). */
+    total: number;
+  };
+}
+
+export interface ActivationJourneyCohort {
+  key: string;
+  label: string;
+  actors: number;
+  activatedActors: number;
+  activationRate: number | null;
+}
+
+export interface ActivationJourneyPath {
+  sequence: ActivationJourneyMilestoneKey[];
+  actors: number;
+  activatedActors: number;
+  activationRate: number | null;
+}
+
+export interface ActivationJourneyEventTaxonomyRow {
+  event: string;
+  mappedMilestone: ActivationJourneyMilestoneKey | null;
+  /** Sub-stage keys this event feeds. One event name (e.g. $pageview) can feed several, by page. */
+  mappedSubStages: string[];
+  count: number;
+  actors: number;
+  firstSeenAt: string | null;
+  lastSeenAt: string | null;
+}
+
+export interface ActivationJourneyObservation {
+  title: string;
+  detail: string;
+  severity: ObservationSeverity;
+}
+
+export interface FrictionSummary {
+  milestoneKey: ActivationJourneyMilestoneKey;
+  label: string;
+  rageClicks: number;
+  deadClicks: number;
+  totalFriction: number;
+}
+
+export interface SequentialFunnelEntry {
+  milestoneKey: ActivationJourneyMilestoneKey;
+  label: string;
+  /** Actors who reached this milestone AND all prior milestones. */
+  sequentialActors: number;
+  /** Actors who reached this milestone in any order. */
+  anyOrderActors: number;
+  /** sequentialActors / total identified actors. */
+  sequentialRate: number | null;
+}
+
+export interface TransitionTime {
+  from: ActivationJourneyMilestoneKey;
+  to: ActivationJourneyMilestoneKey;
+  fromLabel: string;
+  toLabel: string;
+  medianHours: number | null;
+  /** Actors who completed both milestones. */
+  actors: number;
+}
+
+export interface ActorSample {
+  actorId: string;
+  source: AcquisitionSourceKey;
+  milestones: ActivationJourneyMilestoneKey[];
+  furthestMilestone: ActivationJourneyMilestoneKey | null;
+  cohort: ActorCohortKey;
+  sessionReplayUrl: string | null;
+  identityUrl: string | null;
+  analyticsUrl: string | null;
+}
+
+/**
+ * Compact per-actor journey summary sent to the client so it can build
+ * Sankey links and segment funnels for any segmentation mode without
+ * re-fetching.
+ */
+export interface ActorJourneySummary {
+  source: AcquisitionSourceKey;
+  milestones: ActivationJourneyMilestoneKey[];
+  furthest: ActivationJourneyMilestoneKey | null;
+  cohort: ActorCohortKey;
+}
+
+export interface ActivationJourneyDashboardPayload {
+  summary: ActivationJourneySummary;
+  /** All milestones, both funnels, in canonical order. Each carries `funnel`. */
+  milestones: ActivationJourneyMilestone[];
+  /** Marketing website funnel (www.arda.cards): site_visited → … → demo → trial → paid. */
+  marketingFunnel: ActivationJourneyMilestone[];
+  /** Activation funnel (live.app.arda.cards): signup → tour_started → … → activation_completed. */
+  activationFunnel: ActivationJourneyMilestone[];
+  /** Non-linear trial∪paid → signup join between the two funnels. */
+  bridge: ActivationJourneyBridge;
+  cohorts: ActivationJourneyCohort[];
+  paths: ActivationJourneyPath[];
+  eventTaxonomy: ActivationJourneyEventTaxonomyRow[];
+  observations: ActivationJourneyObservation[];
+  source: {
+    status: SourceStatus;
+    unmappedEvents: number;
+    subStageMappedEvents: number;
+    /** PostHog system/plumbing events ($identify, $set, $session_summary_ready) intentionally excluded from journey attribution. */
+    systemEvents: number;
+  };
+  window: {
+    from: string;
+    to: string;
+    days: number;
+  };
+  /** Per-milestone friction roll-up (rage + dead clicks). */
+  friction: FrictionSummary[];
+  /** Strict-order sequential funnel counts. */
+  sequentialFunnel: SequentialFunnelEntry[];
+  /** Median hours between consecutive milestone pairs. */
+  transitionTimes: TransitionTime[];
+  /** Stratified sample of ~12 actor journeys for drill-down. */
+  actorSamples: ActorSample[];
+  /** Compact per-actor summaries for client-side Sankey + segment computation. */
+  actorJourneys: ActorJourneySummary[];
+}
+
+export interface BuildActivationJourneyDashboardInput {
+  prisma: Pick<PrismaClientType, "imladrisRawSourceRecord">;
+  context: {
+    userId?: string | null;
+    organizationId?: string | null;
+  };
+  now?: Date;
+  days?: number;
+  /** Explicit window start (takes precedence over `days`). */
+  from?: Date | null;
+  /** Explicit window end (defaults to `now`). */
+  to?: Date | null;
+  /** Include all available history — ignores `days`/`from`. window.from reports the earliest event. */
+  all?: boolean;
+}
+
+interface NormalizedPostHogEvent {
+  actorId: string;
+  event: string;
+  occurredAt: Date;
+  properties: Record<string, unknown>;
+  sessionId: string | null;
+}
+
+interface ActorJourney {
+  actorId: string;
+  firstEventAt: Date;
+  sessionId: string | null;
+  milestones: Map<ActivationJourneyMilestoneKey, Date>;
+  source: AcquisitionSourceKey;
+}
+
+/**
+ * Real Arda product page paths (taken from live PostHog `$pathname` values),
+ * grouped by the activation stage they belong to. Used to scope page-level
+ * sub-stages ($pageview / $pageleave / $rageclick / $dead_click) to the right
+ * milestone. Paths are compared after `normalizePath`, so trailing slashes and
+ * query strings are ignored.
+ */
+const AUTH_AND_LANDING_PATHS = ["/", "/signup", "/signin", "/reset-password"];
+const ONBOARDING_PATHS = ["/create-free-kanban-cards"];
+const ITEMS_PATHS = ["/items"];
+const PRINT_PATHS = ["/print-viewer"];
+const ORDER_QUEUE_PATHS = ["/order-queue"];
+const RECEIVING_PATHS = ["/receiving"];
+
+// ── Marketing site (Webflow @ www.arda.cards) ──────────────────────────
+const MARKETING_HOST = "www.arda.cards";
+const MARKETING_HOMEPAGE_PATHS = ["/"];
+const MARKETING_PRICING_PATHS = ["/pricing"];
+const MARKETING_FEATURES_PATHS = ["/features"];
+const MARKETING_SCHEDULE_PATHS = ["/schedule-a-call"];
+const MARKETING_BOOKING_PATHS = ["/booking-confirmation"];
+const MARKETING_COMPARE_PATHS = ["/compare"];
+
+interface SubStageDefinition {
+  key: string;
+  label: string;
+  kind: ActivationJourneySubStageKind;
+  description: string;
+  events: string[];
+  include?: (event: NormalizedPostHogEvent) => boolean;
+}
+
+/**
+ * PostHog system / plumbing events that are deliberately NOT attributed to a
+ * customer-journey stage — they describe identity resolution or SDK internals,
+ * not product behavior. Counted separately (source.systemEvents) so they don't
+ * inflate the genuinely-unmapped tally.
+ */
+const SYSTEM_EVENTS = new Set(["$identify", "$set", "$session_summary_ready"]);
+
+/**
+ * Standard page-scoped "secondary signal" sub-stages shared across stages:
+ * engagement ($autocapture), experience ($web_vitals), and friction
+ * ($rageclick / $dead_click / $exception / $pageleave). Generated per stage so
+ * the same diagnostic lenses apply to every page group without hand-repeating
+ * each definition. Only pass the kinds a stage doesn't already define by hand,
+ * so no event is double-counted. All are scoped to `paths`, keeping page-level
+ * events disjoint across stages.
+ */
+type SecondarySignalKind =
+  | "interaction"
+  | "web_vitals"
+  | "rage_click"
+  | "dead_click"
+  | "exception"
+  | "pageleave";
+
+function secondarySignalSubStages(
+  prefix: string,
+  pageLabel: string,
+  paths: string[],
+  kinds: SecondarySignalKind[],
+): SubStageDefinition[] {
+  const matcher = pathMatcher(paths);
+  const blueprints: Record<
+    SecondarySignalKind,
+    { keySuffix: string; label: string; kind: ActivationJourneySubStageKind; events: string[]; description: string }
+  > = {
+    interaction: {
+      keySuffix: "interactions",
+      label: `${pageLabel} interactions`,
+      kind: "interaction",
+      events: ["$autocapture"],
+      description: `$autocapture clicks/inputs on ${pageLabel} pages — engagement depth at this stage.`,
+    },
+    web_vitals: {
+      keySuffix: "web_vitals",
+      label: `${pageLabel} web vitals`,
+      kind: "web_vitals",
+      events: ["$web_vitals"],
+      description: `$web_vitals performance samples on ${pageLabel} pages — load/interaction experience.`,
+    },
+    rage_click: {
+      keySuffix: "rageclick",
+      label: `${pageLabel} rage clicks`,
+      kind: "rage_click",
+      events: ["$rageclick"],
+      description: `$rageclick on ${pageLabel} pages — frustration.`,
+    },
+    dead_click: {
+      keySuffix: "deadclick",
+      label: `${pageLabel} dead clicks`,
+      kind: "dead_click",
+      events: ["$dead_click"],
+      description: `$dead_click on ${pageLabel} pages — clicks on things that look interactive but aren't.`,
+    },
+    exception: {
+      keySuffix: "exceptions",
+      label: `${pageLabel} exceptions`,
+      kind: "exception",
+      events: ["$exception"],
+      description: `$exception on ${pageLabel} pages — client errors that can block progress.`,
+    },
+    pageleave: {
+      keySuffix: "pageleave",
+      label: `${pageLabel} drop-off (pageleave)`,
+      kind: "pageleave",
+      events: ["$pageleave"],
+      description: `$pageleave on ${pageLabel} pages — where people fall off.`,
+    },
+  };
+
+  return kinds.map((signalKind) => {
+    const blueprint = blueprints[signalKind];
+    return {
+      key: `${prefix}_${blueprint.keySuffix}`,
+      label: blueprint.label,
+      kind: blueprint.kind,
+      description: blueprint.description,
+      events: blueprint.events,
+      include: matcher,
+    };
+  });
+}
+
+const milestoneDefinitions: Array<{
+  key: ActivationJourneyMilestoneKey;
+  funnel: ActivationFunnelKey;
+  label: string;
+  description: string;
+  events: string[];
+  include?: (event: NormalizedPostHogEvent) => boolean;
+  subStages: SubStageDefinition[];
+}> = [
+  // ── Marketing website funnel (www.arda.cards) — ends at `paid` ────────
+  {
+    key: "site_visited",
+    funnel: "marketing",
+    label: "Site visited",
+    description: "First visit to arda.cards marketing site (custom event from Webflow tracking code).",
+    events: ["marketing_site_visited"],
+    subStages: [
+      {
+        key: "mkt_homepage",
+        label: "Homepage views",
+        kind: "pageview",
+        description: "$pageview on marketing homepage (www.arda.cards/).",
+        events: ["$pageview"],
+        include: hostAndPathMatcher(MARKETING_HOST, MARKETING_HOMEPAGE_PATHS),
+      },
+      {
+        key: "mkt_pricing",
+        label: "Pricing page views",
+        kind: "pageview",
+        description: "$pageview on marketing pricing page.",
+        events: ["$pageview"],
+        include: hostAndPathMatcher(MARKETING_HOST, MARKETING_PRICING_PATHS),
+      },
+      {
+        key: "mkt_features",
+        label: "Features page views",
+        kind: "pageview",
+        description: "$pageview on marketing features page.",
+        events: ["$pageview"],
+        include: hostAndPathMatcher(MARKETING_HOST, MARKETING_FEATURES_PATHS),
+      },
+      {
+        key: "mkt_blog",
+        label: "Blog & content views",
+        kind: "pageview",
+        description: "$pageview on blog listing or individual posts.",
+        events: ["$pageview"],
+        include: hostAndPathPrefixMatcher(MARKETING_HOST, ["/blog"], ["/post/"]),
+      },
+      {
+        key: "mkt_case_studies",
+        label: "Case study views",
+        kind: "pageview",
+        description: "$pageview on case studies listing or individual case studies.",
+        events: ["$pageview"],
+        include: hostAndPathPrefixMatcher(MARKETING_HOST, ["/case-studies"], ["/case-study/"]),
+      },
+      {
+        key: "mkt_compare",
+        label: "Comparison page views",
+        kind: "pageview",
+        description: "$pageview on comparison/alternatives pages.",
+        events: ["$pageview"],
+        include: hostAndPathPrefixMatcher(MARKETING_HOST, MARKETING_COMPARE_PATHS, ["/compare/"]),
+      },
+      {
+        key: "mkt_interactions",
+        label: "Marketing site interactions",
+        kind: "interaction",
+        description: "$autocapture clicks/inputs on marketing site — engagement depth.",
+        events: ["$autocapture"],
+        include: hostMatcher(MARKETING_HOST),
+      },
+      {
+        key: "mkt_rageclick",
+        label: "Marketing site rage clicks",
+        kind: "rage_click",
+        description: "$rageclick on marketing site — frustration.",
+        events: ["$rageclick"],
+        include: hostMatcher(MARKETING_HOST),
+      },
+      {
+        key: "mkt_deadclick",
+        label: "Marketing site dead clicks",
+        kind: "dead_click",
+        description: "$dead_click on marketing site — clicks on non-interactive elements.",
+        events: ["$dead_click"],
+        include: hostMatcher(MARKETING_HOST),
+      },
+    ],
+  },
+  {
+    key: "kanban_submitted",
+    funnel: "marketing",
+    label: "Free kanban submitted",
+    description: "Visitor submitted the free kanban card form on /create-free-kanban-cards.",
+    events: ["$autocapture"],
+    include: (() => {
+      const isKanbanPath = pathMatcher(ONBOARDING_PATHS);
+      return (event: NormalizedPostHogEvent) =>
+        asString(event.properties["$event_type"]) === "submit" && isKanbanPath(event);
+    })(),
+    subStages: [
+      {
+        key: "kanban_pageview",
+        label: "Kanban page views",
+        kind: "pageview",
+        description: "$pageview on /create-free-kanban-cards — visitors who land on the free kanban tool.",
+        events: ["$pageview"],
+        include: pathMatcher(ONBOARDING_PATHS),
+      },
+      ...secondarySignalSubStages(
+        "kanban",
+        "Free kanban",
+        ONBOARDING_PATHS,
+        ["interaction", "web_vitals", "rage_click", "dead_click", "exception", "pageleave"],
+      ),
+    ],
+  },
+  {
+    key: "cta_clicked",
+    funnel: "marketing",
+    label: "CTA clicked",
+    description: "Clicked a primary CTA on arda.cards (trial, demo, free cards, or action demo).",
+    events: ["marketing_cta_clicked"],
+    subStages: [
+      {
+        key: "mkt_schedule_pageview",
+        label: "Schedule-a-call page views",
+        kind: "pageview",
+        description: "$pageview on /schedule-a-call — intent to book a demo.",
+        events: ["$pageview"],
+        include: hostAndPathMatcher(MARKETING_HOST, MARKETING_SCHEDULE_PATHS),
+      },
+      {
+        key: "mkt_pageleave",
+        label: "Marketing site drop-off",
+        kind: "pageleave",
+        description: "$pageleave on marketing site — where visitors fall off.",
+        events: ["$pageleave"],
+        include: hostMatcher(MARKETING_HOST),
+      },
+    ],
+  },
+  {
+    key: "demo",
+    funnel: "marketing",
+    label: "Demo booked",
+    description: "Booked a demo on arda.cards (reached /booking-confirmation). Default: demo = booked; switch to demo-attended would require a calendar/HubSpot signal.",
+    events: ["marketing_demo_requested"],
+    subStages: [
+      {
+        key: "mkt_booking_confirmation",
+        label: "Booking confirmation views",
+        kind: "pageview",
+        description: "$pageview on /booking-confirmation — demo successfully booked.",
+        events: ["$pageview"],
+        include: hostAndPathMatcher(MARKETING_HOST, MARKETING_BOOKING_PATHS),
+      },
+    ],
+  },
+  {
+    key: "trial",
+    funnel: "marketing",
+    label: "Trial started",
+    description:
+      "Started a product trial. Awaiting the `trial_started` PostHog event from the Arda product app (see PDEV instrumentation ticket); renders as 'missing' until emitted.",
+    events: ["trial_started"],
+    subStages: [],
+  },
+  {
+    key: "paid",
+    funnel: "marketing",
+    label: "Became paid",
+    description:
+      "Converted to a paying customer — the TERMINAL stage of the marketing funnel. Awaiting `subscription_paid` / `checkout_completed` from the product app; renders as 'missing' until emitted.",
+    events: ["subscription_paid", "checkout_completed"],
+    subStages: [],
+  },
+  // ── Activation funnel (live.app.arda.cards) — begins at `signup` ──────
+  {
+    key: "signup",
+    funnel: "activation",
+    label: "Signed up",
+    description:
+      "user_signed_up — a new account is created in live.app.arda.cards. First step of the activation funnel; can follow trial or paid, or be a direct/free signup (see bridge).",
+    events: ["user_signed_up"],
+    subStages: [
+      {
+        key: "auth_landing_pageview",
+        label: "Auth & landing pageviews",
+        kind: "pageview",
+        description: "$pageview on landing, sign-up, sign-in, and reset-password pages.",
+        events: ["$pageview"],
+        include: pathMatcher(AUTH_AND_LANDING_PATHS),
+      },
+      {
+        key: "sign_in",
+        label: "Sign-ins",
+        kind: "sign_in",
+        description: "user_signed_in — a returning user authenticates.",
+        events: ["user_signed_in"],
+      },
+      {
+        key: "password_reset_requested",
+        label: "Password resets requested",
+        kind: "password_reset",
+        description: "password_reset_requested — friction signal during the auth step.",
+        events: ["password_reset_requested"],
+      },
+      {
+        key: "onboarding_rageclick",
+        label: "Auth rage clicks",
+        kind: "rage_click",
+        description: "$rageclick on auth pages — early frustration.",
+        events: ["$rageclick"],
+        include: pathMatcher(AUTH_AND_LANDING_PATHS),
+      },
+      {
+        key: "onboarding_pageleave",
+        label: "Auth drop-off (pageleave)",
+        kind: "pageleave",
+        description: "$pageleave on auth pages — where people fall off before starting.",
+        events: ["$pageleave"],
+        include: pathMatcher(AUTH_AND_LANDING_PATHS),
+      },
+      {
+        key: "sign_out",
+        label: "Sign-outs",
+        kind: "sign_out",
+        description: "user_signed_out — a session ends; auth-lifecycle signal (can occur from any page).",
+        events: ["user_signed_out"],
+      },
+      ...secondarySignalSubStages(
+        "signup",
+        "Auth",
+        AUTH_AND_LANDING_PATHS,
+        ["interaction", "web_vitals", "dead_click", "exception"],
+      ),
+    ],
+  },
+  {
+    key: "tour_started",
+    funnel: "activation",
+    label: "Tour started",
+    description: "PR #915 onboarding tour starts for a newly signed-in user.",
+    events: ["onboarding_tour_started"],
+    subStages: [],
+  },
+  {
+    key: "video_completed",
+    funnel: "activation",
+    label: "Video completed",
+    description: "Welcome video completes with placement=onboarding-tour.",
+    events: ["walkthrough_video_completed"],
+    include: (event) => event.properties.placement === "onboarding-tour",
+    subStages: [
+      {
+        key: "video_shown",
+        label: "Walkthrough video shown",
+        kind: "video",
+        description: "walkthrough_video_shown — the welcome video was surfaced (denominator for completion).",
+        events: ["walkthrough_video_shown"],
+      },
+    ],
+  },
+  {
+    key: "item_created",
+    funnel: "activation",
+    label: "Item created",
+    description: "PR #909 item_created fires server-side after manual item creation succeeds.",
+    events: ["item_created"],
+    subStages: [
+      {
+        key: "items_pageview",
+        label: "Items pageviews",
+        kind: "pageview",
+        description: "$pageview on /items.",
+        events: ["$pageview"],
+        include: pathMatcher(ITEMS_PATHS),
+      },
+      {
+        key: "item_file_uploaded",
+        label: "Item file uploads",
+        kind: "file_upload",
+        description: "item_file_uploaded — a file is uploaded while creating an item.",
+        events: ["item_file_uploaded"],
+      },
+      {
+        key: "items_rageclick",
+        label: "Items rage clicks",
+        kind: "rage_click",
+        description: "$rageclick on /items — friction during item creation.",
+        events: ["$rageclick"],
+        include: pathMatcher(ITEMS_PATHS),
+      },
+      {
+        key: "items_pageleave",
+        label: "Items drop-off (pageleave)",
+        kind: "pageleave",
+        description: "$pageleave on /items — where people abandon item creation.",
+        events: ["$pageleave"],
+        include: pathMatcher(ITEMS_PATHS),
+      },
+      ...secondarySignalSubStages("items", "Items", ITEMS_PATHS, [
+        "interaction",
+        "web_vitals",
+        "dead_click",
+        "exception",
+      ]),
+    ],
+  },
+  {
+    key: "card_printed",
+    funnel: "activation",
+    label: "Card printed",
+    description: "PR #909 card_printed fires for Kanban card and item-label print success.",
+    events: ["card_printed"],
+    subStages: [
+      {
+        key: "print_pageview",
+        label: "Print viewer pageviews",
+        kind: "pageview",
+        description: "$pageview on /print-viewer.",
+        events: ["$pageview"],
+        include: pathMatcher(PRINT_PATHS),
+      },
+      {
+        key: "print_rageclick",
+        label: "Print viewer rage clicks",
+        kind: "rage_click",
+        description: "$rageclick on /print-viewer — a frequently fiddly step.",
+        events: ["$rageclick"],
+        include: pathMatcher(PRINT_PATHS),
+      },
+      {
+        key: "print_deadclick",
+        label: "Print viewer dead clicks",
+        kind: "dead_click",
+        description: "$dead_click on /print-viewer — clicks on things that look interactive but aren't.",
+        events: ["$dead_click"],
+        include: pathMatcher(PRINT_PATHS),
+      },
+      {
+        key: "print_pageleave",
+        label: "Print viewer drop-off (pageleave)",
+        kind: "pageleave",
+        description: "$pageleave on /print-viewer — where people abandon printing.",
+        events: ["$pageleave"],
+        include: pathMatcher(PRINT_PATHS),
+      },
+      ...secondarySignalSubStages("print", "Print viewer", PRINT_PATHS, [
+        "interaction",
+        "web_vitals",
+        "exception",
+      ]),
+    ],
+  },
+  {
+    key: "queue_added",
+    funnel: "activation",
+    label: "Added to order queue",
+    description: "Bridge event from the first item to the order queue.",
+    events: ["card_added_to_order_queue"],
+    subStages: [
+      {
+        key: "order_queue_pageview",
+        label: "Order queue pageviews",
+        kind: "pageview",
+        description: "$pageview on /order-queue.",
+        events: ["$pageview"],
+        include: pathMatcher(ORDER_QUEUE_PATHS),
+      },
+      {
+        key: "order_queue_rageclick",
+        label: "Order queue rage clicks",
+        kind: "rage_click",
+        description: "$rageclick on /order-queue — friction assembling an order.",
+        events: ["$rageclick"],
+        include: pathMatcher(ORDER_QUEUE_PATHS),
+      },
+      {
+        key: "order_queue_pageleave",
+        label: "Order queue drop-off (pageleave)",
+        kind: "pageleave",
+        description: "$pageleave on /order-queue — where people abandon the queue.",
+        events: ["$pageleave"],
+        include: pathMatcher(ORDER_QUEUE_PATHS),
+      },
+      ...secondarySignalSubStages("order_queue", "Order queue", ORDER_QUEUE_PATHS, [
+        "interaction",
+        "web_vitals",
+        "dead_click",
+        "exception",
+      ]),
+    ],
+  },
+  {
+    key: "order_placed",
+    funnel: "activation",
+    label: "Order placed",
+    description: "PR #909 order_placed maps to card accept or fulfillment from the order queue.",
+    events: ["order_placed", "card_fulfilled"],
+    subStages: [],
+  },
+  {
+    key: "activation_completed",
+    funnel: "activation",
+    label: "Activation completed",
+    description: "Terminal marker for users who complete the activation loop (order fully fulfilled / received).",
+    events: ["activation_completed", "all_cards_fulfilled", "cards_received"],
+    subStages: [
+      {
+        key: "receiving_pageview",
+        label: "Receiving pageviews",
+        kind: "pageview",
+        description: "$pageview on /receiving — the user returns to receive their cards.",
+        events: ["$pageview"],
+        include: pathMatcher(RECEIVING_PATHS),
+      },
+      {
+        key: "invitation_accepted",
+        label: "Invitations accepted",
+        kind: "invite",
+        description: "invitation_accepted — a teammate accepts an invite, expanding the activated account.",
+        events: ["invitation_accepted"],
+      },
+      ...secondarySignalSubStages("receiving", "Receiving", RECEIVING_PATHS, [
+        "interaction",
+        "web_vitals",
+        "rage_click",
+        "dead_click",
+        "exception",
+        "pageleave",
+      ]),
+    ],
+  },
+];
+
+/** Flat index of every sub-stage with its parent milestone, for event resolution. */
+const subStageIndex: Array<{ milestoneKey: ActivationJourneyMilestoneKey; definition: SubStageDefinition }> =
+  milestoneDefinitions.flatMap((milestone) =>
+    milestone.subStages.map((definition) => ({ milestoneKey: milestone.key, definition })),
+  );
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function toDate(value: unknown, fallback: unknown): Date | null {
+  const source =
+    asString(value) ?? (fallback instanceof Date ? fallback.toISOString() : asString(fallback));
+  if (!source) return null;
+
+  const parsed = new Date(source);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function percent(numerator: number, denominator: number): number | null {
+  if (denominator <= 0) return null;
+  return Math.round((numerator / denominator) * 10_000) / 100;
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  const raw =
+    sorted.length % 2 === 1 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2;
+  return Math.round(raw * 100) / 100;
+}
+
+function normalizeRawPostHogEvent(row: unknown): NormalizedPostHogEvent | null {
+  const raw = asRecord(row);
+  const payload = asRecord(raw.payload);
+  const actorId = asString(payload.distinct_id) ?? asString(payload.distinctId);
+  const event = asString(payload.event);
+  const occurredAt = toDate(payload.timestamp, raw.occurredAt);
+  const properties = asRecord(payload.properties);
+
+  if (!actorId || !event || !occurredAt) return null;
+
+  return {
+    actorId,
+    event,
+    occurredAt,
+    properties,
+    sessionId:
+      asString(properties["$session_id"]) ??
+      asString(properties.session_id) ??
+      asString(payload["$session_id"]),
+  };
+}
+
+function normalizePostHogAppHost(host: string | null | undefined): string {
+  const raw = host?.trim().replace(/\/+$/, "");
+  if (!raw) return "https://app.posthog.com";
+
+  try {
+    const url = new URL(raw.startsWith("http") ? raw : `https://${raw}`);
+    const hostname =
+      url.hostname === "us.i.posthog.com"
+        ? "us.posthog.com"
+        : url.hostname === "eu.i.posthog.com"
+          ? "eu.posthog.com"
+          : url.hostname;
+    return `${url.protocol}//${hostname}`;
+  } catch {
+    return "https://app.posthog.com";
+  }
+}
+
+function postHogProjectId(): string | null {
+  return asString(process.env.POSTHOG_PROJECT_ID);
+}
+
+function postHogAppHost(): string {
+  return normalizePostHogAppHost(
+    process.env.POSTHOG_APP_HOST ?? process.env.POSTHOG_HOST ?? process.env.POSTHOG_API_HOST,
+  );
+}
+
+function postHogActorLinks(actor: ActorJourney): Pick<
+  ActorSample,
+  "sessionReplayUrl" | "identityUrl" | "analyticsUrl"
+> {
+  const projectId = postHogProjectId();
+  if (!projectId) {
+    return { sessionReplayUrl: null, identityUrl: null, analyticsUrl: null };
+  }
+
+  const baseUrl = `${postHogAppHost()}/project/${encodeURIComponent(projectId)}`;
+  const actorId = encodeURIComponent(actor.actorId);
+  const sessionId = actor.sessionId ? encodeURIComponent(actor.sessionId) : null;
+
+  return {
+    sessionReplayUrl: sessionId ? `${baseUrl}/replay/${sessionId}` : null,
+    identityUrl: `${baseUrl}/person/${actorId}`,
+    analyticsUrl: `${baseUrl}/events?distinct_id=${actorId}`,
+  };
+}
+
+function milestoneForEvent(
+  event: NormalizedPostHogEvent,
+): ActivationJourneyMilestoneKey | null {
+  return (
+    milestoneDefinitions.find(
+      (definition) =>
+        definition.events.includes(event.event) &&
+        (!definition.include || definition.include(event)),
+    )?.key ?? null
+  );
+}
+
+function normalizePath(value: string): string {
+  if (!value) return "";
+  const withoutQuery = value.split(/[?#]/)[0];
+  if (withoutQuery.length > 1) {
+    return withoutQuery.replace(/\/+$/, "");
+  }
+  return withoutQuery;
+}
+
+function eventPath(event: NormalizedPostHogEvent): string {
+  const direct = asString(event.properties["$pathname"]);
+  if (direct) return normalizePath(direct);
+
+  const url = asString(event.properties["$current_url"]);
+  if (url) {
+    try {
+      return normalizePath(new URL(url).pathname);
+    } catch {
+      return "";
+    }
+  }
+  return "";
+}
+
+function pathMatcher(paths: string[]): (event: NormalizedPostHogEvent) => boolean {
+  const normalized = paths.map(normalizePath);
+  return (event) => {
+    const path = eventPath(event);
+    return path !== "" && normalized.includes(path);
+  };
+}
+
+/** Extract host from event, falling back to $current_url when $host is absent. */
+function eventHostname(event: NormalizedPostHogEvent): string {
+  const explicit = asString(event.properties.$host);
+  if (explicit) return explicit.toLowerCase();
+  const url = asString(event.properties.$current_url);
+  if (url) {
+    try { return new URL(url).hostname.toLowerCase(); } catch { /* malformed */ }
+  }
+  return "";
+}
+
+/** Match events from a specific host AND specific paths. */
+function hostAndPathMatcher(
+  host: string,
+  paths: string[],
+): (event: NormalizedPostHogEvent) => boolean {
+  const normalizedPaths = paths.map(normalizePath);
+  const lowerHost = host.toLowerCase();
+  return (event) => {
+    if (eventHostname(event) !== lowerHost) return false;
+    const path = eventPath(event);
+    return path !== "" && normalizedPaths.includes(path);
+  };
+}
+
+/**
+ * Match events from a specific host with exact paths OR path prefixes.
+ * Useful for blog posts (/post/*) and case studies (/case-study/*).
+ */
+function hostAndPathPrefixMatcher(
+  host: string,
+  exactPaths: string[],
+  prefixes: string[],
+): (event: NormalizedPostHogEvent) => boolean {
+  const normalizedExact = exactPaths.map(normalizePath);
+  const lowerHost = host.toLowerCase();
+  // Keep trailing slash on prefixes so "/post/" doesn't match "/postmortem"
+  const normalizedPrefixes = prefixes.map((p) => p.toLowerCase());
+  return (event) => {
+    if (eventHostname(event) !== lowerHost) return false;
+    const path = eventPath(event);
+    if (path === "") return false;
+    if (normalizedExact.includes(path)) return true;
+    return normalizedPrefixes.some((prefix) => path.startsWith(prefix));
+  };
+}
+
+/** Match any event from a specific host. */
+function hostMatcher(host: string): (event: NormalizedPostHogEvent) => boolean {
+  const lowerHost = host.toLowerCase();
+  return (event) => eventHostname(event) === lowerHost;
+}
+
+/**
+ * Classify an actor's acquisition source from PostHog event properties.
+ * Checks both `$initial_utm_*` (person-on-events first-touch properties) and
+ * `utm_*` (current-pageview URL params, used by the Webflow marketing site).
+ * Falls back to `$initial_referring_domain` / `$referring_domain`.
+ */
+function classifySource(properties: Record<string, unknown>): AcquisitionSourceKey {
+  const utmSource = (
+    asString(properties.$initial_utm_source) ??
+    asString(properties.utm_source) ??
+    ""
+  ).toLowerCase();
+  const utmMedium = (
+    asString(properties.$initial_utm_medium) ??
+    asString(properties.utm_medium) ??
+    ""
+  ).toLowerCase();
+  const referrer = (
+    asString(properties.$initial_referring_domain) ??
+    asString(properties.$referring_domain) ??
+    ""
+  ).toLowerCase();
+
+  // Google Ads — paid search (most specific, check first)
+  if (
+    (utmSource === "google" && (utmMedium === "cpc" || utmMedium === "ppc")) ||
+    (utmSource === "adwords" && utmMedium === "ppc") ||
+    asString(properties.$initial_gclid) !== null ||
+    asString(properties.gclid) !== null ||
+    referrer.includes("googleads.g.doubleclick.net")
+  ) {
+    return "google_ads";
+  }
+  // Instagram — check before Facebook so paid_social doesn't swallow IG campaigns
+  if (
+    utmSource === "instagram" || utmSource === "ig" ||
+    referrer.includes("instagram.com")
+  ) {
+    return "instagram";
+  }
+  // Facebook — paid or organic (paid_social only after IG is ruled out)
+  if (
+    utmSource === "facebook" || utmSource === "fb" ||
+    utmMedium === "paid_social" ||
+    referrer.includes("facebook.com")
+  ) {
+    return "facebook";
+  }
+  // Google organic
+  if (utmSource === "google" || referrer.includes("google.")) {
+    return "google_organic";
+  }
+  // LinkedIn
+  if (utmSource === "linkedin" || referrer.includes("linkedin.")) {
+    return "linkedin";
+  }
+  // Email campaigns
+  if (utmSource === "email" || utmSource === "hs_email" || utmMedium === "email") {
+    return "email";
+  }
+  // Referral — has a referring domain that isn't self
+  if (referrer && !referrer.includes("arda.cards") && !referrer.includes("localhost")) {
+    return "referral";
+  }
+  return "direct";
+}
+
+function actorCohort(actor: ActorJourney): ActorCohortKey {
+  if (!actor.milestones.has("tour_started")) return "no_tour";
+  if (actor.milestones.has("video_completed")) return "tour_completed";
+  return "started_not_completed";
+}
+
+function actorFurthestMilestone(
+  actor: ActorJourney,
+  keys: ActivationJourneyMilestoneKey[],
+): ActivationJourneyMilestoneKey | null {
+  for (let i = keys.length - 1; i >= 0; i--) {
+    if (actor.milestones.has(keys[i])) return keys[i];
+  }
+  return null;
+}
+
+/**
+ * Resolve the sub-stage an event belongs to, if any. Only called for events that
+ * are NOT a milestone's primary event, so sub-stages never double-count or
+ * advance the funnel. The first matching sub-stage (in definition order) wins;
+ * page-scoped predicates keep page-level events disjoint across stages.
+ */
+function subStageForEvent(
+  event: NormalizedPostHogEvent,
+): { milestoneKey: ActivationJourneyMilestoneKey; definition: SubStageDefinition } | null {
+  return (
+    subStageIndex.find(
+      ({ definition }) =>
+        definition.events.includes(event.event) &&
+        (!definition.include || definition.include(event)),
+    ) ?? null
+  );
+}
+
+function ensureActorJourney(
+  journeys: Map<string, ActorJourney>,
+  event: NormalizedPostHogEvent,
+): ActorJourney {
+  const existing = journeys.get(event.actorId);
+  if (existing) {
+    if (event.occurredAt < existing.firstEventAt) {
+      existing.firstEventAt = event.occurredAt;
+      // Re-classify source from the genuinely earliest event
+      existing.source = classifySource(event.properties);
+    }
+    if (!existing.sessionId && event.sessionId) {
+      existing.sessionId = event.sessionId;
+    }
+    return existing;
+  }
+
+  const created: ActorJourney = {
+    actorId: event.actorId,
+    firstEventAt: event.occurredAt,
+    sessionId: event.sessionId,
+    milestones: new Map(),
+    source: classifySource(event.properties),
+  };
+  journeys.set(event.actorId, created);
+  return created;
+}
+
+function buildCohort(
+  key: string,
+  label: string,
+  actors: ActorJourney[],
+): ActivationJourneyCohort {
+  const activatedActors = actors.filter((actor) =>
+    actor.milestones.has("activation_completed"),
+  ).length;
+
+  return {
+    key,
+    label,
+    actors: actors.length,
+    activatedActors,
+    activationRate: percent(activatedActors, actors.length),
+  };
+}
+
+export async function buildActivationJourneyDashboard({
+  prisma,
+  context,
+  now = new Date(),
+  days = 30,
+  from = null,
+  to = null,
+  all = false,
+}: BuildActivationJourneyDashboardInput): Promise<ActivationJourneyDashboardPayload> {
+  const boundedDays = Math.max(1, days);
+  const windowEnd = to ?? now;
+  // Precedence: all (everything) > explicit from > rolling `days` window.
+  const windowStart = all
+    ? new Date(0)
+    : from ?? new Date(windowEnd.getTime() - boundedDays * 24 * 60 * 60 * 1000);
+  const rows = await prisma.imladrisRawSourceRecord.findMany({
+    where: {
+      provider: IntegrationProvider.POSTHOG,
+      objectType: "event",
+      occurredAt: {
+        gte: windowStart,
+        lte: windowEnd,
+      },
+      ...(context.organizationId
+        ? { organizationId: context.organizationId }
+        : { userId: context.userId }),
+    },
+    orderBy: [{ occurredAt: "asc" }, { sourceUpdatedAt: "asc" }],
+  } as never);
+
+  const events = rows
+    .map((row) => normalizeRawPostHogEvent(row))
+    .filter((event): event is NormalizedPostHogEvent => event !== null);
+  const journeys = new Map<string, ActorJourney>();
+  const taxonomy = new Map<
+    string,
+    {
+      event: string;
+      mappedMilestone: ActivationJourneyMilestoneKey | null;
+      subStages: Set<string>;
+      count: number;
+      actors: Set<string>;
+      firstSeenAt: Date;
+      lastSeenAt: Date;
+    }
+  >();
+  const subStageMetrics = new Map<string, { count: number; actors: Set<string> }>();
+  let unmappedEvents = 0;
+  let subStageMappedEvents = 0;
+  let systemEvents = 0;
+
+  for (const event of events) {
+    const milestoneKey = milestoneForEvent(event);
+    // Only events that are NOT a milestone's primary event can fall through to a
+    // sub-stage, so the two never overlap.
+    const subStage = milestoneKey ? null : subStageForEvent(event);
+    const actor = ensureActorJourney(journeys, event);
+    const existingTaxonomy = taxonomy.get(event.event);
+
+    if (existingTaxonomy) {
+      existingTaxonomy.count += 1;
+      existingTaxonomy.actors.add(event.actorId);
+      existingTaxonomy.mappedMilestone ??= milestoneKey;
+      if (subStage) existingTaxonomy.subStages.add(subStage.definition.key);
+      if (event.occurredAt < existingTaxonomy.firstSeenAt) {
+        existingTaxonomy.firstSeenAt = event.occurredAt;
+      }
+      if (event.occurredAt > existingTaxonomy.lastSeenAt) {
+        existingTaxonomy.lastSeenAt = event.occurredAt;
+      }
+    } else {
+      taxonomy.set(event.event, {
+        event: event.event,
+        mappedMilestone: milestoneKey,
+        subStages: new Set(subStage ? [subStage.definition.key] : []),
+        count: 1,
+        actors: new Set([event.actorId]),
+        firstSeenAt: event.occurredAt,
+        lastSeenAt: event.occurredAt,
+      });
+    }
+
+    if (subStage) {
+      subStageMappedEvents += 1;
+      const metric = subStageMetrics.get(subStage.definition.key) ?? {
+        count: 0,
+        actors: new Set<string>(),
+      };
+      metric.count += 1;
+      metric.actors.add(event.actorId);
+      subStageMetrics.set(subStage.definition.key, metric);
+    }
+
+    if (!milestoneKey) {
+      // An event with neither a milestone nor a sub-stage home is either a known
+      // system/plumbing event (excluded by design) or genuinely unmapped.
+      if (!subStage) {
+        if (SYSTEM_EVENTS.has(event.event)) systemEvents += 1;
+        else unmappedEvents += 1;
+      }
+      continue;
+    }
+
+    const previous = actor.milestones.get(milestoneKey);
+    if (!previous || event.occurredAt < previous) {
+      actor.milestones.set(milestoneKey, event.occurredAt);
+    }
+  }
+
+  const actors = [...journeys.values()];
+  const milestones = milestoneDefinitions.map<ActivationJourneyMilestone>((definition, index) => {
+    const matchingActors = actors.filter((actor) => actor.milestones.has(definition.key));
+    // Conversion is computed against the previous milestone WITHIN THE SAME FUNNEL.
+    // The first milestone of each funnel (and any milestone whose predecessor lives
+    // in the other funnel) has no in-funnel parent → null. This is what stops
+    // `signup` from being divided by `paid` across the marketing→activation boundary.
+    const previousDefinition = index === 0 ? null : milestoneDefinitions[index - 1];
+    const previousActorCount =
+      previousDefinition && previousDefinition.funnel === definition.funnel
+        ? actors.filter((actor) => actor.milestones.has(previousDefinition.key)).length
+        : null;
+    const conversionFromPrevious =
+      previousActorCount === null ? null : percent(matchingActors.length, previousActorCount);
+    const milestoneEvents = events.filter((event) => milestoneForEvent(event) === definition.key);
+
+    return {
+      key: definition.key,
+      funnel: definition.funnel,
+      label: definition.label,
+      description: definition.description,
+      status: matchingActors.length > 0 ? "instrumented" : "missing",
+      actors: matchingActors.length,
+      events: milestoneEvents.length,
+      conversionFromPrevious,
+      dropoffFromPrevious:
+        conversionFromPrevious === null ? null : Math.round((100 - conversionFromPrevious) * 100) / 100,
+      medianHoursFromFirstEvent: median(
+        matchingActors
+          .map((actor) => {
+            const milestoneAt = actor.milestones.get(definition.key);
+            if (!milestoneAt) return null;
+            return (milestoneAt.getTime() - actor.firstEventAt.getTime()) / (60 * 60 * 1000);
+          })
+          .filter((value): value is number => value !== null && value >= 0),
+      ),
+      subStages: definition.subStages.map<ActivationJourneySubStage>((sub) => {
+        const metric = subStageMetrics.get(sub.key);
+        const count = metric?.count ?? 0;
+        return {
+          key: sub.key,
+          label: sub.label,
+          kind: sub.kind,
+          description: sub.description,
+          events: sub.events,
+          status: count > 0 ? "instrumented" : "missing",
+          eventCount: count,
+          actors: metric?.actors.size ?? 0,
+        };
+      }),
+    };
+  });
+
+  const activatedActors = actors.filter((actor) => actor.milestones.has("activation_completed"));
+  const hoursToActivation = activatedActors
+    .map((actor) => {
+      const end = actor.milestones.get("activation_completed");
+      if (!end) return null;
+      return (end.getTime() - actor.firstEventAt.getTime()) / (60 * 60 * 1000);
+    })
+    .filter((value): value is number => value !== null && value >= 0);
+
+  const pathMap = new Map<
+    string,
+    { sequence: ActivationJourneyMilestoneKey[]; actors: number; activatedActors: number }
+  >();
+  for (const actor of actors) {
+    const sequence = milestoneDefinitions
+      .filter((definition) => actor.milestones.has(definition.key))
+      .map((definition) => definition.key);
+    if (sequence.length === 0) continue;
+
+    const pathKey = sequence.join(">");
+    const existing = pathMap.get(pathKey) ?? {
+      sequence,
+      actors: 0,
+      activatedActors: 0,
+    };
+    existing.actors += 1;
+    if (actor.milestones.has("activation_completed")) {
+      existing.activatedActors += 1;
+    }
+    pathMap.set(pathKey, existing);
+  }
+
+  const lastEventAt =
+    events.length === 0
+      ? null
+      : new Date(Math.max(...events.map((event) => event.occurredAt.getTime()))).toISOString();
+  // For the "all" view, report the actual earliest event as window.from (windowStart is epoch 0).
+  const firstEventAt =
+    events.length === 0
+      ? null
+      : new Date(Math.min(...events.map((event) => event.occurredAt.getTime())));
+  const effectiveStart = all ? (firstEventAt ?? windowStart) : windowStart;
+  const sourceStatus: SourceStatus =
+    events.length === 0 ? "missing" : unmappedEvents > 0 || activatedActors.length === 0 ? "partial" : "ready";
+  const observations: ActivationJourneyObservation[] = [];
+
+  if (events.length === 0) {
+    observations.push({
+      title: "No PostHog events",
+      detail: "The activation map is scaffolded, but live reporting needs synced PostHog raw events.",
+      severity: "critical",
+    });
+  }
+  if (unmappedEvents > 0) {
+    observations.push({
+      title: "Unmapped event names",
+      detail: `${unmappedEvents} event${unmappedEvents === 1 ? "" : "s"} in this window do not map to an activation milestone.`,
+      severity: "warning",
+    });
+  }
+  observations.push({
+    title: "Order semantics need sign-off",
+    detail: "order_placed + card_fulfilled count as the 'order placed' milestone, and all_cards_fulfilled + cards_received complete activation; confirm this before using them as the activation purchase metric.",
+    severity: "warning",
+  });
+  if (subStageMappedEvents > 0) {
+    observations.push({
+      title: "Sub-stage signals mapped",
+      detail: `${subStageMappedEvents} event${subStageMappedEvents === 1 ? "" : "s"} (pageviews, sign-ins, file uploads, rage clicks, fulfillment, etc.) now feed milestone sub-stages instead of sitting unmapped.`,
+      severity: "info",
+    });
+  }
+  if (systemEvents > 0) {
+    observations.push({
+      title: "System events excluded",
+      detail: `${systemEvents} PostHog system event${systemEvents === 1 ? "" : "s"} ($identify, $set, $session_summary_ready) are intentionally not attributed to a journey stage.`,
+      severity: "info",
+    });
+  }
+  const missingSubStages = milestones.flatMap((milestone) =>
+    milestone.subStages.filter((sub) => sub.status === "missing"),
+  );
+  if (events.length > 0 && missingSubStages.length > 0) {
+    observations.push({
+      title: "Sub-stages awaiting data",
+      detail: `${missingSubStages.length} sub-stage signal${missingSubStages.length === 1 ? "" : "s"} recorded no events in this window — either that stage saw no traffic, or the signal isn't reaching the sync yet.`,
+      severity: "info",
+    });
+  }
+
+  // ── New computations for the 3-tab dashboard ──────────────────────────
+
+  const milestoneKeys = milestoneDefinitions.map((d) => d.key);
+
+  // 1. Friction roll-up: aggregate rage_click + dead_click sub-stage counts per milestone
+  const friction: FrictionSummary[] = milestoneDefinitions.map((def) => {
+    let rageClicks = 0;
+    let deadClicks = 0;
+    for (const sub of def.subStages) {
+      const metric = subStageMetrics.get(sub.key);
+      if (!metric) continue;
+      if (sub.kind === "rage_click") rageClicks += metric.count;
+      if (sub.kind === "dead_click") deadClicks += metric.count;
+    }
+    return {
+      milestoneKey: def.key,
+      label: def.label,
+      rageClicks,
+      deadClicks,
+      totalFriction: rageClicks + deadClicks,
+    };
+  });
+
+  // 2. Sequential funnel: strict-order reach, RESTARTED at each funnel boundary so
+  //    activation milestones aren't gated on having completed the marketing funnel.
+  let sequentialSet: ActorJourney[] = [];
+  let sequentialFunnelKey: ActivationFunnelKey | null = null;
+  const sequentialFunnel: SequentialFunnelEntry[] = milestoneDefinitions.map((def) => {
+    if (def.funnel !== sequentialFunnelKey) {
+      sequentialSet = [...actors];
+      sequentialFunnelKey = def.funnel;
+    }
+    sequentialSet = sequentialSet.filter((actor) => actor.milestones.has(def.key));
+    const anyOrderActors = actors.filter((actor) => actor.milestones.has(def.key)).length;
+    return {
+      milestoneKey: def.key,
+      label: def.label,
+      sequentialActors: sequentialSet.length,
+      anyOrderActors,
+      sequentialRate: percent(sequentialSet.length, actors.length),
+    };
+  });
+
+  // 3. Transition times: pairwise median hours between consecutive milestones
+  const transitionTimes: TransitionTime[] = [];
+  for (let i = 0; i < milestoneKeys.length - 1; i++) {
+    // No cross-funnel transition: the marketing→activation hop is the bridge, not a step.
+    if (milestoneDefinitions[i].funnel !== milestoneDefinitions[i + 1].funnel) continue;
+    const fromKey = milestoneKeys[i];
+    const toKey = milestoneKeys[i + 1];
+    const durations: number[] = [];
+    for (const actor of actors) {
+      const fromAt = actor.milestones.get(fromKey);
+      const toAt = actor.milestones.get(toKey);
+      if (fromAt && toAt) {
+        const hours = (toAt.getTime() - fromAt.getTime()) / (60 * 60 * 1000);
+        if (hours >= 0) durations.push(hours);
+      }
+    }
+    transitionTimes.push({
+      from: fromKey,
+      to: toKey,
+      fromLabel: milestoneDefinitions[i].label,
+      toLabel: milestoneDefinitions[i + 1].label,
+      medianHours: median(durations),
+      actors: durations.length,
+    });
+  }
+
+  // 4. Actor samples: ~12 actors stratified by furthest milestone
+  const byFurthest = new Map<string, ActorJourney[]>();
+  for (const actor of actors) {
+    const f = actorFurthestMilestone(actor, milestoneKeys) ?? "none";
+    const bucket = byFurthest.get(f) ?? [];
+    bucket.push(actor);
+    byFurthest.set(f, bucket);
+  }
+  const actorSamples: ActorSample[] = [];
+  // Prioritize later milestones (more interesting journeys)
+  const furthestBucketOrder = ([...milestoneKeys].reverse() as string[]).concat("none");
+  for (const key of furthestBucketOrder) {
+    const bucket = byFurthest.get(key) ?? [];
+    for (const actor of bucket.slice(0, 2)) {
+      if (actorSamples.length >= 12) break;
+      actorSamples.push({
+        actorId: actor.actorId,
+        source: actor.source,
+        milestones: milestoneKeys.filter((k) => actor.milestones.has(k)),
+        furthestMilestone: actorFurthestMilestone(actor, milestoneKeys),
+        cohort: actorCohort(actor),
+        ...postHogActorLinks(actor),
+      });
+    }
+    if (actorSamples.length >= 12) break;
+  }
+
+  // 5. Compact actor journey summaries for client-side Sankey + segment computation
+  const actorJourneys: ActorJourneySummary[] = actors.map((actor) => ({
+    source: actor.source,
+    milestones: milestoneKeys.filter((k) => actor.milestones.has(k)),
+    furthest: actorFurthestMilestone(actor, milestoneKeys),
+    cohort: actorCohort(actor),
+  }));
+
+  // ── End new computations ──────────────────────────────────────────────
+
+  // ── Two-funnel split + non-linear bridge ──────────────────────────────
+  const marketingFunnel = milestones.filter((milestone) => milestone.funnel === "marketing");
+  const activationFunnel = milestones.filter((milestone) => milestone.funnel === "activation");
+
+  // Bridge: trial ∪ paid → signup. `signup` has no single upstream parent, so this
+  // is a set-union join (NOT a funnel step). Each signup is attributed to the
+  // commercial event that preceded it, or "direct" (free/no preceding trial/paid).
+  const commercialActors = actors.filter(
+    (actor) => actor.milestones.has("trial") || actor.milestones.has("paid"),
+  );
+  const signups = actors.filter((actor) => actor.milestones.has("signup"));
+  let postPaid = 0;
+  let postTrial = 0;
+  let direct = 0;
+  for (const actor of signups) {
+    const signupAt = actor.milestones.get("signup")!;
+    const paidAt = actor.milestones.get("paid");
+    const trialAt = actor.milestones.get("trial");
+    if (paidAt && paidAt.getTime() <= signupAt.getTime()) {
+      postPaid += 1;
+    } else if (trialAt && trialAt.getTime() <= signupAt.getTime()) {
+      postTrial += 1;
+    } else {
+      direct += 1;
+    }
+  }
+  const commercialSignedUp = commercialActors.filter((actor) =>
+    actor.milestones.has("signup"),
+  ).length;
+  const bridge: ActivationJourneyBridge = {
+    commercialActors: commercialActors.length,
+    signedUpActors: commercialSignedUp,
+    conversionRate: percent(commercialSignedUp, commercialActors.length),
+    signupAttribution: {
+      postPaid,
+      postTrial,
+      direct,
+      total: signups.length,
+    },
+  };
+
+  return {
+    summary: {
+      totalEvents: events.length,
+      identifiedActors: actors.length,
+      activatedActors: activatedActors.length,
+      activationRate: percent(activatedActors.length, actors.length),
+      medianHoursToActivation: median(hoursToActivation),
+      lastEventAt,
+    },
+    milestones,
+    marketingFunnel,
+    activationFunnel,
+    bridge,
+    cohorts: [
+      buildCohort(
+        "tour_completed",
+        "Tour completed",
+        actors.filter((actor) => actor.milestones.has("video_completed")),
+      ),
+      buildCohort(
+        "tour_started_not_completed",
+        "Tour started, not completed",
+        actors.filter(
+          (actor) =>
+            actor.milestones.has("tour_started") && !actor.milestones.has("video_completed"),
+        ),
+      ),
+      buildCohort(
+        "no_tour",
+        "No tour observed",
+        actors.filter((actor) => !actor.milestones.has("tour_started")),
+      ),
+    ],
+    paths: [...pathMap.values()]
+      .map((path) => ({
+        ...path,
+        activationRate: percent(path.activatedActors, path.actors),
+      }))
+      .sort((left, right) => {
+        if (right.activatedActors !== left.activatedActors) {
+          return right.activatedActors - left.activatedActors;
+        }
+        return right.actors - left.actors;
+      }),
+    eventTaxonomy: [...taxonomy.values()]
+      .map((row) => ({
+        event: row.event,
+        mappedMilestone: row.mappedMilestone,
+        mappedSubStages: [...row.subStages].sort(),
+        count: row.count,
+        actors: row.actors.size,
+        firstSeenAt: row.firstSeenAt.toISOString(),
+        lastSeenAt: row.lastSeenAt.toISOString(),
+      }))
+      .sort((left, right) => right.count - left.count || left.event.localeCompare(right.event)),
+    observations,
+    source: {
+      status: sourceStatus,
+      unmappedEvents,
+      subStageMappedEvents,
+      systemEvents,
+    },
+    window: {
+      from: effectiveStart.toISOString(),
+      to: windowEnd.toISOString(),
+      days: Math.max(1, Math.round((windowEnd.getTime() - effectiveStart.getTime()) / (24 * 60 * 60 * 1000))),
+    },
+    friction,
+    sequentialFunnel,
+    transitionTimes,
+    actorSamples,
+    actorJourneys,
+  };
+}


### PR DESCRIPTION
## Summary
- Add the activation journey dashboard and API route to the Railway-backed WIPGuard app.
- Build actor journey samples with PostHog replay, person identity, and event analytics URLs.
- Render Replay / Identity / Analytics actions on actor sample cards without toggling selection.

## Verification
- npm test -- src/lib/imladris/activation-journey.test.ts
- npm run typecheck:staged -- <changed TS/TSX files>
- npm run lint
- npm test
- npm run build

## Notes
- Railway production already has POSTHOG_PROJECT_ID set, so drilldown links will render when actor samples have identifiers.
- Replay links require PostHog $session_id on the actor events.